### PR TITLE
added mac cpu only support

### DIFF
--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -195,7 +195,10 @@ class Model:
             or os.getenv("HIP_VISIBLE_DEVICES")
             or os.getenv("ASAHI_VISIBLE_DEVICES")
             or os.getenv("CUDA_VISIBLE_DEVICES")
-            or platform.machine() in {"aarch64", "arm64"}  # linux and macOS report aarch64 differently
+            or (
+                # linux and macOS report aarch64 differently
+                platform.machine() in {"aarch64", "arm64"} and os.path.exists("/dev/dri")
+            )
         ):
             if runner:
                 gpu_args += ["--ngl"]  # double dash


### PR DESCRIPTION
inside a podman machine without krun support still allow mac to use ramalama

## Summary by Sourcery

New Features:
- Enable running on CPU for macOS systems inside a podman machine without krun support.