### PR TITLE
On ARM by default turn on GPU acceleration

### DIFF
--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -34,7 +34,7 @@ load helpers
 	is "$output" ".*${image}:latest llama-run" "verify image name"
     else
 	run_ramalama --dryrun run -c 4096 ${model}
-	is "$output" 'llama-run -c 4096 --temp 0.8 /path/to/model.*' "dryrun correct"
+	is "$output" 'llama-run -c 4096 --temp 0.8.*/path/to/model.*' "dryrun correct"
 	is "$output" ".*-c 4096" "verify model name"
 
 	run_ramalama 1 run --ctx-size=4096 --name foobar tiny


### PR DESCRIPTION
On x86 we don't want to do this without a GPU because x86 integrated graphics have very limited access to VRAM and it's normally not worth it. But ARM SoC's share memory between CPU and GPU, meaning it's worth it generally. And we care mostly about Apple Silicon where we want this on in podman machine.

## Summary by Sourcery

Enhancements:
- Increase the number of generations for GPU offload from 99 to 999 on systems where it is enabled.