### PR TITLE
pull for oci:// protocol

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -26,6 +26,7 @@ main() {
 
   # only for macOS for now, which doesn't have containers
   if [ "$os" != "Linux" ]; then
+    /usr/bin/python3 --version
     pip install "huggingface_hub[cli]==0.24.2"
     pip install "omlmd==0.1.1"
   fi

--- a/ci.sh
+++ b/ci.sh
@@ -27,7 +27,7 @@ main() {
   # only for macOS for now, which doesn't have containers
   if [ "$os" != "Linux" ]; then
     pip install "huggingface_hub[cli]==0.24.2"
-    pip install "omlmd"
+    pip install "omlmd==0.1.1"
   fi
 
   chmod +x ramalama install.sh

--- a/ci.sh
+++ b/ci.sh
@@ -28,7 +28,7 @@ main() {
   if [ "$os" != "Linux" ]; then
     /usr/bin/python3 --version
     pip install "huggingface_hub[cli]==0.24.2"
-    pip install "omlmd==0.1.1"
+    pip install "omlmd==0.1.2"
   fi
 
   chmod +x ramalama install.sh

--- a/ci.sh
+++ b/ci.sh
@@ -27,6 +27,7 @@ main() {
   # only for macOS for now, which doesn't have containers
   if [ "$os" != "Linux" ]; then
     pip install "huggingface_hub[cli]==0.24.2"
+    pip install "omlmd"
   fi
 
   chmod +x ramalama install.sh
@@ -45,9 +46,11 @@ main() {
   ./ramalama pull ben1t0/tiny-llm
   ./ramalama pull ollama://tinyllama:1.1b
   ./ramalama pull huggingface://afrideva/Tiny-Vicuna-1B-GGUF/tiny-vicuna-1b.q2_k.gguf
+  ./ramalama pull oci://quay.io/mmortari/gguf-py-example:v1
   ./ramalama list | grep tinyllama
   ./ramalama list | grep tiny-vicuna-1b
   ./ramalama list | grep NAME
+  ./ramalama list | grep oci://quay.io/mmortari/gguf-py-example/v1/example.gguf
 #  ramalama list | grep granite-code
 #  ramalama rm granite-code
 }

--- a/ci.sh
+++ b/ci.sh
@@ -28,7 +28,9 @@ main() {
   if [ "$os" != "Linux" ]; then
     /usr/bin/python3 --version
     pip install "huggingface_hub[cli]==0.24.2"
+    huggingface-cli --help
     pip install "omlmd==0.1.2"
+    omlmd --help
   fi
 
   chmod +x ramalama install.sh

--- a/container-images/ramalama/latest/Containerfile
+++ b/container-images/ramalama/latest/Containerfile
@@ -8,6 +8,7 @@ RUN dnf install -y git jq procps-ng vim vulkan-headers vulkan-loader-devel \
     dnf clean all && \
     rm -rf /var/cache/*dnf*
 
+RUN /usr/bin/python3 --version
 RUN pip install "huggingface_hub[cli]==0.24.2"
 RUN pip install "omlmd==0.1.1"
 

--- a/container-images/ramalama/latest/Containerfile
+++ b/container-images/ramalama/latest/Containerfile
@@ -9,6 +9,7 @@ RUN dnf install -y git jq procps-ng vim vulkan-headers vulkan-loader-devel \
     rm -rf /var/cache/*dnf*
 
 RUN pip install "huggingface_hub[cli]==0.24.2"
+RUN pip install "omlmd"
 
 ENV LLAMA_CCACHE=0
 

--- a/container-images/ramalama/latest/Containerfile
+++ b/container-images/ramalama/latest/Containerfile
@@ -10,7 +10,7 @@ RUN dnf install -y git jq procps-ng vim vulkan-headers vulkan-loader-devel \
 
 RUN /usr/bin/python3 --version
 RUN pip install "huggingface_hub[cli]==0.24.2"
-RUN pip install "omlmd==0.1.1"
+RUN pip install "omlmd==0.1.2"
 
 ENV LLAMA_CCACHE=0
 

--- a/container-images/ramalama/latest/Containerfile
+++ b/container-images/ramalama/latest/Containerfile
@@ -9,7 +9,7 @@ RUN dnf install -y git jq procps-ng vim vulkan-headers vulkan-loader-devel \
     rm -rf /var/cache/*dnf*
 
 RUN pip install "huggingface_hub[cli]==0.24.2"
-RUN pip install "omlmd"
+RUN pip install "omlmd==0.1.1"
 
 ENV LLAMA_CCACHE=0
 

--- a/container_build.sh
+++ b/container_build.sh
@@ -56,8 +56,6 @@ main() {
 
   local conman_bin
   select_container_manager
-  local llm_store
-  get_llm_store
   local conman=("$conman_bin")
   local platform="linux/amd64"
   if [ "$(uname -m)" = "aarch64" ]; then

--- a/container_build.sh
+++ b/container_build.sh
@@ -58,7 +58,7 @@ main() {
   select_container_manager
   local llm_store
   get_llm_store
-  local conman=("$conman_bin" "--root" "$llm_store")
+  local conman=("$conman_bin")
   local platform="linux/amd64"
   if [ "$(uname -m)" = "aarch64" ]; then
     platform="linux/arm64"

--- a/container_build.sh
+++ b/container_build.sh
@@ -16,15 +16,6 @@ select_container_manager() {
   conman_bin="podman"
 }
 
-get_llm_store() {
-  if [ "$EUID" -eq 0 ]; then
-    llm_store="/var/lib/ramalama/storage"
-    return 0
-  fi
-
-  llm_store="$HOME/.local/share/ramalama/storage"
-}
-
 add_build_platform() {
   conman_build+=("build" "--platform" "$platform")
   conman_build+=("-t" "quay.io/ramalama/$image_name" ".")

--- a/install.sh
+++ b/install.sh
@@ -55,6 +55,7 @@ main() {
   # only for macOS for now, which doesn't have containers
   if [ "$os" != "Linux" ]; then
     pip install "huggingface_hub[cli]==0.24.2"
+    pip install "omlmd"
   fi
 
   install -D -m755 "$from" "$bindir/"

--- a/install.sh
+++ b/install.sh
@@ -56,7 +56,7 @@ main() {
   if [ "$os" != "Linux" ]; then
     /usr/bin/python3 --version
     pip install "huggingface_hub[cli]==0.24.2"
-    pip install "omlmd==0.1.1"
+    pip install "omlmd==0.1.2"
   fi
 
   install -D -m755 "$from" "$bindir/"

--- a/install.sh
+++ b/install.sh
@@ -55,7 +55,7 @@ main() {
   # only for macOS for now, which doesn't have containers
   if [ "$os" != "Linux" ]; then
     pip install "huggingface_hub[cli]==0.24.2"
-    pip install "omlmd"
+    pip install "omlmd==0.1.1"
   fi
 
   install -D -m755 "$from" "$bindir/"

--- a/install.sh
+++ b/install.sh
@@ -54,6 +54,7 @@ main() {
 
   # only for macOS for now, which doesn't have containers
   if [ "$os" != "Linux" ]; then
+    /usr/bin/python3 --version
     pip install "huggingface_hub[cli]==0.24.2"
     pip install "omlmd==0.1.1"
   fi

--- a/ramalama
+++ b/ramalama
@@ -291,7 +291,6 @@ def pull_cli(ramalama_store, args, port):
     if len(args) < 1:
         usage()
 
-    mkdirs(ramalama_store)
     model = args.pop(0)
     matching_files = glob.glob(f"{ramalama_store}/models/*/{model}")
     if matching_files:
@@ -398,6 +397,7 @@ def select_container_manager():
 def main(args):
     conman = select_container_manager()
     ramalama_store = get_ramalama_store()
+    mkdirs(ramalama_store)
 
     try:
         dryrun = False

--- a/ramalama
+++ b/ramalama
@@ -10,6 +10,8 @@ import shutil
 import time
 import re
 import logging
+from omlmd.helpers import Helper
+from omlmd.provider import OMLMDRegistry
 from pathlib import Path
 
 x = False
@@ -241,6 +243,37 @@ def pull_huggingface(model, ramalama_store):
     return symlink_path
 
 
+def pull_oci(model, ramalama_store):
+    target = re.sub(r'^oci://', '', model)
+    registry, reference = target.split('/', 1)
+    registry, reference = ("docker.io", target) if "." not in registry else (registry, reference)
+    reference_dir = reference.replace(":", "/")
+    outdir = f"{ramalama_store}/repos/oci/{registry}/{reference_dir}"
+    print(f"Downloading {target}...")
+    omlmd = Helper(OMLMDRegistry())
+    omlmd.pull(target, outdir)
+    ggufs = [file for file in os.listdir(outdir) if file.endswith('.gguf')]
+    if len(ggufs) != 1:
+        print(f"Error: Unable to identify .gguf file in: {outdir}")
+        sys.exit(-1)
+    
+    directory = f"{ramalama_store}/models/oci/{registry}/{reference_dir}"
+    os.makedirs(directory, exist_ok=True)
+    symlink_path = f"{directory}/{ggufs[0]}"
+    relative_target_path = os.path.relpath(f"{outdir}/{ggufs[0]}", start=os.path.dirname(symlink_path))
+    if os.path.exists(symlink_path) and os.readlink(symlink_path) == relative_target_path:
+        # Symlink is already correct, no need to update it
+        return symlink_path
+
+    try:
+        run_cmd(["ln", "-sf", relative_target_path, symlink_path])
+    except subprocess.CalledProcessError as e:
+        print_error(e)
+        sys.exit(e.returncode)
+
+    return symlink_path
+
+
 def pull_cli(ramalama_store, args):
     if len(args) < 1:
         usage()
@@ -255,6 +288,8 @@ def pull_cli(ramalama_store, args):
 
     if model.startswith("huggingface://"):
         return pull_huggingface(model, ramalama_store)
+    if model.startswith("oci://"):
+        return pull_oci(model, ramalama_store)
 
     model = re.sub(r'^ollama://', '', model)
     repos_ollama = ramalama_store + "/repos/ollama"

--- a/ramalama
+++ b/ramalama
@@ -10,8 +10,6 @@ import shutil
 import time
 import re
 import logging
-from omlmd.helpers import Helper
-from omlmd.provider import OMLMDRegistry
 from pathlib import Path
 
 x = False
@@ -250,8 +248,7 @@ def pull_oci(model, ramalama_store):
     reference_dir = reference.replace(":", "/")
     outdir = f"{ramalama_store}/repos/oci/{registry}/{reference_dir}"
     print(f"Downloading {target}...")
-    omlmd = Helper(OMLMDRegistry())
-    omlmd.pull(target, outdir)
+    run_cmd(["omlmd", "pull", target, "--output", outdir]) # note: in the current way ramalama is designed, cannot do Helper(OMLMDRegistry()).pull(target, outdir) since cannot use modules/sdk, can use only cli bindings from pip installs
     ggufs = [file for file in os.listdir(outdir) if file.endswith('.gguf')]
     if len(ggufs) != 1:
         print(f"Error: Unable to identify .gguf file in: {outdir}")

--- a/ramalama
+++ b/ramalama
@@ -244,20 +244,26 @@ def pull_huggingface(model, ramalama_store):
 def pull_oci(model, ramalama_store):
     target = re.sub(r'^oci://', '', model)
     registry, reference = target.split('/', 1)
-    registry, reference = ("docker.io", target) if "." not in registry else (registry, reference)
+    registry, reference = ("docker.io",
+                           target) if "." not in registry else (
+        registry, reference)
     reference_dir = reference.replace(":", "/")
     outdir = f"{ramalama_store}/repos/oci/{registry}/{reference_dir}"
     print(f"Downloading {target}...")
-    run_cmd(["omlmd", "pull", target, "--output", outdir]) # note: in the current way ramalama is designed, cannot do Helper(OMLMDRegistry()).pull(target, outdir) since cannot use modules/sdk, can use only cli bindings from pip installs
+    # note: in the current way ramalama is designed, cannot do Helper(OMLMDRegistry()).pull(target, outdir) since cannot use modules/sdk, can use only cli bindings from pip installs
+    run_cmd(["omlmd", "pull", target, "--output", outdir])
     ggufs = [file for file in os.listdir(outdir) if file.endswith('.gguf')]
     if len(ggufs) != 1:
         print(f"Error: Unable to identify .gguf file in: {outdir}")
         sys.exit(-1)
-    
+
     directory = f"{ramalama_store}/models/oci/{registry}/{reference_dir}"
     os.makedirs(directory, exist_ok=True)
     symlink_path = f"{directory}/{ggufs[0]}"
-    relative_target_path = os.path.relpath(f"{outdir}/{ggufs[0]}", start=os.path.dirname(symlink_path))
+    relative_target_path = os.path.relpath(
+        f"{outdir}/{ggufs[0]}",
+        start=os.path.dirname(symlink_path)
+    )
     if os.path.exists(symlink_path) and os.readlink(symlink_path) == relative_target_path:
         # Symlink is already correct, no need to update it
         return symlink_path

--- a/ramalama
+++ b/ramalama
@@ -158,6 +158,8 @@ def mkdirs(ramalama_store):
     directories = [
         'models/huggingface',
         'repos/huggingface',
+        'models/oci',
+        'repos/oci',
         'models/ollama',
         'repos/ollama'
     ]


### PR DESCRIPTION
using omlmd (https://pypi.org/project/omlmd/)

`ramamlama pull oci://`
to pull OCI Artifact using omlmd sdk

Since a given OCI Artifact may contain multiple files:
1. create symbolic links only when the resulting oci download resulted being able to determine the single (~gguf file or similar) model file
2. and display an error that the model file cannot be uniquely identified from oci://registry/ns/repo when multiple files are present in the referenced container.

see also: https://tarilabs.github.io/omlmd

# Example

Running locally in a venv (I'm on Mac):

```bash
(venv) ramalama % python ramalama pull oci://quay.io/mmortari/gguf-py-example:v1                            
Downloading quay.io/mmortari/gguf-py-example:v1...
(venv) ramalama % ls -la ~/.local/share/ramalama/models/oci/quay.io/mmortari/gguf-py-example/v1/example.gguf
lrwxr-xr-x  1 mmortari  staff  76 Aug  9 17:36 /Users/mmortari/.local/share/ramalama/models/oci/quay.io/mmortari/gguf-py-example/v1/example.gguf -> ../../../../../../repos/oci/quay.io/mmortari/gguf-py-example/v1/example.gguf
(venv) ramalama % python ramalama list                                                                      
NAME                                                                MODIFIED        SIZE  
oci://quay.io/mmortari/gguf-py-example/v1/example.gguf              21 seconds ago  4.0K  
```

I've also tested per @ralphbean 's request:

```bash
(venv) ramalama % python ramalama pull oci://quay.io/redhat-user-workloads/rhel-ai-poc-tenant/models/merlinite-poc:82c0d0ab382f17a8567da12f34640626d207c868
Downloading quay.io/redhat-user-workloads/rhel-ai-poc-tenant/models/merlinite-poc:82c0d0ab382f17a8567da12f34640626d207c868...
(venv) ramalama % python ramalama list                                                                                                                     
NAME                                                                MODIFIED        SIZE  
oci://quay.io/redhat-user-workloads/rhel-ai-poc-tenant/models/merlinite-poc/82c0d0ab382f17a8567da12f34640626d207c868/merlinite-7b-lab-Q4_K_M.gguf 28 seconds ago  4.1G  
oci://quay.io/mmortari/gguf-py-example/v1/example.gguf              19 minutes ago  4.0K
```

and the pull behaviour works to my understanding, netting the time it takes from where I'm sitting to download 4GB from quay.io 😅 

I wish I could test it further, but as mentioned I'm on a Mac...
Kindly let me know @ericcurtin if this matches your original expectations!

Hope this helps :)
This intends to resolve #13 per https://github.com/containers/ramalama/issues/13#issuecomment-2275436350