### PR TITLE
Mount distinfo into container if it exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ ifeq ($(OS),Linux)
 endif
 
 .PHONY:
-pypi: clean
+pypi: clean docs
 	python3 -m build --sdist
 	python3 -m build --wheel
 	python3 -m twine upload dist/*

--- a/bin/ramalama
+++ b/bin/ramalama
@@ -18,7 +18,7 @@ def main(args):
     argcomplete.autocomplete(parser)
 
     if args.version:
-        return ramalama.version(args)
+        return ramalama.print_version(args)
 
     if ramalama.run_container(args):
         return

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ramalama"
-version = "0.0.7"
+version = "0.0.10"
 dependencies = [
   "argcomplete",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ramalama"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
   "argcomplete",
 ]

--- a/ramalama/__init__.py
+++ b/ramalama/__init__.py
@@ -1,9 +1,9 @@
 """ramalama client module."""
 
 from ramalama.common import perror
-from ramalama.cli import init_cli, run_container, version, HelpException
+from ramalama.cli import init_cli, run_container, print_version, HelpException
 import sys
 
 assert sys.version_info >= (3, 6), "Python 3.6 or greater is required."
 
-__all__ = ["perror", "init_cli", "run_container", "version", "HelpException"]
+__all__ = ["perror", "init_cli", "run_container", "print_version", "HelpException"]

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -16,7 +16,7 @@ from ramalama.common import in_container, container_manager, exec_cmd, run_cmd, 
 from ramalama.oci import OCI
 from ramalama.ollama import Ollama
 from ramalama.shortnames import Shortnames
-from ramalama.version import version
+from ramalama.version import version, print_version
 
 
 class HelpException(Exception):
@@ -416,7 +416,7 @@ def version_parser(subparsers):
     parser = subparsers.add_parser("version", help="display version of AI Model")
     # Do not run in a container
     parser.add_argument("--container", default=False, action="store_false", help=argparse.SUPPRESS)
-    parser.set_defaults(func=version)
+    parser.set_defaults(func=print_version)
 
 
 def rm_parser(subparsers):
@@ -494,6 +494,10 @@ def run_container(args):
         f"-v{wd}:/usr/share/ramalama/ramalama:ro",
     ]
 
+    di_volume = distinfo_volume()
+    if di_volume != "":
+        conman_args += [di_volume]
+
     if sys.stdout.isatty():
         conman_args += ["-t"]
 
@@ -550,3 +554,12 @@ def New(model):
         return OCI(model)
 
     return Ollama(model)
+
+
+def distinfo_volume():
+    dist_info = "ramalama-%s.dist-info" % version()
+    path = os.path.join(os.path.dirname(os.path.dirname(__file__)), dist_info)
+    if not os.path.exists(path):
+        return ""
+
+    return f"-v{path}:/usr/share/ramalama/{dist_info}:ro"

--- a/ramalama/huggingface.py
+++ b/ramalama/huggingface.py
@@ -9,6 +9,7 @@ distribution package managers like dnf or apt. Example:
 pip install huggingface_hub[cli] tldm
 """
 
+
 def download(store, model, directory, filename):
     return run_cmd(
         [

--- a/ramalama/shortnames.py
+++ b/ramalama/shortnames.py
@@ -11,6 +11,7 @@ class Shortnames:
         file_paths = [
             "/usr/share/ramalama/shortnames.conf",
             "/etc/ramalama/shortnames.conf",
+            os.path.expanduser("~/.local/share/ramalama/shortnames.conf"),
             os.path.expanduser("~/.config/ramalama/shortnames.conf"),
             "./shortnames/shortnames.conf",  # for development
             "./shortnames.conf",  # for development

--- a/ramalama/version.py
+++ b/ramalama/version.py
@@ -3,13 +3,12 @@ import importlib.metadata
 """Version of RamaLamaPy."""
 
 
-__version__ = 0
-
-
-def version(args):
+def version():
     try:
-        __version__ = importlib.metadata.version("ramalama")
-    except:
-        pass
+        return importlib.metadata.version("ramalama")
+    except importlib.metadata.PackageNotFoundError:
+        return 0
 
-    print("ramalama version " + __version__)
+
+def print_version(args):
+    print("ramalama version %s" % version())


### PR DESCRIPTION
Currently PyPi and make install is creating a distinfo file which is needed in order to retrieve the version of ramalama in use inside of the container.

Also handle shortnames.conf file created via PyPi which is installed in $HOME/.local/share/ramalama/shortnames.conf