### PR TITLE
We are displaying display driver info, scope creep

### DIFF
--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -197,7 +197,7 @@ The RAMALAMA_CONTAINER_ENGINE environment variable modifies default behaviour.""
         dest="ngl",
         type=int,
         default=config.get("ngl", 999),
-        help="Number of layers to offload to the gpu, if available"
+        help="Number of layers to offload to the gpu, if available",
     )
     parser.add_argument(
         "--keep-groups",
@@ -304,7 +304,7 @@ def show_gpus_available_cli(args):
 
     return {
         "Detected GPUs": gpu_info if gpu_info else [{"GPU": "None", "VRAM": "N/A", "INFO": "No GPUs detected"}],
-        "INFO": errors if errors else "No errors"
+        "INFO": errors if errors else "No errors",
     }
 
 

--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -208,7 +208,7 @@ class Model:
             else:
                 gpu_args += ["-ngl"]  # single dash
 
-            gpu_args += [ f'{args.ngl}' ]
+            gpu_args += [f'{args.ngl}']
 
         return gpu_args
 


### PR DESCRIPTION
We have to be mindful of maintenance of the codebase. Display drivers have nothing to do with AI acceleration. Don't show display info such as "Color LCD" :

{
    "Engine": {
        "Name": null
    },
    "GPUs": {
        "Detected GPUs": [
            {
                "Cores": "18",
                "GPU": "Apple M3 Pro",
                "Metal": "Metal 3",
                "Vendor": "Apple (0x106b)"
            },
            {
                "GPU": "Color LCD"
            }
        ],
        "INFO": "No errors"
    },
    "Image": "quay.io/ramalama/ramalama",
    "Runtime": "llama.cpp",
    "Store": "/Users/ecurtin/.local/share/ramalama",
    "UseContainer": false,
    "Version": "0.0.19"
}

Not sure about the "macOS detection covers AMD GPUs" code. We could have external GPUs potentially on macOS but even in that case the code seems illogical.

## Summary by Sourcery

Refine GPU detection and logging to exclude display adapters and streamline logging setup.

Bug Fixes:
- Prevent display adapters from being incorrectly identified as GPUs.

Enhancements:
- Simplify logging configuration.