### PR TITLE
We are passing the same value in twice, causes exception

### DIFF
--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -304,7 +304,7 @@ class Model:
             if args.dryrun:
                 dry_run(exec_args)
                 return
-            exec_cmd(exec_args, args.debug, debug=args.debug)
+            exec_cmd(exec_args, args.debug)
         except FileNotFoundError as e:
             if args.container:
                 raise NotImplementedError(


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix an exception caused by passing the `debug` argument twice to the `exec_cmd` function.