### PR TITLE
add --ngl to specify the number of gpu layers, and --keep-groups so podman has access to gpu

### DIFF
--- a/docs/ramalama.1.md
+++ b/docs/ramalama.1.md
@@ -109,6 +109,13 @@ The default can be overridden in the ramalama.conf file or via the the
 RAMALAMA_IMAGE environment variable. `export RAMALAMA_TRANSPORT=quay.io/ramalama/aiimage:latest` tells
 RamaLama to use the `quay.io/ramalama/aiimage:latest` image.
 
+#### **--keep-groups**
+pass --group-add keep-groups to podman (default: False)
+Needed to access the gpu on some systems, but has an impact on security, use with caution.
+
+#### **--ngl**
+number of gpu layers (default: 999)
+
 #### **--nocontainer**
 do not run RamaLama in the default container (default: False)
 The default can be overridden in the ramalama.conf file.

--- a/docs/ramalama.conf
+++ b/docs/ramalama.conf
@@ -44,6 +44,15 @@
 #
 #host = "0.0.0.0"
 
+# Pass `--group-add keep-groups` to podman, when using podman.
+# In some cases this is needed to access the gpu from a rootless container
+#
+#keep_groups = false
+
+# Default number of layers offloaded to the gpu
+#
+#ngl = 999
+
 # Specify default port for services to listen on
 #
 #port = "8080"

--- a/docs/ramalama.conf.5.md
+++ b/docs/ramalama.conf.5.md
@@ -86,6 +86,15 @@ IP address for llama.cpp to listen on.
 OCI container image to run with the specified AI model
 RAMALAMA_IMAGE environment variable overrides this field.
 
+**keep_groups**=false
+
+Pass `--group-add keep-groups` to podman, when using podman.
+In some cases this is needed to access the gpu from a rootless container
+
+**ngl**=999
+
+Default number of layers to offload to the gpu
+
 **port**="8080"
 
 Specify default port for services to listen on

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -190,6 +190,21 @@ The RAMALAMA_CONTAINER_ENGINE environment variable modifies default behaviour.""
         help="offload the workload to the GPU",
     )
     parser.add_argument(
+        "--ngl",
+        dest="ngl",
+        type=int,
+        default=config.get("ngl", 999),
+        help="Number of layers to offload to the gpu, if available"
+    )
+    parser.add_argument(
+        "--keep-groups",
+        dest="podman_keep_groups",
+        default=config.get("keep_groups", False),
+        action="store_true",
+        help="""pass `--group-add keep-groups` to podman, if using podman.
+Needed to access gpu on some systems, but has security implications.""",
+    )
+    parser.add_argument(
         "--image",
         default=config.get("image"),
         help="OCI container image to run with the specified AI model",


### PR DESCRIPTION
Hi. This follows an invitation to submit a PR in https://github.com/containers/ramalama/issues/655

I do not feel qualified to submit PRs to ramalama, but I tried to keep it as simple as possible, and to not change any defaults.

With these changes the following works on my system (gentoo linux, an ancient 1080ti with just 11gb of GPU memory):
```
ramalama --keep-groups --ngl 34 serve --name deepseek deepseek-r1:32b
```

I didn't touch the documentation yet, hope to get feedback first.

## Summary by Sourcery

Add two new command-line options: `--ngl` to specify the number of GPU layers to use and `--keep-groups` to give podman access to the GPU.

New Features:
- Added `--ngl` option to control the number of GPU layers used by the model.
- Added `--keep-groups` option for podman to enable GPU access.

## Summary by Sourcery

Add support for specifying the number of GPU layers to offload using the --ngl option, and allow keeping user groups when using podman with the --keep-groups flag.

New Features:
- Added `--ngl` option to specify the number of GPU layers to use.
- Added `--keep-groups` option to pass `--group-add keep-groups` to podman when launching the container. This is useful for enabling GPU access in some systems, but has security implications.