### PR TITLE
Add CPU inferencing container build steps to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
            # Install specific podman version
            sudo apt-get upgrade
 
+      - name: Build a container for CPU inferencing
+        run: ./container_build.sh build ramalama
+
       - name: run bats
         run: |
            make validate
@@ -97,6 +100,9 @@ jobs:
            cat /etc/docker/daemon.json
            sudo systemctl restart docker.service
            df -h
+
+      - name: Build a container for CPU inferencing
+        run: ./container_build.sh build ramalama
 
       - name: bats-docker
         run: |

--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -47,6 +47,9 @@ jobs:
         run: |
            df -h
 
+      - name: Build a container for CPU inferencing
+        run: ./container_build.sh build ramalama
+
       - name: Run a one-line script
         run: make test
 
@@ -126,7 +129,7 @@ jobs:
             image: quay.io/ramalama/ramalama
             tags: latest
             containerfiles: |
-              container-images/cpuonly/Containerfile
+              container-images/ramalama/Containerfile
             platforms: linux/amd64, linux/arm64
 
         - name: push images to registry

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Docker info
         run: docker info
 
+      - name: Build a container for CPU inferencing
+        run: ./container_build.sh build ramalama
+
       - name: Run a one-line script
         run: make test
 
@@ -93,7 +96,7 @@ jobs:
             image: quay.io/ramalama/ramalama
             tags: nightly
             containerfiles: |
-              container-images/cpuonly/Containerfile
+              container-images/ramalama/Containerfile
             platforms: linux/amd64, linux/arm64
 
         - name: push images to registry


### PR DESCRIPTION
Simplified `cmake_steps` function by removing unnecessary `mv` command and adjusted `cmake_flags` handling. Improved `configure_common_flags` function to directly manipulate `common_flags` array. Refactored `clone_and_build_whisper_cpp` and `clone_and_build_llama_cpp` functions to utilize `common_flags` directly. Added `ldconfig` call in the `main` function to ensure library paths are updated.

## Summary by Sourcery

Add CPU inferencing container build steps to CI workflows and refactor build scripts.

Enhancements:
- Simplify and refactor build scripts to use common flags and improve library handling.

CI:
- Add CPU inferencing container build step to CI workflows.