### PR TITLE
Add flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -10,6 +10,8 @@
       supportedSystems = [
         "x86_64-linux"
         "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
       ];
 
       forAllSystems = nixpkgs.lib.genAttrs supportedSystems;

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,55 @@
+{
+  inputs = {
+    nixpkgs = {
+      url = "github:NixOS/nixpkgs/nixos-unstable";
+    };
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      supportedSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+
+      mkRamalama = pkgs: with pkgs;
+        callPackage
+          (
+            { ramalamaOverrides ? { }
+            , llamaCppOverrides ? { }
+            }:
+              python3Packages.buildPythonPackage ({
+                name = "ramalama";
+                src = ./.;
+                dependencies = [ (llama-cpp.override llamaCppOverrides) ];
+              } // ramalamaOverrides)
+          )
+          { llamaCppOverrides.vulkanSupport = true; }
+          ;
+
+      ramalama = forAllSystems (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+          package = mkRamalama pkgs;
+        in {
+          inherit package;
+          app = {
+            type = "app";
+            program = toString (pkgs.writeShellScript "ramalama" "${package}/bin/ramalama \"$@\"");
+          };
+        }
+      );
+    in {
+      packages = forAllSystems (system: {
+        ramalama = ramalama.${system}.package;
+        default = ramalama.${system}.package;
+      });
+
+      apps = forAllSystems (system :{
+        ramalama = ramalama.${system}.app;
+        default = ramalama.${system}.app;
+      });
+    };
+}


### PR DESCRIPTION
I added a `flake.nix` to make it easier to install and/or run on Nix-enabled systems.

To install, add the `packages.ramalama` to the configuration's package list.

I have enabled Vulkan support for `llama-cpp`, since it's not default. ROCm and Cuda support can be enabled for llama.cpp by setting `llamaCppOverrides.rocmSupport` and `llamaCppOverrides.cudaSupport` respectively.

It can also be run directly by `nix run github:containers/ramalama`.

Extra arguments can be passed after a `--`: `nix run github:containers/ramalama -- --nocontainer --gpu run llama3.1:8b`

## Summary by Sourcery

Build:
- Introduce a flake.nix file to define the Nix build process.