### PR TITLE
ramalama container: Make it possible to build basic container on all RHEL architectures

### DIFF
--- a/container_build.sh
+++ b/container_build.sh
@@ -70,7 +70,14 @@ build() {
 }
 
 determine_platform() {
-  local platform="linux/amd64"
+  case $conman_bin in
+    podman)
+      local platform="$(podman info --format '{{ .Version.OsArch }}' 2>/dev/null)"
+      ;;
+    docker)
+      local platform="$(docker info --format '{{ .ClientInfo.Os }}/{{ .ClientInfo.Arch }}' 2>/dev/null)"
+      ;;
+  esac
   if [ "$(uname -m)" = "aarch64" ] || { [ "$(uname -s)" = "Darwin" ] && [ "$(uname -m)" = "arm64" ]; }; then
     platform="linux/arm64"
   fi


### PR DESCRIPTION
Make it possible to build ramalama container on all RHEL arches.

## Summary by Sourcery

Build:
- Add support for building the ramalama container on multiple architectures by conditionally installing dependencies based on the architecture.