### PR TITLE
allow empty RAMALAMA_CONTAINER_ENGINE

### DIFF
--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -18,7 +18,7 @@ def in_container():
 
 def container_manager():
     engine = os.getenv("RAMALAMA_CONTAINER_ENGINE")
-    if engine:
+    if engine is not None:
         return engine
 
     if available("podman"):


### PR DESCRIPTION
i noticed that on one laptop ramalama was running really fast and well, but on other laptop it was slow(ish) - turned out the second one was using podman container engine.

I tried to find ways to disable it so just use llama directly as my first laptop did.

turns out that ramalama will always assume I want container if podman or docker available in PATH; so I made the check that honors RAMALAMA_CONTAINER_ENGINE allow empty string so that users can set this and not have to add `--no-container` all the time.