### PR TITLE
DONT MERGE: fix: change install path for atomic desktop support

### DIFF
--- a/install.py
+++ b/install.py
@@ -85,7 +85,7 @@ def setup_ramalama(bindir, tmp_dir):
     to_file = os.path.join(tmp_dir, from_file)
     download(url, to_file)
     ramalama_bin = os.path.join(bindir, binfile)
-    syspath = "/usr/share/ramalama"
+    syspath = "/usr/local/share/ramalama"
     if sys.platform == "darwin":
         install_mac_dependencies()
         sharedirs = ["/opt/homebrew/share", "/usr/local/share"]


### PR DESCRIPTION
https://github.com/containers/ramalama/issues/177

I am still getting errors and would like to debug them

```fish
~/.local/bin ❯❯❯ cat patched-install.py | sudo python3
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   883  100   883    0     0  13763      0 --:--:-- --:--:-- --:--:-- 13796
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 13994  100 13994    0     0  47045      0 --:--:-- --:--:-- --:--:-- 46959
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2338  100  2338    0     0   8050      0 --:--:-- --:--:-- --:--:--  8062
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  3538  100  3538    0     0  12891      0 --:--:-- --:--:-- --:--:-- 12912
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  3676  100  3676    0     0  14003      0 --:--:-- --:--:-- --:--:-- 13977
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2169  100  2169    0     0   8514      0 --:--:-- --:--:-- --:--:--  8539
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   218  100   218    0     0    751      0 --:--:-- --:--:-- --:--:--   754
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  4038  100  4038    0     0   9777      0 --:--:-- --:--:-- --:--:--  9777
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   118  100   118    0     0    422      0 --:--:-- --:--:-- --:--:--   422
~/.local/bin ❯❯❯ ramalama
Traceback (most recent call last):
  File "/usr/local/bin/ramalama", line 36, in <module>
    main(sys.argv[1:])
  File "/usr/local/bin/ramalama", line 17, in main
    import ramalama
```