### PR TITLE
Support non-default namespace for Ollama

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -39,6 +39,7 @@ main() {
   set -o pipefail
 
   ./ramalama pull tinyllama
+  ./ramalama pull ben1t0/tiny-llm
   ./ramalama pull huggingface://afrideva/Tiny-Vicuna-1B-GGUF/tiny-vicuna-1b.q2_k.gguf
   ./ramalama list | grep tinyllama
   ./ramalama list | grep tiny-vicuna-1b

--- a/ramalama
+++ b/ramalama
@@ -254,7 +254,11 @@ def pull_cli(ramalama_store, args):
     ramalama_models = ramalama_store + "/models/ollama"
     registry_scheme = "https"
     registry = "registry.ollama.ai"
-    model_full = "library/" + model
+    if '/' in model:
+        model_full = model
+    else:
+        model_full = "library/" + model
+
     accept = "Accept: application/vnd.docker.distribution.manifest.v2+json"
     if ':' in model_full:
         model_name, model_tag = model_full.split(':', 1)
@@ -269,7 +273,7 @@ def pull_cli(ramalama_store, args):
 
     manifests = os.path.join(repos_ollama, "manifests",
                              registry, model_name, model_tag)
-    registry_head = f"{registry_scheme}://{registry}/v2/{model_name}"
+    registry_head = f"{registry_scheme}://{registry}/v2/{model_full}"
     return init_pull(repos_ollama, manifests, accept, registry_head, model_name, model_tag, ramalama_models, symlink_path, model)
 
 


### PR DESCRIPTION
Anything that wasn't in the default namespace didn't work before, like:

ben1t0/tiny-llm