### PR TITLE
If podman or docker is available and we are not in a container

### DIFF
--- a/ramalama
+++ b/ramalama
@@ -5,6 +5,7 @@ import sys
 import subprocess
 import json
 import hashlib
+import shutil
 
 x = False
 
@@ -158,6 +159,27 @@ def get_ramalama_store():
         return "/var/lib/ramalama"
 
     return os.path.expanduser("~/.local/share/ramalama")
+
+
+def in_container():
+    if os.path.exists("/run/.containerenv") or os.path.exists("/.dockerenv") or os.getenv("container"):
+        return True
+
+    return False
+
+
+def available(command):
+    return shutil.which(command) is not None
+
+
+def select_container_manager():
+    if available("podman"):
+        return "podman"
+
+    if available("docker"):
+        return "docker"
+
+    return ""
 
 
 def main():


### PR DESCRIPTION
We should re-exec this script inside a llama.cpp container (incomplete
in this commit), truth is these AI runtime evironment are complex to
set up by say installing a few packages, etc. The often require a
certain version of mesa, llama.cpp, kernel drivers, ROCm, the list goes
on and on depending on hardware. Although if one does want
to run outside a container and or say they are running on macOS we
should support that.