### PR TITLE
Simplify installation spec file

### DIFF
--- a/rpm/python-ramalama.spec
+++ b/rpm/python-ramalama.spec
@@ -47,13 +47,8 @@ configure the system for AI themselves. After the initialization, RamaLama
 will run the AI Models within a container based on the OCI image.
 
 %package -n python%{python3_pkgversion}-%{pypi_name}
-Requires: podman
-%if 0%{?fedora} >= 40
-# Needed as seen by BZ: 2327515
-Requires: python%{python3_pkgversion}-omlmd
-%else
+Recommends: podman
 Recommends: python%{python3_pkgversion}-omlmd
-%endif
 Summary: %{summary}
 Provides: %{pypi_name} = %{version}-%{release}
 
@@ -68,10 +63,8 @@ configure the system for AI themselves. After the initialization, RamaLama
 will run the AI Models within a container based on the OCI image.
 
 
-%if 0%{?fedora} >= 40
 %generate_buildrequires
 %pyproject_buildrequires
-%endif
 
 %prep
 %forgeautosetup -p1


### PR DESCRIPTION
Fedora 39 is no longer supported, so remove checks in spec file.

More Podman and omlmd to Recommends,  You can run RamaLama with no container engine or with Docker.

## Summary by Sourcery

Remove Fedora 39 checks and move `podman` and `omlmd` to Recommends in the spec file.

Build:
- Move `podman` and `omlmd` to Recommends in the spec file.
- Remove Fedora 39 checks in the spec file.