### PR TITLE
Remove useless `cli run` parameter `--prompt`

### DIFF
--- a/docs/ramalama-run.1.md
+++ b/docs/ramalama-run.1.md
@@ -14,9 +14,6 @@ show this help message and exit
 #### **--name**, **-n**
 name of the container to run the Model in
 
-#### **--prompt**
-modify the prompt in the AI Chatbot
-
 ## DESCRIPTION
 Run specified AI Model as a chat bot. RamaLama pulls specified AI Model from
 registry if it does not exist in local storage. By default a prompt for a chat

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -351,10 +351,9 @@ def _name():
 
 def run_parser(subparsers):
     parser = subparsers.add_parser("run", help="run specified AI Model as a chatbot")
-    parser.add_argument("--prompt", dest="prompt", action="store_true", help="modify chatbot prompt")
     parser.add_argument("-n", "--name", dest="name", help="name of container in which the Model will be run")
     parser.add_argument("MODEL")  # positional argument
-    parser.add_argument("ARGS", nargs="*", help="additional options to pass to the AI Model")
+    parser.add_argument("ARGS", nargs="*", help="Overrides the default prompt")
     parser.set_defaults(func=run_cli)
 
 

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -353,7 +353,7 @@ def run_parser(subparsers):
     parser = subparsers.add_parser("run", help="run specified AI Model as a chatbot")
     parser.add_argument("-n", "--name", dest="name", help="name of container in which the Model will be run")
     parser.add_argument("MODEL")  # positional argument
-    parser.add_argument("ARGS", nargs="*", help="Overrides the default prompt")
+    parser.add_argument("ARGS", nargs="*", help="Overrides the default prompt, and the output is returned without entering the chatbot")
     parser.set_defaults(func=run_cli)
 
 


### PR DESCRIPTION
`--prompt` arg is not used, if ARGS exists it will be used as a prompt.