### PR TITLE
Replace `huggingface-cli download` command with simple https client to pull models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build
 ramalama/*.patch
 dist
 .#*
+venv/

--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -63,7 +63,7 @@ class Model:
                 file_has_a_symlink = False
                 for file in files:
                     file_path = os.path.join(root, file)
-                    if (repo == "ollama" and file.startswith("sha256:")) or file.endswith(".gguf"):
+                    if file.startswith("sha256:") or file.endswith(".gguf"):
                         file_path = os.path.join(root, file)
                         for model_root, model_dirs, model_files in os.walk(model_dir):
                             for model_file in model_files:


### PR DESCRIPTION
Resolves #335 

This PR replaces huggingface-cli with the same `download_file()` function as used in `ollama.py`. This makes the pull output similar for `huggingface://` and `ollama://` transports.
However, the depdency on huggingface-cli is not fully removed. If huggingface-cli is installed then it can be used for other commands (such as login, logout, push) but **not** for pulling the models. If huggingface-cli is not present, then a simple message will be printed on the console for those other commands.

Example run:
```
(venv) spande-mac:ramalama (hf-https-pulls*) $ ./bin/ramalama pull huggingface://TheBloke/Tinyllama-2-1b-miniguanaco-GGUF/tinyllama-2-1b-miniguanaco.Q2_K.gguf
Pulling sha256:17b5d82a52b71b74ce303fbe17fbba66462d80fb8b42b80629012b58c1a0b6a7: 100% ▕####################▏ 460M/460M 3.30MB/s 00:00 

(venv) spande-mac:ramalama (hf-https-pulls*) $ tree $HOME/.local/share/ramalama    
/Users/spande/.local/share/ramalama
├── models
│   ├── huggingface
│   │   └── TheBloke
│   │       └── Tinyllama-2-1b-miniguanaco-GGUF
│   │           └── tinyllama-2-1b-miniguanaco.Q2_K.gguf -> ../../../../repos/huggingface/TheBloke/Tinyllama-2-1b-miniguanaco-GGUF/tinyllama-2-1b-miniguanaco.Q2_K.gguf/sha256:17b5d82a52b71b74ce303fbe17fbba66462d80fb8b42b80629012b58c1a0b6a7
│   ├── oci
│   └── ollama
└── repos
    ├── huggingface
    │   └── TheBloke
    │       └── Tinyllama-2-1b-miniguanaco-GGUF
    │           └── tinyllama-2-1b-miniguanaco.Q2_K.gguf
    │               └── sha256:17b5d82a52b71b74ce303fbe17fbba66462d80fb8b42b80629012b58c1a0b6a7
    ├── oci
    └── ollama

14 directories, 2 files
```