### PR TITLE
When using podman run add --pull=newer to update container image

### DIFF
--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -135,6 +135,9 @@ class Model:
             name,
         ]
 
+        if os.path.basename(args.engine) == "podman":
+            conman_args += ["--pull=newer"]
+
         if sys.stdout.isatty() or sys.stdin.isatty():
             conman_args += ["-t"]
 


### PR DESCRIPTION
The default for podman is to use --pull=missing, this means that if the OCI Image was previously pulled, Podman will use it, even if there is a newer image available.  Switching to "newer" means that podman will compare the image on the OCI registry to the local one, and pull it if it was updated.

Docker does not support this feature.

## Summary by Sourcery

Enhancements:
- Use the `--pull=newer` option with `podman run` to update the container image if a newer version is available on the registry.