### PR TITLE
Handles stdin input

### DIFF
--- a/docs/ramalama-run.1.md
+++ b/docs/ramalama-run.1.md
@@ -34,6 +34,14 @@ ramalama run merlinite "when is the summer solstice"
 The summer solstice, which is the longest day of the year, will happen on June ...
 ```
 
+Run command with a custom prompt and a file passed by the stdin
+```
+cat file.py | ramalama run granite-code 'what does this program do?'
+
+This program is a Python script that allows the user to interact with a terminal. ...
+ [end of text]
+```
+
 ## SEE ALSO
 **[ramalama(1)](ramalama.1.md)**
 

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -564,7 +564,7 @@ def run_container(args):
     if di_volume != "":
         conman_args += [di_volume]
 
-    if sys.stdout.isatty():
+    if sys.stdout.isatty() and sys.stdin.isatty():
         conman_args += ["-t"]
 
     if hasattr(args, "detach") and args.detach is True:

--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -98,6 +98,12 @@ class Model:
         if args.ARGS:
             prompt = " ".join(args.ARGS)
 
+        # Build a prompt with the stdin text that prepend the prompt passed as an
+        # argument to ramalama cli
+        if not sys.stdin.isatty():
+            input = sys.stdin.read()
+            prompt = input + "\n\n" + prompt
+
         symlink_path = self.pull(args)
         exec_args = [
             "llama-cli",
@@ -111,7 +117,7 @@ class Model:
             "-p",
             prompt,
         ] + self.common_params
-        if not args.ARGS:
+        if not args.ARGS and sys.stdin.isatty():
             exec_args.append("-cnv")
 
         try:


### PR DESCRIPTION
Be able to pass a prompt or a file by stdin like :
```
cat file | ramalama run model prompt
```

Works by prepending the input to the prompt as I didn't managed to make stdin for llama.cpp work.
Prepending the input to the prompt is inspired by shell_gpt, that's the way they do it.