### PR TITLE
github actions: ramalama install

### DIFF
--- a/.github/workflows/install_ramalama.yml
+++ b/.github/workflows/install_ramalama.yml
@@ -1,0 +1,48 @@
+name: Install RamaLama
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  install_ramalama:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]  # Runs on Ubuntu, macOS, and Fedora
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Set Up Dependencies (Ubuntu)
+        timeout-minutes: 10
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get install -y lshw curl
+
+      - name: Set Up Dependencies (macOS)
+        if: matrix.os == 'macos-latest'
+        run: |
+          if ! command -v brew &> /dev/null; then
+            echo "Homebrew is required but not found. Please install it."
+            exit 1
+          fi
+
+      - name: Run RamaLama Installer
+        run: |
+          chmod +x install.sh
+          sudo ./install.sh -l
+
+      - name: Ramalama info
+        run: |
+          ramalama info
+
+      - name: Ramalama info
+        run: |
+          ramalama pull tinyllama


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Set up a GitHub Actions workflow to install `ramalama` and pull the `tinyllama` model on push to `main` and pull requests targeting `main`. The workflow runs on Ubuntu and macOS and installs required dependencies like `lshw` and `curl`.