### PR TITLE
Add pipx paths to PATH environment variable

### DIFF
--- a/bin/ramalama
+++ b/bin/ramalama
@@ -6,6 +6,16 @@ import errno
 import subprocess
 import sys
 
+def add_pipx_venvs_bin_to_path():
+    """
+    Adds available pipx virtual environments bin directories to PATH.
+    This function looks for venv in ~/.local/pipx/venvs/ramalama/bin and
+    if it exists appends it to the environment variable PATH.
+    """
+    pipx_bin_path = os.path.expanduser(f'~/.local/pipx/venvs/ramalama/bin')
+    if os.path.exists(pipx_bin_path):
+        os.environ["PATH"] += ":" + pipx_bin_path
+
 def add_pipx_venvs_to_syspath():
     """
     Adds all available pipx virtual environments' site-packages directories to sys.path.
@@ -35,6 +45,7 @@ def main(args):
         sys.path.insert(0, syspath)
 
     add_pipx_venvs_to_syspath()
+    add_pipx_venvs_bin_to_path()
     try:
         import ramalama
     except:

--- a/docs/readme/wsl2-docker-cuda.md
+++ b/docs/readme/wsl2-docker-cuda.md
@@ -4,35 +4,35 @@ This guide will walk you through the steps required to set up Ramalama in WSL2 w
 
 ## Prerequisites
 
-1. **NVIDIA Game-Ready Drivers**  
+1. **NVIDIA Game-Ready Drivers**
    Ensure that you have the appropriate NVIDIA game-ready drivers installed on your Windows system. This is necessary for CUDA support in WSL2.
 
-2. **Docker Desktop Installation**  
+2. **Docker Desktop Installation**
    Install Docker Desktop and in settings under **General**, ensure the option to **Use the WSL 2 based engine** is checked :white_check_mark:.
 
 ## Installing CUDA Toolkit
 
-1. **Install the CUDA Toolkit**  
+1. **Install the CUDA Toolkit**
    Follow the instructions in the [NVIDIA CUDA WSL User Guide](https://docs.nvidia.com/cuda/wsl-user-guide/index.html) to install the CUDA toolkit.
 
-   - **Download the CUDA Toolkit**  
+   - **Download the CUDA Toolkit**
      Visit the [NVIDIA CUDA Downloads page](https://developer.nvidia.com/cuda-downloads?target_os=Linux&target_arch=x86_64&Distribution=WSL-Ubuntu&target_version=2.0&target_type=deb_local) to download the appropriate version for WSL-Ubuntu.
 
-2. **Remove Existing Keys (if needed)**  
+2. **Remove Existing Keys (if needed)**
    Run this command to remove any old keys that might conflict:
    ```bash
    sudo apt-key del 7fa2af80
    ```
 
-3. **Select Your Environment**  
+3. **Select Your Environment**
    Head back to the [NVIDIA CUDA Downloads page](https://developer.nvidia.com/cuda-downloads?target_os=Linux&target_arch=x86_64&Distribution=WSL-Ubuntu&target_version=2.0&target_type=deb_local) and choose the environment that fits your setup. Follow the installation instructions to install the CUDA package (deb format is recommended).
 
    > **Note:** This package enables WSL to interact with Windows drivers, allowing CUDA support.
 
-4. **Install the NVIDIA Container Toolkit**  
+4. **Install the NVIDIA Container Toolkit**
    Follow the installation instructions provided in the [NVIDIA Container Toolkit installation guide](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html).
 
-5. **Configure the NVIDIA Container Toolkit**  
+5. **Configure the NVIDIA Container Toolkit**
    Run the following command to configure the NVIDIA container runtime for Docker:
    ```bash
    sudo nvidia-ctk runtime configure --runtime=docker
@@ -43,13 +43,13 @@ This guide will walk you through the steps required to set up Ramalama in WSL2 w
 
 ## Testing the Setup
 
-1. **Test the Installation**  
+1. **Test the Installation**
    Run the following command to verify your setup:
    ```bash
    docker run --rm --gpus all nvidia/cuda:12.6.1-devel-ubi9 nvidia-smi
    ```
 
-2. **Expected Output**  
+2. **Expected Output**
    If everything is set up correctly, you should see an output similar to this:
    ```text
    Wed Oct  9 17:53:31 2024

--- a/docs/readme/wsl2-podman-cuda.md
+++ b/docs/readme/wsl2-podman-cuda.md
@@ -4,36 +4,36 @@ This guide will walk you through the steps required to set up Ramalama in WSL2 w
 
 ## Prerequisites
 
-1. **NVIDIA Game-Ready Drivers**  
+1. **NVIDIA Game-Ready Drivers**
    Make sure you have the appropriate NVIDIA game-ready drivers installed on your Windows system for CUDA support in WSL2.
 
 ## Installing CUDA Toolkit
 
-1. **Install the CUDA Toolkit**  
+1. **Install the CUDA Toolkit**
    Follow the instructions in the [NVIDIA CUDA WSL User Guide](https://docs.nvidia.com/cuda/wsl-user-guide/index.html) to install the CUDA toolkit.
 
-   - **Download the CUDA Toolkit**  
+   - **Download the CUDA Toolkit**
      Visit the [NVIDIA CUDA Downloads page](https://developer.nvidia.com/cuda-downloads?target_os=Linux&target_arch=x86_64&Distribution=WSL-Ubuntu&target_version=2.0&target_type=deb_local) to download the appropriate version for WSL-Ubuntu.
 
-2. **Remove Existing Keys (if needed)**  
+2. **Remove Existing Keys (if needed)**
    Run this command to remove any old keys that might conflict:
    ```bash
    sudo apt-key del 7fa2af80
    ```
 
-3. **Select Your Environment**  
+3. **Select Your Environment**
    Head back to the [NVIDIA CUDA Downloads page](https://developer.nvidia.com/cuda-downloads?target_os=Linux&target_arch=x86_64&Distribution=WSL-Ubuntu&target_version=2.0&target_type=deb_local) and choose the environment that fits your setup. Follow the installation instructions to install the CUDA package (deb format is recommended).
 
    > **Note:** This allows WSL2 to interact with Windows drivers for CUDA support.
 
-4. **Install the NVIDIA Container Toolkit**  
+4. **Install the NVIDIA Container Toolkit**
    Install the NVIDIA Container Toolkit by following the instructions in the [NVIDIA Container Toolkit installation guide](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html).
 
    > **Important:** This package is essential for allowing Podman to access CUDA.
 
 ## Setting Up Podman NVIDIA Hook
 
-1. **Create the `nvidia-hook.json` file**  
+1. **Create the `nvidia-hook.json` file**
    Run the following command to create the NVIDIA hook configuration for Podman:
    ```bash
    sudo mkdir -p /usr/share/containers/oci/hooks.d/
@@ -41,15 +41,15 @@ This guide will walk you through the steps required to set up Ramalama in WSL2 w
    {
       "version": "1.0.0",
       "hook": {
-         "path": "/usr/bin/nvidia-container-toolkit",
-         "args": ["nvidia-container-toolkit", "prestart"],
-         "env": [
-               "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-         ]
+	 "path": "/usr/bin/nvidia-container-toolkit",
+	 "args": ["nvidia-container-toolkit", "prestart"],
+	 "env": [
+	       "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+	 ]
       },
       "when": {
-         "always": true,
-         "commands": [".*"]
+	 "always": true,
+	 "commands": [".*"]
       },
       "stages": ["prestart"]
    }
@@ -57,7 +57,7 @@ This guide will walk you through the steps required to set up Ramalama in WSL2 w
    ```
      > Hook from [https://gist.github.com/alexandreteles/634006078874ee5e3225b3d9ff64d4df](https://gist.github.com/alexandreteles/634006078874ee5e3225b3d9ff64d4df)
 
-2. **Modify the NVIDIA Container Runtime Configuration**  
+2. **Modify the NVIDIA Container Runtime Configuration**
    Open and edit the NVIDIA container runtime configuration:
    ```bash
    sudo nano /etc/nvidia-container-runtime/config.toml
@@ -69,13 +69,13 @@ This guide will walk you through the steps required to set up Ramalama in WSL2 w
 
 ## Testing the Setup
 
-1. **Test the Installation**  
+1. **Test the Installation**
    Run the following command to verify your setup:
    ```bash
    podman run --rm --gpus all nvidia/cuda:12.6.1-devel-ubi9 nvidia-smi
    ```
 
-2. **Expected Output**  
+2. **Expected Output**
    If everything is set up correctly, you should see an output similar to this:
    ```text
    Wed Oct  9 17:53:31 2024

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ramalama"
-version = "0.0.14"
+version = "0.0.16"
 dependencies = [
   "argcomplete",
   "tqdm",

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -11,7 +11,15 @@ import sys
 import time
 
 from ramalama.huggingface import Huggingface
-from ramalama.common import in_container, container_manager, exec_cmd, run_cmd, default_image, find_working_directory, perror
+from ramalama.common import (
+    in_container,
+    container_manager,
+    exec_cmd,
+    run_cmd,
+    default_image,
+    find_working_directory,
+    perror,
+)
 from ramalama.oci import OCI
 from ramalama.ollama import Ollama
 from ramalama.shortnames import Shortnames
@@ -225,7 +233,8 @@ def _list_containers(args):
         return output.split("\n")
     except subprocess.CalledProcessError as e:
         perror("ramalama list command requires a running container engine")
-        raise(e)
+        raise (e)
+
 
 def list_containers(args):
     if len(_list_containers(args)) == 0:
@@ -353,7 +362,9 @@ def run_parser(subparsers):
     parser = subparsers.add_parser("run", help="run specified AI Model as a chatbot")
     parser.add_argument("-n", "--name", dest="name", help="name of container in which the Model will be run")
     parser.add_argument("MODEL")  # positional argument
-    parser.add_argument("ARGS", nargs="*", help="Overrides the default prompt, and the output is returned without entering the chatbot")
+    parser.add_argument(
+        "ARGS", nargs="*", help="Overrides the default prompt, and the output is returned without entering the chatbot"
+    )
     parser.set_defaults(func=run_cli)
 
 
@@ -405,7 +416,7 @@ def _stop_container(args, name):
 
     conman_args = [conman, "stop", "-t=0"]
     if args.ignore:
-        conman_args += [ "--ignore", str(args.ignore)]
+        conman_args += ["--ignore", str(args.ignore)]
     conman_args += [name]
     run_cmd(conman_args)
 


### PR DESCRIPTION
When installing via pipx, requirement executables of RamaLama are
stored in the venvs/ramalama/bin directory.  Have to modify the
system PATH so ramalama can find them.