### PR TITLE
feat: add argument to define amd gpu targets

### DIFF
--- a/container-images/rocm/Containerfile
+++ b/container-images/rocm/Containerfile
@@ -3,6 +3,8 @@ FROM registry.access.redhat.com/ubi9/ubi:9.5
 COPY rocm/amdgpu.repo /etc/yum.repos.d/
 COPY rocm/rocm.repo /etc/yum.repos.d/
 COPY scripts /scripts
+
+ARG AMDGPU_TARGETS=
+ENV AMDGPU_TARGETS=${AMDGPU_TARGETS}
 RUN chmod +x /scripts/*.sh && \
     /scripts/build_llama_and_whisper.sh "rocm"
-

--- a/container-images/scripts/build_llama_and_whisper.sh
+++ b/container-images/scripts/build_llama_and_whisper.sh
@@ -62,7 +62,7 @@ configure_common_flags() {
   common_flags=("-DGGML_NATIVE=OFF")
   case "$containerfile" in
     rocm)
-      common_flags+=("-DGGML_HIP=ON" "-DAMDGPU_TARGETS=gfx1010,gfx1030,gfx1032,gfx1100,gfx1101,gfx1102")
+      common_flags+=("-DGGML_HIP=ON" "-DAMDGPU_TARGETS=${AMDGPU_TARGETS:-gfx1010,gfx1030,gfx1032,gfx1100,gfx1101,gfx1102}")
       ;;
     cuda)
       common_flags+=("-DGGML_CUDA=ON" "-DCMAKE_EXE_LINKER_FLAGS=-Wl,--allow-shlib-undefined")


### PR DESCRIPTION
This commit add a container buid arg to set custom the amd gpu targets. It also keeps the default amd gpu target values.

## Summary by Sourcery

New Features:
- Allow users to specify custom AMD GPU targets when building the ROCm container image.