### PR TITLE
When it debug mode show the exception for subcommand missing

### DIFF
--- a/bin/ramalama
+++ b/bin/ramalama
@@ -72,9 +72,11 @@ def main(args):
         args.func(args)
     except ramalama.HelpException:
         parser.print_help()
-    except AttributeError:
+    except AttributeError as e:
         parser.print_usage()
         print("ramalama: requires a subcommand")
+        if args.debug:
+            raise e
     except IndexError as e:
         eprint(e, errno.EINVAL)
     except KeyError as e:


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Display the exception when a subcommand is missing in debug mode.