### PR TITLE
When calling ramalama with no args, display usage

### DIFF
--- a/ramalama.py
+++ b/ramalama.py
@@ -14,6 +14,9 @@ def main(args):
         store = ramalama.create_store()
 
         dryrun = False
+        if len(args) < 1:
+            ramalama.usage()
+
         while len(args) > 0:
             if args[0] == "--dryrun":
                 args.pop(0)


### PR DESCRIPTION
Previously it was displaying this:

$ ./ramalama.py
pop from empty list