### PR TITLE
Fix incompatible Ollama paths

### DIFF
--- a/ramalama/oci.py
+++ b/ramalama/oci.py
@@ -21,12 +21,14 @@ class OCI(Model):
                 self.omlmd = f"{i}/../../../bin/omlmd"
                 if os.path.exists(self.omlmd):
                     break
-            raise NotImplementedError("""\
+            raise NotImplementedError(
+                """\
 OCI models requires the omlmd module.
 This module can be installed via PyPi tools like pip, pip3, pipx or via
 distribution package managers like dnf or apt. Example:
 pip install omlmd
-""")
+"""
+            )
 
     def login(self, args):
         conman_args = [self.conman, "login"]


### PR DESCRIPTION
Resolves #352 

This PR fixes incompatible Ollama paths, by fetching the manifest file when needed and not downloading the same. (Using the approach as disscussed in #352).

Example run: 
```
(venv) spande-mac:ramalama (fix-ollama-paths*) $ ./bin/ramalama pull ollama://tinyllama:latest
Pulling 83e42c043d6c7816: 100% ▕####################▏ 608M/608M 3.81MB/s 00:00 

(venv) spande-mac:ramalama (fix-ollama-paths*) $ tree $HOME/.local/share/ramalama 
/Users/spande/.local/share/ramalama
├── models
│   ├── huggingface
│   ├── oci
│   └── ollama
│       └── tinyllama:latest -> ../../repos/ollama/blobs/sha256:2af3b81862c6be03c769683af18efdadb2c33f60ff32ab6f83e42c043d6c7816
└── repos
    ├── huggingface
    ├── oci
    └── ollama
        └── blobs
            ├── sha256:2af3b81862c6be03c769683af18efdadb2c33f60ff32ab6f83e42c043d6c7816
            └── sha256:6331358be52a6ebc2fd0755a51ad1175734fd17a628ab5ea6897109396245362

10 directories, 3 files
```
As visible in the above tree command, no more incompatible problematic paths.