### PR TITLE
Remove %version0 from spec file

### DIFF
--- a/rpm/python-ramalama.spec
+++ b/rpm/python-ramalama.spec
@@ -1,7 +1,5 @@
 %global pypi_name ramalama
 %global forgeurl  https://github.com/containers/%{pypi_name}
-# see ramalama/version.py
-%global version0  0.2.0
 %forgemeta
 
 %global summary   RamaLama is a command line tool for working with AI LLM models


### PR DESCRIPTION
This was something to allow for the package to build in Fedora koji and to pass review since it needed to be in the upstream code and the Fedora spec file. Now that we are using packit, it is not needed and should be removed from the spec.

## Summary by Sourcery

Build:
- Remove the %version0 macro from the spec file as it is no longer needed with the use of packit.