### PR TITLE
Point macOS users to script install

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ pip install ramalama
 ```
 
 ## Install by script
+> [!TIP]
+> If you are a MacOS user, this is the preferred method.
+
 
 Install RamaLama by running this one-liner:
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ pip install ramalama
 
 ## Install by script
 > [!TIP]
-> If you are a MacOS user, this is the preferred method.
+> If you are a macOS user, this is the preferred method.
 
 
 Install RamaLama by running this one-liner:


### PR DESCRIPTION
To avoid caveats mentioned in #626, point users to the install script when using a macOS based setup.

## Summary by Sourcery

Documentation:
- Recommend using the install script for macOS users.