### PR TITLE
Remove curl dependency from Ollama models and improve progress bar

### DIFF
--- a/container-images/ramalama/latest/Containerfile
+++ b/container-images/ramalama/latest/Containerfile
@@ -4,6 +4,8 @@ FROM registry.access.redhat.com/ubi9/ubi:9.4-1214.1726694543
 ARG HUGGINGFACE_HUB_VERSION=0.25.1
 # renovate: datasource=github-releases depName=containers/omlmd extractVersion=^v(?<version>.*)
 ARG OMLMD_VERSION=0.1.4
+# renovate: datasource=github-releases depName=tqdm/tqdm extractVersion=^v(?<version>.*)
+ARG TQDM_VERSION=4.66.5
 # renovate: datasource=git-refs depName=ggerganov/llama.cpp packageName=https://github.com/ggerganov/llama.cpp gitRef=master versioning=loose type=digest
 ARG LLAMA_CPP_SHA=32b2ec88bc44b086f3807c739daf28a1613abde1
 # renovate: datasource=git-refs depName=ggerganov/whisper.cpp packageName=https://github.com/ggerganov/whisper.cpp gitRef=master versioning=loose type=digest
@@ -22,6 +24,7 @@ RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.n
 RUN /usr/bin/python3 --version
 RUN pip install "huggingface_hub[cli]==${HUGGINGFACE_HUB_VERSION}"
 RUN pip install "omlmd==${OMLMD_VERSION}"
+RUN pip install "tqdm==${TQDM_VERSION}"
 
 ENV GGML_CCACHE=0
 

--- a/install.py
+++ b/install.py
@@ -78,6 +78,7 @@ directory containing brew to the PATH before continuing to install RamaLama
 def install_mac_dependencies():
     subprocess.run(["pip3", "install", "huggingface_hub[cli]"], check=True)
     subprocess.run(["pip3", "install", "omlmd==0.1.4"], check=True)
+    subprocess.run(["pip3", "install", "tqdm"], check=True)
     subprocess.run(["brew", "install", "llama.cpp"], check=True)
 
 
@@ -100,6 +101,7 @@ def setup_ramalama(bindir, tmp_dir):
     syspath += "/ramalama"
     subprocess.run(["install", "-m755", "-d", syspath], check=True)
     subprocess.run(["install", "-m755", to_file, ramalama_bin], check=True)
+
     python_files = [
         "cli.py",
         "huggingface.py",


### PR DESCRIPTION
Resolves #115

Example run:
```
(venv) ramalama (feat*) $ python ramalama.py pull ollama://tinyllama       
Pulling tinyllama/latest: 100% ▕####################▏ 852/852 2.47MB/s 00:00
Pulling 6897109396245362: 100% ▕####################▏ 483/483 753kB/s 00:00
Pulling 83e42c043d6c7816:  22% ▕####4               ▏ 134M/608M 4.57MB/s 01:48 
```