### PR TITLE
Remove container from diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ ramalama pull granite-code
                                                      |       |      |
                                                      v       v      v
                                                    +------------------+
-                                                   | Start container  |
-                                                   | with llama.cpp   |
-                                                   | and granite-code |
+                                                   | Start with       |
+                                                   | llama.cpp and    |
+                                                   | granite-code     |
                                                    | model            |
                                                    +------------------+
 ```


### PR DESCRIPTION
We want to remove OCI containers as a strict dependancy of ramalama, so running in containers is options, reflecting this in the diagram.