### PR TITLE
ramalama rm should require at least one argument

### DIFF
--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -244,7 +244,7 @@ def parse_arguments(parser):
 def post_parse_setup(args):
     """Perform additional setup after parsing arguments."""
     mkdirs(args.store)
-    if hasattr(args, "MODEL"):
+    if hasattr(args, "MODEL") and args.subcommand != "rm":
         resolved_model = shortnames.resolve(args.MODEL)
         if resolved_model:
             args.UNRESOLVED_MODEL = args.MODEL
@@ -776,7 +776,7 @@ def rm_parser(subparsers):
     parser.add_argument("--container", default=False, action="store_false", help=argparse.SUPPRESS)
     parser.add_argument("-a", "--all", action="store_true", help="remove all local Models")
     parser.add_argument("--ignore", action="store_true", help="ignore errors when specified Model does not exist")
-    parser.add_argument("MODELS", nargs="*")
+    parser.add_argument("MODEL", nargs="*")
     parser.set_defaults(func=rm_cli)
 
 
@@ -807,9 +807,12 @@ def _rm_model(models, args):
 
 def rm_cli(args):
     if not args.all:
-        return _rm_model(args.MODELS, args)
+        if len(args.MODEL) == 0:
+            raise IndexError("one MODEL or --all must be specified")
 
-    if len(args.MODELS) > 0:
+        return _rm_model(args.MODEL, args)
+
+    if len(args.MODEL) > 0:
         raise IndexError("can not specify --all as well MODEL")
 
     args.noheading = True

--- a/test/system/015-help.bats
+++ b/test/system/015-help.bats
@@ -243,4 +243,10 @@ EOF
     is "$output" ".*port for AI Model server to listen on.*1776"  "Verify default port"
 }
 
+@test "ramalama verify one argument to rm" {
+
+    run_ramalama 22 rm
+    is "$output" "Error: one MODEL or --all must be specified"  "Verify at least one argument"
+}
+
 # vim: filetype=sh

--- a/test/system/040-serve.bats
+++ b/test/system/040-serve.bats
@@ -150,7 +150,7 @@ verify_begin=".*run --rm -i --label RAMALAMA --security-opt=label=disable --name
 
     rm tinyllama.container
     run_ramalama 2 serve --name=${name} --port 1234 --generate=bogus tiny
-    is "$output" ".*error: argument --generate: invalid choice: 'bogus' (choose from 'quadlet', 'kube', 'quadlet/kube')" "Should fail"
+    is "$output" ".*error: argument --generate: invalid choice: 'bogus' (choose from.*quadlet.*kube.*quadlet/kube.*)" "Should fail"
 }
 
 @test "ramalama serve --generate=quadlet and --generate=kube with OCI" {


### PR DESCRIPTION
Fixes: https://github.com/containers/ramalama/issues/515

## Summary by Sourcery

Require at least one argument for the 'ramalama rm' command to prevent accidental deletions and add a corresponding test to verify this behavior.

Bug Fixes:
- Ensure the 'ramalama rm' command requires at least one argument to prevent accidental deletions.

Tests:
- Add a test to verify that the 'ramalama rm' command requires at least one argument.