### PR TITLE
Update llama.cpp to 8962422b1c6f9b8b15f5aeaea42600bcc2d44177

### DIFF
--- a/container-images/ramalama/latest/Containerfile
+++ b/container-images/ramalama/latest/Containerfile
@@ -18,7 +18,7 @@ ENV GGML_CCACHE=0
 
 RUN git clone https://github.com/ggerganov/llama.cpp && \
     cd llama.cpp && \
-    git reset --hard 50addec9a532a6518146ab837a85504850627316 && \
+    git reset --hard 32b2ec88bc44b086f3807c739daf28a1613abde1 && \
     cmake -B build -DCMAKE_INSTALL_PREFIX:PATH=/usr -DGGML_CCACHE=0 && \
     cmake --build build --config Release -j $(nproc) && \
     cmake --install build && \


### PR DESCRIPTION
The latest granite-code:3b isn't working in the version before this commit, time to upgrade.