### PR TITLE
Fix handling of README.md in docs directory

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -11,7 +11,7 @@ endif
 # This must never include the 'hack' directory
 export PATH := $(shell $(GO) env GOPATH)/bin:$(PATH)
 
-docs:  $(patsubst %.md,%,$(wildcard *.md))
+docs:  $(patsubst %.md,%,$(wildcard *[15].md))
 
 %.1: %.1.md
 ### sed is used to filter http/s links as well as relative links


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Correct the pattern used in the Makefile to handle README.md in the docs directory.