### PR TITLE
With Ollama images, ensure model is stored locally in it's namespace

### DIFF
--- a/ramalama/ollama.py
+++ b/ramalama/ollama.py
@@ -70,7 +70,7 @@ def init_pull(repos, manifests, accept, registry_head, model_name, model_tag, mo
 class Ollama(Model):
     def __init__(self, model):
         super().__init__(model.removeprefix("ollama://"))
-        self.type = "Olama"
+        self.type = "Ollama"
 
     def pull(self, args):
         repos = args.store + "/repos/ollama"
@@ -78,6 +78,7 @@ class Ollama(Model):
         registry = "https://registry.ollama.ai"
         if '/' in self.model:
             model_full = self.model
+            models = os.path.join(models, model_full.rsplit("/", 1)[0])
         else:
             model_full = "library/" + self.model
 


### PR DESCRIPTION
This way we don't have model name collisions for models with the same name in separate namespaces. So granite-code which is in the default namespace in Ollama registry would have no namespace locally, whilst instructlab/merlinite-7b-lab:latest would be stored in the "instructlab" namespace locally.

```
$ ramalama ls
NAME                                                                MODIFIED        SIZE
ollama://instructlab/merlinite-7b-lab:latest                        49 seconds ago  4.1G
ollama://granite-code:3b                                            1 month ago     1.9G
```

Also, noticed a small typo nearby s/Olama/Ollama/g