### PR TITLE
Simplify install

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,15 +73,7 @@ pipx install ramalama
 
 ## Install by script
 
-Install RamaLama by running this one-liner (on macOS run without sudo):
-
-Linux:
-
-```
-curl -fsSL https://raw.githubusercontent.com/containers/ramalama/s/install.sh | sudo bash
-```
-
-macOS:
+Install RamaLama by running this one-liner:
 
 ```
 curl -fsSL https://raw.githubusercontent.com/containers/ramalama/s/install.sh | bash


### PR DESCRIPTION
So we can just have one version of the installer from the user perspective

## Summary by Sourcery

Simplify the installation process by modifying the install script to conditionally use sudo based on user permissions and update the README to reflect the unified installation method for both Linux and macOS.

Enhancements:
- Simplify the installation script by allowing it to run with or without sudo, depending on user permissions.

Documentation:
- Update the installation instructions in the README to unify the process for Linux and macOS.