### PR TITLE
Update model.py to enable CUDA when available

### DIFF
--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -3,6 +3,8 @@ import sys
 import glob
 import atexit
 import shlex
+import subprocess
+import shutil
 
 from ramalama.common import (
     default_image,


### PR DESCRIPTION
Shell out to nvidia-smi for NVidia detection, add device or gpu args to conman as appropriate for docker vs podman.  Import subprocess (to shell out for nvidia-smi) and shutil (to duplicate available() functionality and test whether we're using podman or docker)

## Summary by Sourcery

Enhancements:
- Enable CUDA support in container setup by detecting NVidia GPUs using nvidia-smi and configuring container arguments accordingly.