### PR TITLE
Remove these lines they are unused

### DIFF
--- a/container-images/ramalama/Containerfile
+++ b/container-images/ramalama/Containerfile
@@ -3,6 +3,3 @@ FROM registry.access.redhat.com/ubi9/ubi:9.5
 COPY ../scripts /scripts
 RUN chmod +x /scripts/*.sh && \
     /scripts/build_llama_and_whisper.sh "ramalama"
-
-ENV WHISPER_CPP_SHA=${WHISPER_CPP_SHA}
-ENV LLAMA_CPP_SHA=${LLAMA_CPP_SHA}


### PR DESCRIPTION
We now store the sha in the shell script

## Summary by Sourcery

Build:
- Remove the `WHISPER_CPP_SHA` and `LLAMA_CPP_SHA` environment variables from the Containerfile.