### PR TITLE
Cleanup execution of the container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,15 @@ name: ci
 on: [push, pull_request]
 jobs:
   linux:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: install bats
+        shell: bash
+        run: |
+	   sudo apt update
+	   sudo apt -y install bats
+	apt-get bash
       - name: Run a one-line script
         run: make test
 
@@ -17,5 +23,8 @@ jobs:
         run: brew install go
       - name: Run a one-line script
         shell: bash
-        run: make test
+        run: make validate
+      - name: Run ci
+        shell: bash
+        run: make ci
 

--- a/Makefile
+++ b/Makefile
@@ -87,9 +87,12 @@ bats:
 	RAMALAMA=$(CURDIR)/ramalama.py bats -T test/system/
 	_RAMALAMA_TEST_OPTS=--nocontainer RAMALAMA=$(CURDIR)/ramalama.py bats -T test/system/
 
-.PHONY: test
-test: validate
+.PHONY: ci
+ci:
 	test/ci.sh
+
+.PHONY: test
+test: validate bats ci
 	make clean
 	hack/tree_status.sh
 

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -6,7 +6,7 @@ load helpers
     model=m_$(safename)
     image=m_$(safename)
 
-    verify_begin="podman run --rm -it --label \"RAMALAMA container\" --security-opt=label=disable -v/tmp:/tmp -e RAMALAMA_TRANSPORT --name"
+    verify_begin="podman run --rm -it --label \"RAMALAMA container\" --security-opt=label=disable -e RAMALAMA_TRANSPORT --name"
 
     run_ramalama --dryrun run ${model}
     is "$output" "${verify_begin} ramalama_.*" "dryrun correct"
@@ -28,7 +28,7 @@ load helpers
 
 @test "ramalama run granite with prompt" {
     run_ramalama run --name foobar granite "How often to full moons happen"
-    is "$output" ".*Moon" "should include some info about the Moon"
+    is "$output" ".*month" "should include some info about the Moon"
     run_ramalama list
     is "$output" ".*granite" "granite model should have been pulled"
 }

--- a/test/system/050-pull.bats
+++ b/test/system/050-pull.bats
@@ -16,7 +16,6 @@ load helpers
     is "$output" ".*ollama://tinyllama" "image was actually pulled locally"
 
     RAMALAMA_TRANSPORT=ollama run_ramalama pull tinyllama:1.1b
-ben1t0/tiny-llm
     run_ramalama pull ollama://tinyllama:1.1b
     run_ramalama list
     is "$output" ".*ollama://tinyllama:1.1b" "image was actually pulled locally"


### PR DESCRIPTION
No reason to leak /tmp, $HOME into the container.
The container is not run interactively, so we should not use --it Always name the container