### PR TITLE
Switched DGGML_CUDA to ON in cuda containerfile

### DIFF
--- a/container-images/cuda/Containerfile
+++ b/container-images/cuda/Containerfile
@@ -9,7 +9,7 @@ COPY ../scripts /scripts
 RUN chmod +x /scripts/*.sh && \
     /scripts/build_llama_and_whisper.sh "cuda" "$LLAMA_CPP_SHA" \
       "$WHISPER_CPP_SHA" "/tmp/install" \
-      "-DGGML_CUDA=1" "-DCMAKE_EXE_LINKER_FLAGS=-Wl,--allow-shlib-undefined"
+      "-DGGML_CUDA=ON" "-DCMAKE_EXE_LINKER_FLAGS=-Wl,--allow-shlib-undefined"
 
 # Final runtime image
 FROM docker.io/nvidia/cuda:12.6.2-runtime-ubi9


### PR DESCRIPTION
Just a simple fix while testing Nvidia GPU support I noticed that -DGGML_CUDA should be equal to ON instead of 1.  The container file will build but it won't recognize the GPU.

I tested this and everything works! (with adding -ngl to llama-chat-simple and changing the container to cuda)

## Summary by Sourcery

Build:
- Change the DGGML_CUDA flag from 1 to ON in the CUDA container file to ensure proper GPU recognition.