### PR TITLE
Add support for http, https and file pulls

### DIFF
--- a/bin/ramalama
+++ b/bin/ramalama
@@ -36,7 +36,7 @@ def add_site_packages_to_syspath(base_path):
             sys.path.insert(0, path)
 
 def main(args):
-    sharedirs = ["./", "/opt/homebrew/share/ramalama", "/usr/local/share/ramalama", "/usr/share/ramalama"]
+    sharedirs = ["/opt/homebrew/share/ramalama", "/usr/local/share/ramalama", "/usr/share/ramalama"]
     syspath = next((d for d in sharedirs if os.path.exists(d+"/ramalama/cli.py")), None)
     if syspath:
         sys.path.insert(0, syspath)
@@ -44,6 +44,7 @@ def main(args):
     add_site_packages_to_syspath('~/.local/pipx/venvs/*')
     add_site_packages_to_syspath('/usr/local')
     add_pipx_venvs_bin_to_path()
+    sys.path.insert(0, './')
     try:
         import ramalama
     except:
@@ -62,6 +63,10 @@ def main(args):
     if args.version:
         return ramalama.print_version(args)
 
+    def eprint(e, exit_code):
+        ramalama.perror("Error: " + str(e).strip("'\""))
+        sys.exit(exit_code)
+
     # Process CLI
     try:
         args.func(args)
@@ -73,22 +78,17 @@ def main(args):
         if args.debug:
             raise
     except IndexError as e:
-        ramalama.perror("Error: " + str(e).strip("'"))
-        sys.exit(errno.EINVAL)
+        eprint(e, errno.EINVAL)
     except KeyError as e:
-        ramalama.perror("Error: " + str(e).strip("'"))
-        sys.exit(1)
+        eprint(e, 1)
     except NotImplementedError as e:
-        ramalama.perror("Error: " + str(e).strip("'"))
-        sys.exit(errno.ENOTSUP)
+        eprint(e, errno.ENOTSUP)
     except subprocess.CalledProcessError as e:
-        ramalama.perror("Error: " + str(e).strip("'"))
-        sys.exit(e.returncode)
+        eprint(e, e.returncode)
     except KeyboardInterrupt:
         sys.exit(0)
     except ValueError as e:
-        ramalama.perror("Error: " + str(e).strip("'"))
-        sys.exit(errno.EINVAL)
+        eprint(e, errno.EINVAL)
 
 
 if __name__ == "__main__":

--- a/docs/ramalama.1.md
+++ b/docs/ramalama.1.md
@@ -40,12 +40,20 @@ RamaLama supports multiple AI model registries types called transports. Supporte
 | OCI Container Registries | [`opencontainers.org`](https://opencontainers.org)|
 ||Examples: [`quay.io`](https://quay.io),  [`Docker Hub`](https://docker.io), and [`Artifactory`](https://artifactory.com)|
 
+RamaLama can also pull directly using URL syntax.
+
+http://, https:// and file://.
+
+This means if a model is on a web site or even on your local system, you can run it directly.
+
 RamaLama uses the Ollama registry transport by default. The default can be overridden in the ramalama.conf file or use the RAMALAMA_TRANSPORTS
 environment. `export RAMALAMA_TRANSPORT=huggingface` Changes RamaLama to use huggingface transport.
 
-Individual model transports can be modifies when specifying a model via the `huggingface://`, `oci://`, or `ollama://` prefix.
+Individual model transports can be modifies when specifying a model via the `huggingface://`, `oci://`, `ollama://`, `https://`, `http://`, `file://` prefix.
 
 ramalama pull `huggingface://`afrideva/Tiny-Vicuna-1B-GGUF/tiny-vicuna-1b.q2_k.gguf
+
+ramalama run `file://`$HOME/granite-7b-lab-Q4_K_M.gguf
 
 To make it easier for users, RamaLama uses shortname files, which container
 alias names for fully specified AI Models allowing users to specify the shorter

--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -17,7 +17,7 @@ from ramalama.quadlet import Quadlet
 from ramalama.kube import Kube
 from ramalama.common import mnt_dir, mnt_file
 
-model_types = ["oci", "huggingface", "hf", "ollama"]
+model_types = ["file", "https", "http", "oci", "huggingface", "hf", "ollama"]
 
 
 file_not_found = """\
@@ -87,17 +87,12 @@ class Model:
 
     def remove(self, args):
         model_path = self.model_path(args)
-        if os.path.exists(model_path):
-            try:
-                os.remove(model_path)
-                print(f"Untagged: {self.model}")
-            except OSError as e:
-                if not args.ignore:
-                    raise KeyError(f"removing {self.model}: {e}")
-        else:
+        try:
+            os.remove(model_path)
+            print(f"Untagged: {self.model}")
+        except OSError as e:
             if not args.ignore:
-                raise KeyError(f"model {self.model} not found")
-
+                raise KeyError(f"removing {self.model}: {e}")
         self.garbage_collection(args)
 
     def _image(self, args):

--- a/ramalama/url.py
+++ b/ramalama/url.py
@@ -1,0 +1,45 @@
+import os
+from ramalama.common import download_file
+from ramalama.model import Model
+
+
+class URL(Model):
+    def __init__(self, model):
+        self.type = ""
+        for prefix in ["file", "http", "https"]:
+            if model.startswith(f"{prefix}://"):
+                self.type = prefix
+                model = model.removeprefix(f"{prefix}://")
+                break
+
+        super().__init__(model)
+        split = self.model.rsplit("/", 1)
+        self.directory = split[0].removeprefix("/") if len(split) > 1 else ""
+        self.filename = split[1] if len(split) > 1 else split[0]
+
+    def pull(self, args):
+        model_path = self.model_path(args)
+        directory_path = os.path.join(args.store, "repos", self.type, self.directory, self.filename)
+        os.makedirs(directory_path, exist_ok=True)
+
+        symlink_dir = os.path.dirname(model_path)
+        os.makedirs(symlink_dir, exist_ok=True)
+
+        target_path = os.path.join(directory_path, self.filename)
+
+        if self.type == "file":
+            if not os.path.exists(self.model):
+                raise FileNotFoundError(f"{self.model} no such file")
+            os.symlink(self.model, os.path.join(symlink_dir, self.filename))
+            os.symlink(self.model, target_path)
+        else:
+            url = self.type + "://" + self.model
+            # Download the model file to the target path
+            download_file(url, target_path, headers={}, show_progress=True)
+            relative_target_path = os.path.relpath(target_path, start=os.path.dirname(model_path))
+            if self.check_valid_model_path(relative_target_path, model_path):
+                # Symlink is already correct, no need to update it
+                return model_path
+            os.symlink(relative_target_path, model_path)
+
+        return model_path

--- a/test/system/010-list.bats
+++ b/test/system/010-list.bats
@@ -36,9 +36,9 @@ size              | [0-9]\\\+
     run_ramalama list --json
 
     while read field expect; do
-        actual=$(echo "$output" | jq -r ".[0].$field")
-        dprint "# actual=<$actual> expect=<$expect}>"
-        is "$actual" "$expect" "jq .$field"
+	actual=$(echo "$output" | jq -r ".[0].$field")
+	dprint "# actual=<$actual> expect=<$expect}>"
+	is "$actual" "$expect" "jq .$field"
     done < <(parse_table "$tests")
 }
 
@@ -51,9 +51,9 @@ size              | [0-9]\\\+
 
 @test "ramalama rm --ignore" {
     random_image_name=i_$(safename)
-    run_ramalama 1 rm $random_image_name
-    is "$output" "Error: model $random_image_name not found.*"
-    run_ramalama rm --ignore $random_image_name
+    run_ramalama 1 rm ${random_image_name}
+    is "$output" "Error: removing ${random_image_name}: \[Errno 2\] No such file or directory:.*"
+    run_ramalama rm --ignore ${random_image_name}
     is "$output" ""
 }
 

--- a/test/system/050-pull.bats
+++ b/test/system/050-pull.bats
@@ -65,6 +65,39 @@ load setup_suite
     run_ramalama rm oci://quay.io/mmortari/gguf-py-example:v1
 }
 
+@test "ramalama URL" {
+      model=$RAMALAMA_TMPDIR/mymodel.gguf
+      touch $model
+      file_url=file://${model}
+      https_url=https://github.com/containers/ramalama/blob/main/README.md
+
+      for url in $file_url $https_url; do
+          run_ramalama pull $url
+          run_ramalama list
+          is "$output" ".*$url" "URL exists"
+          run_ramalama rm $url
+          run_ramalama list
+          assert "$output" !~ ".*$url" "URL no longer exists"
+      done
+}
+
+@test "ramalama file URL" {
+      model=$RAMALAMA_TMPDIR/mymodel.gguf
+      touch $model
+      url=file://${model}
+
+      run_ramalama pull $url
+      run_ramalama list
+      is "$output" ".*$url" "URL exists"
+      # test if model is removed, nothing blows up
+      rm ${model}
+      run_ramalama list
+      is "$output" ".*$url does not exist" "URL exists"
+      run_ramalama rm $url
+      run_ramalama list
+      assert "$output" !~ ".*$url" "URL no longer exists"
+}
+
 @test "ramalama use registry" {
     skip_if_darwin
     skip_if_docker

--- a/test/system/helpers.podman.bash
+++ b/test/system/helpers.podman.bash
@@ -1114,7 +1114,7 @@ function parse_table() {
 function random_string() {
     local length=${1:-10}
 
-    head /dev/urandom | tr -dc a-zA-Z0-9 | head -c$length
+    head /dev/urandom | LC_ALL=C tr -dc a-zA-Z0-9 | head -c$length
 }
 
 ##############


### PR DESCRIPTION
RamaLama should be able to handle Models stored on web sites as well as previously pulled to the machine.

## Summary by Sourcery

Add support for pulling models using http, https, and file URLs, enabling direct execution of models from web or local sources. Update documentation and add tests to cover the new functionality.

New Features:
- Add support for pulling models using http, https, and file URLs, allowing models to be run directly from web sources or local files.

Enhancements:
- Refactor the symlink creation process to use os.symlink directly instead of run_cmd.

Documentation:
- Update documentation to include new URL syntax support for http, https, and file protocols, explaining how models can be pulled from these sources.

Tests:
- Add system tests to verify the functionality of pulling models using file and https URLs, ensuring they can be listed and removed correctly.