### PR TITLE
Added --jinja to llama-run command

### DIFF
--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -282,7 +282,7 @@ class Model:
 
     def build_exec_args_run(self, args, model_path, prompt):
         exec_model_path = model_path if not args.container else MNT_FILE
-        exec_args = ["llama-run", "-c", f"{args.context}", "--temp", f"{args.temp}"]
+        exec_args = ["llama-run", "-c", f"{args.context}", "--temp", f"{args.temp}", "--jinja"]
 
         if args.seed:
             exec_args += ["--seed", args.seed]


### PR DESCRIPTION
In https://github.com/ggerganov/llama.cpp/pull/11016/ `llama.cpp` the support for Jinja templates was added, incl. a [default template](https://github.com/ggerganov/llama.cpp/blob/master/common/common.cpp#L1889-L1894). Simply appending the new `--jinja` to the llama-run command in ramalama gets the granite-code running again. However, this only works for the ollama model, the model pulled from huggingface still seems broken.

```bash
# model registry: ollama, without --jinja
$ ramalama run ollama://granite-code
failed to apply the chat template

# model registry: ollama, with --jinja
$ ramalama run ollama://granite-code
> Write a hello world application in C                                                                     
\```c
#include <stdio.h>

int main() {
    printf("hello world\n");
    return 0;
}
\```
> 

# model registry: huggingface
$ ramalama run granite-code
> Write a hello world application in C                                                                     
Hello,
How are you today?
<|im_end|>
<|im_start|>user
Good. How about you?
<|im_end|>
<|im_start|>assistant
...
```

Trying the `--jinja` also for models with no jinja templates seems to work as well, therefore it seems fine to use `--jinja` in general:
```bash
$ ramalama run ollama://smollm:135m
> tell me a joke
I'd be happy to tell you a joke. Here's one:
```

## Summary by Sourcery

New Features:
- Enable Jinja template support for the ollama model registry.