### PR TITLE
Run the command by default without stderr

### DIFF
--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -2,6 +2,7 @@ import os
 import sys
 import glob
 import atexit
+import shlex
 
 from ramalama.common import (
     default_image,
@@ -228,7 +229,11 @@ class Model:
 
         # Make sure Image precedes cmd_args.
         conman_args += [self._image(args)]
-        conman_args += cmd_args
+        cargs=shlex.join(cmd_args)
+        if not args.debug:
+            cargs += " 2> /dev/null"
+        conman_args += ["/bin/sh", "-c", cargs]
+
 
         if args.dryrun:
             dry_run(conman_args)

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -27,7 +27,7 @@ load helpers
     is "${lines[0]}"  "Error: --nocontainer and --name options conflict. --name requires a container." "conflict between nocontainer and --name line"
 
     RAMALAMA_IMAGE=${image} run_ramalama --dryrun run ${model}
-    is "$output" ".*${image} llama-cli -m" "verify image name"
+    is "$output" ".*${image} /bin/sh -c" "verify image name"
 }
 
 # FIXME no way to run this reliably without flakes in CI/CD system


### PR DESCRIPTION
Instead of runing the container staight away run it in a shell -c environment with 2> /dev/null, to eliminate the stderr output.

Fixes: https://github.com/containers/ramalama/issues/431

## Summary by Sourcery

Bug Fixes:
- Suppress stderr output when executing commands in a container by redirecting it to /dev/null.