### PR TITLE
cli.py: remove errant slash preventing the loading of user conf file(s)

### DIFF
--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -64,7 +64,7 @@ def load_config():
         "/etc/ramalama/ramalama.conf",
     ]
     config_home = os.getenv("XDG_CONFIG_HOME", os.path.join("~", ".config"))
-    config_paths.extend([os.path.expanduser(os.path.join(config_home, "/ramalama", "ramalama.conf"))])
+    config_paths.extend([os.path.expanduser(os.path.join(config_home, "ramalama", "ramalama.conf"))])
 
     # Load configuration from each path
     for path in config_paths:


### PR DESCRIPTION
Hello, thanks for a great project.  

I am not a Python coder, but the official Python docs say of os.path.join that "if a segment is an absolute path, then all previous segments are ignored and joining continues from the absolute path segment".  So, I expect "os.path.join(config_home, "/ramalama", "ramalama.conf")" to always elide the config_home (read: "~/.config") and fail to load user config files when XDG_CONFIG_HOME is not set.  I do not believe this is the intended behavior.  I suspect that removing the slash renders the code correct, but... I am not a Python coder.  Works for me, but needs review, please.

Best regards,
FNG

## Summary by Sourcery

Bug Fixes:
- Fix the issue where user configuration files were not being loaded due to an incorrect path construction in cli.py.