### PR TITLE
Unify CLI options (verbosity, version)

### DIFF
--- a/bin/ramalama
+++ b/bin/ramalama
@@ -64,9 +64,6 @@ def main(args):
     except Exception:
         None
 
-    if args.version:
-        return ramalama.print_version(args)
-
     def eprint(e, exit_code):
         ramalama.perror("Error: " + str(e).strip("'\""))
         sys.exit(exit_code)

--- a/docs/ramalama-list.1.md
+++ b/docs/ramalama-list.1.md
@@ -22,9 +22,6 @@ print Model list in json format
 #### **--noheading**, **-n**
 do not print heading
 
-#### **--quiet**, **-q**
-print only Model names
-
 ## EXAMPLES
 
 List all Models downloaded to users homedir

--- a/docs/ramalama.1.md
+++ b/docs/ramalama.1.md
@@ -130,6 +130,9 @@ Needed to access the gpu on some systems, but has an impact on security, use wit
 do not run RamaLama in the default container (default: False)
 The default can be overridden in the ramalama.conf file.
 
+#### **--quiet**
+Decrease output verbosity.
+
 #### **--runtime**=*llama.cpp* | *vllm*
 specify the runtime to use, valid options are 'llama.cpp' and 'vllm' (default: llama.cpp)
 The default can be overridden in the ramalama.conf file.

--- a/docs/ramalama.1.md
+++ b/docs/ramalama.1.md
@@ -141,9 +141,6 @@ The default can be overridden in the ramalama.conf file.
 store AI Models in the specified directory (default rootless: `$HOME/.local/share/ramalama`, default rootful: `/var/lib/ramalama`)
 The default can be overridden in the ramalama.conf file.
 
-#### **--version**, **-v**
-show RamaLama version
-
 ## COMMANDS
 
 | Command                                           | Description                                                |

--- a/hack/xref-helpmsgs-manpages
+++ b/hack/xref-helpmsgs-manpages
@@ -116,7 +116,6 @@ OPTIONS:
   -n, --dry-run  make no actual changes
 
   --help         display this message
-  --version      display program name and version
 END_USAGE
 
     exit;

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -166,11 +166,6 @@ def configure_arguments(parser):
 The RAMALAMA_IN_CONTAINER environment variable modifies default behaviour.""",
     )
     parser.add_argument(
-        "--debug",
-        action="store_true",
-        help="display debug messages",
-    )
-    parser.add_argument(
         "--dryrun", dest="dryrun", action="store_true", help="show container runtime command without executing it"
     )
     parser.add_argument("--dry-run", dest="dryrun", action="store_true", help=argparse.SUPPRESS)
@@ -214,6 +209,13 @@ The RAMALAMA_IN_CONTAINER environment variable modifies default behaviour.""",
         help="store AI Models in the specified directory",
     )
     parser.add_argument("-v", "--version", dest="version", action="store_true", help="show RamaLama version")
+    verbosity_group = parser.add_mutually_exclusive_group()
+    verbosity_group.add_argument("--quiet", "-q", dest="quiet", action="store_true", help="reduce output.")
+    verbosity_group.add_argument(
+        "--debug",
+        action="store_true",
+        help="display debug messages",
+    )
 
 
 def configure_subcommands(parser):
@@ -514,7 +516,6 @@ def list_parser(subparsers):
     parser.add_argument("--container", default=False, action="store_false", help=argparse.SUPPRESS)
     parser.add_argument("--json", dest="json", action="store_true", help="print using json")
     parser.add_argument("-n", "--noheading", dest="noheading", action="store_true", help="do not display heading")
-    parser.add_argument("-q", "--quiet", dest="quiet", action="store_true", help="print only Model names")
     parser.set_defaults(func=list_cli)
 
 

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -168,7 +168,7 @@ The RAMALAMA_IN_CONTAINER environment variable modifies default behaviour.""",
     parser.add_argument(
         "--dryrun", dest="dryrun", action="store_true", help="show container runtime command without executing it"
     )
-    parser.add_argument("--dry-run", dest="dryrun", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--dry-run", dest="dryrun", action="store_true", help=argparse.SUPPRESS)  # Alternative spelling
     parser.add_argument(
         "--engine",
         dest="engine",

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -208,7 +208,6 @@ The RAMALAMA_IN_CONTAINER environment variable modifies default behaviour.""",
         default=config.get("store"),
         help="store AI Models in the specified directory",
     )
-    parser.add_argument("-v", "--version", dest="version", action="store_true", help="show RamaLama version")
     verbosity_group = parser.add_mutually_exclusive_group()
     verbosity_group.add_argument("--quiet", "-q", dest="quiet", action="store_true", help="reduce output.")
     verbosity_group.add_argument(

--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -198,7 +198,7 @@ def download_file(url, dest_path, headers=None, show_progress=True):
     while retries < max_retries:
         try:
             # Initialize HTTP client for the request
-            http_client.init(url=url, headers=headers, output_file=dest_path, progress=show_progress)
+            http_client.init(url=url, headers=headers, output_file=dest_path, show_progress=show_progress)
             return  # Exit function if successful
 
         except urllib.error.HTTPError as e:

--- a/ramalama/http_client.py
+++ b/ramalama/http_client.py
@@ -13,7 +13,7 @@ class HttpClient:
     def __init__(self):
         pass
 
-    def init(self, url, headers, output_file, progress, response_str=None):
+    def init(self, url, headers, output_file, show_progress, response_str=None):
         output_file_partial = None
         if output_file:
             output_file_partial = output_file + ".partial"
@@ -33,7 +33,7 @@ class HttpClient:
 
             self.now_downloaded = 0
             self.start_time = time.time()
-            self.perform_download(out.file, progress)
+            self.perform_download(out.file, show_progress)
 
         if output_file:
             os.rename(output_file_partial, output_file)
@@ -46,7 +46,7 @@ class HttpClient:
         if self.response.status not in (200, 206):
             raise IOError(f"Request failed: {self.response.status}")
 
-    def perform_download(self, file, progress):
+    def perform_download(self, file, show_progress):
         self.total_to_download += self.file_size
         self.now_downloaded = 0
         self.start_time = time.time()
@@ -58,7 +58,7 @@ class HttpClient:
                 return
 
             size = file.write(data)
-            if progress:
+            if show_progress:
                 accumulated_size += size
                 if time.time() - last_update_time >= 0.1:
                     self.update_progress(accumulated_size)
@@ -68,7 +68,7 @@ class HttpClient:
         if accumulated_size > 0:
             self.update_progress(accumulated_size)
 
-        if progress:
+        if show_progress:
             print("\033[K", end="\r")
 
     def human_readable_time(self, seconds):

--- a/ramalama/oci.py
+++ b/ramalama/oci.py
@@ -283,6 +283,8 @@ Tagging build instead"""
             raise NotImplementedError("OCI images require a container engine like Podman or Docker")
 
         conman_args = [args.engine, "pull"]
+        if args.quiet:
+            conman_args.extend(['--quiet'])
         if str(args.tlsverify).lower() == "false":
             conman_args.extend([f"--tls-verify={args.tlsverify}"])
         if args.authfile:

--- a/ramalama/url.py
+++ b/ramalama/url.py
@@ -29,9 +29,10 @@ class URL(Model):
             os.symlink(self.model, os.path.join(symlink_dir, self.filename))
             os.symlink(self.model, target_path)
         else:
+            show_progress = not args.quiet
             url = self.type + "://" + self.model
             # Download the model file to the target path
-            download_file(url, target_path, headers={}, show_progress=True)
+            download_file(url, target_path, headers={}, show_progress=show_progress)
             relative_target_path = os.path.relpath(target_path, start=os.path.dirname(model_path))
             if self.check_valid_model_path(relative_target_path, model_path):
                 # Symlink is already correct, no need to update it

--- a/test/system/001-basic.bats
+++ b/test/system/001-basic.bats
@@ -17,9 +17,6 @@ function setup() {
 @test "ramalama version" {
     run_ramalama version
     is "$output" "ramalama version .*"               "'Version line' in output with version command"
-
-    run_ramalama -v
-    is "$output" "ramalama version .*"               "'Version line' in output with -v "
 }
 
 # vim: filetype=sh

--- a/test/system/010-list.bats
+++ b/test/system/010-list.bats
@@ -15,10 +15,10 @@ load helpers
     run_ramalama list -n
     assert "${lines[0]}" !~ "$headings" "header line should not be there"
 
-    run_ramalama list --quiet
+    run_ramalama --quiet list
     assert "${lines[0]}" !~ "$headings" "header line should not be there"
 
-    run_ramalama list --q
+    run_ramalama -q list
     assert "${lines[0]}" !~ "$headings" "header line should not be there"
 }
 

--- a/test/system/015-help.bats
+++ b/test/system/015-help.bats
@@ -116,7 +116,7 @@ function check_help() {
     # Test for regression of #7273 (spurious "--remote" help on output)
     for helpopt in help --help -h; do
         run_ramalama $helpopt
-        is "${lines[0]}" "usage: ramalama [-h] [--container] [--debug] [--dryrun] [--engine ENGINE]" \
+        is "${lines[0]}" "usage: ramalama [-h] [--container] [--dryrun] [--engine ENGINE]" \
            "ramalama $helpopt: first line of output"
     done
 

--- a/test/system/060-info.bats
+++ b/test/system/060-info.bats
@@ -9,8 +9,7 @@ load helpers
     run_ramalama 2 info bogus
     is "$output" ".*ramalama: error: unrecognized arguments: bogus"
 
-    run_ramalama --version
-    run_ramalama -v
+    run_ramalama version
     version=$(cut -f3 -d " " <<<"$output")
 
     run_ramalama version


### PR DESCRIPTION
Feel free to adjust block size. But 1k blocks are ridiculously low for downloading GiB of LLM data.

Related: #684

## Summary by Sourcery

New Features:
- Added a `--quiet` flag to suppress the progress bar during downloads.