### PR TITLE
Use subpath for OCI Models

### DIFF
--- a/ramalama/oci.py
+++ b/ramalama/oci.py
@@ -25,7 +25,7 @@ def list_models(args):
         "--filter",
         f"label={ocilabeltype}",
         "--format",
-        '{"name":"oci://{{ index .Names 0 }}","modified":"{{ .Created }}","size":"{{ .Size }}"},',
+        '{"name":"oci://{{ .Repository }}:{{ .Tag }}","modified":"{{ .Created }}","size":"{{ .Size }}"},',
     ]
     output = run_cmd(conman_args, debug=args.debug).stdout.decode("utf-8").strip()
     if output == "":
@@ -95,11 +95,11 @@ pip install omlmd
         model_name = os.path.basename(source)
         model_raw = f"""\
 FROM {args.image} as builder
-RUN mkdir -p /mnt/models; cd /mnt/models; ln -s {model_name} model.file
+RUN mkdir -p /models; cd /models; ln -s {model_name} model.file
 
 FROM scratch
-COPY --from=builder /mnt/models /
-COPY {model} /{model_name}
+COPY --from=builder /models /models
+COPY {model} /models/{model_name}
 LABEL {ociimage_raw}
 """
         model_car = f"""\
@@ -160,7 +160,7 @@ LABEL {ociimage_car}
                     conman_args.extend([f"--authfile={args.authfile}"])
                 conman_args.extend([self.model])
                 run_cmd(conman_args, debug=args.debug)
-                return "/run/model/model.file"
+                return "/mnt/model/model.file"
             except subprocess.CalledProcessError:
                 pass
         return self._pull_omlmd(args)

--- a/ramalama/quadlet.py
+++ b/ramalama/quadlet.py
@@ -68,7 +68,7 @@ Driver=image
 Image={self.name}.image
 """
             )
-            return f"Mount=type=volume,source={self.name}.volume,dest=/mnt/models,ro"
+            return f"Mount=type=volume,source={self.name}.volume,dest=/mnt/models,subpath=/mounts,ro"
 
     def gen_image(self):
         outfile = self.name + ".image"


### PR DESCRIPTION
Adding subpath=/models to the Mount command in quadlet

Currently model-cars store AI Model in /models subdir but standard model-raw are storing them in /.

Changing bot model-cars and model-raw to use the same /models directory allows quadlets to support either model.

The big difference between model cars is that they include executables with the image, where a model-raw is just the model.

Also found a crash when doing ramalama list with images without a tag.

Improved tests to check model type flags.