### PR TITLE
use basename to avoid attempting to make invalid volume names

### DIFF
--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -490,7 +490,7 @@ def run_container(args):
         "--name",
         name,
         f"-v{args.store}:/var/lib/ramalama",
-        f"-v{sys.argv[0]}:/usr/bin/ramalama:ro",
+        f"-v{os.path.realpath(sys.argv[0])}:/usr/bin/ramalama:ro",
         f"-v{wd}:/usr/share/ramalama/ramalama:ro",
     ]
 


### PR DESCRIPTION
When running the base command like:
```
bin/ramalama
```

I got the following error:
```
rror: creating named volume "bin/ramalama": running volume create option: names must match [a-zA-Z0-9][a-zA-Z0-9_.-]*: invalid argument
```

This PR takes the basename of the first argument to force this volume to be created with the same name as the script itself.