### PR TITLE
fixed rocm detection by adding gfx targets in containerfile

### DIFF
--- a/container-images/scripts/build_llama_and_whisper.sh
+++ b/container-images/scripts/build_llama_and_whisper.sh
@@ -62,7 +62,7 @@ configure_common_flags() {
   common_flags=("-DGGML_NATIVE=OFF")
   case "$containerfile" in
     rocm)
-      common_flags+=("-DGGML_HIP=ON")
+      common_flags+=("-DGGML_HIP=ON" "-DAMDGPU_TARGETS=gfx1010,gfx1030,gfx1032,gfx1100,gfx1101,gfx1102")
       ;;
     cuda)
       common_flags+=("-DGGML_CUDA=ON" "-DCMAKE_EXE_LINKER_FLAGS=-Wl,--allow-shlib-undefined")


### PR DESCRIPTION
`REPOSITORY                                 TAG         IMAGE ID      CREATED            SIZE
localhost/rocm                             latest      f901b99e3216  37 minutes ago     6.34 GB
quay.io/ramalama/rocm                      latest      a50e205ddb8f  43 hours ago       6.21 GB
`

Adding the targets increased the container marginally but now it works on my system. Wondering how I can update the quay.io file