### PR TITLE
Add ramalama convert command

### DIFF
--- a/docs/ramalama-convert.1.md
+++ b/docs/ramalama-convert.1.md
@@ -1,0 +1,47 @@
+% ramalama-convert 1
+
+## NAME
+ramalama\-convert - convert AI Models from local storage to OCI Image
+
+## SYNOPSIS
+**ramalama convert** [*options*] *model* [*target*]
+
+## DESCRIPTION
+Convert specified AI Model to an OCI Formatted AI Model
+
+The model can be from RamaLama model storage in Huggingface, Ollama, or local model stored on disk.
+
+## OPTIONS
+
+#### **--help**, **-h**
+Print usage message
+
+#### **--type**=*raw* | *car*
+
+type of OCI Model Image to convert.
+
+| Type | Description                                                   |
+| ---- | ------------------------------------------------------------- |
+| car  | Includes base image with the model stored in a /models subdir |
+| raw  | Only the model and a link file model.file to it stored at /   |
+
+## EXAMPLE
+
+Generate an oci model out of an Ollama model.
+```
+$ ramalama convert ollama://tinyllama:latest oci://quay.io/rhatdan/tiny:latest
+Building quay.io/rhatdan/tiny:latest...
+STEP 1/2: FROM scratch
+STEP 2/2: COPY sha256:2af3b81862c6be03c769683af18efdadb2c33f60ff32ab6f83e42c043d6c7816 /model
+--> Using cache 69db4a10191c976d2c3c24da972a2a909adec45135a69dbb9daeaaf2a3a36344
+COMMIT quay.io/rhatdan/tiny:latest
+--> 69db4a10191c
+Successfully tagged quay.io/rhatdan/tiny:latest
+69db4a10191c976d2c3c24da972a2a909adec45135a69dbb9daeaaf2a3a36344
+```
+
+## SEE ALSO
+**[ramalama(1)](ramalama.1.md)**, **[ramalama-push(1)](ramalama-push.1.md)**
+
+## HISTORY
+Aug 2024, Originally compiled by Eric Curtin <ecurtin@redhat.com>

--- a/docs/ramalama-push.1.md
+++ b/docs/ramalama-push.1.md
@@ -12,6 +12,8 @@ Push specified AI Model (OCI-only at present)
 The model can be from RamaLama model storage in Huggingface, Ollama, or OCI Model format.
 The model can also just be a model stored on disk.
 
+Users can convert without pushing using the `ramalama convert` command.
+
 ## OPTIONS
 
 #### **--authfile**=*password*
@@ -65,7 +67,7 @@ Writing manifest to image destination
 ```
 
 ## SEE ALSO
-**[ramalama(1)](ramalama.1.md)**
+**[ramalama(1)](ramalama.1.md)**, **[ramalama-convert(1)](ramalama-convert.1.md)**
 
 ## HISTORY
 Aug 2024, Originally compiled by Eric Curtin <ecurtin@redhat.com>

--- a/docs/ramalama.1.md
+++ b/docs/ramalama.1.md
@@ -129,6 +129,7 @@ The default can be overridden in the ramalama.conf file.
 | Command                                           | Description                                                |
 | ------------------------------------------------- | ---------------------------------------------------------- |
 | [ramalama-containers(1)](ramalama-containers.1.md)| list all RamaLama containers                               |
+| [ramalama-convert(1)](ramalama-convert.1.md)      | convert AI Models from local storage to OCI Image          |
 | [ramalama-info(1)](ramalama-info.1.md)            | Display RamaLama configuration information                 |
 | [ramalama-list(1)](ramalama-list.1.md)            | list all downloaded AI Models                              |
 | [ramalama-login(1)](ramalama-login.1.md)          | login to remote registry                                   |

--- a/test/system/055-convert.bats
+++ b/test/system/055-convert.bats
@@ -1,0 +1,60 @@
+#!/usr/bin/env bats
+
+load helpers
+
+# bats test_tags=distro-integration
+@test "ramalama convert basic" {
+    skip_if_darwin
+    run_ramalama 2 convert
+    is "$output" ".*ramalama convert: error: the following arguments are required: SOURCE, TARGET"
+    run_ramalama 2 convert tiny
+    is "$output" ".*ramalama convert: error: the following arguments are required: TARGET"
+    run_ramalama 1 convert bogus foobar
+    is "$output" "Error: bogus does not exist"
+}
+
+@test "ramalama convert file to image" {
+    skip_if_darwin
+    echo "hello" > $RAMALAMA_TMPDIR/aimodel
+    run_ramalama convert $RAMALAMA_TMPDIR/aimodel foobar
+    run_ramalama list
+    is "$output" ".*foobar:latest"
+    run_ramalama rm foobar
+    assert "$output" !~ ".*foobar" "image was removed"
+
+    run_ramalama convert $RAMALAMA_TMPDIR/aimodel oci://foobar
+    run_ramalama list
+    is "$output" ".*foobar:latest"
+    run_ramalama rm foobar
+    run_ramalama list
+    assert "$output" !~ ".*foobar" "image was removed"
+
+    run_ramalama 22 convert $RAMALAMA_TMPDIR/aimodel ollama://foobar
+    is "$output" "Error: ollama://foobar invalid: Only OCI Model types supported" "verify oci image"
+
+    podman image prune --force
+}
+
+@test "ramalama convert tiny to image" {
+    skip_if_darwin
+    run_ramalama pull tiny
+    run_ramalama convert tiny oci://ramalama/tiny
+    run_ramalama list
+    is "$output" ".*ramalama/tiny:latest"
+    run_ramalama rm ramalama/tiny
+    run_ramalama list
+    assert "$output" !~ ".*ramalama/tiny" "image was removed"
+
+    run_ramalama convert ollama://tinyllama oci://ramalama/tiny
+    run_ramalama list
+    is "$output" ".*ramalama/tiny:latest"
+    run_ramalama rm ramalama/tiny
+    run_ramalama list
+    assert "$output" !~ ".*ramalama/tiny" "image was removed"
+
+    podman image prune --force
+}
+
+
+
+# vim: filetype=sh


### PR DESCRIPTION
This command will convert from an image file stored on disk into an OCI Image. This functionality is similar to ramalama push except that it does not actually push the image to a registry.

## Summary by Sourcery

Add a new 'convert' command to the ramalama CLI for converting AI models from local storage to OCI Image format, update documentation, and introduce tests for this functionality.

New Features:
- Introduce a new 'convert' command in the ramalama CLI to convert AI models from local storage to OCI Image format without pushing to a registry.

Enhancements:
- Add validation in the OCI class to ensure only OCI model types are supported, raising an error for unsupported types.

Documentation:
- Update documentation to include the new 'ramalama convert' command, detailing its usage and options.

Tests:
- Add system tests for the 'ramalama convert' command to verify its functionality and error handling.