### PR TITLE
whisper.cpp now installs properly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ help:
 	@echo "Build Container"
 	@echo
 	@echo "  - make build"
+	@echo "  - make build IMAGE=ramalama"
 	@echo
 	@echo "Build docs"
 	@echo

--- a/container-images/scripts/build_llama_and_whisper.sh
+++ b/container-images/scripts/build_llama_and_whisper.sh
@@ -81,9 +81,6 @@ clone_and_build_whisper_cpp() {
   git submodule update --init --recursive
   git reset --hard "$whisper_cpp_sha"
   cmake_steps whisper_flags
-  mkdir -p "$install_prefix/bin"
-  mv build/bin/main "$install_prefix/bin/whisper-main"
-  mv build/bin/server "$install_prefix/bin/whisper-server"
   cd ..
 }
 

--- a/container_build.sh
+++ b/container_build.sh
@@ -19,7 +19,7 @@ select_container_manager() {
 }
 
 add_build_platform() {
-  conman_build+=("build" "--platform" "$platform")
+  conman_build+=("build" "--no-cache" "--platform" "$platform")
   conman_build+=("-t" "quay.io/ramalama/$image_name")
   conman_build+=("-f" "$image_name/Containerfile" ".")
 }
@@ -45,6 +45,7 @@ build() {
   case "${2:-}" in
     build)
       add_build_platform
+      echo "${conman_build[@]}"
       "${conman_build[@]}"
       "${conman_show_size[@]}"
       rm_container_image


### PR DESCRIPTION
These changes are required for building images.

## Summary by Sourcery

Update container build to use --no-cache and remove manual whisper binary move. Update help text to include IMAGE argument.

Build:
- Use `--no-cache` when building the container image.
- Remove manual move of whisper binaries after build step.
- Add `IMAGE` argument to build help text.