### PR TITLE
Update llama.cpp to contain llama-run fix

### DIFF
--- a/container-images/scripts/build_llama_and_whisper.sh
+++ b/container-images/scripts/build_llama_and_whisper.sh
@@ -84,7 +84,7 @@ clone_and_build_whisper_cpp() {
 }
 
 clone_and_build_llama_cpp() {
-  local llama_cpp_sha="a4dd490069a66ae56b42127048f06757fc4de4f7"
+  local llama_cpp_sha="f8feb4b01af374ad2fce302fd5790529c615710b"
 
   git clone https://github.com/ggerganov/llama.cpp
   cd llama.cpp


### PR DESCRIPTION
This version of llama.cpp has fixes which help exit llama-run, before Ctrl-C and CTRL-D were failing to exit llama-run.

## Summary by Sourcery

Update llama.cpp to a version that fixes issues with exiting llama-run using Ctrl-C and Ctrl-D.

Bug Fixes:
- Fix issues where Ctrl-C and Ctrl-D would not exit llama-run.

Build:
- Update the llama.cpp SHA to f8feb4b01af374ad2fce302fd5790529c615710b.