### PR TITLE
Add --seed option

### DIFF
--- a/docs/ramalama-containers.1.md
+++ b/docs/ramalama-containers.1.md
@@ -11,7 +11,7 @@ ramalama\-containers - list all RamaLama containers
 ## DESCRIPTION
 List all containers running AI Models
 
-Command will not work when run with --nocontainer option.
+Command conflicts with the --nocontainer option.
 
 ## OPTIONS
 

--- a/docs/ramalama-push.1.md
+++ b/docs/ramalama-push.1.md
@@ -9,7 +9,7 @@ ramalama\-push - push AI Models from local storage to remote registries
 ## DESCRIPTION
 Push specified AI Model (OCI-only at present)
 
-The model could be from RamaLama model storage in Huggingface, Ollama, or OCI Model format.
+The model can be from RamaLama model storage in Huggingface, Ollama, or OCI Model format.
 The model can also just be a model stored on disk.
 
 ## OPTIONS

--- a/docs/ramalama-run.1.md
+++ b/docs/ramalama-run.1.md
@@ -20,13 +20,16 @@ show this help message and exit
 #### **--name**, **-n**
 name of the container to run the Model in
 
+#### **--seed**=
+Specify seed rather than using random seed model interaction
+
 #### **--temp**="0.8"
 Temperature of the response from the AI Model
 llama.cpp explains this as:
 
-    The lower the number is, the more deterministic the response will be.
+    The lower the number is, the more deterministic the response.
 
-    The higher the number is the more creative the response will be, but moe likely to go off topic if set too high.
+    The higher the number is the more creative the response is, but more likely to hallucinate when set too high.
 
         Usage: Lower numbers are good for virtual assistants where we need deterministic responses. Higher numbers are good for roleplay or creative tasks like editing stories
 
@@ -36,7 +39,7 @@ require HTTPS and verify certificates when contacting OCI registries
 ## DESCRIPTION
 Run specified AI Model as a chat bot. RamaLama pulls specified AI Model from
 registry if it does not exist in local storage. By default a prompt for a chat
-bot will be started. When arguments are specified, the arguments will be given
+bot is started. When arguments are specified, the arguments will be given
 to the AI Model and the output returned without entering the chatbot.
 
 ## EXAMPLES

--- a/docs/ramalama-serve.1.md
+++ b/docs/ramalama-serve.1.md
@@ -50,13 +50,16 @@ Name of the container to run the Model in.
 #### **--port**, **-p**
 port for AI Model server to listen on
 
+#### **--seed**=
+Specify seed rather than using random seed model interaction
+
 #### **--temp**="0.8"
 Temperature of the response from the AI Model
 llama.cpp explains this as:
 
-    The lower the number is, the more deterministic the response will be.
+    The lower the number is, the more deterministic the response.
 
-    The higher the number is the more creative the response will be, but moe likely to go off topic if set too high.
+    The higher the number is the more creative the response is, but more likely to hallucinate when set too high.
 
         Usage: Lower numbers are good for virtual assistants where we need deterministic responses. Higher numbers are good for roleplay or creative tasks like editing stories
 

--- a/docs/ramalama-stop.1.md
+++ b/docs/ramalama-stop.1.md
@@ -8,7 +8,7 @@ ramalama\-stop - stop named container that is running AI Model
 
 Tells container engine to stop the specified container.
 
-Command will not work when run with --nocontainer option.
+The stop command conflicts with --nocontainer option.
 
 ## OPTIONS
 
@@ -24,9 +24,7 @@ Ignore missing containers when stopping
 ## DESCRIPTION
 Stop specified container that is executing the AI Model.
 
-If ramalama command was executed with the --nocontainer model, then
-this command will have no effect. The user will need to stop the RamaLama
-processes manually.
+The ramalama stop command conflicts with the --nocontainer option. The user needs to stop the RamaLama processes manually when running with --nocontainer.
 
 ## EXAMPLES
 

--- a/docs/ramalama.1.md
+++ b/docs/ramalama.1.md
@@ -17,9 +17,9 @@ RamaLama uses container engines like Podman or Docker to pull the appropriate OC
 
 Running in containers eliminates the need for users to configure the host system for AI. After the initialization, RamaLama runs the AI Models within a container based on the OCI image.
 
-RamaLama then pulls AI Models from model registries. Starting a chatbot or a rest API service from a simple single command. Models are treated similarly to how Podman and Docker treat container images.
+RamaLama pulls AI Models from model registries. Starting a chatbot or a rest API service from a simple single command. Models are treated similarly to how Podman and Docker treat container images.
 
-When both Podman and Docker are installed, RamaLama defaults to Podman, The `RAMALAMA_CONTAINER_ENGINE=docker` environment variable can override this behaviour. When neither are installed RamaLama will attempt to run the model with software on the local system.
+When both Podman and Docker are installed, RamaLama defaults to Podman, The `RAMALAMA_CONTAINER_ENGINE=docker` environment variable can override this behavior. When neither are installed RamaLama attempts to run the model with software on the local system.
 
 Note:
 

--- a/docs/ramalama.conf
+++ b/docs/ramalama.conf
@@ -4,9 +4,9 @@
 
 # Please refer to ramalama.conf(5) for details of all configuration options.
 # Not all container engines implement all of the options.
-# All of the options have hard coded defaults and these options will override
-# the built in defaults. Users can then override these options via the command
-# line. Container engines will read ramalama.conf files in up to three
+# All of the options have hard coded defaults and these options override
+# the built in defaults. Users can override these options via the command
+# line. Container engines read ramalama.conf files in up to three
 # locations in the following order:
 #  1. /usr/share/ramalama/ramalama.conf
 #  2. /etc/ramalama/ramalama.conf
@@ -60,9 +60,9 @@
 # Temperature of the response from the AI Model
 # llama.cpp explains this as:
 #
-#    The lower the number is, the more deterministic the response will be.
+#    The lower the number is, the more deterministic the response is.
 #
-#    The higher the number is the more creative the response will be, but moe likely to go off topic if set too high.
+#    The higher the number is the more creative the response, but more likely to hallucinate when set too high.
 #
 #        Usage: Lower numbers are good for virtual assistants where we need deterministic responses. Higher numbers are good for roleplay or creative tasks like editing stories
 #temp=0.8

--- a/docs/ramalama.conf.5.md
+++ b/docs/ramalama.conf.5.md
@@ -2,7 +2,7 @@
 
 # NAME
 ramalama.conf - These configuration files specifies default
-configuration options and command-line flags for RamaLa.
+configuration options and command-line flags for RamaLama.
 
 # DESCRIPTION
 RamaLama reads the ramalama.conf file, if it exists
@@ -32,7 +32,7 @@ Config files in the `.d` directories, are added in alpha numeric sorted order an
 
 ## ENVIRONMENT VARIABLES
 If the `RAMALAMA_CONF` environment variable is set, all system and user
-config files are ignored and only the specified config file will be loaded.
+config files are ignored and only the specified config file is loaded.
 
 # FORMAT
 The [TOML format][toml] is used as the encoding of the configuration file.
@@ -103,9 +103,9 @@ Store AI Models in the specified directory
 Temperature of the response from the AI Model
 llama.cpp explains this as:
 
-    The lower the number is, the more deterministic the response will be.
+    The lower the number is, the more deterministic the response.
 
-    The higher the number is the more creative the response will be, but moe likely to go off topic if set too high.
+    The higher the number is the more creative the response is, but moee likely to hallucinate when set too high.
 
         Usage: Lower numbers are good for virtual assistants where we need deterministic responses. Higher numbers are good for roleplay or creative tasks like editing stories
 

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -614,8 +614,7 @@ def push_cli(args):
             raise e
 
 
-def run_parser(subparsers):
-    parser = subparsers.add_parser("run", help="run specified AI Model as a chatbot")
+def _run(parser):
     parser.add_argument("--authfile", help="path of the authentication file")
     parser.add_argument(
         "-c",
@@ -625,6 +624,7 @@ def run_parser(subparsers):
         help="size of the prompt context (0 = loaded from model)",
     )
     parser.add_argument("-n", "--name", dest="name", help="name of container in which the Model will be run")
+    parser.add_argument("--seed", help="override random seed")
     parser.add_argument(
         "--temp", default=config.get('temp', "0.8"), help="temperature of the response from the AI model"
     )
@@ -634,6 +634,11 @@ def run_parser(subparsers):
         default=True,
         help="require HTTPS and verify certificates when contacting registries",
     )
+
+
+def run_parser(subparsers):
+    parser = subparsers.add_parser("run", help="run specified AI Model as a chatbot")
+    _run(parser)
     parser.add_argument("MODEL")  # positional argument
     parser.add_argument(
         "ARGS", nargs="*", help="Overrides the default prompt, and the output is returned without entering the chatbot"
@@ -648,28 +653,11 @@ def run_cli(args):
 
 def serve_parser(subparsers):
     parser = subparsers.add_parser("serve", help="serve REST API on specified AI Model")
-    parser.add_argument("--authfile", help="path of the authentication file")
-    parser.add_argument(
-        "-c",
-        "--ctx-size",
-        dest="context",
-        default=config.get('ctx_size', 2048),
-        help="size of the prompt context (0 = loaded from model)",
-    )
+    _run(parser)
     parser.add_argument("-d", "--detach", action="store_true", dest="detach", help="run the container in detached mode")
     parser.add_argument("--host", default=config.get('host', "0.0.0.0"), help="IP address to listen")
-    parser.add_argument("-n", "--name", dest="name", help="name of container in which the Model will be run")
     parser.add_argument(
         "-p", "--port", default=config.get('port', "8080"), help="port for AI Model server to listen on"
-    )
-    parser.add_argument(
-        "--temp", default=config.get('temp', "0.8"), help="temperature of the response from the AI model"
-    )
-    parser.add_argument(
-        "--tls-verify",
-        dest="tlsverify",
-        default=True,
-        help="require HTTPS and verify certificates when contacting registries",
     )
     parser.add_argument(
         "--generate",

--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -270,6 +270,9 @@ class Model:
             f"{args.temp}",
         ]
 
+        if args.seed:
+            exec_args += ["--seed", args.seed]
+
         if not args.debug:
             exec_args += ["--no-display-prompt"]
         exec_args += [
@@ -311,16 +314,20 @@ class Model:
         if not args.container and not args.generate:
             exec_model_path = model_path
 
-        exec_args = ["llama-server",
-                     "--port",
-                     args.port,
-                     "-m",
-                     exec_model_path,
-                     "-c",
-                     f"{args.context}",
-                     "--temp",
-                     f"{args.temp}",
-                     ]
+        exec_args = [
+            "llama-server",
+            "--port",
+            args.port,
+            "-m",
+            exec_model_path,
+            "-c",
+            f"{args.context}",
+            "--temp",
+            f"{args.temp}",
+        ]
+        if args.seed:
+            exec_args += ["--seed", args.seed]
+
         if args.runtime == "vllm":
             if not (exec_model_path.endswith(".GGUF") or exec_model_path.endswith(".gguf")):
                 exec_model_path = os.path.dirname(exec_model_path)

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -15,12 +15,14 @@ load helpers
 	is "$output" "${verify_begin} ramalama_.*" "dryrun correct"
 	is "$output" ".*${model}" "verify model name"
 	is "$output" ".*-c 2048" "verify model name"
+	assert "$output" !~ ".*--seed" "assert seed does not show by default"
 
-	run_ramalama --dryrun run -c 4096 --name foobar ${model}
+	run_ramalama --dryrun run --seed 9876 -c 4096 --name foobar ${model}
 	is "$output" "${verify_begin} foobar .*" "dryrun correct with --name"
 	is "$output" ".*${model}" "verify model name"
 	is "$output" ".*-c 4096" "verify ctx-size is set"
 	is "$output" ".*--temp 0.8" "verify temp is set"
+	is "$output" ".*--seed 9876" "verify seed is set"
 
 	run_ramalama --dryrun run --name foobar ${model}
 	is "$output" "${verify_begin} foobar .*" "dryrun correct with --name"

--- a/test/system/040-serve.bats
+++ b/test/system/040-serve.bats
@@ -18,6 +18,7 @@ verify_begin=".*run --rm -i --label RAMALAMA --security-opt=label=disable --name
 	is "$output" "${verify_begin} foobar .*" "dryrun correct with --name"
 	assert "$output" =~ ".*--host 0.0.0.0" "verify host 0.0.0.0 is added when run within container"
 	is "$output" ".*${model}" "verify model name"
+	assert "$output" !~ ".*--seed" "assert seed does not show by default"
 
 	run_ramalama --dryrun serve --host 127.1.2.3 --name foobar ${model}
 	assert "$output" =~ ".*--host 127.1.2.3" "verify --host is modified when run within container"
@@ -27,14 +28,18 @@ verify_begin=".*run --rm -i --label RAMALAMA --security-opt=label=disable --name
 	run_ramalama --dryrun serve --temp 0.1 ${model}
 	is "$output" ".*--temp 0.1" "verify temp is set"
 
+	run_ramalama --dryrun serve --seed 1234 ${model}
+	is "$output" ".*--seed 1234" "verify seed is set"
+
 	run_ramalama 1 --nocontainer serve --name foobar tiny
 	is "${lines[0]}"  "Error: --nocontainer and --name options conflict. --name requires a container." "conflict between nocontainer and --name line"
 	run_ramalama stop --all
     else
 	run_ramalama --dryrun serve ${model}
 	assert "$output" =~ ".*--host 0.0.0.0" "Outside container sets host to 0.0.0.0"
-	run_ramalama --dryrun serve --host 127.0.0.1 ${model}
+	run_ramalama --dryrun serve --seed abcd --host 127.0.0.1 ${model}
 	assert "$output" =~ ".*--host 127.0.0.1" "Outside container overrides host to 127.0.0.1"
+	assert "$output" =~ ".*--seed abcd" "Verify seed is set"
 	run_ramalama 1 --nocontainer serve --name foobar tiny
 	is "${lines[0]}"  "Error: --nocontainer and --name options conflict. --name requires a container." "conflict between nocontainer and --name line"
      fi


### PR DESCRIPTION
Also consolidate option handling between run and serve

## Summary by Sourcery

Add a '--seed' option to the CLI for specifying a random seed, consolidate option handling between 'run' and 'serve' commands, update documentation, and enhance tests to cover the new feature.

New Features:
- Introduce a '--seed' option to allow users to specify a random seed for model interactions, enhancing reproducibility.

Enhancements:
- Consolidate option handling between 'run' and 'serve' commands to reduce code duplication and improve maintainability.

Documentation:
- Update documentation to include details about the new '--seed' option for both 'run' and 'serve' commands.

Tests:
- Add tests to verify the functionality of the new '--seed' option, ensuring it is correctly set and not shown by default.