### PR TITLE
Set --host option when the server will end up in a container

### DIFF
--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -317,7 +317,7 @@ class Model:
         else:
             if args.gpu:
                 exec_args.extend(self.gpu_args())
-            if in_container():
+            if in_container() or (args.container and args.engine):
                 exec_args.extend(["--host", "0.0.0.0"])
 
         if args.generate == "quadlet":


### PR DESCRIPTION
A small patch to extend the use of the --host '0.0.0.0' argument for llama-server to the cases when the app will end up being run in a container.

Fixes #442

## Summary by Sourcery

Bug Fixes:
- Fix the server configuration to correctly set the '--host' option to '0.0.0.0' when the application is run in a container.