### PR TITLE
Pull the source model if it isn't already in local storage for the convert and push functions

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -89,8 +89,8 @@ setup_ramalama() {
   local binfile="ramalama"
   local from_file="${binfile}"
   local host="https://raw.githubusercontent.com"
-  local branch="main"
-  local url="${host}/kush-gupt/ramalama/${branch}/bin/${from_file}"
+  local branch="${BRANCH:-s}"
+  local url="${host}/containers/ramalama/${branch}/bin/${from_file}"
   local to_file="${2}/${from_file}"
 
   if [ "$os" == "Darwin" ]; then

--- a/install.sh
+++ b/install.sh
@@ -89,8 +89,8 @@ setup_ramalama() {
   local binfile="ramalama"
   local from_file="${binfile}"
   local host="https://raw.githubusercontent.com"
-  local branch="${BRANCH:-s}"
-  local url="${host}/containers/ramalama/${branch}/bin/${from_file}"
+  local branch="main"
+  local url="${host}/kush-gupt/ramalama/${branch}/bin/${from_file}"
   local to_file="${2}/${from_file}"
 
   if [ "$os" == "Darwin" ]; then

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -663,6 +663,8 @@ def _get_source(args):
     if smodel.type == "OCI":
         return src
     else:
+        if not smodel.exists(args):
+            return smodel.pull(args)
         return smodel.path(args)
 
 

--- a/ramalama/ollama.py
+++ b/ramalama/ollama.py
@@ -107,6 +107,8 @@ class Ollama(Model):
         try:
             return init_pull(repos, accept, registry_head, model_name, model_tag, models, model_path, self.model)
         except urllib.error.HTTPError as e:
+            if "Not Found" in e.reason:
+                raise KeyError(f"{self.model} was not found in the Ollama registry")
             raise KeyError(f"failed to pull {registry_head}: " + str(e).strip("'"))
 
     def model_path(self, args):

--- a/test/system/040-serve.bats
+++ b/test/system/040-serve.bats
@@ -45,7 +45,7 @@ verify_begin=".*run --rm -i --label RAMALAMA --security-opt=label=disable --name
      fi
 
     run_ramalama 1 serve MODEL
-    is "$output" ".*Error: failed to pull .*MODEL" "failed to pull model"
+    is "$output" "Error: MODEL was not found in the Ollama registry"
 }
 
 @test "ramalama --detach serve" {

--- a/test/system/050-pull.bats
+++ b/test/system/050-pull.bats
@@ -26,7 +26,7 @@ load setup_suite
 
     random_image_name=i_$(safename)
     run_ramalama 1 pull ${random_image_name}
-    is "$output" "Error: failed to pull https://registry.ollama.ai/v2/library/${random_image_name}: HTTP Error 404: Not Found" "image does not exist"
+    is "$output" "Error: ${random_image_name} was not found in the Ollama registry"
 }
 
 # bats test_tags=distro-integration

--- a/test/system/055-convert.bats
+++ b/test/system/055-convert.bats
@@ -10,7 +10,7 @@ load helpers
     run_ramalama 2 convert tiny
     is "$output" ".*ramalama convert: error: the following arguments are required: TARGET"
     run_ramalama 1 convert bogus foobar
-    is "$output" "Error: bogus does not exist"
+    is "$output" "Error: bogus was not found in the Ollama registry"
 }
 
 @test "ramalama convert file to image" {


### PR DESCRIPTION
Added a condition to the _get_source function used by the convert and push cli to check if the model exists locally, else try to pull it. An attempted implementation of Dan's comment in #675 

I also added handling for the 404 Error message coming from models not existing in the Ollama registry to better reflect that instead of deferring to "{model} does not exist" or  "failed to pull" and changed some expected outputs in the convert, pull and serve tests .

## Summary by Sourcery

Bug Fixes:
- Improved error messages when a model is not found in the Ollama registry, now specifying that the model was not found in the registry instead of simply stating that it failed to pull or does not exist.