### PR TITLE
This should save some space

### DIFF
--- a/container-images/rocm/Containerfile
+++ b/container-images/rocm/Containerfile
@@ -1,4 +1,4 @@
-FROM quay.io/ramalama/ramalama:latest
+FROM registry.access.redhat.com/ubi9/ubi:9.5
 
 COPY rocm/amdgpu.repo /etc/yum.repos.d/
 COPY rocm/rocm.repo /etc/yum.repos.d/

--- a/container-images/scripts/build_llama_and_whisper.sh
+++ b/container-images/scripts/build_llama_and_whisper.sh
@@ -6,7 +6,10 @@ dnf_install() {
                   "procps-ng" "git" "dnf-plugins-core")
   local vulkan_rpms=("vulkan-headers" "vulkan-loader-devel" "vulkan-tools" \
                      "spirv-tools" "glslc" "glslang")
-  if [ "$containerfile" = "ramalama" ]; then
+
+  # All the UBI-based ones
+  if [ "$containerfile" = "ramalama" ] || [ "$containerfile" = "rocm" ] || \
+    [ "$containerfile" = "vulkan" ]; then
     local url="https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm"
     dnf install -y "$url"
     crb enable # this is in epel-release, can only install epel-release via url
@@ -21,7 +24,9 @@ dnf_install() {
       /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-Official "$url"
     rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-Official
     dnf install -y mesa-vulkan-drivers "${vulkan_rpms[@]}"
-  elif [ "$containerfile" = "asahi" ]; then
+  fi
+
+  if [ "$containerfile" = "asahi" ]; then
     dnf copr enable -y @asahi/fedora-remix-branding
     dnf install -y asahi-repos
     dnf install -y mesa-vulkan-drivers "${vulkan_rpms[@]}" "${rpm_list[@]}"
@@ -32,9 +37,6 @@ dnf_install() {
     # shellcheck disable=SC1091
     . /opt/rh/gcc-toolset-12/enable
   fi
-
-  # For Vulkan image, we don't need to install anything extra but rebuild with
-  # -DGGML_VULKAN
 }
 
 cmake_steps() {

--- a/container-images/vulkan/Containerfile
+++ b/container-images/vulkan/Containerfile
@@ -1,4 +1,4 @@
-FROM quay.io/ramalama/ramalama:latest
+FROM registry.access.redhat.com/ubi9/ubi:9.5
 
 COPY ../scripts /scripts
 RUN chmod +x /scripts/*.sh && \

--- a/container_build.sh
+++ b/container_build.sh
@@ -19,7 +19,14 @@ select_container_manager() {
 }
 
 add_build_platform() {
-  conman_build+=("build" "--no-cache" "--platform" "$platform")
+  conman_build+=("build")
+
+  # This build saves space
+  if ! $rm_after_build; then
+    conman_build+=("--no-cache")
+  fi
+
+  conman_build+=("--platform" "$platform")
   conman_build+=("-t" "quay.io/ramalama/$image_name")
   conman_build+=("-f" "$image_name/Containerfile" ".")
 }
@@ -67,6 +74,7 @@ determine_platform() {
   if [ "$(uname -m)" = "aarch64" ] || { [ "$(uname -s)" = "Darwin" ] && [ "$(uname -m)" = "arm64" ]; }; then
     platform="linux/arm64"
   fi
+
   echo "$platform"
 }
 
@@ -135,9 +143,7 @@ main() {
   local command=""
   local option=""
   local rm_after_build="false"
-
   parse_arguments "$@"
-
   if [ -z "$command" ]; then
     echo "Error: command is required (build or push)"
     print_usage
@@ -145,7 +151,6 @@ main() {
   fi
 
   target="${target:-all}"
-
   if [ "$target" = "all" ]; then
     process_all_targets "$command" "$option"
   else


### PR DESCRIPTION
All builds inherit just from the OS image. Helps save space as the derived images just overwrite llama.cpp and whisper.cpp which is wasteful.

## Summary by Sourcery

Build:
- Update ROCm and Vulkan container images to inherit from the base OS image.