### PR TITLE
Add --host=0.0.0.0 if running llama.cpp serve within a container

### DIFF
--- a/docs/ramalama-serve.1.md
+++ b/docs/ramalama-serve.1.md
@@ -38,6 +38,9 @@ Generate specified configuration format for running the AI Model as a service
 #### **--help**, **-h**
 show this help message and exit
 
+#### **--host**="0.0.0.0"
+ip address to listen
+
 #### **--name**, **-n**
 Name of the container to run the Model in.
 

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -614,6 +614,7 @@ def serve_parser(subparsers):
     parser = subparsers.add_parser("serve", help="serve REST API on specified AI Model")
     parser.add_argument("--authfile", help="path of the authentication file")
     parser.add_argument("-d", "--detach", action="store_true", dest="detach", help="run the container in detached mode")
+    parser.add_argument("--host", default=config.get('host', "0.0.0.0"), help="ip address to listen")
     parser.add_argument("-n", "--name", dest="name", help="name of container in which the Model will be run")
     parser.add_argument(
         "-p", "--port", default=config.get('port', "8080"), help="port for AI Model server to listen on"

--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -267,9 +267,6 @@ class Model:
         if not args.container:
             exec_model_path = model_path
 
-        # if args.container:
-        #     model_path = mnt_file
-
         exec_args = ["llama-cli", "-m", exec_model_path, "--in-prefix", "", "--in-suffix", ""]
 
         if not args.debug:
@@ -288,6 +285,9 @@ class Model:
 
         try:
             if self.exec_model_in_container(model_path, exec_args, args):
+                return
+            if args.dryrun:
+                dry_run(exec_args)
                 return
             exec_cmd(exec_args, args.debug, debug=args.debug)
         except FileNotFoundError as e:
@@ -317,8 +317,7 @@ class Model:
         else:
             if args.gpu:
                 exec_args.extend(self.gpu_args())
-            if in_container():
-                exec_args.extend(["--host", "0.0.0.0"])
+            exec_args.extend(["--host", args.host])
 
         if args.generate == "quadlet":
             return self.quadlet(model_path, args, exec_args)
@@ -331,6 +330,9 @@ class Model:
 
         try:
             if self.exec_model_in_container(model_path, exec_args, args):
+                return
+            if args.dryrun:
+                dry_run(exec_args)
                 return
             exec_cmd(exec_args, debug=args.debug)
         except FileNotFoundError as e:

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -3,31 +3,37 @@
 load helpers
 
 @test "ramalama --dryrun run basic output" {
-    skip_if_nocontainer
-
     model=tiny
     image=m_$(safename)
 
-    run_ramalama info
-    conman=$(jq .Engine <<< $output | tr -d '"' )
-    verify_begin="${conman} run --rm -i --label RAMALAMA --security-opt=label=disable --name"
+    if is_container; then
+	run_ramalama info
+	conman=$(jq .Engine <<< $output | tr -d '"' )
+	verify_begin="${conman} run --rm -i --label RAMALAMA --security-opt=label=disable --name"
 
-    run_ramalama --dryrun run ${model}
-    is "$output" "${verify_begin} ramalama_.*" "dryrun correct"
-    is "$output" ".*${model}" "verify model name"
+	run_ramalama --dryrun run ${model}
+	is "$output" "${verify_begin} ramalama_.*" "dryrun correct"
+	is "$output" ".*${model}" "verify model name"
 
-    run_ramalama --dryrun run --name foobar ${model}
-    is "$output" "${verify_begin} foobar .*" "dryrun correct with --name"
-    is "$output" ".*${model}" "verify model name"
+	run_ramalama --dryrun run --name foobar ${model}
+	is "$output" "${verify_begin} foobar .*" "dryrun correct with --name"
+	is "$output" ".*${model}" "verify model name"
 
-    run_ramalama --dryrun run --name foobar ${model}
-    is "$output" "${verify_begin} foobar .*" "dryrun correct with --name"
+	run_ramalama --dryrun run --name foobar ${model}
+	is "$output" "${verify_begin} foobar .*" "dryrun correct with --name"
 
-    run_ramalama 1 --nocontainer run --name foobar tiny
-    is "${lines[0]}"  "Error: --nocontainer and --name options conflict. --name requires a container." "conflict between nocontainer and --name line"
+	run_ramalama 1 --nocontainer run --name foobar tiny
+	is "${lines[0]}"  "Error: --nocontainer and --name options conflict. --name requires a container." "conflict between nocontainer and --name line"
 
-    RAMALAMA_IMAGE=${image} run_ramalama --dryrun run ${model}
-    is "$output" ".*${image} /bin/sh -c" "verify image name"
+	RAMALAMA_IMAGE=${image} run_ramalama --dryrun run ${model}
+	is "$output" ".*${image} /bin/sh -c" "verify image name"
+    else
+	run_ramalama --dryrun run ${model}
+	is "$output" 'llama-cli -m /path/to/model --in-prefix --in-suffix --no-display-prompt -p.*' "dryrun correct"
+
+	run_ramalama 1 run --name foobar tiny
+	is "${lines[0]}"  "Error: --nocontainer and --name options conflict. --name requires a container." "conflict between nocontainer and --name line"
+    fi
 }
 
 @test "ramalama run tiny with prompt" {


### PR DESCRIPTION
Turn on some testing of --nocontainer serve and run, at least with dryrun.

## Summary by Sourcery

Add --host=0.0.0.0 when running llama.cpp serve within a container and improve error handling for conflicting options. Enhance system tests to cover new scenarios.

New Features:
- Add support for running llama.cpp serve with --host=0.0.0.0 when executed within a container.

Enhancements:
- Improve the handling of --nocontainer and --name options by providing clearer error messages when they conflict.

Tests:
- Enhance system tests to include scenarios for --nocontainer serve and run, with dryrun mode.