### PR TITLE
This might temporarily fix an issue we are having

### DIFF
--- a/container-images/scripts/build_llama_and_whisper.sh
+++ b/container-images/scripts/build_llama_and_whisper.sh
@@ -74,7 +74,6 @@ clone_and_build_whisper_cpp() {
   local install_prefix="$1"
   local whisper_flags=("${!2}")
   local whisper_cpp_sha="8a9ad7844d6e2a10cddf4b92de4089d7ac2b14a9"
-  whisper_flags+=("-DBUILD_SHARED_LIBS=NO")
 
   git clone https://github.com/ggerganov/whisper.cpp
   cd whisper.cpp
@@ -106,7 +105,7 @@ main() {
   local common_flags
   configure_common_flags "$containerfile" common_flags
 
-  common_flags+=("-DGGML_CCACHE=0" "-DCMAKE_INSTALL_PREFIX=$install_prefix")
+  common_flags+=("-DGGML_CCACHE=0" "-DCMAKE_INSTALL_PREFIX=$install_prefix" "-DBUILD_SHARED_LIBS=NO")
   dnf_install
   clone_and_build_whisper_cpp "$install_prefix" common_flags[@]
   case "$containerfile" in


### PR DESCRIPTION
But long-term we should use shared libs for llama.cpp, it duplicates a lot of binary data when we don't use them.

## Summary by Sourcery

Build:
- Disable shared libraries for llama.cpp.