### PR TITLE
Cleaner output if a machine executes this command

### DIFF
--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -381,7 +381,7 @@ def containers_parser(subparsers):
 
 def _list_containers(args):
     conman = args.engine
-    if conman == "":
+    if conman == "" or conman is None:
         raise ValueError("no container manager (Podman, Docker) found")
 
     conman_args = [conman, "ps", "-a", "--filter", "label=RAMALAMA"]


### PR DESCRIPTION
Without podman-machine running, ramalama ps will return:

Error: no container manager (Podman, Docker) found

## Summary by Sourcery

Bug Fixes:
- Return a more informative error message when no container manager is available.