### PR TITLE
fixed rocm permission error and updated rocm containerfile

### DIFF
--- a/container-images/rocm/Containerfile
+++ b/container-images/rocm/Containerfile
@@ -16,23 +16,28 @@ RUN curl --retry 8 --retry-all-errors -o \
       cat /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-Official
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-Official
 
+# Set amd gpu architecture for RDNA3
+# https://llvm.org/docs/AMDGPUUsage.html#processors
+ENV AMDGPU_TARGETS=gfx1100
+
 RUN dnf install -y rocm-dev hipblas-devel rocblas-devel && \
     dnf clean all && \
     git clone https://github.com/ggerganov/llama.cpp && \
     cd llama.cpp && \
     git reset --hard ${LLAMA_CPP_SHA} && \
     cmake -B build -DCMAKE_INSTALL_PREFIX:PATH=/usr -DGGML_CCACHE=0 \
-      -DGGML_HIPBLAS=1 && \
-    cmake --build build --config Release -j $(nproc) && \
+      -DGGML_HIPBLAS=ON -DAMDGPU_TARGETS=${ROCM_DOCKER_ARCH} && \
+    cmake --build build --config Release -j$(nproc) && \
     cmake --install build && \
     cd / && \
     git clone https://github.com/ggerganov/whisper.cpp.git && \
     cd whisper.cpp && \
     git reset --hard ${WHISPER_CPP_SHA} && \
-    make -j $(nproc) GGML_HIPBLAS=1 && \
-    mv main /usr/bin/whisper-main && \
-    mv server /usr/bin/whisper-server && \
+    cmake -B build -DCMAKE_INSTALL_PREFIX:PATH=/usr -DGGML_CCACHE=0 \
+      -DGGML_HIPBLAS=ON -DAMDGPU_TARGETS=${ROCM_DOCKER_ARCH} && \
+    cmake --build build --config Release -j$(nproc) && \
+    mv build/bin/main /usr/bin/whisper-main && \
+    mv build/bin/server /usr/bin/whisper-server && \
     cd / && \
     rm -rf /var/cache/*dnf* /opt/rocm-*/lib/llvm \
       /opt/rocm-*/lib/rocblas/library/*gfx9* llama.cpp whisper.cpp
-

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -679,6 +679,8 @@ def run_container(args):
     if gpu_type == "HIP_VISIBLE_DEVICES":
         conman_args += ["-e", f"{gpu_type}={gpu_num}"]
         if args.image == default_image():
+            # https://github.com/containers/podman/issues/10166
+            conman_args += ["--group-add", "keep-groups"]
             conman_args += ["quay.io/ramalama/rocm:latest"]
         else:
             conman_args += [args.image]


### PR DESCRIPTION
I updated the rocm container to include the ability to build with a selected GPU architecture. The original rocm container didnt work for me until I built it with the RDNA3 gfx code=1100 (supports 7800 and 7900).

I followed the steps in the build doc for hipblas
[https://github.com/ggerganov/llama.cpp/blob/master/docs/build.md](url)

Also I used`-DGGML_HIPBLAS=ON` instead of `-DGGML_HIPBLAS=1` when using cmake. The container would build but llama.cpp would not utilize the gpu even with -ngl enabled.

Also, I'm currently running Ubuntu 24.04  and I ran into a peculiar issue where podman wasn't giving the correct permission for passing -device path inside the container. It turned out to be an issue with running in rootless. I followed this thread [https://github.com/containers/podman/issues/10166]
and added
```
--group-add keep-groups
```
and it worked! Not sure if this issue is unique to my environment. For this to work podman oci runtime should be crun. Not sure if runc still has this issue, I'll dig into this some more.

I'll write up a doc based on my troubleshooting. It might help speed debugging for others!