### PR TITLE
Adding MD files for security, CoC & updates contributing.md

### DIFF
--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -1,0 +1,71 @@
+![Containers Logo](https://github.com/containers/common/blob/main/logos/containers-full-horiz.png)
+## Containers Community Code of Conduct
+
+### Contributor Code of Conduct
+
+As contributors and maintainers of the projects under the [Containers](https://github.com/containers) repository,
+and in the interest of fostering an open and welcoming community, we pledge to
+respect all people who contribute through reporting issues, posting feature
+requests, updating documentation, submitting pull requests or patches, and other
+activities to any of the projects under the containers umbrella.  These projects
+include Buildah, Conmon, Image, Podman, Ramalama, Storage, Skopeo, et al.
+as found [here](https://github.com/containers).
+
+We are committed to making participation in these projects a harassment-free experience for
+everyone, regardless of level of experience, gender, gender identity and expression,
+sexual orientation, disability, personal appearance, body size, race, ethnicity, age,
+religion, or nationality.
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery.
+* Personal attacks.
+* Trolling or insulting/derogatory comments.
+* Public or private harassment.
+* Publishing other's private information, such as physical or electronic addresses,
+ without explicit permission.
+* Other unethical or unprofessional conduct.
+
+Project maintainers have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are not
+aligned to this Code of Conduct.  By adopting this Code of Conduct, project maintainers
+commit themselves to fairly and consistently applying these principles to every aspect
+of managing their project.  Project maintainers who do not follow or enforce the Code of
+Conduct may be permanently removed from the project team or teams if they are in multiple
+projects.
+
+This code of conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting a maintainer of the project, the Container Organization's Code of Conduct Mailing List <codeofconduct@lists.podman.io> ([List Members](#List-Members)), Dan Walsh <dwalsh@redhat.com>, and/or Tom Sweeney <tsweeney@redhat.com>.
+
+
+### Containers Events Code of Conduct
+
+Containers events are working conferences intended for professional networking and collaboration in the
+Containers community.  Attendees are expected to behave according to professional standards and in accordance
+with their employer's policies on appropriate workplace behavior.
+
+While at Containers events or related social networking opportunities, attendees should not engage in
+discriminatory or offensive speech or actions regarding gender, sexuality, race, or religion.  Speakers should
+be especially aware of these concerns.
+
+The maintainers of the Containers projects do not condone any statements by speakers contrary to these standards.
+The maintainers of the Containers projects reserves the right to deny entrance and/or eject from an event
+(without refund) any individual found to be engaging in discriminatory or offensive speech or actions.
+
+Please bring any concerns to the immediate attention of a maintainer of the project, the Container Organization's Code of Conduct Mailing List <codeofconduct@lists.podman.io> ([List Members](#List-Members)), Dan Walsh <dwalsh@redhat.com>, and/or Tom Sweeney <tsweeney@redhat.com>.
+
+This Code of Conduct was adapted from the [CNCF Community Code of Conduct v1.0](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).
+
+### List Members
+
+| List Member      | email  |
+| ------------     | ------ |
+| Chris Evich      | cevich@redhat.com      |
+| Dan Walsh        | dwalsh@redhat.com      |
+| Lokesh Mandvekar | lsm5@redhat.com        |
+| Mohan Boddu      | mboddu@redhat.com      |
+| Paul Holzinger   | pholzing@redhat.com    |
+| Preethi Thomas   | pthomas@redhat.com     |
+| Tom Sweeney      | tsweeney@redhat.com    |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,8 @@ Below summarizes the processes that we follow.
 * [Contributing To RamaLama](#contributing-to-ramalama)
 * [Submitting Pull Requests](#submitting-pull-requests)
 * [Communications](#communications)
+* [Code of Conduct](#code-of-conduct)
+  
 
 ## Reporting Issues
 
@@ -323,6 +325,9 @@ For discussions around issues/bugs and features, you can use the GitHub
 and
 [PRs](https://github.com/containers/ramalama/pulls)
 tracking system.
+
+## Code of Conduct
+
 
 ### Bot Interactions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -328,6 +328,14 @@ tracking system.
 
 ## Code of Conduct
 
+As contributors and maintainers of the projects under the [Containers](https://github.com/containers) repository,
+and in the interest of fostering an open and welcoming community, we pledge to
+respect all people who contribute through reporting issues, posting feature
+requests, updating documentation, submitting pull requests or patches, and other
+activities to any of the projects under the containers umbrella. The full code of conduct guidelines can be
+include Buildah, Conmon, Image, Podman, Ramalama, Storage, Skopeo, et al.
+found [here](https://github.com/containers).
+
 
 ### Bot Interactions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -334,7 +334,7 @@ respect all people who contribute through reporting issues, posting feature
 requests, updating documentation, submitting pull requests or patches, and other
 activities to any of the projects under the containers umbrella. The full code of conduct guidelines can be
 include Buildah, Conmon, Image, Podman, Ramalama, Storage, Skopeo, et al.
-found [here](https://github.com/containers).
+found [here]([https://github.com/containers](https://github.com/caradelia/ramalama/blob/main/CODE-OF-CONDUCT.md)).
 
 
 ### Bot Interactions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -333,8 +333,7 @@ and in the interest of fostering an open and welcoming community, we pledge to
 respect all people who contribute through reporting issues, posting feature
 requests, updating documentation, submitting pull requests or patches, and other
 activities to any of the projects under the containers umbrella. The full code of conduct guidelines can be
-include Buildah, Conmon, Image, Podman, Ramalama, Storage, Skopeo, et al.
-found [here]([https://github.com/containers](https://github.com/caradelia/ramalama/blob/main/CODE-OF-CONDUCT.md)).
+found [here](https://github.com/caradelia/ramalama/blob/main/CODE-OF-CONDUCT.md).
 
 
 ### Bot Interactions

--- a/SECURITY
+++ b/SECURITY
@@ -1,3 +1,0 @@
-## Security and Disclosure Information Policy for the Ramalama Project
-
-The Ramalama Project follows the [Security and Disclosure Information Policy](https://github.com/containers/common/blob/main/SECURITY.md) for the Containers Projects.

--- a/SECURITY
+++ b/SECURITY
@@ -1,0 +1,3 @@
+## Security and Disclosure Information Policy for the Ramalama Project
+
+The Ramalama Project follows the [Security and Disclosure Information Policy](https://github.com/containers/common/blob/main/SECURITY.md) for the Containers Projects.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,3 @@
+## Security and Disclosure Information Policy for the Ramalama Project
+
+The Ramalama Project follows the [Security and Disclosure Information Policy](https://github.com/containers/common/blob/main/SECURITY.md) for the Containers Projects.


### PR DESCRIPTION
Signed-off-by: Cara Delia <cdelia@redhat.com>

## Summary by Sourcery

Add a Code of Conduct and Security policy.

New Features:
- Introduce a Code of Conduct for the community.
- Add a security policy.

Documentation:
- Document the Code of Conduct and Security policy. Update contributing guidelines with a link to the Code of Conduct.