### PR TITLE
Update progress bar only once every 100ms

### DIFF
--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -197,7 +197,7 @@ The RAMALAMA_CONTAINER_ENGINE environment variable modifies default behaviour.""
         dest="ngl",
         type=int,
         default=config.get("ngl", -1),
-        help="Number of layers to offload to the gpu, if available"
+        help="Number of layers to offload to the gpu, if available",
     )
     parser.add_argument(
         "--keep-groups",

--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -23,7 +23,8 @@ MNT_DIR = "/mnt/models"
 MNT_FILE = f"{MNT_DIR}/model.file"
 HTTP_RANGE_NOT_SATISFIABLE = 416
 
-DEFAULT_IMAGE="quay.io/ramalama/ramalama"
+DEFAULT_IMAGE = "quay.io/ramalama/ramalama"
+
 
 def container_manager():
     engine = os.getenv("RAMALAMA_CONTAINER_ENGINE")

--- a/ramalama/http_client.py
+++ b/ramalama/http_client.py
@@ -59,6 +59,8 @@ class HttpClient:
         self.total_to_download += self.file_size
         self.now_downloaded = 0
         self.start_time = time.time()
+        accumulated_size = 0
+        last_update_time = time.time()
         while True:
             data = self.response.read(1024)
             if not data:
@@ -66,7 +68,12 @@ class HttpClient:
 
             size = file.write(data)
             if progress:
-                self.update_progress(size)
+                accumulated_size += size
+                if time.time() - last_update_time >= 0.1:
+                    self.now_downloaded += accumulated_size
+                    self.update_progress(self.now_downloaded, self.total_to_download)
+                    accumulated_size = 0
+                    last_update_time = time.time()
 
     def human_readable_time(self, seconds):
         hrs = int(seconds) // 3600


### PR DESCRIPTION
To help with CPU usage

## Summary by Sourcery

Enhancements:
- Limit progress bar updates to once every 100ms.