### PR TITLE
container_build.sh: identify macOS on Apple Silicon

### DIFF
--- a/container_build.sh
+++ b/container_build.sh
@@ -49,7 +49,7 @@ main() {
   select_container_manager
   local conman=("$conman_bin")
   local platform="linux/amd64"
-  if [ "$(uname -m)" = "aarch64" ]; then
+  if [ "$(uname -m)" = "aarch64" ] || ([ "$(uname -s)" = "Darwin" ] && [ "$(uname -m)" = "arm64" ]); then
     platform="linux/arm64"
   fi
 


### PR DESCRIPTION
On systems running macOS on Apple Silicon, "uname -m" returns "arm64" instead of "aarch64", as returned by Linux. Fix the script so it chooses the right architecture when building the container.