### PR TITLE
Changes to start trimming rocm image

### DIFF
--- a/container-images/rocm/Containerfile
+++ b/container-images/rocm/Containerfile
@@ -14,9 +14,7 @@ RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-Official
 
 RUN dnf install -y rocm-dev hipblas-devel rocblas-devel && \
     dnf clean all && \
-    rm -rf /var/cache/*dnf*
-
-RUN git clone https://github.com/ggerganov/llama.cpp && \
+    git clone https://github.com/ggerganov/llama.cpp && \
     cd llama.cpp && \
     git reset --hard ${LLAMA_CPP_SHA} && \
     cmake -B build -DCMAKE_INSTALL_PREFIX:PATH=/usr -DGGML_CCACHE=0 \
@@ -24,14 +22,13 @@ RUN git clone https://github.com/ggerganov/llama.cpp && \
     cmake --build build --config Release -j $(nproc) && \
     cmake --install build && \
     cd / && \
-    rm -rf llama.cpp
-
-RUN git clone https://github.com/ggerganov/whisper.cpp.git && \
+    git clone https://github.com/ggerganov/whisper.cpp.git && \
     cd whisper.cpp && \
     git reset --hard ${WHISPER_CPP_SHA} && \
     make -j $(nproc) GGML_HIPBLAS=1 && \
     mv main /usr/bin/whisper-main && \
     mv server /usr/bin/whisper-server && \
     cd / && \
-    rm -rf whisper.cpp
+    rm -rf /var/cache/*dnf* /opt/rocm-*/lib/llvm \
+      /opt/rocm-*/lib/rocblas/library/*gfx9* llama.cpp whisper.cpp
 


### PR DESCRIPTION
So it can fit in CI and it's easier to download

We removed support for gfx9. Which are roughly AMD GPUs prior to
2019. This saves us a ton of container image size.

gfx11 corresponds to the RDNA 3 architecture.
gfx10 corresponds to the RDNA and RDNA 2 architecture.
gfx9 corresponds to the Vega and some Navi-based architectures.