### PR TITLE
Run does not have generate, so remove it

### DIFF
--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -260,7 +260,7 @@ class Model:
                 model_path = self.pull(args)
 
         exec_model_path = mnt_file
-        if not args.container and not args.generate:
+        if not args.container:
             exec_model_path = model_path
 
         # if args.container:


### PR DESCRIPTION
Replaces https://github.com/containers/ramalama/pull/433

## Summary by Sourcery

Bug Fixes:
- Remove unused 'generate' argument check in the 'run' method.