### PR TITLE
If podman machine is running use containers

### DIFF
--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -27,16 +27,9 @@ def container_manager():
             return "podman"
 
         podman_machine_list = ["podman", "machine", "list"]
-        conman_args = ["podman", "machine", "list", "--format", "{{ .VMType }}"]
         try:
             output = run_cmd(podman_machine_list).stdout.decode("utf-8").strip()
             if "running" not in output:
-                return None
-
-            output = run_cmd(conman_args).stdout.decode("utf-8").strip()
-            if output == "krunkit" or output == "libkrun":
-                return "podman"
-            else:
                 return None
 
         except subprocess.CalledProcessError:


### PR DESCRIPTION
Don't check for krunkit hypervisor specifically, it will still work without this, just unaccelerated.

## Summary by Sourcery

Enhancements:
- Remove the check for krunkit hypervisor.