### PR TITLE
Add --network-mode option

### DIFF
--- a/docs/ramalama-bench.1.md
+++ b/docs/ramalama-bench.1.md
@@ -28,6 +28,9 @@ URL support means if a model is on a web site or even on your local system, you 
 #### **--help**, **-h**
 show this help message and exit
 
+#### **--network-mode**=*none*
+set the network mode for the container
+
 ## DESCRIPTION
 Benchmark specified AI Model.
 

--- a/docs/ramalama-convert.1.md
+++ b/docs/ramalama-convert.1.md
@@ -16,6 +16,9 @@ The model can be from RamaLama model storage in Huggingface, Ollama, or local mo
 #### **--help**, **-h**
 Print usage message
 
+#### **--network-mode**=*none*
+sets the configuration for network namespaces when handling RUN instructions
+
 #### **--type**=*raw* | *car*
 
 type of OCI Model Image to convert.

--- a/docs/ramalama-push.1.md
+++ b/docs/ramalama-push.1.md
@@ -22,6 +22,9 @@ path of the authentication file for OCI registries
 #### **--help**, **-h**
 Print usage message
 
+#### **--network-mode**=*none*
+sets the configuration for network namespaces when handling RUN instructions
+
 #### **--tls-verify**=*true*
 require HTTPS and verify certificates when contacting OCI registries
 

--- a/docs/ramalama-run.1.md
+++ b/docs/ramalama-run.1.md
@@ -37,6 +37,9 @@ show this help message and exit
 #### **--name**, **-n**
 name of the container to run the Model in
 
+#### **--network-mode**=*none*
+set the network mode for the container
+
 #### **--seed**=
 Specify seed rather than using random seed model interaction
 

--- a/docs/ramalama-serve.1.md
+++ b/docs/ramalama-serve.1.md
@@ -64,6 +64,9 @@ IP address for llama.cpp to listen on.
 #### **--name**, **-n**
 Name of the container to run the Model in.
 
+#### **--network-mode**=*""*
+set the network mode for the container
+
 #### **--port**, **-p**
 port for AI Model server to listen on
 

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -449,6 +449,12 @@ def bench_cli(args):
 
 def bench_parser(subparsers):
     parser = subparsers.add_parser("bench", aliases=["benchmark"], help="benchmark specified AI Model")
+    parser.add_argument(
+        "--network-mode",
+        type=str,
+        default="none",
+        help="set the network mode for the container",
+    )
     parser.add_argument("MODEL")  # positional argument
     parser.set_defaults(func=bench_cli)
 
@@ -672,6 +678,13 @@ type of OCI Model Image to push.
 Model "car" includes base image with the model stored in a /models subdir.
 Model "raw" contains the model and a link file model.file to it stored at /.""",
     )
+    # https://docs.podman.io/en/latest/markdown/podman-build.1.html#network-mode-net
+    parser.add_argument(
+        "--network-mode",
+        type=str,
+        default="none",
+        help="sets the configuration for network namespaces when handling RUN instructions",
+    )
     parser.add_argument("SOURCE")  # positional argument
     parser.add_argument("TARGET")  # positional argument
     parser.set_defaults(func=convert_cli)
@@ -701,6 +714,12 @@ def push_parser(subparsers):
         "--carimage",
         default=config['carimage'],
         help=argparse.SUPPRESS,
+    )
+    parser.add_argument(
+        "--network-mode",
+        type=str,
+        default="none",
+        help="set the network mode for the container",
     )
     parser.add_argument(
         "--type",
@@ -791,6 +810,15 @@ def _run(parser):
 def run_parser(subparsers):
     parser = subparsers.add_parser("run", help="run specified AI Model as a chatbot")
     _run(parser)
+    # Disable network access by default, and give the option to pass any supported network mode into
+    # podman if needed:
+    # https://docs.podman.io/en/latest/markdown/podman-run.1.html#network-mode-net
+    parser.add_argument(
+        "--network-mode",
+        type=str,
+        default="none",
+        help="set the network mode for the container",
+    )
     parser.add_argument("MODEL")  # positional argument
     parser.add_argument(
         "ARGS", nargs="*", help="Overrides the default prompt, and the output is returned without entering the chatbot"
@@ -815,6 +843,12 @@ def serve_parser(subparsers):
     )
     parser.add_argument(
         "-p", "--port", default=config.get('port', "8080"), help="port for AI Model server to listen on"
+    )
+    parser.add_argument(
+        "--network-mode",
+        type=str,
+        default="",
+        help="set the network mode for the container",
     )
     parser.add_argument("MODEL")  # positional argument
     parser.set_defaults(func=serve_cli)

--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -188,6 +188,8 @@ class Model:
             if k == "CUDA_VISIBLE_DEVICES":
                 conman_args += ["--device", "nvidia.com/gpu=all"]
             conman_args += ["-e", f"{k}={v}"]
+        if args.network_mode != "":
+            conman_args += ["--network", args.network_mode]
         return conman_args
 
     def gpu_args(self, args, runner=False):

--- a/ramalama/oci.py
+++ b/ramalama/oci.py
@@ -174,7 +174,19 @@ LABEL {ociimage_car}
             else:
                 c.write(model_raw)
         imageid = (
-            run_cmd([self.conman, "build", "--no-cache", "-q", "-f", containerfile.name, contextdir], debug=args.debug)
+            run_cmd(
+                [
+                    self.conman,
+                    "build",
+                    "--no-cache",
+                    f"--network={args.network_mode}",
+                    "-q",
+                    "-f",
+                    containerfile.name,
+                    contextdir,
+                ],
+                debug=args.debug,
+            )
             .stdout.decode("utf-8")
             .strip()
         )


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Added a `--network-mode` option to the `bench`, `convert`, `push`, `run`, and `serve` commands. This option allows users to specify the network mode for the container, such as `host`, `bridge`, or `none`.