### PR TITLE
Only do dnf install for cuda images

### DIFF
--- a/container-images/scripts/build_llama_and_whisper.sh
+++ b/container-images/scripts/build_llama_and_whisper.sh
@@ -31,9 +31,12 @@ dnf_install() {
       "${rpm_list[@]}"
   elif [ "$containerfile" = "rocm" ]; then
     dnf install -y rocm-dev hipblas-devel rocblas-devel
-  else
+  elif [ "$containerfile" = "cuda" ]; then
     dnf install -y "${rpm_list[@]}"
   fi
+
+  # For Vulkan image, we don't need to install anything extra but rebuild with
+  # -DGGML_VULKAN
 }
 
 cmake_steps() {


### PR DESCRIPTION
Should fix container build for Vulkan images

## Summary by Sourcery

Enhancements:
- Modify the dnf_install function to conditionally install packages only for CUDA images, avoiding unnecessary installations for Vulkan images.