### PR TITLE
Bump to v0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ curl -fsSL https://raw.githubusercontent.com/containers/ramalama/s/install.sh | 
 
 ### Running Models
 
-You can `run` a chatbot on a model using the `run` command. By default, it pulls from the ollama registry.
+You can `run` a chatbot on a model using the `run` command. By default, it pulls from the Ollama registry.
 
 Note: RamaLama will inspect your machine for native GPU support and then will
 use a container engine like Podman to pull an OCI container image with the
@@ -158,7 +158,7 @@ ollama://moondream:latest                                           6 days ago  
 ```
 ### Pulling Models
 
-You can `pull` a model using the `pull` command. By default, it pulls from the ollama registry.
+You can `pull` a model using the `pull` command. By default, it pulls from the Ollama registry.
 
 ```
 $ ramalama pull granite-code
@@ -167,7 +167,7 @@ $ ramalama pull granite-code
 
 ### Serving Models
 
-You can `serve` multiple models using the `serve` command. By default, it pulls from the ollama registry.
+You can `serve` multiple models using the `serve` command. By default, it pulls from the Ollama registry.
 
 ```
 $ ramalama serve --name mylama llama3

--- a/docs/ramalama.1.md
+++ b/docs/ramalama.1.md
@@ -19,7 +19,7 @@ Running in containers eliminates the need for users to configure the host system
 
 RamaLama pulls AI Models from model registries. Starting a chatbot or a rest API service from a simple single command. Models are treated similarly to how Podman and Docker treat container images.
 
-When both Podman and Docker are installed, RamaLama defaults to Podman, The `RAMALAMA_CONTAINER_ENGINE=docker` environment variable can override this behaviour. When neither are installed RamaLama attempts to run the model with software on the local system.
+When both Podman and Docker are installed, RamaLama defaults to Podman, The `RAMALAMA_CONTAINER_ENGINE=docker` environment variable can override this behavior. When neither are installed RamaLama attempts to run the model with software on the local system.
 
 Note:
 

--- a/docs/ramalama.conf.5.md
+++ b/docs/ramalama.conf.5.md
@@ -105,7 +105,7 @@ llama.cpp explains this as:
 
     The lower the number is, the more deterministic the response.
 
-    The higher the number is the more creative the response is, but moee likely to hallucinate when set too high.
+    The higher the number is the more creative the response is, but more likely to hallucinate when set too high.
 
         Usage: Lower numbers are good for virtual assistants where we need deterministic responses. Higher numbers are good for roleplay or creative tasks like editing stories
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ramalama"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
   "argcomplete",
 ]

--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -99,16 +99,6 @@ def find_working_directory():
     return os.path.dirname(__file__)
 
 
-def run_curl_cmd(args, filename):
-    if not verify_checksum(filename):
-        try:
-            run_cmd(args, debug=args.debug)
-        except subprocess.CalledProcessError as e:
-            if e.returncode == 22:
-                perror(filename + " not found")
-            raise e
-
-
 def verify_checksum(filename):
     """
     Verifies if the SHA-256 checksum of a file matches the checksum provided in

--- a/rpm/python-ramalama.spec
+++ b/rpm/python-ramalama.spec
@@ -1,7 +1,7 @@
 %global pypi_name ramalama
 %global forgeurl  https://github.com/containers/%{pypi_name}
 # see ramalama/version.py
-%global version0  0.4.0
+%global version0  0.5.0
 %forgemeta
 
 %global summary   RamaLama is a command line tool for working with AI LLM models

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ class build_py(build_py_orig):
 
 setuptools.setup(
     name="ramalama",
-    version="0.4.0",
+    version="0.5.0",
     packages=find_packages(),
     cmdclass={"build_py": build_py},
     scripts=["bin/ramalama"],


### PR DESCRIPTION
Also remove unused function run_curl_cmd.

## Summary by Sourcery

Bump version to 0.5.0 and remove the unused function `run_curl_cmd`.

Enhancements:
- Remove unused `run_curl_cmd` function.

Chores:
- Bump version to 0.5.0.