### PR TITLE
Support huggingface-cli older than 0.25.0, like on Fedora 40 and 41

### DIFF
--- a/ramalama/huggingface.py
+++ b/ramalama/huggingface.py
@@ -1,6 +1,6 @@
 import os
 import urllib.request
-from ramalama.common import run_cmd, exec_cmd, download_file, verify_checksum
+from ramalama.common import available, run_cmd, exec_cmd, download_file, verify_checksum
 from ramalama.model import Model
 
 missing_huggingface = """
@@ -13,10 +13,9 @@ pip install huggingface_hub tqdm
 
 def is_huggingface_cli_available():
     """Check if huggingface-cli is available on the system."""
-    try:
-        run_cmd(["huggingface-cli", "version"])
+    if available("huggingface-cli"):
         return True
-    except FileNotFoundError:
+    else:
         print("huggingface-cli not found. Some features may be limited.\n" + missing_huggingface)
         return False
 


### PR DESCRIPTION
Currently, on Fedora 40 and 41, pulling a model from Hugging Face fails with:
```ShellSession
  $ ramalama pull
      huggingface://afrideva/Tiny-Vicuna-1B-GGUF/tiny-vicuna-1b.q2_k.gguf
  usage: huggingface-cli <command> [<args>]
  huggingface-cli: error: argument {env,login,whoami,logout,repo,upload,
      download,lfs-enable-largefiles,lfs-multipart-upload,scan-cache,
      delete-cache,tag}: invalid choice: 'version' (choose from 'env',
      'login', 'whoami', 'logout', 'repo', 'upload', 'download',
      'lfs-enable-largefiles', 'lfs-multipart-upload', 'scan-cache',
      'delete-cache', 'tag')
  Error: Command '['huggingface-cli', 'version']' returned non-zero exit
      status 2.
```

This is because the `huggingface-cli version` command is a recent addition in version 0.25.0 [1], and it's not present in any stable Fedora release [2].

Therefore, it might be worth using a slightly different signature to detect the presence of `huggingface-cli` - one that isn't bound to a `huggingface-cli` version and is used elsewhere in the code.

[1] huggingface_hub commit ebac1b2a1aa4a9f4
    https://github.com/huggingface/huggingface_hub/commit/ebac1b2a1aa4a9f4
    https://github.com/huggingface/huggingface_hub/issues/2441

[2] https://src.fedoraproject.org/rpms/python-huggingface-hub

Fixes: 5749154b1e21b802 ("Replace huggingface-cli with a simple ...")

## Summary by Sourcery

Bug Fixes:
- Fix compatibility issue with older versions of huggingface-cli on Fedora 40 and 41 by changing the command used to check its availability.