### PR TITLE
Change pip to pipx in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ $ cat /usr/share/ramalama/shortnames.conf
 RamaLama is available via PyPi [https://pypi.org/project/ramalama](https://pypi.org/project/ramalama)
 
 ```
-pipx install ramalama
+pip install ramalama
 ```
 
 ## Install by script


### PR DESCRIPTION
It's most common to recommend pip even though it doesn't work on various platforms. Let the users with the tricky platforms figure that out.

## Summary by Sourcery

Documentation:
- Updated installation instructions to use pip instead of pipx.