### PR TITLE
Add generated man pages for section 7 into gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 ramalama/__pycache__
 docs/*.1
 docs/*.5
+docs/*.7
 build
 *.egg-info
 *.dist


### PR DESCRIPTION
Sections 1 and 5 are already ignored, but there is also `ramalama-cuda.7.md` file now which gets rendered into `ramalama-cuda.7`, so the latter should be in gitignore.

## Summary by Sourcery

Chores:
- Ignore generated man pages for section 7.