### PR TITLE
When running on macOS via ramalama run we were throwing exceptions

### DIFF
--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -615,7 +615,9 @@ def serve_parser(subparsers):
     parser.add_argument("--authfile", help="path of the authentication file")
     parser.add_argument("-d", "--detach", action="store_true", dest="detach", help="run the container in detached mode")
     parser.add_argument("-n", "--name", dest="name", help="name of container in which the Model will be run")
-    parser.add_argument("-p", "--port", default=config.get('port', "8080"), help="port for AI Model server to listen on")
+    parser.add_argument(
+        "-p", "--port", default=config.get('port', "8080"), help="port for AI Model server to listen on"
+    )
     parser.add_argument(
         "--tls-verify",
         dest="tlsverify",
@@ -714,7 +716,7 @@ def _rm_model(models, args):
         except KeyError as e:
             try:
                 # attempt to remove as a container image
-                m=OCI(model, config.get('engine', container_manager()))
+                m = OCI(model, config.get('engine', container_manager()))
                 m.remove(args)
             except Exception:
                 raise e

--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -216,7 +216,7 @@ class Model:
 
     def exec_model_in_container(self, model_path, cmd_args, args):
         if not args.container:
-                return False
+            return False
         conman_args = self.setup_container(args)
         if len(conman_args) == 0:
             return False
@@ -236,6 +236,9 @@ class Model:
 
         exec_cmd(conman_args, args.debug, debug=args.debug)
         return True
+
+    def not_args_generate(self, args):
+        return not hasattr(args, "generate") or not args.generate
 
     def run(self, args):
         if hasattr(args, "name") and args.name:
@@ -260,7 +263,7 @@ class Model:
                 model_path = self.pull(args)
 
         exec_model_path = mnt_file
-        if not args.container and not args.generate:
+        if not args.container and self.not_args_generate(args):
             exec_model_path = model_path
 
         # if args.container:
@@ -292,9 +295,8 @@ class Model:
             raise NotImplementedError(file_not_found % (exec_args[0], exec_args[0], exec_args[0], str(e).strip("'")))
 
     def serve(self, args):
-        if hasattr(args, "name") and args.name:
-            if not args.container and not args.generate:
-                raise KeyError("--nocontainer and --name options conflict. --name requires a container.")
+        if hasattr(args, "name") and args.name and not args.container and self.not_args_generate(args):
+            raise KeyError("--nocontainer and --name options conflict. --name requires a container.")
 
         if args.dryrun:
             model_path = "/path/to/model"
@@ -304,7 +306,7 @@ class Model:
                 model_path = self.pull(args)
 
         exec_model_path = mnt_file
-        if not args.container and not args.generate:
+        if not args.container and self.not_args_generate(args):
             exec_model_path = model_path
 
         exec_args = ["llama-server", "--port", args.port, "-m", exec_model_path]


### PR DESCRIPTION
Because in the "run" flow, generate isn't even a present argument

## Summary by Sourcery

Bug Fixes:
- Fix exception thrown on macOS when running via ramalama by checking for the presence of the 'generate' argument.