### PR TITLE
There's a comma in the list of files in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -35,12 +35,12 @@ dnf_install() {
 }
 
 apt_get_install() {
-  apt-get -qq -y install "$1"
+  apt-get -y install "$1"
 }
 
 apt_install() {
   if ! available podman; then
-    $sudo apt-get update -qq || true
+    $sudo apt-get update || true
 
     # only install docker if podman can't be
     if ! $sudo apt_get_install podman; then
@@ -130,7 +130,7 @@ setup_ramalama() {
                       "common.py" "__init__.py" "quadlet.py" "kube.py" \
                       "oci.py" "version.py" "shortnames.py" "toml_parser.py" \
                       "file.py" "http_client.py" "url.py" "annotations.py" \
-                      "gpu_detector.py", "console.py" )
+                      "gpu_detector.py" "console.py")
   for i in "${python_files[@]}"; do
     if $local_install; then
       url="ramalama/${i}"


### PR DESCRIPTION
It shouldn't be there. Also remove the -qq, it makes it feel like the script isn't making progress as podman takes a while to install.

## Summary by Sourcery

Remove the -qq flag from apt-get to show installation progress and fix a syntax error in a list of files.

Bug Fixes:
- Removed the unnecessary `-qq` flag from `apt-get` to make the installation progress visible.

Chores:
- Fixed a syntax error in a Python file list by removing an extra comma.