### PR TITLE
Realign omlmd push to latest ramalama

### DIFF
--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -50,11 +50,18 @@ def exec_cmd(args, stderr=True):
         raise
 
 
-def run_cmd(args):
+def run_cmd(args, cwd=None):
+    """
+    Run the given command arguments.
+
+    Args:
+    args: command line arguments to execute in a subprocess
+    cwd: optional working directory to run the command from
+    """
     if x:
         print(*args)
 
-    return subprocess.run(args, check=True, stdout=subprocess.PIPE)
+    return subprocess.run(args, check=True, cwd=cwd, stdout=subprocess.PIPE)
 
 
 def find_working_directory():

--- a/ramalama/oci.py
+++ b/ramalama/oci.py
@@ -50,7 +50,7 @@ class OCI(Model):
         return registry, reference, reference_dir
 
     def push(self, args):
-        registry, _, reference_dir = self._target_decompose(self.model)
+        registry, _, reference_dir = self._target_decompose()
         target = re.sub(r"^oci://", "", args.TARGET)
 
         # Validate the model exists locally


### PR DESCRIPTION
- re-added support to execute internal run_cmd function by specifying cwd

- due to separate refactorings, the internal call
to _target_decompose() had wrong number of params, now re-aligned

tested locally with:

```
(venv) ramalama % ramalama pull oci://quay.io/mmortari/gguf-py-example:v1                                                           
Downloading quay.io/mmortari/gguf-py-example:v1...

(venv) ramalama % ramalama ls                                                                                                       
NAME                                                   MODIFIED     SIZE   
oci://quay.io/mmortari/gguf-py-example/v1/example.gguf 1 minute ago 1.06 KB

(venv) ramalama % ramalama push oci://quay.io/mmortari/gguf-py-example/v1/example.gguf oci://quay.io/mmortari/gguf-py-example:latest
WARNING:omlmd.cli:Pushing to quay.io/mmortari/gguf-py-example:latest with empty metadata.
WARNING:omlmd.helpers:No metadata supplied, but reusing md files found in path.
```

![Screenshot 2024-10-05 at 14 29 02](https://github.com/user-attachments/assets/d8b062e1-b95c-484f-995e-8f457c92a276)

I'm happy to consider alternative behaviour, 
this simply realigns to push the supplied file OR directory as the ml-model layer in a standard OCI artifact,
typically without additional metadata parameters (or re-using in case of originating from OCI artifact with known metadata parameters, like in this test).

Also not personally familiar with bats,
but if in the testing infrastructure there is the chance to have setup a local quay/OCI registry,
I believe also this push side can be put under non-regression testing, 
using similar example as what shown above.

wdyt?