### PR TITLE
Allow pushing from one type of AI Image to an OCI Image

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -2,7 +2,7 @@
 [codespell]
 
 # Comma-separated list of files to skip.
-skip = ./vendor,./.git #,bin,vendor,.git,go.sum,changelog.txt,.cirrus.yml,"RELEASE_NOTES.md,*.xz,*.gz,*.tar,*.tgz,bin2img,*ico,*.png,*.1,*.5,copyimg,*.orig,apidoc.go"
+skip = ./logos,./vendor,./.git #,bin,vendor,.git,go.sum,changelog.txt,.cirrus.yml,"RELEASE_NOTES.md,*.xz,*.gz,*.tar,*.tgz,bin2img,*ico,*.png,*.1,*.5,copyimg,*.orig,apidoc.go"
 
 # Comma separated list of words to be ignored. Words must be lowercased.
 ignore-words-list = clos,creat,ro,hastable,shouldnot,mountns,passt

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -323,14 +323,17 @@ def pull_cli(args):
 
 def push_parser(subparsers):
     parser = subparsers.add_parser("push", help="push AI Model from local storage to remote registry")
-    parser.add_argument("MODEL")  # positional argument
+    parser.add_argument("SOURCE")  # positional argument
     parser.add_argument("TARGET")  # positional argument
     parser.set_defaults(func=push_cli)
 
 
 def push_cli(args):
-    model = New(args.MODEL)
-    model.push(args)
+    smodel = New(args.SOURCE)
+    source = smodel.path(args)
+
+    model = New(args.TARGET)
+    model.push(source, args)
 
 
 def _name():

--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -22,10 +22,13 @@ class Model:
     def logout(self, args):
         raise NotImplementedError(f"ramalama logout for {self.type} not implemented")
 
+    def path(self, source, args):
+        raise NotImplementedError(f"ramalama puath for {self.type} not implemented")
+
     def pull(self, args):
         raise NotImplementedError(f"ramalama pull for {self.type} not implemented")
 
-    def push(self, args):
+    def push(self, source, args):
         raise NotImplementedError(f"ramalama push for {self.type} not implemented")
 
     def is_symlink_to(self, file_path, target_path):


### PR DESCRIPTION
This PR allows users to push images pulled as one type and then push them to an OCI Registry.

For example
ramalama pull tiny
ramalama push tiny quay.io/myregistry/tiny:latest