### PR TITLE
Fix handling of missing args for login/logout

### DIFF
--- a/docs/ramalama-login.1.md
+++ b/docs/ramalama-login.1.md
@@ -7,7 +7,7 @@ ramalama\-login - login to remote registry
 **ramalama login** [*options*] [*registry*]
 
 ## DESCRIPTION
-login to remote registry
+login to remote model registry
 
 ## OPTIONS
 Options are specific to registry types.

--- a/docs/ramalama-logout.1.md
+++ b/docs/ramalama-logout.1.md
@@ -4,7 +4,7 @@
 ramalama\-logout - logout from remote registry
 
 ## SYNOPSIS
-**ramalama logout** [*options*]
+**ramalama logout** [*options*] [*registry*]
 
 ## DESCRIPTION
 Logout to remote model registry

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -275,10 +275,12 @@ def login_parser(subparsers):
 
 
 def normalize_registry(registry):
-    if registry in ["", "ollama", "hf" "huggingface"]:
+    if not registry or registry == "" or registry.startswith("oci://"):
+        return "oci://"
+
+    if registry in ["ollama", "hf" "huggingface"]:
         return registry
-    if registry.startswith("oci://"):
-        return registry
+
     return "oci://" + registry
 
 
@@ -294,13 +296,13 @@ def logout_parser(subparsers):
     # Do not run in a container
     parser.add_argument("--container", default=False, action="store_false", help=argparse.SUPPRESS)
     parser.add_argument("--token", help="token for registry")
-    parser.add_argument("TRANSPORT", nargs="?", type=str, default=config.get("transport"))  # positional argument
+    parser.add_argument("REGISTRY", nargs="?", type=str, help="OCI Registry where AI models are stored")
     parser.set_defaults(func=logout_cli)
 
 
 def logout_cli(args):
-    transport = args.TRANSPORT
-    model = New(str(transport), args)
+    registry = normalize_registry(args.REGISTRY)
+    model = New(registry, args)
     return model.logout(args)
 
 

--- a/ramalama/oci.py
+++ b/ramalama/oci.py
@@ -139,7 +139,8 @@ pip install omlmd
             conman_args.extend([f"--password={args.password}"])
         if args.passwordstdin:
             conman_args.append("--password-stdin")
-        conman_args.append(args.REGISTRY.removeprefix(prefix))
+        if args.REGISTRY:
+            conman_args.append(args.REGISTRY.removeprefix(prefix))
         return exec_cmd(conman_args, debug=args.debug)
 
     def logout(self, args):


### PR DESCRIPTION
## Summary by Sourcery

Fix handling of missing arguments for login and logout commands, improve registry URL normalization, and update related documentation.

Bug Fixes:
- Fix handling of missing arguments for login and logout commands by ensuring default values are set appropriately.

Enhancements:
- Improve the normalization of registry URLs by setting a default 'oci://' prefix when necessary.

Documentation:
- Update documentation to reflect changes in login and logout command usage, including the addition of registry as an optional argument.