### PR TITLE
Remove `tqdm` dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ jobs:
            sudo apt-get update
            sudo apt-get install podman bats bash codespell python3-argcomplete pipx
            make install-requirements
-           pip install tqdm --break-system-packages
 
       - name: Upgrade to podman 5
         run: |
@@ -57,7 +56,6 @@ jobs:
 
       - name: bats-nocontainer
         run: |
-           pip install tqdm --break-system-packages
            make bats-nocontainer
 
   docker:
@@ -103,7 +101,6 @@ jobs:
       - name: bats-docker
         run: |
            docker info
-           pip install tqdm --break-system-packages
            make bats-docker
 
   macos:

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ help:
 
 .PHONY: install-requirements
 install-requirements:
-	pipx install tqdm black flake8 argcomplete wheel omlmd huggingface_hub codespell
+	pipx install black flake8 argcomplete wheel omlmd huggingface_hub codespell
 
 .PHONY: install-completions
 install-completions: completions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,6 @@ name = "ramalama"
 version = "0.3.0"
 dependencies = [
   "argcomplete",
-  "tqdm",
 ]
 requires-python = ">= 3.8"
 maintainers = [

--- a/ramalama/huggingface.py
+++ b/ramalama/huggingface.py
@@ -5,10 +5,10 @@ from ramalama.common import available, run_cmd, exec_cmd, download_file, verify_
 from ramalama.model import Model
 
 missing_huggingface = """
-Optional: Huggingface models require the huggingface-cli and tqdm modules.
+Optional: Huggingface models require the huggingface-cli module.
 These modules can be installed via PyPi tools like pip, pip3, pipx, or via
 distribution package managers like dnf or apt. Example:
-pip install huggingface_hub tqdm
+pip install huggingface_hub
 """
 
 

--- a/rpm/python-ramalama.spec
+++ b/rpm/python-ramalama.spec
@@ -35,9 +35,6 @@ BuildRequires:    python%{python3_pkgversion}-devel
 BuildRequires:    python%{python3_pkgversion}-pip
 BuildRequires:    python%{python3_pkgversion}-setuptools
 BuildRequires:    python%{python3_pkgversion}-wheel
-%if 0%{?fedora} >= 40
-BuildRequires:    python%{python3_pkgversion}-tqdm
-%endif
 
 %description
 %summary
@@ -52,11 +49,9 @@ will run the AI Models within a container based on the OCI image.
 %package -n python%{python3_pkgversion}-%{pypi_name}
 Requires: podman
 %if 0%{?fedora} >= 40
-Requires: python%{python3_pkgversion}-tqdm
 # Needed as seen by BZ: 2327515
 Requires: python%{python3_pkgversion}-omlmd
 %else
-Recommends: python%{python3_pkgversion}-tqdm
 Recommends: python%{python3_pkgversion}-omlmd
 %endif
 Summary: %{summary}


### PR DESCRIPTION
This PR removes the `tqdm` dependency, and updates all the mentions of the same.

## Summary by Sourcery

Remove the `tqdm` dependency.

Enhancements:
- Update installation instructions to remove `tqdm`.

Build:
- Remove `tqdm` from the RPM build dependencies.

CI:
- Remove `tqdm` installation step from CI workflows.

Tests:
- Remove `tqdm` from installation requirements.