### PR TITLE
Remove huggingface warning

### DIFF
--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -167,6 +167,10 @@ def download_file(url, dest_path, headers=None, show_progress=True):
 
     headers = headers or {}
 
+    # if we are not a tty, don't show progress, can pollute CI output and such
+    if not sys.stdout.isatty():
+        show_progress = False
+
     try:
         http_client.init(url=url, headers=headers, output_file=dest_path, progress=show_progress)
     except urllib.error.HTTPError as e:

--- a/ramalama/huggingface.py
+++ b/ramalama/huggingface.py
@@ -17,7 +17,6 @@ def is_huggingface_cli_available():
     if available("huggingface-cli"):
         return True
     else:
-        print("huggingface-cli not found. Some features may be limited.\n" + missing_huggingface)
         return False
 
 

--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -129,7 +129,7 @@ class Model:
             name,
         ]
 
-        if sys.stdout.isatty() and sys.stdin.isatty():
+        if sys.stdout.isatty() or sys.stdin.isatty():
             conman_args += ["-t"]
 
         if hasattr(args, "detach") and args.detach is True:


### PR DESCRIPTION
It prints on all usages of huggingface, it's ugly.

We don't really need huggingface-cli for most usages of hf, this suggests we do.

## Summary by Sourcery

Remove the warning about the huggingface CLI not being available.

Bug Fixes:
- Removed the warning message displayed when the huggingface CLI is not available.

Enhancements:
- Removed the check for huggingface CLI availability.