### PR TITLE
Add model transport info to ramalama run/serve manpage

### DIFF
--- a/docs/ramalama-run.1.md
+++ b/docs/ramalama-run.1.md
@@ -6,6 +6,23 @@ ramalama\-run - run specified AI Model as a chatbot
 ## SYNOPSIS
 **ramalama run** [*options*] *model* [arg ...]
 
+## MODEL TRANSPORTS
+
+| Transports    | Prefix | Web Site                                            |
+| ------------- | ------ | --------------------------------------------------- |
+| URL based    | https://, http://, file:// | `https://web.site/ai.model`, `file://tmp/ai.model`|
+| HuggingFace   | huggingface://, hf:// | [`huggingface.co`](https://www.huggingface.co)      |
+| Ollama        | ollama:// | [`ollama.com`](https://www.ollama.com)              |
+| OCI Container Registries | oci:// | [`opencontainers.org`](https://opencontainers.org)|
+|||Examples: [`quay.io`](https://quay.io),  [`Docker Hub`](https://docker.io),[`Artifactory`](https://artifactory.com)|
+
+RamaLama defaults to the Ollama registry transport. This default can be overridden in the `ramalama.conf` file or via the RAMALAMA_TRANSPORTS
+environment. `export RAMALAMA_TRANSPORT=huggingface` Changes RamaLama to use huggingface transport.
+
+Modify individual model transports by specifying the `huggingface://`, `oci://`, `ollama://`, `https://`, `http://`, `file://` prefix to the model.
+
+URL support means if a model is on a web site or even on your local system, you can run it directly.
+
 ## OPTIONS
 
 #### **--authfile**=*password*
@@ -47,7 +64,12 @@ to the AI Model and the output returned without entering the chatbot.
 Run command without arguments starts a chatbot
 ```
 ramalama run granite
+>
+```
 
+Run command with local downloaoded model
+```
+ramalama run file:///tmp/mymodel
 >
 ```
 
@@ -58,7 +80,7 @@ The summer solstice, which is the longest day of the year, will happen on June .
 
 Run command with a custom prompt and a file passed by the stdin
 ```
-cat file.py | ramalama run granite-code 'what does this program do?'
+cat file.py | ramalama run quay.io/USER/granite-code:1.0 'what does this program do?'
 
 This program is a Python script that allows the user to interact with a terminal. ...
  [end of text]

--- a/docs/ramalama-serve.1.md
+++ b/docs/ramalama-serve.1.md
@@ -10,6 +10,23 @@ ramalama\-serve - serve REST API on specified AI Model
 Serve specified AI Model as a chat bot. RamaLama pulls specified AI Model from
 registry if it does not exist in local storage.
 
+## MODEL TRANSPORTS
+
+| Transports    | Prefix | Web Site                                            |
+| ------------- | ------ | --------------------------------------------------- |
+| URL based    | https://, http://, file:// | `https://web.site/ai.model`, `file://tmp/ai.model`|
+| HuggingFace   | huggingface://, hf:// | [`huggingface.co`](https://www.huggingface.co)      |
+| Ollama        | ollama:// | [`ollama.com`](https://www.ollama.com)              |
+| OCI Container Registries | oci:// | [`opencontainers.org`](https://opencontainers.org)|
+|||Examples: [`quay.io`](https://quay.io),  [`Docker Hub`](https://docker.io),[`Artifactory`](https://artifactory.com)|
+
+RamaLama defaults to the Ollama registry transport. This default can be overridden in the `ramalama.conf` file or via the RAMALAMA_TRANSPORTS
+environment. `export RAMALAMA_TRANSPORT=huggingface` Changes RamaLama to use huggingface transport.
+
+Modify individual model transports by specifying the `huggingface://`, `oci://`, `ollama://`, `https://`, `http://`, `file://` prefix to the model.
+
+URL support means if a model is on a web site or even on your local system, you can run it directly.
+
 ## REST API ENDPOINTS
 Under the hood, `ramalama-serve` uses the `LLaMA.cpp` HTTP server by default.
 

--- a/docs/ramalama.1.md
+++ b/docs/ramalama.1.md
@@ -31,25 +31,22 @@ Default settings for flags are defined in `ramalama.conf(5)`.
 
 RamaLama supports multiple AI model registries types called transports. Supported transports:
 
-## TRANSPORTS
+## MODEL TRANSPORTS
 
-| Transports    | Web Site                                            |
-| ------------- | --------------------------------------------------- |
-| HuggingFace   | [`huggingface.co`](https://www.huggingface.co)      |
-| Ollama        | [`ollama.com`](https://www.ollama.com)              |
-| OCI Container Registries | [`opencontainers.org`](https://opencontainers.org)|
-||Examples: [`quay.io`](https://quay.io),  [`Docker Hub`](https://docker.io), and [`Artifactory`](https://artifactory.com)|
+| Transports    | Prefix | Web Site                                            |
+| ------------- | ------ | --------------------------------------------------- |
+| URL based    | https://, http://, file:// | `https://web.site/ai.model`, `file://tmp/ai.model`|
+| HuggingFace   | huggingface://, hf:// | [`huggingface.co`](https://www.huggingface.co)      |
+| Ollama        | ollama:// | [`ollama.com`](https://www.ollama.com)              |
+| OCI Container Registries | oci:// | [`opencontainers.org`](https://opencontainers.org)|
+|||Examples: [`quay.io`](https://quay.io),  [`Docker Hub`](https://docker.io),[`Artifactory`](https://artifactory.com)|
 
-RamaLama can also pull directly using URL syntax.
-
-http://, https:// and file://.
-
-This means if a model is on a web site or even on your local system, you can run it directly.
-
-RamaLama uses the Ollama registry transport by default. The default can be overridden in the ramalama.conf file or use the RAMALAMA_TRANSPORTS
+RamaLama uses to the Ollama registry transport. This default can be overridden in the `ramalama.conf` file or via the RAMALAMA_TRANSPORTS
 environment. `export RAMALAMA_TRANSPORT=huggingface` Changes RamaLama to use huggingface transport.
 
-Individual model transports can be modifies when specifying a model via the `huggingface://`, `oci://`, `ollama://`, `https://`, `http://`, `file://` prefix.
+Modify individual model transports by specifying the `huggingface://`, `oci://`, `ollama://`, `https://`, `http://`, `file://` prefix to the model.
+
+URL support means if a model is on a web site or even on your local system, you can run it directly.
 
 ramalama pull `huggingface://`afrideva/Tiny-Vicuna-1B-GGUF/tiny-vicuna-1b.q2_k.gguf
 


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Added documentation for using URLs, Hugging Face, Ollama, and OCI container registries as model transports.