### PR TITLE
Attempt to remove OCI Image if removing as Ollama or Huggingface fails

### DIFF
--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -708,8 +708,16 @@ def _rm_model(models, args):
         if resolved_model:
             model = resolved_model
 
-        model = New(model, args)
-        model.remove(args)
+        try:
+            m = New(model, args)
+            m.remove(args)
+        except KeyError as e:
+            try:
+                # attempt to remove as a container image
+                m=OCI(model, config.get('engine', container_manager()))
+                m.remove(args)
+            except Exception:
+                raise e
 
 
 def rm_cli(args):

--- a/test/system/050-pull.bats
+++ b/test/system/050-pull.bats
@@ -89,7 +89,7 @@ load setup_suite
 
     run_ramalama rm oci://$registry/tiny
     run_ramalama rm oci://$registry/tiny-car
-    run_ramalama rm oci://$registry/mymodel
+    run_ramalama rm $registry/mymodel
 
     run_ramalama list
     assert "$output" !~ ".*oci://$registry/tiny-car" "OCI image does not exist in list"


### PR DESCRIPTION
## Summary by Sourcery

Implement a fallback mechanism to remove a model as an OCI Image if removal as Ollama or Huggingface fails, and update the system test accordingly.

Bug Fixes:
- Fix the issue where removing a model as Ollama or Huggingface fails by attempting to remove it as an OCI Image instead.

Tests:
- Update system test to correctly remove a model from the registry without the 'oci://' prefix.