### PR TITLE
Fix handling of completions on MacOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,42 +34,45 @@ help:
 	@echo
 
 
-.PHONY:
+.PHONY: install-requirements
 install-requirements:
 	pipx install tqdm black flake8 argcomplete wheel omlmd huggingface_hub codespell
 
-.PHONY:
-install-completions:
+.PHONY: install-completions
+install-completions: completions
 	install ${SELINUXOPT} -d -m 755 $(DESTDIR)${SHAREDIR}/bash-completion/completions
-	register-python-argcomplete --shell bash ramalama > $(DESTDIR)${SHAREDIR}/bash-completion/completions/ramalama
+	install ${SELINUXOPT} -m 644 completions/bash-completion/completions/ramalama \
+		$(DESTDIR)${SHAREDIR}/bash-completion/completions/ramalama
 	install ${SELINUXOPT} -d -m 755 $(DESTDIR)${SHAREDIR}/fish/vendor_completions.d
-	register-python-argcomplete --shell fish ramalama > $(DESTDIR)${SHAREDIR}/fish/vendor_completions.d/ramalama.fish
+	install ${SELINUXOPT} -m 644 completions/fish/vendor_completions.d/ramalama.fish \
+		$(DESTDIR)${SHAREDIR}/fish/vendor_completions.d/ramalama.fish
 	install ${SELINUXOPT} -d -m 755 $(DESTDIR)${SHAREDIR}/zsh/site
-	register-python-argcomplete --shell zsh ramalama > $(DESTDIR)${SHAREDIR}/zsh/site/_ramalama
+	install ${SELINUXOPT} -m 644 completions/zsh/vendor-completions/_ramalama \
+		$(DESTDIR)${SHAREDIR}/zsh/vendor-completions/_ramalama
 
-.PHONY:
+.PHONY: install-shortnames
 install-shortnames:
 	install ${SELINUXOPT} -d -m 755 $(DESTDIR)$(SHAREDIR)/ramalama
 	install ${SELINUXOPT} -m 644 shortnames/shortnames.conf \
 		$(DESTDIR)$(SHAREDIR)/ramalama
 
-.PHONY:
+.PHONY: completions
 completions:
-	mkdir -p build/completions/bash-completion/completions
-	register-python-argcomplete --shell bash ramalama > build/completions/bash-completion/completions/ramalama
+	mkdir -p completions/bash-completion/completions
+	register-python-argcomplete --shell bash ramalama > completions/bash-completion/completions/ramalama
 
-	mkdir -p build/completions/fish/vendor_completions.d
-	register-python-argcomplete --shell fish ramalama > build/completions/fish/vendor_completions.d/ramalama.fish
+	mkdir -p completions/fish/vendor_completions.d
+	register-python-argcomplete --shell fish ramalama > completions/fish/vendor_completions.d/ramalama.fish
 
-	mkdir -p build/completions/zsh/site
-	register-python-argcomplete --shell zsh ramalama > build/completions/zsh/site/_ramalama
+	mkdir -p completions/zsh/vendor-completions
+	register-python-argcomplete --shell zsh ramalama > completions/zsh/vendor-completions/_ramalama
 
-.PHONY:
+.PHONY: install
 install: docs completions
 	RAMALAMA_VERSION=$(RAMALAMA_VERSION) \
 	pip install . --no-deps --root $(DESTDIR) --prefix ${PREFIX}
 
-.PHONY:
+.PHONY: build
 build:
 ifeq ($(OS),Linux)
 	./container_build.sh
@@ -99,7 +102,7 @@ ifeq ($(OS),Linux)
 	hack/xref-helpmsgs-manpages
 endif
 
-.PHONY:
+.PHONY: pypi
 pypi:   clean
 	make docs
 	python3 -m build --sdist

--- a/completions/bash-completion/completions/ramalama
+++ b/completions/bash-completion/completions/ramalama
@@ -1,0 +1,81 @@
+#compdef ramalama
+# Run something, muting output or redirecting it to the debug stream
+# depending on the value of _ARC_DEBUG.
+# If ARGCOMPLETE_USE_TEMPFILES is set, use tempfiles for IPC.
+__python_argcomplete_run() {
+    if [[ -z "${ARGCOMPLETE_USE_TEMPFILES-}" ]]; then
+        __python_argcomplete_run_inner "$@"
+        return
+    fi
+    local tmpfile="$(mktemp)"
+    _ARGCOMPLETE_STDOUT_FILENAME="$tmpfile" __python_argcomplete_run_inner "$@"
+    local code=$?
+    cat "$tmpfile"
+    rm "$tmpfile"
+    return $code
+}
+
+__python_argcomplete_run_inner() {
+    if [[ -z "${_ARC_DEBUG-}" ]]; then
+        "$@" 8>&1 9>&2 1>/dev/null 2>&1
+    else
+        "$@" 8>&1 9>&2 1>&9 2>&1
+    fi
+}
+
+_python_argcomplete() {
+    local IFS=$'\013'
+    local script=""
+    if [[ -n "${ZSH_VERSION-}" ]]; then
+        local completions
+        completions=($(IFS="$IFS" \
+            COMP_LINE="$BUFFER" \
+            COMP_POINT="$CURSOR" \
+            _ARGCOMPLETE=1 \
+            _ARGCOMPLETE_SHELL="zsh" \
+            _ARGCOMPLETE_SUPPRESS_SPACE=1 \
+            __python_argcomplete_run ${script:-${words[1]}}))
+        local nosort=()
+        local nospace=()
+        if is-at-least 5.8; then
+            nosort=(-o nosort)
+        fi
+        if [[ "${completions-}" =~ ([^\\]): && "${match[1]}" =~ [=/:] ]]; then
+            nospace=(-S '')
+        fi
+        _describe "${words[1]}" completions "${nosort[@]}" "${nospace[@]}"
+    else
+        local SUPPRESS_SPACE=0
+        if compopt +o nospace 2> /dev/null; then
+            SUPPRESS_SPACE=1
+        fi
+        COMPREPLY=($(IFS="$IFS" \
+            COMP_LINE="$COMP_LINE" \
+            COMP_POINT="$COMP_POINT" \
+            COMP_TYPE="$COMP_TYPE" \
+            _ARGCOMPLETE_COMP_WORDBREAKS="$COMP_WORDBREAKS" \
+            _ARGCOMPLETE=1 \
+            _ARGCOMPLETE_SHELL="bash" \
+            _ARGCOMPLETE_SUPPRESS_SPACE=$SUPPRESS_SPACE \
+            __python_argcomplete_run ${script:-$1}))
+        if [[ $? != 0 ]]; then
+            unset COMPREPLY
+        elif [[ $SUPPRESS_SPACE == 1 ]] && [[ "${COMPREPLY-}" =~ [=/:]$ ]]; then
+            compopt -o nospace
+        fi
+    fi
+}
+if [[ -z "${ZSH_VERSION-}" ]]; then
+    complete -o nospace -o default -o bashdefault -F _python_argcomplete ramalama
+else
+    # When called by the Zsh completion system, this will end with
+    # "loadautofunc" when initially autoloaded and "shfunc" later on, otherwise,
+    # the script was "eval"-ed so use "compdef" to register it with the
+    # completion system
+    autoload is-at-least
+    if [[ $zsh_eval_context == *func ]]; then
+        _python_argcomplete "$@"
+    else
+        compdef _python_argcomplete ramalama
+    fi
+fi

--- a/completions/fish/vendor_completions.d/ramalama.fish
+++ b/completions/fish/vendor_completions.d/ramalama.fish
@@ -1,0 +1,17 @@
+
+function __fish_ramalama_complete
+    set -x _ARGCOMPLETE 1
+    set -x _ARGCOMPLETE_DFS \t
+    set -x _ARGCOMPLETE_IFS \n
+    set -x _ARGCOMPLETE_SUPPRESS_SPACE 1
+    set -x _ARGCOMPLETE_SHELL fish
+    set -x COMP_LINE (commandline -p)
+    set -x COMP_POINT (string length (commandline -cp))
+    set -x COMP_TYPE
+    if set -q _ARC_DEBUG
+        ramalama 8>&1 9>&2 1>&9 2>&1
+    else
+        ramalama 8>&1 9>&2 1>/dev/null 2>&1
+    end
+end
+complete --command ramalama -f -a '(__fish_ramalama_complete)'

--- a/completions/zsh/vendor-completions/_ramalama
+++ b/completions/zsh/vendor-completions/_ramalama
@@ -1,0 +1,81 @@
+#compdef ramalama
+# Run something, muting output or redirecting it to the debug stream
+# depending on the value of _ARC_DEBUG.
+# If ARGCOMPLETE_USE_TEMPFILES is set, use tempfiles for IPC.
+__python_argcomplete_run() {
+    if [[ -z "${ARGCOMPLETE_USE_TEMPFILES-}" ]]; then
+        __python_argcomplete_run_inner "$@"
+        return
+    fi
+    local tmpfile="$(mktemp)"
+    _ARGCOMPLETE_STDOUT_FILENAME="$tmpfile" __python_argcomplete_run_inner "$@"
+    local code=$?
+    cat "$tmpfile"
+    rm "$tmpfile"
+    return $code
+}
+
+__python_argcomplete_run_inner() {
+    if [[ -z "${_ARC_DEBUG-}" ]]; then
+        "$@" 8>&1 9>&2 1>/dev/null 2>&1
+    else
+        "$@" 8>&1 9>&2 1>&9 2>&1
+    fi
+}
+
+_python_argcomplete() {
+    local IFS=$'\013'
+    local script=""
+    if [[ -n "${ZSH_VERSION-}" ]]; then
+        local completions
+        completions=($(IFS="$IFS" \
+            COMP_LINE="$BUFFER" \
+            COMP_POINT="$CURSOR" \
+            _ARGCOMPLETE=1 \
+            _ARGCOMPLETE_SHELL="zsh" \
+            _ARGCOMPLETE_SUPPRESS_SPACE=1 \
+            __python_argcomplete_run ${script:-${words[1]}}))
+        local nosort=()
+        local nospace=()
+        if is-at-least 5.8; then
+            nosort=(-o nosort)
+        fi
+        if [[ "${completions-}" =~ ([^\\]): && "${match[1]}" =~ [=/:] ]]; then
+            nospace=(-S '')
+        fi
+        _describe "${words[1]}" completions "${nosort[@]}" "${nospace[@]}"
+    else
+        local SUPPRESS_SPACE=0
+        if compopt +o nospace 2> /dev/null; then
+            SUPPRESS_SPACE=1
+        fi
+        COMPREPLY=($(IFS="$IFS" \
+            COMP_LINE="$COMP_LINE" \
+            COMP_POINT="$COMP_POINT" \
+            COMP_TYPE="$COMP_TYPE" \
+            _ARGCOMPLETE_COMP_WORDBREAKS="$COMP_WORDBREAKS" \
+            _ARGCOMPLETE=1 \
+            _ARGCOMPLETE_SHELL="bash" \
+            _ARGCOMPLETE_SUPPRESS_SPACE=$SUPPRESS_SPACE \
+            __python_argcomplete_run ${script:-$1}))
+        if [[ $? != 0 ]]; then
+            unset COMPREPLY
+        elif [[ $SUPPRESS_SPACE == 1 ]] && [[ "${COMPREPLY-}" =~ [=/:]$ ]]; then
+            compopt -o nospace
+        fi
+    fi
+}
+if [[ -z "${ZSH_VERSION-}" ]]; then
+    complete -o nospace -o default -o bashdefault -F _python_argcomplete ramalama
+else
+    # When called by the Zsh completion system, this will end with
+    # "loadautofunc" when initially autoloaded and "shfunc" later on, otherwise,
+    # the script was "eval"-ed so use "compdef" to register it with the
+    # completion system
+    autoload is-at-least
+    if [[ $zsh_eval_context == *func ]]; then
+        _python_argcomplete "$@"
+    else
+        compdef _python_argcomplete ramalama
+    fi
+fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ramalama"
-version = "0.0.18"
+version = "0.0.19"
 dependencies = [
   "argcomplete",
   "tqdm",

--- a/rpm/python-ramalama.spec
+++ b/rpm/python-ramalama.spec
@@ -72,7 +72,7 @@ Provides: %{pypi_name} = %{version}-%{release}
 %{_mandir}/man1/%{pypi_name}*
 %{_datadir}/bash-completion/completions/%{pypi_name}
 %{_datadir}/fish/vendor_completions.d/%{pypi_name}.fish
-%{_datadir}/zsh/site/_ramalama
+%{_datadir}/zsh/vendor-completions/_ramalama
 %dir %{python3_sitelib}/*
 %{python3_sitelib}/*
 

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,6 @@ setuptools.setup(
     cmdclass={"build_py": build_py},
     scripts=["bin/ramalama"],
     data_files=[("share/ramalama", ["shortnames/shortnames.conf"])]
-    + generate_completions("share", "build/completions")
+    + generate_completions("share", "completions")
     + generate_man_pages("share/man/man1", "docs"),
 )


### PR DESCRIPTION
Currently we are not installing command completions via PyPi. For some reason python is ignoring the build directory. Moving the completions from build to completions fixes the issue.