### PR TITLE
Add -image option to override defaut OCI Image

### DIFF
--- a/docs/ramalama.1.md
+++ b/docs/ramalama.1.md
@@ -77,6 +77,15 @@ show container runtime command without executing it (default: False)
 #### **--help**, **-h**
 show this help message and exit
 
+#### **--image**=IMAGE
+OCI container image to run with specified AI model. By default RamaLama
+attempts to use the best AI OCI image based on GPU on the local system.
+The --image option allows users to override the default.
+
+The RAMALAMA_IMAGE environment variable can be used to modify the default
+image. `export RAMALAMA_TRANSPORT=quay.io/ramalama/aiimage:latest` tells
+RamaLama to use the `quay.io/ramalama/aiimage:latest` image.
+
 #### **--nocontainer**
 do not run RamaLama in the default container (default: False)
 
@@ -101,7 +110,6 @@ store AI Models in the specified directory (default rootless: `$HOME/.local/shar
 | [ramalama-serve(1)](ramalama-serve.1.md)          | serve REST API on specified AI Model                       |
 | [ramalama-stop(1)](ramalama-stop.1.md)            | stop named container that is running AI Model              |
 | [ramalama-version(1)](ramalama-version.1.md)      | display version of RamaLama
-
 ## CONFIGURATION FILES
 
 

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -51,6 +51,11 @@ def init_cli():
         help="run RamaLama in the default container",
     )
     parser.add_argument(
+        "--image",
+        default=default_image(),
+        help="OCI container image to run with specified AI model",
+    )
+    parser.add_argument(
         "--nocontainer",
         dest="container",
         default=False,
@@ -518,7 +523,7 @@ def run_container(args):
     if os.path.exists("/dev/kfd"):
         conman_args += ["--device", "/dev/kfd"]
 
-    conman_args += [default_image(), "python3", "/usr/bin/ramalama"]
+    conman_args += [args.image, "python3", "/usr/bin/ramalama"]
     conman_args += sys.argv[1:]
     if hasattr(args, "UNRESOLVED_MODEL"):
         index = conman_args.index(args.UNRESOLVED_MODEL)

--- a/test/system/015-help.bats
+++ b/test/system/015-help.bats
@@ -133,10 +133,21 @@ function check_help() {
     # Test for regression of #7273 (spurious "--remote" help on output)
     for helpopt in help --help -h; do
         run_ramalama $helpopt
-        is "${lines[0]}" "usage: ramalama [-h] [--store STORE] [--dryrun] [--container] [--nocontainer]" \
+        is "${lines[0]}" "usage: ramalama [-h] [--store STORE] [--dryrun] [--container] [--image IMAGE]" \
            "ramalama $helpopt: first line of output"
     done
 
+}
+
+@test "ramalama verify default image" {
+
+    run_ramalama --help
+    is "$output" ".*image IMAGE.*OCI container image to run with specified AI model"  "Verify default image"
+    is "$output" ".*default: quay.io/ramalama/ramalama:latest"  "Verify default image"
+
+    image=m_$(safename)
+    RAMALAMA_IMAGE=${image} run_ramalama --help
+    is "$output" ".*default: ${image}"  "Verify default image"
 }
 
 # vim: filetype=sh


### PR DESCRIPTION
By default ramalama attempts to use the best AI image based on GPU on the local system. The --image option allows users to override the default.