### PR TITLE
Require containers for Linux always if podman is available

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -13,7 +13,7 @@ main() {
   fi
 
   local os
-  os="$(uname)"
+  os="$(uname -s)"
   if ! available autopep8; then
     if [ "$os" = "Linux" ]; then
       if available apt; then
@@ -24,7 +24,10 @@ main() {
     fi
   fi
 
-  pip install "huggingface_hub[cli]==0.24.2"
+  # only for macOS for now, which doesn't have containers
+  if [ "$os" != "Linux" ]; then
+    pip install "huggingface_hub[cli]==0.24.2"
+  fi
 
   chmod +x ramalama install.sh
   if [ "$os" = "Linux" ]; then

--- a/install.sh
+++ b/install.sh
@@ -26,7 +26,9 @@ download() {
 main() {
   set -e -o pipefail
 
-  if [ "$(uname -s)" != "Linux" ]; then
+  local os
+  os="$(uname -s)"
+  if [ "$os" != "Linux" ]; then
     echo "This script is intended to run on Linux only"
     return 1
   fi
@@ -49,7 +51,12 @@ main() {
   local url="raw.githubusercontent.com/containers/ramalama/s/$from"
   local from="$TMP/$from"
   download
-  pip install "huggingface_hub[cli]==0.24.2"
+
+  # only for macOS for now, which doesn't have containers
+  if [ "$os" != "Linux" ]; then
+    pip install "huggingface_hub[cli]==0.24.2"
+  fi
+
   install -D -m755 "$from" "$bindir/"
 
   if false; then # to be done

--- a/ramalama
+++ b/ramalama
@@ -352,7 +352,7 @@ def main(args):
 
     try:
         cmd = args[0]
-        if conman and (cmd == 'serve' or cmd == 'run'):
+        if conman:
             conman_args = [conman, "run", "--rm", "-it", "--security-opt=label=disable", f"-v{ramalama_store}:/var/lib/ramalama", f"-v{os.path.expanduser('~')}:{os.path.expanduser('~')}", "-v/tmp:/tmp",
                            f"-v{__file__}:{__file__}", "quay.io/ramalama/ramalama:latest", __file__] + args
             os.execvp(conman, conman_args)


### PR DESCRIPTION
Less confusing UX, long-term we may want to remove the dependancies on containers for macOS support and those that want to deploy without containers.