### PR TITLE
Make it easier to test-run manually

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,11 @@ lint:
 codespell:
 	codespell --dictionary=- -w
 
+.PHONY: test-run
+test-run:
+	_RAMALAMA_TEST=local RAMALAMA=$(CURDIR)/bin/ramalama bats -T test/system/030-run.bats
+	_RAMALAMA_OPTIONS=--nocontainer _RAMALAMA_TEST=local bats -T test/system/030-run.bats
+
 .PHONY: validate
 validate: codespell lint
 ifeq ($(OS),Linux)

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -615,7 +615,9 @@ def serve_parser(subparsers):
     parser.add_argument("--authfile", help="path of the authentication file")
     parser.add_argument("-d", "--detach", action="store_true", dest="detach", help="run the container in detached mode")
     parser.add_argument("-n", "--name", dest="name", help="name of container in which the Model will be run")
-    parser.add_argument("-p", "--port", default=config.get('port', "8080"), help="port for AI Model server to listen on")
+    parser.add_argument(
+        "-p", "--port", default=config.get('port', "8080"), help="port for AI Model server to listen on"
+    )
     parser.add_argument(
         "--tls-verify",
         dest="tlsverify",
@@ -714,7 +716,7 @@ def _rm_model(models, args):
         except KeyError as e:
             try:
                 # attempt to remove as a container image
-                m=OCI(model, config.get('engine', container_manager()))
+                m = OCI(model, config.get('engine', container_manager()))
                 m.remove(args)
             except Exception:
                 raise e

--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -136,7 +136,6 @@ class Model:
             "--security-opt=label=disable",
             "--name",
             name,
-            f"-v{args.store}:/var/lib/ramalama",
         ]
 
         if sys.stdout.isatty() and sys.stdin.isatty():
@@ -170,6 +169,7 @@ class Model:
         wd = find_working_directory()
 
         conman_args += [
+            f"-v{args.store}:/var/lib/ramalama",
             f"-v{os.path.realpath(sys.argv[0])}:/usr/bin/ramalama:ro",
             f"-v{wd}:/usr/share/ramalama/ramalama:ro",
             f"-v{short_file}:/usr/share/ramalama/shortnames.conf:ro,Z",
@@ -216,13 +216,13 @@ class Model:
 
     def exec_model_in_container(self, model_path, cmd_args, args):
         if not args.container:
-                return False
+            return False
         conman_args = self.setup_container(args)
         if len(conman_args) == 0:
             return False
 
         if model_path and os.path.exists(model_path):
-            conman_args += [f"--mount=type=bind,src={model_path},destination={mnt_file},rw=false,Z"]
+            conman_args += [f"--mount=type=bind,src={model_path},destination={mnt_file},rw=false"]
         else:
             conman_args += [f"--mount=type=image,src={self.model},destination={mnt_dir},rw=false,subpath=/models"]
 

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -30,12 +30,9 @@ load helpers
     is "$output" ".*${image} llama-cli -m" "verify image name"
 }
 
-# FIXME no way to run this reliably without flakes in CI/CD system
-#@test "ramalama run granite with prompt" {
-#    run_ramalama run --name foobar granite "How often to full moons happen"
-#    is "$output" ".*month" "should include some info about the Moon"
-#    run_ramalama list
-#    is "$output" ".*granite" "granite model should have been pulled"
-#}
+@test "ramalama run tiny with prompt" {
+      skip_if_notlocal
+      run_ramalama run --name foobar tiny "Write a 1 line poem"
+}
 
 # vim: filetype=sh

--- a/test/system/helpers.bash
+++ b/test/system/helpers.bash
@@ -252,6 +252,12 @@ function skip_if_nocontainer() {
     fi
 }
 
+function skip_if_notlocal() {
+    if [[ "${_RAMALAMA_TEST}" != "local" ]]; then
+	skip "Not supported unless --local"
+    fi
+}
+
 function skip_if_docker() {
     if [[ "${_RAMALAMA_TEST_OPTS}" == "--engine=docker" ]]; then
 	skip "Not supported with ----engine=docker"


### PR DESCRIPTION
NO need to leak ramalama storage into container any longer.

Since we are disabling SELinux don't add Z.

## Summary by Sourcery

Enhance the test infrastructure by introducing a new helper function to skip tests in non-local environments and updating a specific test to use this function. Add a new Makefile target to simplify manual test execution. Remove unnecessary SELinux options from container setup and adjust volume mounting logic.

Enhancements:
- Improve the test system by adding a new helper function 'skip_if_notlocal' to conditionally skip tests not supported in non-local environments.

Tests:
- Modify the system test 'ramalama run tiny with prompt' to include a conditional skip for non-local environments, ensuring more reliable test execution.

Chores:
- Add a new 'test-run' target to the Makefile to facilitate manual test execution with specific environment variables.