### PR TITLE
Packit: downstream jobs for EPEL 9,10

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -61,6 +61,8 @@ jobs:
     packages: [ramalama-fedora]
     dist_git_branches: &fedora_targets
       - fedora-all
+      - epel10
+      - epel9
 
   - job: koji_build
     trigger: commit
@@ -72,3 +74,5 @@ jobs:
     packages: [ramalama-fedora]
     dist_git_branches:
       - fedora-branched # rawhide updates are created automatically
+      - epel10
+      - epel9


### PR DESCRIPTION
This commit enables downstream jobs for EPEL 9 and 10.

Since we're only updating epel branches downstream and not running tests on EPEL targets, we can include the epel targets, we can keep them as part of `&fedora_targets` yaml anchor and not include them separately.

## Summary by Sourcery

CI:
- Enable downstream jobs for EPEL 9 and 10 using the existing `fedora_targets` YAML anchor.