### PR TITLE
Fix macOS emoji compatibility with Alacritty

### DIFF
--- a/ramalama/console.py
+++ b/ramalama/console.py
@@ -4,7 +4,7 @@ import logging
 
 def is_locale_utf8():
     """Check if the system locale is UTF-8."""
-    return 'UTF-8' in os.getenv('LC_CTYPE', '') or 'UTF-8' in os.getenv('LANG', '')
+    return any('UTF-8' in os.getenv(var, '') for var in ['LC_ALL', 'LC_CTYPE', 'LANG'])
 
 
 def supports_emoji():
@@ -18,22 +18,21 @@ def supports_emoji():
 
 # Allow users to override emoji support via an environment variable
 # If RAMALAMA_FORCE_EMOJI is not set, it defaults to checking supports_emoji()
-RAMALAMA_FORCE_EMOJI = os.getenv("RAMALAMA_FORCE_EMOJI")
-FORCE_EMOJI = RAMALAMA_FORCE_EMOJI.lower() == "true" if RAMALAMA_FORCE_EMOJI else None
-EMOJI = FORCE_EMOJI if FORCE_EMOJI is not None else supports_emoji()
+EMOJI = os.getenv("RAMALAMA_FORCE_EMOJI", '').lower() == "true" or supports_emoji()
 
 
 # Define emoji-aware logging messages
+def log_message(level, msg, emoji_msg):
+    return f"{emoji_msg} {msg}" if EMOJI else f"[{level}] {msg}"
+
+
 def error(msg):
-    formatted_msg = f"❌ {msg}" if EMOJI else f"[ERROR] {msg}"
-    logging.error(formatted_msg)
+    logging.error(log_message("ERROR", msg, "❌"))
 
 
 def warning(msg):
-    formatted_msg = f"⚠️  {msg}" if EMOJI else f"[WARNING] {msg}"
-    logging.warning(formatted_msg)
+    logging.warning(log_message("WARNING", msg, "⚠️"))
 
 
 def info(msg):
-    formatted_msg = f"ℹ️  {msg}" if EMOJI else f"[INFO] {msg}"
-    logging.info(formatted_msg)
+    logging.info(log_message("INFO", msg, "ℹ️"))


### PR DESCRIPTION
The main fix here is to check LC_ALL also. It's required for this
platform combination. The rest is code simplifications and
refactorings. Fix to have consitent spacing (there was a mix of
double and single spacings in output based on log-level).

## Summary by Sourcery

Bug Fixes:
- Fix UTF-8 locale detection on macOS when using Alacritty.