### PR TITLE
Fix pip installation where shebang is altered

### DIFF
--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -515,7 +515,7 @@ def run_container(args):
     if os.path.exists("/dev/kfd"):
         conman_args += ["--device", "/dev/kfd"]
 
-    conman_args += [default_image(), "/usr/bin/ramalama"]
+    conman_args += [default_image(), "python3", "/usr/bin/ramalama"]
     conman_args += sys.argv[1:]
     if hasattr(args, "UNRESOLVED_MODEL"):
         index = conman_args.index(args.UNRESOLVED_MODEL)

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -25,7 +25,7 @@ load helpers
     is "${lines[0]}"  "Error: --nocontainer and --name options conflict. --name requires a container." "conflict between nocontainer and --name line"
 
     RAMALAMA_IMAGE=${image} run_ramalama --dryrun run ${model}
-    is "$output" ".*${image} /usr/bin/ramalama" "verify image name"
+    is "$output" ".*${image} python3 /usr/bin/ramalama" "verify image name"
 }
 
 # FIXME no way to run this reliably without flakes in CI/CD system


### PR DESCRIPTION
When using pip to install, the shebang of the python files are altered, therefore the python interpreter cannot be found.

Fixes #246.

The fix is a bit naive as the interpreter is hardcoded, but it's a good start.
