### PR TITLE
Resolves - Debug option shows traceback when no subcommand is passed

### DIFF
--- a/bin/ramalama
+++ b/bin/ramalama
@@ -75,8 +75,6 @@ def main(args):
     except AttributeError:
         parser.print_usage()
         print("ramalama: requires a subcommand")
-        if args.debug:
-            raise
     except IndexError as e:
         eprint(e, errno.EINVAL)
     except KeyError as e:


### PR DESCRIPTION
Resolves #514

## Summary by Sourcery

Bug Fixes:
- Prevent traceback from being shown when no subcommand is passed to the CLI.