### PR TITLE
Fix up building and pushing OCI Images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,10 +70,6 @@ jobs:
            sudo systemctl restart docker.service
            df -h
 
-      - name: build image
-        run: |
-          make build IMAGE=ramalama
-
       - name: bats-docker
         run: |
            docker info

--- a/docs/ramalama.1.md
+++ b/docs/ramalama.1.md
@@ -19,7 +19,7 @@ Running in containers eliminates the need for users to configure the host system
 
 RamaLama pulls AI Models from model registries. Starting a chatbot or a rest API service from a simple single command. Models are treated similarly to how Podman and Docker treat container images.
 
-When both Podman and Docker are installed, RamaLama defaults to Podman, The `RAMALAMA_CONTAINER_ENGINE=docker` environment variable can override this behavior. When neither are installed RamaLama attempts to run the model with software on the local system.
+When both Podman and Docker are installed, RamaLama defaults to Podman, The `RAMALAMA_CONTAINER_ENGINE=docker` environment variable can override this behaviour. When neither are installed RamaLama attempts to run the model with software on the local system.
 
 Note:
 

--- a/ramalama/annotations.py
+++ b/ramalama/annotations.py
@@ -1,0 +1,112 @@
+# These annotations are based off the proposed standard:
+# https://github.com/CloudNativeAI/model-spec
+
+# ArtifactTypeModelManifest specifies the media type for a model manifest.
+ArtifactTypeModelManifest = "application/vnd.cnai.model.manifest.v1+json"
+
+# ArtifactTypeModelLayer is the media type used for layers referenced by the
+# manifest.
+ArtifactTypeModelLayer = "application/vnd.cnai.model.layer.v1.tar"
+
+# ArtifactTypeModelLayerGzip is the media type used for gzipped layers
+# referenced by the manifest.
+ArtifactTypeModelLayerGzip = "application/vnd.cnai.model.layer.v1.tar+gzip"
+
+# AnnotationCreated is the annotation key for the date and time on which the
+# model was built (date-time string as defined by RFC 3339).
+AnnotationCreated = "org.cnai.model.created"
+
+# AnnotationAuthors is the annotation key for the contact details of the people
+# or organization responsible for the model (freeform string).
+AnnotationAuthors = "org.cnai.model.authors"
+
+# AnnotationURL is the annotation key for the URL to find more information on
+# the model.
+AnnotationURL = "org.cnai.model.url"
+
+# AnnotationDocumentation is the annotation key for the URL to get documentation
+# on the model.
+AnnotationDocumentation = "org.cnai.model.documentation"
+
+# AnnotationSource is the annotation key for the URL to get source code for
+# building the model.
+AnnotationSource = "org.cnai.model.source"
+
+# AnnotationVersion is the annotation key for the version of the packaged
+# software.
+# The version MAY match a label or tag in the source code repository.
+# The version MAY be Semantic versioning-compatible.
+AnnotationVersion = "org.cnai.model.version"
+
+# AnnotationRevision is the annotation key for the source control revision
+# identifier for the packaged software.
+AnnotationRevision = "org.cnai.model.revision"
+
+# AnnotationVendor is the annotation key for the name of the distributing
+# entity, organization or individual.
+AnnotationVendor = "org.cnai.model.vendor"
+
+# AnnotationLicenses is the annotation key for the license(s) under which
+# contained software is distributed as an SPDX License Expression.
+AnnotationLicenses = "org.cnai.model.licenses"
+
+# AnnotationRefName is the annotation key for the name of the reference for a
+# target.
+# SHOULD only be considered valid when on descriptors on `index.json` within
+# model layout.
+AnnotationRefName = "org.cnai.model.ref.name"
+
+# AnnotationTitle is the annotation key for the human-readable title of the
+# model.
+AnnotationTitle = "org.cnai.model.title"
+
+# AnnotationDescription is the annotation key for the human-readable description
+# of the software packaged in the model.
+AnnotationDescription = "org.cnai.model.description"
+
+# AnnotationArchitecture is the annotation key for the model architecture, such
+# as `transformer`, `cnn`, `rnn`, etc.
+AnnotationArchitecture = "org.cnai.model.architecture"
+
+# AnnotationFamily is the annotation key for the model family, such as
+# `llama3`, `gpt2`, `qwen2`, etc.
+AnnotationFamily = "org.cnai.model.family"
+
+# AnnotationName is the annotation key for the model name, such as
+# `llama3-8b-instruct`, `gpt2-xl`, `qwen2-vl-72b-instruct`, etc.
+AnnotationName = "org.cnai.model.name"
+
+# AnnotationFormat is the annotation key for the model format, such as
+# `onnx`, `tensorflow`, `pytorch`, etc.
+AnnotationFormat = "org.cnai.model.format"
+
+# AnnotationParamSize is the annotation key for the size of the model
+# parameters.
+AnnotationParamSize = "org.cnai.model.param.size"
+
+# AnnotationPrecision is the annotation key for the model precision, such as
+# `bf16`, `fp16`, `int8`, etc.
+AnnotationPrecision = "org.cnai.model.precision"
+
+# AnnotationQuantization is the annotation key for the model quantization,
+# such as `awq`, `gptq`, etc.
+AnnotationQuantization = "org.cnai.model.quantization"
+
+# AnnotationReadme is the annotation key for the layer is a README.md file
+# (boolean), such as `true` or `false`.
+AnnotationReadme = "org.cnai.model.readme"
+
+# AnnotationLicense is the annotation key for the layer is a license file
+# (boolean), such as `true` or `false`.
+AnnotationLicense = "org.cnai.model.license"
+
+# AnnotationConfig is the annotation key for the layer is a configuration file
+# (boolean), such as `true` or `false`.
+AnnotationConfig = "org.cnai.model.config"
+
+# AnnotationModel is the annotation key for the layer is a model file (boolean),
+# such as `true` or `false`.
+AnnotationModel = "org.cnai.model.model"
+
+# AnnotationFilepath is the annotation key for the file path of the layer.
+AnnotationFilepath = "org.cnai.model.filepath"

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -602,14 +602,14 @@ def push_cli(args):
     try:
         model = New(tgt, args)
         model.push(source, args)
-    except KeyError as e:
+    except NotImplementedError as e:
         for mtype in model_types:
-            if model.startswith(mtype + "://"):
+            if tgt.startswith(mtype + "://"):
                 raise e
         try:
             # attempt to push as a container image
-            m = OCI(model, config.get('engine', container_manager()))
-            m.push(args)
+            m = OCI(tgt, config.get('engine', container_manager()))
+            m.push(source, args)
         except Exception:
             raise e
 

--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -221,3 +221,9 @@ pip install tqdm
                 print(f"File {url} already fully downloaded.")
         else:
             raise e
+
+
+def engine_version(engine):
+    # Create manifest list for target with imageid
+    cmd_args = [engine, "version", "--format", "{{ .Client.Version }}"]
+    return run_cmd(cmd_args).stdout.decode("utf-8").strip()


### PR DESCRIPTION
## Summary by Sourcery

Refactor the OCI image building and pushing process to separate the build and manifest creation steps, and fix the push command to handle image names correctly.

Bug Fixes:
- Fix the push command to correctly handle source and target image names, ensuring proper image conversion and manifest creation.

Enhancements:
- Refactor the OCI image building process to separate the build and manifest creation steps, improving code clarity and maintainability.