### PR TITLE
Use __file__ over sys.argv[0]

### DIFF
--- a/ramalama.py
+++ b/ramalama.py
@@ -31,10 +31,17 @@ def main(args):
 
         if conman:
             home = os.path.expanduser('~')
-            cwd = os.getcwd()
-            wd = os.path.join(cwd, "ramalama")
-            if not os.path.exists(wd):
-                wd = "/usr/lib/python3.12/site-packages/podman"
+            wd = "ramalama"
+            for path in sys.path:
+                path = os.path.join(path, 'ramalama')
+                # Check if the "ramalama" directory exists in the current path
+                if os.path.exists(path):
+                    wd = path
+                    break
+                else:
+                    print("ramalama not found in any sys.path directories")
+
+            # To do, unsafe, this may not be a valid path in the guest
             libpath = "/usr/lib/python3.12/site-packages/ramalama"
             conman_args = [conman, "run",
                            "--rm",
@@ -43,7 +50,7 @@ def main(args):
                            f"-v{store}:/var/lib/ramalama",
                            f"-v{home}:{home}",
                            "-v/tmp:/tmp",
-                           f"-v{sys.argv[0]}:/usr/bin/ramalama",
+                           f"-v{__file__}:/usr/bin/ramalama",
                            f"-v{wd}:{libpath}",
                            "-e", "RAMALAMA_HOST",
                            "-p", f"{host}:{port}",


### PR DESCRIPTION
`__file__` uses absolute path, it's safer, if we call ramalama like:

ramalama

argv[0] will be "ramalama" which is not the location of the python script.

Also fixed a typo s/podman/ramalama/g