### PR TITLE
Implement shortnames feature

### DIFF
--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -11,6 +11,7 @@ import string
 import subprocess
 import sys
 import time
+import configparser
 
 from ramalama.huggingface import Huggingface
 from ramalama.common import in_container, container_manager, exec_cmd, run_cmd
@@ -66,6 +67,12 @@ def init_cli():
         return version(args)
     # create stores directories
     mkdirs(args.store)
+    if hasattr(args, "MODEL"):
+        resolved_model = resolve_shortname(args.MODEL)
+        if resolved_model:
+            args.UNRESOLVED_MODEL = args.MODEL
+            args.MODEL = resolved_model
+
     if run_container(args):
         return
 
@@ -390,14 +397,15 @@ def get_store():
 
 
 def find_working_directory():
-    wd = "./ramalama"
-    for p in sys.path:
-        target = os.path.join(p, "ramalama")
-        if os.path.exists(target):
-            wd = target
-            break
+    if os.path.exists("./ramalama"):
+        return "./ramalama"
 
-    return wd
+    for p in sys.path:
+        p = os.path.join(p, "ramalama")
+        if os.path.exists(p):
+            return p
+
+    return ""
 
 
 def run_container(args):
@@ -455,11 +463,49 @@ def run_container(args):
 
     conman_args += ["quay.io/ramalama/ramalama:latest", "/usr/bin/ramalama"]
     conman_args += sys.argv[1:]
+    if hasattr(args, "UNRESOLVED_MODEL"):
+        index = conman_args.index(args.UNRESOLVED_MODEL)
+        conman_args[index] = args.MODEL
+
     if args.dryrun:
         print(*conman_args)
         return True
 
     exec_cmd(conman_args)
+
+
+def strip_quotes(s):
+    return s.strip("'\"")
+
+
+def remove_quotes(data):
+    # Remove leading and trailing quotes from keys and values
+    cleaned_dict = {strip_quotes(key): strip_quotes(value) for key, value in data.items()}
+
+    return cleaned_dict
+
+
+def load_shortnames():
+    config = configparser.ConfigParser()
+    aliases = {}
+    file_paths = [
+        "usr/share/ramalama/aliases.conf",  # for development
+        "/usr/share/ramalama/aliases.conf",
+        "/etc/ramalama/aliases.conf",
+        os.path.expanduser("~/.config/ramalama/aliases.conf"),
+    ]
+
+    for file_path in file_paths:
+        config.read(file_path)
+        if "aliases" in config:
+            aliases.update(config["aliases"])
+
+    return remove_quotes(aliases)
+
+
+def resolve_shortname(model):
+    shortnames = load_shortnames()
+    return shortnames.get(model)
 
 
 def New(model):

--- a/ramalama/ollama.py
+++ b/ramalama/ollama.py
@@ -41,7 +41,7 @@ def init_pull(repos, manifests, accept, registry_head, model_name, model_tag, mo
             manifest_data = json.load(f)
     except subprocess.CalledProcessError as e:
         if e.returncode == 22:
-            raise KeyError((f"{model}:{model_tag} not found"))
+            raise KeyError((f"{model} not found"))
 
         raise e
 

--- a/usr/share/ramalama/aliases.conf
+++ b/usr/share/ramalama/aliases.conf
@@ -1,0 +1,4 @@
+[aliases]
+  "granite-lab-7b" = "huggingface://instructlab/granite-7b-lab-GGUF/granite-7b-lab-Q4_K_M.gguf"
+  "merlinite-lab-7b" = "huggingface://instructlab/merlinite-7b-lab-GGUF/merlinite-7b-lab-Q4_K_M.gguf"
+


### PR DESCRIPTION
Add support for resolving model shortnames. Parse shortnames from /etc/ramalama/registries.conf.d/000-shortnames.conf . Modify New() function to use resolved shortnames. Improve user experience by allowing use of familiar shorthand names for models. This change allows users to use shortnames instead of full model names, similar to podman functionality. The feature enhances usability while maintaining compatibility with existing model naming conventions.