### PR TITLE
Check for apple,arm-platform in /proc

### DIFF
--- a/container-images/asahi/Containerfile
+++ b/container-images/asahi/Containerfile
@@ -1,5 +1,6 @@
 FROM fedora:41
 
+ENV ASAHI_VISIBLE_DEVICES 1
 COPY ../scripts /scripts
 RUN chmod +x /scripts/*.sh && \
     /scripts/build_llama_and_whisper.sh "asahi"

--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -244,12 +244,16 @@ def get_gpu():
         return
 
     # ASAHI CASE
-    if os.path.exists('/etc/os-release'):
-        with open('/etc/os-release', 'r') as file:
-            if "asahi" in file.read().lower():
-                # Set Env Var and break
-                os.environ["ASAHI_VISIBLE_DEVICES"] = "1"
-                return
+    if os.path.exists('/proc/device-tree/compatible'):
+        try:
+            with open('/proc/device-tree/compatible', 'rb') as f:
+                content = f.read().split(b"\0")
+                # Check if "apple,arm-platform" is in the content
+                if b"apple,arm-platform" in content:
+                    os.environ["ASAHI_VISIBLE_DEVICES"] = "1"
+        except OSError:
+            # Handle the case where the file does not exist
+            pass
 
     # NVIDIA CASE
     try:


### PR DESCRIPTION
In /proc/device-tree/compatible specifically, thanks Asahi Lina!

It's more portable accross Fedora Asahi Remix and Ubuntu Asahi
Remix.

Also added env var to container image.

Co-authored-by: Asahi Lina <lina@asahilina.net>
Co-authored-by: Daniel J Walsh <dwalsh@redhat.com>