### PR TITLE
run_cmd to exec_cmd

### DIFF
--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -213,7 +213,7 @@ class Model:
 
         atexit.register(cleanup)
 
-        run_cmd(conman_args, stdout=None, debug=args.debug)
+        exec_cmd(conman_args, debug=args.debug)
         return True
 
     def gpu_args(self):
@@ -250,7 +250,7 @@ class Model:
             dry_run(conman_args)
             return True
 
-        run_cmd(conman_args, debug=args.debug)
+        exec_cmd(conman_args, debug=args.debug)
         return True
 
     def run(self, args):


### PR DESCRIPTION
podman run with llama-run is only working for me when we use exec_cmd, which should be ok as it's the last process we execute.

## Summary by Sourcery

Enhancements:
- Replace run_cmd with exec_cmd for executing container commands.