### PR TITLE
Enable containers on macOS to use the GPU

### DIFF
--- a/container-images/ramalama/Containerfile
+++ b/container-images/ramalama/Containerfile
@@ -6,7 +6,7 @@ ARG HUGGINGFACE_HUB_VERSION=0.26.2
 ARG OMLMD_VERSION=0.1.6
 # renovate: datasource=github-releases depName=tqdm/tqdm extractVersion=^v(?<version>.*)
 ARG TQDM_VERSION=4.66.6
-ARG LLAMA_CPP_SHA=3f1ae2e32cde00c39b96be6d01c2997c29bae555
+ARG LLAMA_CPP_SHA=1329c0a75e6a7defc5c380eaf80d8e0f66d7da78
 # renovate: datasource=git-refs depName=ggerganov/whisper.cpp packageName=https://github.com/ggerganov/whisper.cpp gitRef=master versioning=loose type=digest
 ARG WHISPER_CPP_SHA=19dca2bb1464326587cbeb7af00f93c4a59b01fd
 

--- a/docs/ramalama.1.md
+++ b/docs/ramalama.1.md
@@ -89,6 +89,9 @@ show container runtime command without executing it (default: False)
 run RamaLama using the specified container engine. Default is `podman` if installed otherwise docker.
 The default can be overridden in the ramalama.conf file or via the RAMALAMA_CONTAINER_ENGINE environment variable.
 
+#### **--gpu**
+offload the workload to the GPU (default: False)
+
 #### **--help**, **-h**
 show this help message and exit
 

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -197,6 +197,13 @@ The RAMALAMA_CONTAINER_ENGINE environment variable modifies default behaviour.""
 The RAMALAMA_IN_CONTAINER environment variable modifies default behaviour.""",
     )
     parser.add_argument(
+        "--gpu",
+        dest="gpu",
+        default=False,
+        action="store_true",
+        help="offload the workload to the GPU",
+    )
+    parser.add_argument(
         "--runtime",
         default=config.get("runtime"),
         choices=["llama.cpp", "vllm"],

--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -232,8 +232,11 @@ class Model:
         exec_args = ["llama-server", "--port", args.port, "-m", model_path]
         if args.runtime == "vllm":
             exec_args = ["vllm", "serve", "--port", args.port, model_path]
-        elif args.gpu:
-            exec_args.extend(self.gpu_args())
+        else:
+            if args.gpu:
+                exec_args.extend(self.gpu_args())
+            if in_container():
+                exec_args.extend(["--host", "0.0.0.0"])
 
         if args.generate == "quadlet":
             return self.quadlet(model_path, args, exec_args)


### PR DESCRIPTION
Three changes:
- Bump llama.cpp to latest upstream, which enables the kompute backend to offload Q4_K_M models.
- Add a `--gpu` flag to request the model to be offloaded to the GPU.
- When running in a container, bind the server to `0.0.0.0` so the port can be accessed from outside the container.