### PR TITLE
py: fix huggingface repos layout

### DIFF
--- a/ramalama
+++ b/ramalama
@@ -9,6 +9,7 @@ import hashlib
 import shutil
 import time
 import re
+import logging
 from pathlib import Path
 
 x = False
@@ -135,11 +136,10 @@ def init_pull(repos_ollama, manifests, accept, registry_head, model_name, model_
 
 
 def huggingface_download(ramalama_store, model, directory, filename):
-    return run_cmd(["huggingface-cli", "download", directory, filename, "--cache-dir", ramalama_store + "/repos/huggingface/.cache", "--local-dir", ramalama_store + "/repos/huggingface"])
+    return run_cmd(["huggingface-cli", "download", directory, filename, "--cache-dir", ramalama_store + "/repos/huggingface/.cache", "--local-dir", ramalama_store + "/repos/huggingface/" + directory])
 
 
 def try_huggingface_download(ramalama_store, model, directory, filename):
-    huggingface_download(ramalama_store, model, directory, filename)
     proc = huggingface_download(ramalama_store, model, directory, filename)
     return proc.stdout.decode('utf-8')
 


### PR DESCRIPTION
Hi 👋 
I'm familiarizing with the project code.

It looks to me:

a file from hf:// would have downloaded straigh into {ramalama_store}/repos/huggingface
and possibly colliding with other model files
having same name coming from other repos.

the huggingface_download() was actually called
twice, fixed by calling once.

This PR addresses both points.
If that was intended behaviour, kindly explain because I might be missing something 😅 

Edit: as I was later browsing open issues, this one seems indeed resolves #23 

# Before (today)

```
./ramalama pull huggingface://tarilabs/mnist/README.md
# ...

tree ~/.local/share/ramalama
/Users/mmortari/.local/share/ramalama
├── models
│   ├── huggingface
│   │   └── tarilabs
│   │       └── mnist
│   │           └── README.md -> ../../../../repos/huggingface/README.md
│   └── ollama
└── repos
    ├── huggingface
    │   └── README.md    # <-- notice the model file is downloaded in root here? 🤔 
    └── ollama

```

# After

```
./ramalama pull huggingface://tarilabs/mnist/README.md
# ...

tree ~/.local/share/ramalama 
/Users/mmortari/.local/share/ramalama
├── models
│   ├── huggingface
│   │   └── tarilabs
│   │       └── mnist
│   │           └── README.md -> ../../../../repos/huggingface/tarilabs/mnist/README.md
│   └── ollama
└── repos
    ├── huggingface
    │   └── tarilabs    # <-- HF org/user/ns
    │       └── mnist    # <-- HF repo
    │           └── README.md
    └── ollama
```