### PR TITLE
Fall back to huggingface-cli when pulling via URL fails

### DIFF
--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -297,6 +297,8 @@ class Model:
 
         exec_args = ["llama-server", "--port", args.port, "-m", exec_model_path]
         if args.runtime == "vllm":
+            if not (exec_model_path.endswith(".GGUF") or exec_model_path.endswith(".gguf")):
+                exec_model_path = os.path.dirname(exec_model_path)
             exec_args = ["vllm", "serve", "--port", args.port, exec_model_path]
         else:
             if args.gpu:

--- a/test/system/040-serve.bats
+++ b/test/system/040-serve.bats
@@ -205,7 +205,7 @@ verify_begin=".*run --rm -i --label RAMALAMA --security-opt=label=disable --name
 
 	run cat $name.yaml
 	is "$output" ".*command: \[\"vllm\"\]" "command is correct"
-	is "$output" ".*args: \['serve', '--port', '1234', '/mnt/models/model.file'\]" "args is correct"
+	is "$output" ".*args: \['serve', '--port', '1234', '/mnt/models'\]" "args is correct"
 
 	is "$output" ".*image: quay.io/ramalama/ramalama:latest" "image is correct"
 	is "$output" ".*reference: ${ociimage}" "AI image should be created"

--- a/test/system/050-pull.bats
+++ b/test/system/050-pull.bats
@@ -45,6 +45,11 @@ load setup_suite
     run_ramalama list
     is "$output" ".*afrideva/Tiny-Vicuna-1B-GGUF/tiny-vicuna-1b.q2_k" "image was actually pulled locally"
     run_ramalama rm huggingface://afrideva/Tiny-Vicuna-1B-GGUF/tiny-vicuna-1b.q2_k.gguf
+
+    run_ramalama pull hf://TinyLlama/TinyLlama-1.1B-Chat-v1.0
+    run_ramalama list
+    is "$output" ".*TinyLlama/TinyLlama-1.1B-Chat-v1.0" "image was actually pulled locally"
+    run_ramalama rm huggingface://TinyLlama/TinyLlama-1.1B-Chat-v1.0
 }
 
 # bats test_tags=distro-integration


### PR DESCRIPTION
Handle non GGUF files as well.

## Summary by Sourcery

Implement a fallback mechanism to use 'huggingface-cli' for model pulling when URL-based pulling fails, and fix the argument path for the 'vllm serve' command. Update system tests to reflect these changes.

Bug Fixes:
- Fix the argument path for the 'vllm serve' command to use the directory path instead of the model file path.

Enhancements:
- Implement a fallback mechanism to use 'huggingface-cli' for model pulling when URL-based pulling fails.

Tests:
- Update system test to verify the correct arguments for the 'vllm serve' command.