### PR TITLE
Set Ollama as the default

### DIFF
--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -349,4 +349,4 @@ def New(model):
     if transport == "oci":
         return OCI(model)
 
-    return OCI(model)
+    return Ollama(model)


### PR DESCRIPTION
In future, we will likely set OCI as the default again (with Ollama as a fallback) so Ollama users won't notice a breakage.

OCI as a default today isn't very useful, we haven't built up a catalog of models as OCI artefacts yet.