### PR TITLE
Make minimal change to allow for ramalama to build on EL9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,8 @@ class build_py(build_py_orig):
 
 
 setuptools.setup(
+    name = "ramalama",
+    version = "0.0.20",
     packages=find_packages(),
     cmdclass={"build_py": build_py},
     scripts=["bin/ramalama"],


### PR DESCRIPTION
The base version of python shipped with EL9 is python-3.9 and the setuptools shipped with that is too old to understand most of the pyproject.toml input. So the setup.py must contain the name of the project and the version for it to properly build a package in EL9.