### PR TITLE
Look for configs also in /usr/local/share/ramalama

### DIFF
--- a/docs/ramalama.1.md
+++ b/docs/ramalama.1.md
@@ -60,10 +60,11 @@ the model. The following table specifies the order which RamaLama reads the file
 . Any duplicate names that exist override previously defined shortnames.
 
 | Shortnames type | Path                                            |
-| --------------- | ---------------------------------------- |
-| Distribution    | /usr/share/ramalama/shortnames.conf      |
-| Administrators  | /etc/ramamala/shortnames.conf            |
-| Users           | $HOME/.config/ramalama/shortnames.conf   |
+| --------------- | ----------------------------------------  |
+| Distribution    | /usr/share/ramalama/shortnames.conf       |
+| Local install   | /usr/local/share/ramalama/shortnames.conf |
+| Administrators  | /etc/ramamala/shortnames.conf             |
+| Users           | $HOME/.config/ramalama/shortnames.conf    |
 
 ```code
 $ cat /usr/share/ramalama/shortnames.conf

--- a/docs/ramalama.conf.5.md
+++ b/docs/ramalama.conf.5.md
@@ -12,10 +12,11 @@ a TOML format that can be easily modified and versioned.
 RamaLama reads the he following paths for global configuration that effects all users.
 
 | Paths       |
-| -----------------------------------       |
-| __/usr/share/ramalama/ramalama.conf__     |
-| __/etc/ramalama/ramalama.conf__           |
-| __/etc/ramalama/ramalama.conf.d/\*.conf__ |
+| -----------------------------------         |
+| __/usr/share/ramalama/ramalama.conf__       |
+| __/usr/local/share/ramalama/ramalama.conf__ |
+| __/etc/ramalama/ramalama.conf__             |
+| __/etc/ramalama/ramalama.conf.d/\*.conf__   |
 
 For user specific configuration it reads
 

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -59,6 +59,7 @@ def load_config():
     config = {}
     config_paths = [
         "/usr/share/ramalama/ramalama.conf",
+        "/usr/local/share/ramalama/ramalama.conf",
         "/etc/ramalama/ramalama.conf",
     ]
     config_home = os.getenv("XDG_CONFIG_HOME", os.path.join("~", ".config"))

--- a/ramalama/shortnames.py
+++ b/ramalama/shortnames.py
@@ -11,6 +11,7 @@ class Shortnames:
     def __init__(self):
         file_paths = [
             "/usr/share/ramalama/shortnames.conf",
+            "/usr/local/share/ramalama/shortnames.conf",
             "/etc/ramalama/shortnames.conf",
             os.path.expanduser("~/.local/share/ramalama/shortnames.conf"),
             os.path.expanduser("~/.config/ramalama/shortnames.conf"),


### PR DESCRIPTION
The /usr/local/... path should be considered a valid location [1].

It is important for `pip install ramalama` to work correctly, because that command, when run as root (e.g. in a toolbox or toolbox-like container), installs the default config files into the `/usr/local/share/ramalama` directory.

Resolves: https://github.com/containers/ramalama/issues/671

[1] https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch04s09.html

## Summary by Sourcery

Documentation:
- Document `/usr/local/share/ramalama` as a valid configuration directory.