### PR TITLE
Build container images only on changes

### DIFF
--- a/.github/workflows/ci-images.yml
+++ b/.github/workflows/ci-images.yml
@@ -56,6 +56,6 @@ jobs:
         run: |
           df -h
 
-      - name: run bats
+      - name: Build Images
         run: |
           make build

--- a/.github/workflows/ci-images.yml
+++ b/.github/workflows/ci-images.yml
@@ -1,0 +1,61 @@
+# Split the image builds into a separate workflow so we can easily run it
+# when only the Containerfiles have changed without introducing new external
+# GitHub Actions dependencies, such as the `tj-actions/changed-files` action.
+name: ci images
+
+on:
+  pull_request:
+    paths:
+      - "**/container-images/**"
+  push:
+    branches:
+      - main
+    paths:
+      - "**/container-images/**"
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: install
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install podman bash
+          make install-requirements
+
+      - name: Print disk space before cleanup
+        shell: bash
+        run: |
+          df -h
+
+      - name: Free Disk Space Linux
+        shell: bash
+        run: |
+          sudo docker rmi "$(docker image ls -aq)" >/dev/null 2>&1 || true
+          sudo rm -rf \
+            /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /usr/local/share/powershell /usr/share/swift /usr/local/.ghcup \
+            /usr/lib/jvm || true
+
+      # /mnt has ~ 65 GB free disk space. / is too small.
+      - name: Reconfigure Docker data-root
+        run: |
+          sudo mkdir -p /mnt/docker /etc/docker
+          echo '{"data-root": "/mnt/docker"}' > /tmp/daemon.json
+          sudo mv /tmp/daemon.json /etc/docker/daemon.json
+          cat /etc/docker/daemon.json
+          sudo systemctl restart docker.service
+          df -h
+
+      - name: Print disk space after cleanup
+        shell: bash
+        run: |
+          df -h
+
+      - name: run bats
+        run: |
+          make build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,49 +7,6 @@ on:
       - main
 
 jobs:
-  build:
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v4
-      - name: install
-        shell: bash
-        run: |
-           sudo apt-get update
-           sudo apt-get install podman bash
-           make install-requirements
-      - name: Print disk space before cleanup
-        shell: bash
-        run: |
-           df -h
-      - name: Free Disk Space Linux
-        shell: bash
-        run: |
-           sudo docker rmi "$(docker image ls -aq)" >/dev/null 2>&1 || true
-           sudo rm -rf \
-              /usr/share/dotnet /usr/local/lib/android /opt/ghc \
-              /usr/local/share/powershell /usr/share/swift /usr/local/.ghcup \
-              /usr/lib/jvm || true
-
-      # /mnt has ~ 65 GB free disk space. / is too small.
-      - name: Reconfigure Docker data-root
-        run: |
-           sudo mkdir -p /mnt/docker /etc/docker
-           echo '{"data-root": "/mnt/docker"}' > /tmp/daemon.json
-           sudo mv /tmp/daemon.json /etc/docker/daemon.json
-           cat /etc/docker/daemon.json
-           sudo systemctl restart docker.service
-           df -h
-
-
-      - name: Print disk space after cleanup
-        shell: bash
-        run: |
-           df -h
-
-      - name: run bats
-        run: |
-           make build
-
   bats:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,6 @@ jobs:
            make validate
            make bats
 
-      - name: bats-nocontainer
-        run: |
-           pip install tqdm --break-system-packages
-           make bats-nocontainer
-
   bats-nocontainer:
     runs-on: ubuntu-24.04
     steps:
@@ -54,6 +49,10 @@ jobs:
            sudo apt-get update
            sudo apt-get install bats bash codespell python3-argcomplete pipx
            make install-requirements
+
+      - name: build image
+        run: |
+          make build cpuonly
 
       - name: bats-docker
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: build image
         run: |
-          make build cpuonly
+          make build IMAGE=cpuonly
 
       - name: bats-docker
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: build image
         run: |
-          make build IMAGE=cpuonly
+          make build IMAGE=ramalama
 
       - name: bats-docker
         run: |

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ install: docs completions
 .PHONY: build
 build:
 ifeq ($(OS),Linux)
-	./container_build.sh
+	./container_build.sh $(IMAGE)
 endif
 
 .PHONY: install-docs

--- a/container_build.sh
+++ b/container_build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 available() {
   command -v "$1" >/dev/null
 }
@@ -63,10 +65,20 @@ main() {
     platform="linux/arm64"
   fi
 
-  for i in container-images/*; do
-    build "$i" "$@"
-  done
+  local target="${1:-all}"
+
+  if [ "$target" = "--help" ]; then
+    echo "Usage: $0 [all|image_name]"
+    exit 0
+  fi
+
+  if [ "$target" = "all" ]; then
+    for i in container-images/*; do
+      build "$i" "${@:2}"
+    done
+  else
+    build "container-images/$target" "${@:2}"
+  fi
 }
 
 main "$@"
-


### PR DESCRIPTION
This PR splits the container image builds into a separate GHA workflow so we only need to run these when the ./container-images/ directory is changed.

We could have done this inside the existing workflow, but it would have either involved some verbose Git commands and/or introducing a new third party dependency (e.g. [tj-actions/changed-files](https://github.com/tj-actions/changed-files)), but I feel we benefit more to having minimal dependencies or complexity to help with keeping the repo secure and easy to contribute to.

There are further optimizations which can be done, the ones I can think of are parallelising the builds and detecting which specific Containerfile is updated and only building that one.  For now, this seems like a good start.