### PR TITLE
remove ro as an option when mounting images

### DIFF
--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -220,7 +220,7 @@ class Model:
         if model_path and os.path.exists(model_path):
             conman_args += [f"--mount=type=bind,src={model_path},destination={MNT_FILE},ro"]
         else:
-            conman_args += [f"--mount=type=image,src={self.model},destination={MNT_DIR},ro,subpath=/models"]
+            conman_args += [f"--mount=type=image,src={self.model},destination={MNT_DIR},subpath=/models"]
 
         # Make sure Image precedes cmd_args.
         conman_args += [self._image(args)] + cmd_args


### PR DESCRIPTION
From #675 , ro is an invalid mount option for `type=image`.

From the podman [--mount option docs](https://docs.podman.io/en/v5.1.1/markdown/podman-run.1.html#mount-type-type-type-specific-option):
```
Options specific to type=image:

- rw, readwrite: true or false (default if unspecified: false).

- subpath: Mount only a specific path within the image, instead of the whole image.
```

## Summary by Sourcery

Bug Fixes:
- Fixed an issue where the `ro` mount option was incorrectly used with `type=image`, which is invalid according to the podman documentation.