### PR TITLE
Packit: disable osh diff scan

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -25,6 +25,7 @@ jobs:
     targets: &fedora_copr_targets
       - fedora-development
       - fedora-latest-stable
+    osh_diff_scan_after_copr_build: false
 
   # Copr builds for CentOS Stream
   - job: copr_build


### PR DESCRIPTION
Often takes too long and results are being ignored for now.

Ref: https://packit.dev/docs/configuration#osh_diff_scan_after_copr_build