### PR TITLE
Skip codespell of `venv` by adding `--skip` in the command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ lint:
 
 .PHONY: codespell
 codespell:
-	codespell --dictionary=- -w
+	codespell --dictionary=- -w --skip="*/venv*"
 
 .PHONY: test-run
 test-run:


### PR DESCRIPTION
Running `make validate`, changes the files in `venv` virtual environment, if the virtual environment is present. 
Hence, adding `--skip` in codespell command similar to `--exclude` in black and flake8 commands in `.PHONY: lint` as follows,
https://github.com/containers/ramalama/blob/542ef332237b76582b196b124e6e0cacf9858386/Makefile#L89-L92

## Summary by Sourcery

Build:
- Ignore "venv" directory during the codespell check.