### PR TITLE
code crashes for rocm added proper type cast for env var

### DIFF
--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -230,7 +230,7 @@ def get_gpu():
         i += 1
 
     if gpu_bytes:
-        os.environ["HIP_VISIBLE_DEVICES"] = gpu_num
+        os.environ["HIP_VISIBLE_DEVICES"] = str(gpu_num)
         return
 
 


### PR DESCRIPTION
Hey @ericcurtin while checking into rocm detection I realized this can break the code so here is a quick fix!

## Summary by Sourcery

Bug Fixes:
- Fix crash when setting HIP_VISIBLE_DEVICES environment variable.