### PR TITLE
Remove cruft added to redirect llama-cli 2>/dev/null

### DIFF
--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -1,7 +1,6 @@
 import os
 import sys
 import atexit
-import shlex
 
 from ramalama.common import (
     container_manager,
@@ -119,7 +118,7 @@ class Model:
             return "quay.io/modh/vllm:rhoai-2.17-cuda"
 
         split = version().split(".")
-        vers=".".join(split[:2])
+        vers = ".".join(split[:2])
         conman = container_manager()
         images = {
             "HIP_VISIBLE_DEVICES": "quay.io/ramalama/rocm",
@@ -245,9 +244,7 @@ class Model:
             conman_args += [f"--mount=type=image,src={self.model},destination={mnt_dir},rw=false,subpath=/models"]
 
         # Make sure Image precedes cmd_args.
-        conman_args += [self._image(args)]
-        cargs = shlex.join(cmd_args)
-        conman_args += ["/bin/sh", "-c", cargs]
+        conman_args += [self._image(args)] + cmd_args
 
         if args.dryrun:
             dry_run(conman_args)
@@ -295,8 +292,11 @@ class Model:
 
         exec_args += [
             exec_model_path,
-            prompt,
         ]
+        if len(prompt) > 0:
+            exec_args += [
+                prompt,
+            ]
 
         try:
             if self.exec_model_in_container(model_path, exec_args, args):

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -31,7 +31,7 @@ load helpers
 	is "${lines[0]}"  "Error: --nocontainer and --name options conflict. --name requires a container." "conflict between nocontainer and --name line"
 
 	RAMALAMA_IMAGE=${image} run_ramalama --dryrun run ${model}
-	is "$output" ".*${image}:latest /bin/sh -c" "verify image name"
+	is "$output" ".*${image}:latest llama-run" "verify image name"
     else
 	run_ramalama --dryrun run -c 4096 ${model}
 	is "$output" 'llama-run -c 4096 --temp 0.8 /path/to/model.*' "dryrun correct"


### PR DESCRIPTION
Since we are using llama-run the need for this goes away.

Also do not pass empty prompt to llama-run command

## Summary by Sourcery

Remove unnecessary redirection and handle empty prompts when executing the model in a container.

New Features:
- Handle empty prompts correctly when running the model.

Enhancements:
- Pass command arguments directly to the container execution command.