### PR TITLE
Treat hf.co/ prefix the same as hf://

### DIFF
--- a/docs/ramalama-run.1.md
+++ b/docs/ramalama-run.1.md
@@ -11,7 +11,7 @@ ramalama\-run - run specified AI Model as a chatbot
 | Transports    | Prefix | Web Site                                            |
 | ------------- | ------ | --------------------------------------------------- |
 | URL based    | https://, http://, file:// | `https://web.site/ai.model`, `file://tmp/ai.model`|
-| HuggingFace   | huggingface://, hf:// | [`huggingface.co`](https://www.huggingface.co)      |
+| HuggingFace   | huggingface://, hf://, hf.co/ | [`huggingface.co`](https://www.huggingface.co)      |
 | Ollama        | ollama:// | [`ollama.com`](https://www.ollama.com)              |
 | OCI Container Registries | oci:// | [`opencontainers.org`](https://opencontainers.org)|
 |||Examples: [`quay.io`](https://quay.io),  [`Docker Hub`](https://docker.io),[`Artifactory`](https://artifactory.com)|

--- a/docs/ramalama-serve.1.md
+++ b/docs/ramalama-serve.1.md
@@ -15,7 +15,7 @@ registry if it does not exist in local storage.
 | Transports    | Prefix | Web Site                                            |
 | ------------- | ------ | --------------------------------------------------- |
 | URL based    | https://, http://, file:// | `https://web.site/ai.model`, `file://tmp/ai.model`|
-| HuggingFace   | huggingface://, hf:// | [`huggingface.co`](https://www.huggingface.co)      |
+| HuggingFace   | huggingface://, hf://, hf.co/ | [`huggingface.co`](https://www.huggingface.co)      |
 | Ollama        | ollama:// | [`ollama.com`](https://www.ollama.com)              |
 | OCI Container Registries | oci:// | [`opencontainers.org`](https://opencontainers.org)|
 |||Examples: [`quay.io`](https://quay.io),  [`Docker Hub`](https://docker.io),[`Artifactory`](https://artifactory.com)|

--- a/docs/ramalama.1.md
+++ b/docs/ramalama.1.md
@@ -36,7 +36,7 @@ RamaLama supports multiple AI model registries types called transports. Supporte
 | Transports    | Prefix | Web Site                                            |
 | ------------- | ------ | --------------------------------------------------- |
 | URL based    | https://, http://, file:// | `https://web.site/ai.model`, `file://tmp/ai.model`|
-| HuggingFace   | huggingface://, hf:// | [`huggingface.co`](https://www.huggingface.co)      |
+| HuggingFace   | huggingface://, hf://, hf.co/ | [`huggingface.co`](https://www.huggingface.co)      |
 | Ollama        | ollama:// | [`ollama.com`](https://www.ollama.com)              |
 | OCI Container Registries | oci:// | [`opencontainers.org`](https://opencontainers.org)|
 |||Examples: [`quay.io`](https://quay.io),  [`Docker Hub`](https://docker.io),[`Artifactory`](https://artifactory.com)|

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -844,7 +844,7 @@ def rm_cli(args):
 
 
 def New(model, args):
-    if model.startswith("huggingface") or model.startswith("hf://"):
+    if model.startswith("huggingface://") or model.startswith("hf://") or model.startswith("hf.co/"):
         return Huggingface(model)
     if model.startswith("ollama"):
         return Ollama(model)

--- a/ramalama/huggingface.py
+++ b/ramalama/huggingface.py
@@ -35,6 +35,7 @@ class Huggingface(Model):
     def __init__(self, model):
         model = model.removeprefix("huggingface://")
         model = model.removeprefix("hf://")
+        model = model.removeprefix("hf.co/")
         super().__init__(model)
         self.type = "huggingface"
         split = self.model.rsplit("/", 1)


### PR DESCRIPTION
ollama uses hf.co/ to specify huggingface prefix, like RamaLama uses hf://

Treat them similarly.

## Summary by Sourcery

New Features:
- Support "hf.co/" URLs as a way to specify Hugging Face models, similar to existing support for "hf://".