### PR TITLE
fix error on macOS for M1 pro

### DIFF
--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -175,7 +175,7 @@ class Model:
         if hasattr(args, "port"):
             conman_args += ["-p", f"{args.port}:{args.port}"]
 
-        if sys.platform == "darwin" or os.path.exists("/dev/dri"):
+        if (sys.platform == "darwin" and os.path.basename(args.engine) != "docker") or os.path.exists("/dev/dri"):
             conman_args += ["--device", "/dev/dri"]
 
         if os.path.exists("/dev/kfd"):


### PR DESCRIPTION
Fixes #686 

## Summary by Sourcery

Bug Fixes:
- Fix a bug where the container setup on macOS was failing when a `/dev/dri` device file does not exist.