### PR TITLE
We can now run models via Kompute in podman-machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ curl -fsSL https://raw.githubusercontent.com/containers/ramalama/s/install.sh | 
 | CPU                                | :white_check_mark: |
 | Apple Silicon GPU (Linux / Asahi)  | :white_check_mark: |
 | Apple Silicon GPU (macOS)          | :white_check_mark: |
-| Apple Silicon GPU (podman-machine) | :x: |
+| Apple Silicon GPU (podman-machine) | :white_check_mark: |
 | Nvidia GPU (cuda)                  | :x: [Containerfile](https://github.com/containers/ramalama/blob/main/container-images/cuda/Containerfile) available but not published to quay.io |
 | AMD GPU (rocm)                     | :white_check_mark: |
 


### PR DESCRIPTION
Reflect this in README.md

## Summary by Sourcery

Documentation:
- Update README.md to reflect that models can now be run via Kompute in podman-machine.