### PR TITLE
update mountPath in kube yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ venv/
 *.container
 *.image
 *.volume
+**ramalama_**

--- a/ramalama/kube.py
+++ b/ramalama/kube.py
@@ -2,7 +2,7 @@ import os
 
 
 from ramalama.version import version
-from ramalama.common import genname, MNT_DIR, get_env_vars
+from ramalama.common import genname, MNT_FILE, get_env_vars
 
 
 class Kube:
@@ -25,8 +25,7 @@ class Kube:
     def gen_volumes(self):
         mounts = f"""\
         volumeMounts:
-        - mountPath: {MNT_DIR}
-          subPath: /models
+        - mountPath: {MNT_FILE}
           name: model"""
 
         volumes = """

--- a/ramalama/quadlet.py
+++ b/ramalama/quadlet.py
@@ -1,6 +1,6 @@
 import os
 
-from ramalama.common import default_image, MNT_DIR, MNT_FILE, get_env_vars
+from ramalama.common import default_image, MNT_FILE, get_env_vars
 
 
 class Quadlet:
@@ -92,7 +92,7 @@ Driver=image
 Image={self.name}.image
 """
             )
-            return f"Mount=type=image,source={self.ai_image},destination={MNT_DIR},subpath=/models,readwrite=false"
+            return f"Mount=type=image,source={self.ai_image},destination={MNT_FILE},readwrite=false"
 
     def gen_image(self):
         outfile = self.name + ".image"


### PR DESCRIPTION
I've found this change is necessary to make a working kube.yaml for `podman kube play ramalama_*.yaml` 

without the fix:
```
$ podman kube play ramalama_MicXluJjP3.yaml 
Pod:
starting container d5f9654b06b3a6fb209a3a9c38986e9c78313417c57a55435050b08d87ca0fab: not a directory
```

to test, this will serve granite-code at localhost:8888:
```
ramalama serve --generate kube granite-code
podman kube play ramalama_*.yaml --publish 8888:8080
```

## Summary by Sourcery

Bug Fixes:
- Fix issue where `podman kube play` would fail with a "not a directory" error when the mount path was set to a directory that didn't exist.