### PR TITLE
Build to build_rm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ ifeq ($(OS),Linux)
 endif
 
 .PHONY: build_rm
-build:
+build_rm:
 ifeq ($(OS),Linux)
 	./container_build.sh -r build $(IMAGE)
 endif


### PR DESCRIPTION
This should be build_rm

## Summary by Sourcery

Build:
- Rename the make target `build` to `build_rm`.