### PR TITLE
Only use the X/Y parts of the version when pulling images

### DIFF
--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -118,7 +118,8 @@ class Model:
 
             return "quay.io/modh/vllm:rhoai-2.17-cuda"
 
-        vers = version()
+        split = version().split(".")
+        vers=".".join(split[:2])
         conman = container_manager()
         images = {
             "HIP_VISIBLE_DEVICES": "quay.io/ramalama/rocm",

--- a/ramalama/version.py
+++ b/ramalama/version.py
@@ -7,9 +7,9 @@ def version():
     try:
         return importlib.metadata.version("ramalama")
     except importlib.metadata.PackageNotFoundError:
-        return 0
+        return "0"
 
-    return 0
+    return "0"
 
 
 def print_version(args):


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Pull VLLM images using only the major and minor version numbers, instead of the full version string.