### PR TITLE
Run container_build first

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,9 @@ install:
 	make -C docs install
 .PHONY:
 build:
+ifeq ($(OS),Linux)
 	./container_build.sh
+endif
 
 .PHONY: docs
 docs:
@@ -58,7 +60,7 @@ codespell:
 	codespell --dictionary=- -w
 
 .PHONY: validate
-validate: codespell autopep8
+validate: build codespell autopep8
 ifeq ($(OS),Linux)
 	hack/man-page-checker
 	hack/xref-helpmsgs-manpages

--- a/test/ci.sh
+++ b/test/ci.sh
@@ -9,7 +9,6 @@ mac_steps() {
 }
 
 linux_steps() {
-  ./container_build.sh
   shellcheck -- *.sh
   if [ -n "$BRANCH" ]; then
     $maybe_sudo BRANCH=$BRANCH ./install.py


### PR DESCRIPTION
Things like xref-helpmsgs-manpages execute ramalama, so all the python modules must be available at this point.