### PR TITLE
modify container_build.sh to add capability to use podman farm for multi-arch images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ build_rm:
 	./container_build.sh -r build $(IMAGE)
 
 .PHONY: build_multi_arch
-build_multi_arch
+build_multi_arch:
 	./container_build.sh multi-arch $(IMAGE)
 
 .PHONY: install-docs

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@ help:
 	@echo
 	@echo "  - make build"
 	@echo "  - make build IMAGE=ramalama"
+	@echo "  - make multi-arch"
+	@echo "  - make multi-arch IMAGE=ramalama"
 	@echo
 	@echo "Build docs"
 	@echo
@@ -80,6 +82,10 @@ build:
 .PHONY: build_rm
 build_rm:
 	./container_build.sh -r build $(IMAGE)
+
+.PHONY: build_multi_arch
+build_multi_arch
+	./container_build.sh multi-arch $(IMAGE)
 
 .PHONY: install-docs
 install-docs: docs

--- a/container_build.sh
+++ b/container_build.sh
@@ -115,8 +115,13 @@ process_all_targets() {
     if [ "$i" == "container-images/scripts" ]; then
       continue
     fi
-    if [ "$command" = "multi-arch" ] && [ ! -f "$i"/.multi-arch ]; then
-      continue
+    # skip images that don't make sense for multi-arch builds
+    if [ "$command" = "multi-arch" ]; then
+      case "${i//container-images\//}" in
+        rocm|intel-gpu)
+          continue
+          ;;
+      esac
     fi
     build "$i" "$command" "$option"
   done

--- a/container_build.sh
+++ b/container_build.sh
@@ -115,7 +115,7 @@ process_all_targets() {
     if [ "$i" == "container-images/scripts" ]; then
       continue
     fi
-    if [ "$command" = "multi-arch" ] && [ !-f $"i"/.multi-arch ]; then
+    if [ "$command" = "multi-arch" ] && [ ! -f "$i"/.multi-arch ]; then
       continue
     fi
     build "$i" "$command" "$option"

--- a/multi-arch-targets.list
+++ b/multi-arch-targets.list
@@ -1,2 +1,0 @@
-vulkan
-ramalama

--- a/multi-arch-targets.list
+++ b/multi-arch-targets.list
@@ -1,0 +1,2 @@
+vulkan
+ramalama


### PR DESCRIPTION
Modified container_build.sh -

1. Add `multi-arch` as a command
2. Add `multi-arch-targets.list` to be processed if `$target` == `all`

Usage: 

`./container_build.sh multi-arch all` - Uses `podman farm` to build all of the images in `multi-arch-targets.list`

`./container_build.sh multi-arch vulkan` - Uses`podman farm` to build quay.io/ramalama/vulkan.

## Summary by Sourcery

Add support for building multi-arch images using `podman farm`.

New Features:
- Building multi-architecture container images is now supported through the `multi-arch` command in `container_build.sh` script.

Build:
- Add `multi-arch` command to `container_build.sh` to build multi-arch images using `podman farm`.
- Add support for building all multi-arch images defined in `multi-arch-targets.list`.
- Set default registry path to `quay.io/ramalama`.