### PR TITLE
Stop checking if command is running in container

### DIFF
--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -11,7 +11,6 @@ from ramalama.huggingface import Huggingface
 from ramalama.common import (
     container_manager,
     default_image,
-    in_container,
     perror,
     run_cmd,
 )
@@ -34,9 +33,6 @@ def use_container():
     use_container = os.getenv("RAMALAMA_IN_CONTAINER")
     if use_container:
         return use_container.lower() == "true"
-
-    if in_container():
-        return False
 
     conman = container_manager()
     return conman is not None
@@ -787,9 +783,6 @@ def run_container(args):
         # --nocontainer implies --detach=false
         if hasattr(args, "detach"):
             args.detach = False
-        return False
-
-    if in_container():
         return False
 
     model = New(args.image, args)

--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -14,13 +14,6 @@ mnt_dir = "/mnt/models"
 mnt_file = f"{mnt_dir}/model.file"
 
 
-def in_container():
-    if os.path.exists("/run/.containerenv") or os.path.exists("/.dockerenv") or os.getenv("container"):
-        return True
-
-    return False
-
-
 def container_manager():
     engine = os.getenv("RAMALAMA_CONTAINER_ENGINE")
     if engine is not None:

--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -9,7 +9,6 @@ from ramalama.common import (
     exec_cmd,
     find_working_directory,
     genname,
-    in_container,
     run_cmd,
 )
 from ramalama.version import version
@@ -294,7 +293,7 @@ class Model:
                 return
             exec_cmd(exec_args, args.debug, debug=args.debug)
         except FileNotFoundError as e:
-            if in_container():
+            if args.container:
                 raise NotImplementedError(
                     file_not_found_in_container % {"cmd": exec_args[0], "error": str(e).strip("'")}
                 )
@@ -356,7 +355,7 @@ class Model:
                 return
             exec_cmd(exec_args, debug=args.debug)
         except FileNotFoundError as e:
-            if in_container():
+            if args.container:
                 raise NotImplementedError(
                     file_not_found_in_container % {"cmd": exec_args[0], "error": str(e).strip("'")}
                 )


### PR DESCRIPTION
Back when we were embedding the python code into the container image we would check if we were already injected and not run a container, the problem with this, is it is breaking when ramalama is run within a toolbx container or running via podman or docker. If the user of RamaLama wants to run without containers, then they should specify, and the tool should not try to handle this on it's own.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2329826

## Summary by Sourcery

Bug Fixes:
- Remove the check for whether the command is running in a container to prevent issues when running within toolbox, podman, or docker containers.