### PR TITLE
Update install.sh to include "gpu_detector.py"

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -129,7 +129,8 @@ setup_ramalama() {
   local python_files=("cli.py" "huggingface.py" "model.py" "ollama.py" \
                       "common.py" "__init__.py" "quadlet.py" "kube.py" \
                       "oci.py" "version.py" "shortnames.py" "toml_parser.py" \
-                      "file.py" "http_client.py" "url.py" "annotations.py")
+                      "file.py" "http_client.py" "url.py" "annotations.py" \
+                      "gpu_detector.py" )
   for i in "${python_files[@]}"; do
     if $local_install; then
       url="ramalama/${i}"


### PR DESCRIPTION
Added `gpu_detector.py` to the list of Python files to be installed, else the CLI fails to run due to the missing module.

## Summary by Sourcery

Bug Fixes:
- Fix the CLI failing to run due to a missing module.