### PR TITLE
Re-add mkdir -p

### DIFF
--- a/container-images/scripts/build_llama_and_whisper.sh
+++ b/container-images/scripts/build_llama_and_whisper.sh
@@ -81,6 +81,7 @@ clone_and_build_whisper_cpp() {
   git submodule update --init --recursive
   git reset --hard "$whisper_cpp_sha"
   cmake_steps whisper_flags
+  mkdir -p "$install_prefix/bin"
   cd ..
 }
 


### PR DESCRIPTION
It's failing the build

## Summary by Sourcery

Build:
- Ensure the installation directory exists before copying the built binary.