### PR TITLE
Docu

### DIFF
--- a/docs/ramalama-login.1.md
+++ b/docs/ramalama-login.1.md
@@ -47,7 +47,7 @@ $ ramalama login ollama
 
 Login to huggingface registry
 ```
-$ ramalama login --token=XYZ ollama
+$ ramalama login --token=XYZ huggingface
 ```
 
 ## SEE ALSO


### PR DESCRIPTION
- correct docu 
in the logout section it is huggingface

## Summary by Sourcery

Documentation:
- Correct the documentation in the logout section to accurately reflect the login command for the huggingface registry.