### PR TITLE
Guide users to install huggingface-cli to login to huggingface

### DIFF
--- a/docs/ramalama-login.1.md
+++ b/docs/ramalama-login.1.md
@@ -49,6 +49,7 @@ Login to huggingface registry
 ```
 $ ramalama login --token=XYZ huggingface
 ```
+Logging in to Hugging Face requires the `huggingface-cli` tool. For installation and usage instructions, see the documentation of the Hugging Face command line interface: [*https://huggingface.co/docs/huggingface_hub/en/guides/cli*](https://huggingface.co/docs/huggingface_hub/en/guides/cli).
 
 ## SEE ALSO
 **[ramalama(1)](ramalama.1.md)**


### PR DESCRIPTION
Relates-to: #643

## Summary by Sourcery

Documentation:
- Document the requirement for the `huggingface-cli` tool when logging in to Hugging Face.