### PR TITLE
Consistency changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,18 +84,18 @@ curl -fsSL https://raw.githubusercontent.com/containers/ramalama/s/install.py | 
 
 | Command                                                | Description                                                |
 | ------------------------------------------------------ | ---------------------------------------------------------- |
-| [ramalama(1)](docs/ramalama.1.md)                      | Primary ramalama man page.                                 |
-| [ramalama-containers(1)](docs/ramalama-containers.1.md)| List all ramalama containers.                              |
-| [ramalama-list(1)](docs/ramalama-list.1.md)            | List all AI models in local storage.                       |
-| [ramalama-login(1)](docs/ramalama-login.1.md)          | Login to remote model registry.                            |
-| [ramalama-logout(1)](docs/ramalama-logout.1.md)        | Logout from remote model registry.                         |
-| [ramalama-pull(1)](docs/ramalama-pull.1.md)            | Pull AI Models into local storage.                         |
-| [ramalama-push(1)](docs/ramalama-push.1.md)            | Push AI Model (OCI-only at present)                        |
-| [ramalama-rm(1)](docs/ramalama-rm.1.md)                | Remove specified AI Model from local storage.              |
-| [ramalama-run(1)](docs/ramalama-run.1.md)              | Run specified AI Model as a chatbot.                       |
-| [ramalama-serve(1)](docs/ramalama-serve.1.md)          | Serve specified AI Model as an API server.                 |
-| [ramalama-stop(1)](docs/ramalama-stop.1.md)            | Stop ramalaman container running an AI Model.              |
-| [ramalama-version(1)](docs/ramalama-version.1.md)      | Display the ramalama version.                              |
+| [ramalama(1)](docs/ramalama.1.md)                      | primary ramalama man page                                  |
+| [ramalama-containers(1)](docs/ramalama-containers.1.md)| list all ramalama containers                               |
+| [ramalama-list(1)](docs/ramalama-list.1.md)            | list all downloaded AI Models                              |
+| [ramalama-login(1)](docs/ramalama-login.1.md)          | login to remote registry                                   |
+| [ramalama-logout(1)](docs/ramalama-logout.1.md)        | logout from remote registry                                |
+| [ramalama-pull(1)](docs/ramalama-pull.1.md)            | pull AI Model from Model registry to local storage         |
+| [ramalama-push(1)](docs/ramalama-push.1.md)            | push AI Model from local storage to remote registry        |
+| [ramalama-rm(1)](docs/ramalama-rm.1.md)                | remove AI Model from local storage                         |
+| [ramalama-run(1)](docs/ramalama-run.1.md)              | run specified AI Model as a chatbot                        |
+| [ramalama-serve(1)](docs/ramalama-serve.1.md)          | serve rest api on specified AI Model                       |
+| [ramalama-stop(1)](docs/ramalama-stop.1.md)            | stop named container that is running AI Model              |
+| [ramalama-version(1)](docs/ramalama-version.1.md)      | display version of AI Model                                |
 
 ## Usage
 

--- a/docs/ramalama-containers.1.md
+++ b/docs/ramalama-containers.1.md
@@ -1,7 +1,7 @@
 % ramalama-containers 1
 
 ## NAME
-ramalama\-containers - List all ramalama containers
+ramalama\-containers - list all ramalama containers
 
 ## SYNOPSIS
 **ramalama containers** [*options*]
@@ -14,8 +14,7 @@ List all containers running AI Models
 ## OPTIONS
 
 #### **--format**=*format*
-
-Pretty-print containers to JSON or using a Go template
+pretty-print containers to JSON or using a Go template
 
 Valid placeholders for the Go template are listed below:
 

--- a/docs/ramalama-list.1.md
+++ b/docs/ramalama-list.1.md
@@ -1,7 +1,7 @@
 % ramalama-list 1
 
 ## NAME
-ramalama\-list - List all AI models in local storage
+ramalama\-list - list all downloaded AI Models
 
 ## SYNOPSIS
 **ramalama list** [*options*]
@@ -14,20 +14,20 @@ List all the AI Models in local storage
 ## OPTIONS
 
 #### **--help**, **-h**
-Print usage message
+show this help message and exit
 
 #### **--json**
-Print model list in json format
+print Model list in json format
 
 #### **--noheading**, **-n**
-Do not print heading
+do not print heading
 
 #### **--quiet**, **-q**
-Print only model names
+print only Model names
 
 ## EXAMPLES
 
-List all models downloaded to users homedir
+List all Models downloaded to users homedir
 ```
 $ ramalama list
 NAME                                                                MODIFIED     SIZE
@@ -37,7 +37,8 @@ ollama://granite-code:3b                                            5 days ago  
 ollama://granite-code:latest                                        1 day ago    1.9G
 ollama://moondream:latest                                           6 days ago   791M
 ```
-List all models in json format
+
+List all Models in json format
 ```
 $ ramalama list --json
 {"models": [{"name": "oci://quay.io/mmortari/gguf-py-example/v1/example.gguf", "modified": 427330, "size": "4.0K"}, {"name": "huggingface://afrideva/Tiny-Vicuna-1B-GGUF/tiny-vicuna-1b.q2_k.gguf", "modified": 427333, "size": "460M"}, {"name": "ollama://tiny-llm:latest", "modified": 420833, "size": "5.5M"}, {"name": "ollama://mistral:latest", "modified": 433998, "size": "3.9G"}, {"name": "ollama://granite-code:latest", "modified": 2180483, "size": "1.9G"}, {"name": "ollama://tinyllama:latest", "modified": 364870, "size": "609M"}, {"name": "ollama://tinyllama:1.1b", "modified": 364866, "size": "609M"}]}

--- a/docs/ramalama-login.1.md
+++ b/docs/ramalama-login.1.md
@@ -1,36 +1,31 @@
 % ramalama-login 1
 
 ## NAME
-ramalama\-login - Login to remote model registry
+ramalama\-login - login to remote registry
 
 ## SYNOPSIS
 **ramalama login** [*options*]
 
 ## DESCRIPTION
-Login to remote model registry
+login to remote registry
 
 ## OPTIONS
-
 Options are specific to registry types.
 
 #### **--help**, **-h**
-Print usage message
+show this help message and exit
 
 #### **--password**, **-p**=*password*
-
-Password for registry
+password for registry
 
 #### **--password-stdin**
-
-Take the password from stdin
+take the password from stdin
 
 #### **--token**
-
-Token to be passed to Model registry
+token to be passed to Model registry
 
 #### **--username**, **-u**=*username*
-
-Username for registry
+username for registry
 
 ## EXAMPLES
 

--- a/docs/ramalama-logout.1.md
+++ b/docs/ramalama-logout.1.md
@@ -1,7 +1,7 @@
 % ramalama-logout 1
 
 ## NAME
-ramalama\-logout - Logout from remote model registry
+ramalama\-logout - logout from remote registry
 
 ## SYNOPSIS
 **ramalama logout** [*options*]

--- a/docs/ramalama-pull.1.md
+++ b/docs/ramalama-pull.1.md
@@ -1,7 +1,7 @@
 % ramalama-pull 1
 
 ## NAME
-ramalama\-pull - Pull AI Models into local storage
+ramalama\-pull - pull AI Model from Model registry to local storage
 
 ## SYNOPSIS
 **ramalama pull** [*options*] *model*

--- a/docs/ramalama-push.1.md
+++ b/docs/ramalama-push.1.md
@@ -1,7 +1,7 @@
 % ramalama-push 1
 
 ## NAME
-ramalama\-push - Push AI Model (OCI-only at present)
+ramalama\-push - push AI Model from local storage to remote registry
 
 ## SYNOPSIS
 **ramalama push** [*options*] *model* *target*

--- a/docs/ramalama-rm.1.md
+++ b/docs/ramalama-rm.1.md
@@ -1,24 +1,24 @@
 % ramalama-rm 1
 
 ## NAME
-ramalama\-rm - Remove specified AI Model from local storage
+ramalama\-rm - remove AI Model from local storage
 
 ## SYNOPSIS
 **ramalama rm** [*options*] *model*
 
 ## DESCRIPTION
-Remove specified AI Model from local storage
+remove AI Model from local storage
 
 ## OPTIONS
 
 #### **--all**, **-a**
-Remove all local models
+remove all local Models
 
 #### **--help**, **-h**
-Print usage message
+show this help message and exit
 
 #### **--ignore**
-Ignore errors when specified model does not exist
+ignore errors when specified Model does not exist
 
 ## EXAMPLES
 

--- a/docs/ramalama-run.1.md
+++ b/docs/ramalama-run.1.md
@@ -1,7 +1,7 @@
 % ramalama-run 1
 
 ## NAME
-ramalama\-run - Run specified AI Model as a chatbot
+ramalama\-run - run specified AI Model as a chatbot
 
 ## SYNOPSIS
 **ramalama run** [*options*] *model* [arg ...]
@@ -9,14 +9,13 @@ ramalama\-run - Run specified AI Model as a chatbot
 ## OPTIONS
 
 #### **--help**, **-h**
-Print usage message
+show this help message and exit
 
 #### **--name**, **-n**
-Name of the container to run the model in.
+name of the container to run the Model in
 
 #### **--prompt**
-
-Modify the prompt in the AI Chatbot
+modify the prompt in the AI Chatbot
 
 ## DESCRIPTION
 Run specified AI Model as a chat bot. Ramalama pulls specified AI Model from

--- a/docs/ramalama-serve.1.md
+++ b/docs/ramalama-serve.1.md
@@ -1,7 +1,7 @@
 % ramalama-serve 1
 
 ## NAME
-ramalama\-serve - Serve specified AI Model as an API server
+ramalama\-serve - serve rest api on specified AI Model
 
 ## SYNOPSIS
 **ramalama serve** [*options*] *model*
@@ -16,16 +16,16 @@ registry if it does not exist in local storage.
 Run the container in the background and print the new container ID.
 The default is false. Conflicts with the --nocontainer option.
 
-Use the `ramalama stop` command to stop the container running the served ramalama model.
+Use the `ramalama stop` command to stop the container running the served ramalama Model.
 
 #### **--help**, **-h**
-Print usage message
+show this help message and exit
 
 #### **--name**, **-n**
-Name of the container to run the model in.
+Name of the container to run the Model in.
 
 #### **--port**, **-p**
-Port for AI Model server to listen on
+port for AI Model server to listen on
 
 ## EXAMPLES
 

--- a/docs/ramalama-stop.1.md
+++ b/docs/ramalama-stop.1.md
@@ -1,7 +1,7 @@
 % ramalama-stop 1
 
 ## NAME
-ramalama\-stop - Stop ramalaman container running an AI Model
+ramalama\-stop - stop named container that is running AI Model
 
 ## SYNOPSIS
 **ramalama stop** [*options*] *name*

--- a/docs/ramalama-version.1.md
+++ b/docs/ramalama-version.1.md
@@ -1,7 +1,7 @@
 % ramalama-version 1
 
 ## NAME
-ramalama\-version - Display the ramalama version
+ramalama\-version - display version of AI Model
 
 ## SYNOPSIS
 **ramalama version**

--- a/docs/ramalama.1.md
+++ b/docs/ramalama.1.md
@@ -68,35 +68,33 @@ $ cat /usr/share/ramalama/shortnames.conf
 ## GLOBAL OPTIONS
 
 #### **--dryrun**
-Show container runtime command without executing it (default: False)
+show container runtime command without executing it (default: False)
 
 #### **--help**, **-h**
-
-Show this help message and exit
+show this help message and exit
 
 #### **--nocontainer**
-Do not run ramalama in the default container (default: False)
-Use environment variable "RAMALAMA_IN_CONTAINER=false" to change default.
+do not run ramalama in the default container (default: False)
+use environment variable "RAMALAMA_IN_CONTAINER=false" to change default.
 
 #### **--store**=STORE
-
-Store AI Models in the specified directory (default rootless: `$HOME/.local/share/ramalama`, default rootful: `/var/lib/ramalama`)
+store AI Models in the specified directory (default rootless: `$HOME/.local/share/ramalama`, default rootful: `/var/lib/ramalama`)
 
 ## COMMANDS
 
 | Command                                           | Description                                                |
 | ------------------------------------------------- | ---------------------------------------------------------- |
-| [ramalama-containers(1)](ramalama-containers.1.md)| List all ramalama containers.                              |
-| [ramalama-list(1)](ramalama-list.1.md)            | List all AI models in local storage.                       |
-| [ramalama-login(1)](ramalama-login.1.md)          | Login to remote model registry.                            |
-| [ramalama-logout(1)](ramalama-logout.1.md)        | Logout from remote model registry.                         |
-| [ramalama-pull(1)](ramalama-pull.1.md)            | Pull AI Models into local storage.                         |
-| [ramalama-push(1)](ramalama-push.1.md)            | Push AI Model (OCI-only at present)                        |
-| [ramalama-rm(1)](ramalama-rm.1.md)                | Remove specified AI Model from local storage.              |
-| [ramalama-run(1)](ramalama-run.1.md)              | Run specified AI Model as a chatbot.                       |
-| [ramalama-serve(1)](ramalama-serve.1.md)          | Serve specified AI Model as an API server.                 |
-| [ramalama-stop(1)](ramalama-stop.1.md)            | Stop ramalaman container running an AI Model.              |
-| [ramalama-version(1)](ramalama-version.1.md)      | Display the ramalama version.                              |
+| [ramalama-containers(1)](ramalama-containers.1.md)| list all ramalama containers                               |
+| [ramalama-list(1)](ramalama-list.1.md)            | list all downloaded AI Models                              |
+| [ramalama-login(1)](ramalama-login.1.md)          | login to remote registry                                   |
+| [ramalama-logout(1)](ramalama-logout.1.md)        | logout from remote registry                                |
+| [ramalama-pull(1)](ramalama-pull.1.md)            | pull AI Model from Model registry to local storage         |
+| [ramalama-push(1)](ramalama-push.1.md)            | push AI Model from local storage to remote registry        |
+| [ramalama-rm(1)](ramalama-rm.1.md)                | remove AI Model from local storage                         |
+| [ramalama-run(1)](ramalama-run.1.md)              | run specified AI Model as a chatbot                        |
+| [ramalama-serve(1)](ramalama-serve.1.md)          | serve rest api on specified AI Model                       |
+| [ramalama-stop(1)](ramalama-stop.1.md)            | stop named container that is running AI Model              |
+| [ramalama-version(1)](ramalama-version.1.md)      | display version of AI Model                                |
 
 ## CONFIGURATION FILES
 

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -36,16 +36,16 @@ def init_cli():
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         description="Simple management tool for working with AI Models.",
     )
-    parser.add_argument("--store", default=get_store(), help="Store AI Models in the specified directory")
-    parser.add_argument("--dryrun", action="store_true", help="Show container runtime command without executing it")
+    parser.add_argument("--store", default=get_store(), help="store AI Models in the specified directory")
+    parser.add_argument("--dryrun", action="store_true", help="show container runtime command without executing it")
     parser.add_argument(
         "--nocontainer",
         default=not use_container(),
         action="store_true",
-        help="Do not run ramalama in the default container",
+        help="do not run ramalama in the default container",
     )
 
-    parser.add_argument("-v", dest="version", action="store_true", help="Show ramalama version")
+    parser.add_argument("-v", dest="version", action="store_true", help="show ramalama version")
 
     subparsers = parser.add_subparsers(dest="subcommand")
     subparsers.required = False
@@ -88,15 +88,15 @@ def init_cli():
 
 
 def login_parser(subparsers):
-    parser = subparsers.add_parser("login", help="Login to remote registry")
+    parser = subparsers.add_parser("login", help="login to remote registry")
     # Do not run in a container
     parser.add_argument("--nocontainer", action="store_true", help=argparse.SUPPRESS)
-    parser.add_argument("-p", "--password", dest="password", help="Password for registry")
+    parser.add_argument("-p", "--password", dest="password", help="password for registry")
     parser.add_argument(
-        "--password-stdin", dest="passwordstdin", action="store_true", help="Take the password for registry from stdin"
+        "--password-stdin", dest="passwordstdin", action="store_true", help="take the password for registry from stdin"
     )
-    parser.add_argument("--token", dest="token", help="Token for registry")
-    parser.add_argument("-u", "--username", dest="username", help="Username for registry")
+    parser.add_argument("--token", dest="token", help="token for registry")
+    parser.add_argument("-u", "--username", dest="username", help="username for registry")
     parser.add_argument("TRANSPORT", nargs="?", type=str, default="")  # positional argument
     parser.set_defaults(func=login_cli)
 
@@ -110,10 +110,10 @@ def login_cli(args):
 
 
 def logout_parser(subparsers):
-    parser = subparsers.add_parser("logout", help="Logout from remote registry")
+    parser = subparsers.add_parser("logout", help="logout from remote registry")
     # Do not run in a container
     parser.add_argument("--nocontainer", default=True, action="store_true", help=argparse.SUPPRESS)
-    parser.add_argument("--token", help="Token for registry")
+    parser.add_argument("--token", help="token for registry")
     parser.add_argument("TRANSPORT", nargs="?", type=str, default="")  # positional argument
     parser.add_argument("TRANSPORT", nargs="?", type=str, default="")  # positional argument
     parser.set_defaults(func=logout_cli)
@@ -182,9 +182,9 @@ def list_files_by_modification():
 
 
 def containers_parser(subparsers):
-    parser = subparsers.add_parser("containers", aliases=["ps"], help="List all ramalama containers")
-    parser.add_argument("--format", help="Pretty-print containers to JSON or using a Go template")
-    parser.add_argument("-n", "--noheading", dest="noheading", action="store_true", help="Do not display heading")
+    parser = subparsers.add_parser("containers", aliases=["ps"], help="list all ramalama containers")
+    parser.add_argument("--format", help="pretty-print containers to JSON or using a Go template")
+    parser.add_argument("-n", "--noheading", dest="noheading", action="store_true", help="do not display heading")
     parser.add_argument("--nocontainer", default=True, action="store_true", help=argparse.SUPPRESS)
     parser.set_defaults(func=list_containers)
 
@@ -214,10 +214,10 @@ def list_containers(args):
 
 
 def list_parser(subparsers):
-    parser = subparsers.add_parser("list", aliases=["ls"], help="List all downloaded AI Models")
-    parser.add_argument("-n", "--noheading", dest="noheading", action="store_true", help="Do not display heading")
-    parser.add_argument("--json", dest="json", action="store_true", help="Print using json")
-    parser.add_argument("-q", "--quiet", dest="quiet", action="store_true", help="Print only model names")
+    parser = subparsers.add_parser("list", aliases=["ls"], help="list all downloaded AI Models")
+    parser.add_argument("-n", "--noheading", dest="noheading", action="store_true", help="do not display heading")
+    parser.add_argument("--json", dest="json", action="store_true", help="print using json")
+    parser.add_argument("-q", "--quiet", dest="quiet", action="store_true", help="print only Model names")
     parser.set_defaults(func=list_cli)
 
 
@@ -270,7 +270,7 @@ def list_cli(args):
 
 
 def help_parser(subparsers):
-    parser = subparsers.add_parser("help", help="Help about any command")
+    parser = subparsers.add_parser("help", help="help about any command")
     # Do not run in a container
     parser.add_argument("--nocontainer", default=True, action="store_true", help=argparse.SUPPRESS)
     parser.set_defaults(func=help_cli)
@@ -281,7 +281,7 @@ def help_cli(args):
 
 
 def pull_parser(subparsers):
-    parser = subparsers.add_parser("pull", help="Pull AI Model from model registry to local storage")
+    parser = subparsers.add_parser("pull", help="pull AI Model from Model registry to local storage")
     parser.add_argument("MODEL")  # positional argument
     parser.set_defaults(func=pull_cli)
 
@@ -296,7 +296,7 @@ def pull_cli(args):
 
 
 def push_parser(subparsers):
-    parser = subparsers.add_parser("push", help="Push AI model from local storage to remote registry")
+    parser = subparsers.add_parser("push", help="push AI Model from local storage to remote registry")
     parser.add_argument("MODEL")  # positional argument
     parser.add_argument("TARGET")  # positional argument
     parser.set_defaults(func=push_cli)
@@ -312,9 +312,9 @@ def _name():
 
 
 def run_parser(subparsers):
-    parser = subparsers.add_parser("run", help="Run specified AI Model as a chatbot")
-    parser.add_argument("--prompt", dest="prompt", action="store_true", help="Modify chatbot prompt")
-    parser.add_argument("-n", "--name", dest="name", help="Name of container in which the model will be run")
+    parser = subparsers.add_parser("run", help="run specified AI Model as a chatbot")
+    parser.add_argument("--prompt", dest="prompt", action="store_true", help="modify chatbot prompt")
+    parser.add_argument("-n", "--name", dest="name", help="name of container in which the Model will be run")
     parser.add_argument("MODEL")  # positional argument
     parser.add_argument("ARGS", nargs="*", help="Additional options to pass to the AI Model")
     parser.set_defaults(func=run_cli)
@@ -326,10 +326,10 @@ def run_cli(args):
 
 
 def serve_parser(subparsers):
-    parser = subparsers.add_parser("serve", help="Serve REST API on specified AI Model")
-    parser.add_argument("-d", "--detach", dest="detach", action="store_true", help="Run the container in detached mode")
-    parser.add_argument("-n", "--name", dest="name", help="Name of container in which the model will be run")
-    parser.add_argument("-p", "--port", default="8080", help="Port for AI Model server to listen on")
+    parser = subparsers.add_parser("serve", help="serve rest api on specified AI Model")
+    parser.add_argument("-d", "--detach", dest="detach", action="store_true", help="run the container in detached mode")
+    parser.add_argument("-n", "--name", dest="name", help="name of container in which the Model will be run")
+    parser.add_argument("-p", "--port", default="8080", help="port for AI Model server to listen on")
     parser.add_argument("MODEL")  # positional argument
     parser.set_defaults(func=serve_cli)
 
@@ -345,11 +345,11 @@ def stop_cli(args):
 
 
 def stop_parser(subparsers):
-    parser = subparsers.add_parser("stop", help="Stop named container that is running AI Model")
+    parser = subparsers.add_parser("stop", help="stop named container that is running AI Model")
     parser.add_argument("--nocontainer", default=True, action="store_true", help=argparse.SUPPRESS)
-    parser.add_argument("-a", "--all", action="store_true", help="Stop all ramalama containers")
+    parser.add_argument("-a", "--all", action="store_true", help="stop all ramalama containers")
     parser.add_argument(
-        "--ignore", action="store_true", help="Ignore errors when specified ramalama containersis missing"
+        "--ignore", action="store_true", help="ignore errors when specified ramalama container is missing"
     )
     parser.add_argument("NAME", nargs="?")  # positional argument
     parser.set_defaults(func=stop_container)
@@ -380,16 +380,16 @@ def stop_container(args):
 
 
 def version_parser(subparsers):
-    parser = subparsers.add_parser("version", help="Display version of AI Model")
+    parser = subparsers.add_parser("version", help="display version of AI Model")
     # Do not run in a container
     parser.add_argument("--nocontainer", default=True, action="store_true", help=argparse.SUPPRESS)
     parser.set_defaults(func=version)
 
 
 def rm_parser(subparsers):
-    parser = subparsers.add_parser("rm", help="Remove AI Model from local storage")
-    parser.add_argument("-a", "--all", action="store_true", help="Remove all local models")
-    parser.add_argument("--ignore", action="store_true", help="Ignore errors when specified model does not exist")
+    parser = subparsers.add_parser("rm", help="remove AI Model from local storage")
+    parser.add_argument("-a", "--all", action="store_true", help="remove all local Models")
+    parser.add_argument("--ignore", action="store_true", help="ignore errors when specified Model does not exist")
     parser.add_argument("MODEL", nargs="?")
     parser.set_defaults(func=rm_cli)
 
@@ -429,7 +429,7 @@ def run_container(args):
 
         if hasattr(args, "detach") and args.detach:
             raise IndexError(
-                "--nocontainer and --detach options conflict. --detach requires the model to be run in a container."
+                "--nocontainer and --detach options conflict. --detach requires the Model to be run in a container."
             )
 
     if args.nocontainer or in_container() or sys.platform == "darwin":


### PR DESCRIPTION
The default help text in the python parsers starts with a lower-case, the only way to make everything consistent is to make everything start with a lower-case:

  -h, --help            show this help message and exit

Also, various other consistency changes.

Also make Model capital everywhere.

Some typo fixes like "containersis".