### PR TITLE
Packit: enable fedora downstream jobs

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -55,3 +55,20 @@ jobs:
     trigger: pull_request
     packages: [ramalama-centos]
     targets: *centos_copr_targets
+
+  - job: propose_downstream
+    trigger: release
+    packages: [ramalama-fedora]
+    dist_git_branches: &fedora_targets
+      - fedora-all
+
+  - job: koji_build
+    trigger: commit
+    packages: [ramalama-fedora]
+    dist_git_branches: *fedora_targets
+
+  - job: bodhi_update
+    trigger: commit
+    packages: [ramalama-fedora]
+    dist_git_branches:
+      - fedora-branched # rawhide updates are created automatically


### PR DESCRIPTION
@rhatdan @smooge @ericcurtin PTAL . Once this is merged, you can release a v0.1.4 and packit will do the rest

## Summary by Sourcery

Enable Fedora downstream jobs in Packit configuration to automate propose_downstream, koji_build, and bodhi_update processes for Fedora packages.

CI:
- Add propose_downstream job for Fedora packages triggered by release.
- Add koji_build job for Fedora packages triggered by commit.
- Add bodhi_update job for Fedora packages triggered by commit.