### PR TITLE
Docs: Typo Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Running in containers eliminates the need for users to configure the host system
 
 RamaLama then pulls AI Models from model registries. Starting a chatbot or a rest API service from a simple single command. Models are treated similarly to how Podman and Docker treat container images.
 
-When both Podman and Docker are installed, RamaLama defaults to Podman, The `RAMALAMA_CONTAINER_ENGINE=docker` environment variable can override this behavior. When neather are installed RamaLama will attempt to run the model with software on the local system.
+When both Podman and Docker are installed, RamaLama defaults to Podman, The `RAMALAMA_CONTAINER_ENGINE=docker` environment variable can override this behavior. When neither are installed RamaLama will attempt to run the model with software on the local system.
 
 RamaLama supports multiple AI model registries types called transports.
 Supported transports:


### PR DESCRIPTION
Corrected " neather" to " neither" in [README.md].

This pull request addresses a minor typo found in repository. The typo has been corrected to improve clarity and maintain the quality of the documentation.

This change is purely cosmetic and does not affect functionality.