### PR TITLE
We need the rocm libraries in here

### DIFF
--- a/container-images/scripts/build_llama_and_whisper.sh
+++ b/container-images/scripts/build_llama_and_whisper.sh
@@ -118,8 +118,7 @@ main() {
 
   clone_and_build_llama_cpp
   dnf clean all
-  rm -rf /var/cache/*dnf* /opt/rocm-*/lib/llvm \
-    /opt/rocm-*/lib/*/library/*gfx9* llama.cpp whisper.cpp
+  rm -rf /var/cache/*dnf* /opt/rocm-*/lib/*/library/*gfx9* llama.cpp whisper.cpp
   ldconfig # needed for libraries
 }
 


### PR DESCRIPTION
We didn't before, now we do, or else we crash.

## Summary by Sourcery

Build:
- Remove the LLVM libraries and ROCm gfx9 libraries from the Llama and Whisper build.