### PR TITLE
Enable GCC Toolet 12 to support AVX VNNI

### DIFF
--- a/container-images/scripts/build_llama_and_whisper.sh
+++ b/container-images/scripts/build_llama_and_whisper.sh
@@ -29,7 +29,8 @@ dnf_install() {
   elif [ "$containerfile" = "rocm" ]; then
     dnf install -y rocm-dev hipblas-devel rocblas-devel
   elif [ "$containerfile" = "cuda" ]; then
-    dnf install -y "${rpm_list[@]}"
+    dnf install -y "${rpm_list[@]}" gcc-toolset-12
+    source /opt/rh/gcc-toolset-12/enable
   fi
 
   # For Vulkan image, we don't need to install anything extra but rebuild with


### PR DESCRIPTION
Fixes issue #471 based on a Red Hat KBase article (subscription required), to use AVX VNNI on platforms that support it a later version of binutils is needed.

This adds the GCC 12 Toolset and directly sources the environment vars into the build script.

There are also toolsets available for GCC 13 and 14 available if there's a need for more current versions. They should work the same way.

## Summary by Sourcery

Build:
- Add GCC Toolset 12 to the build script for AVX VNNI support.