### PR TITLE
Detect Intel ARC GPU in Meteor Lake chipset

### DIFF
--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -283,15 +283,15 @@ def get_gpu():
         return
 
     # INTEL iGPU CASE (Look for ARC GPU)
-    if os.path.exists('/sys/bus/pci/drivers/i915/0000:00:02.0/device'):
-        try:
-            with open('/sys/bus/pci/drivers/i915/0000:00:02.0/device', 'rb') as f:
-                content = f.read()
-                if b"0x7d55" in content:
-                    os.environ["INTEL_VISIBLE_DEVICES"] = "1"
-        except OSError:
-            # Handle the case where the file does not exist
-            pass
+    igpu_num = 0
+    for fp in sorted(glob.glob('/sys/bus/pci/drivers/i915/*/device')):
+        with open(fp, 'rb') as file:
+            content = file.read()
+            if b"0x7d55" in content:
+                igpu_num += 1
+
+    if igpu_num:
+        os.environ["INTEL_VISIBLE_DEVICES"] = str(igpu_num)
 
 def get_env_vars():
     prefixes = ("ASAHI_", "CUDA_", "HIP_", "HSA_", "INTEL_")

--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -282,9 +282,19 @@ def get_gpu():
         os.environ["HIP_VISIBLE_DEVICES"] = str(gpu_num)
         return
 
+    # INTEL iGPU CASE (Look for ARC GPU)
+    if os.path.exists('/sys/bus/pci/drivers/i915/0000:00:02.0/device'):
+        try:
+            with open('/sys/bus/pci/drivers/i915/0000:00:02.0/device', 'rb') as f:
+                content = f.read()
+                if b"0x7d55" in content:
+                    os.environ["INTEL_VISIBLE_DEVICES"] = "1"
+        except OSError:
+            # Handle the case where the file does not exist
+            pass
 
 def get_env_vars():
-    prefixes = ("ASAHI_", "CUDA_", "HIP_", "HSA_")
+    prefixes = ("ASAHI_", "CUDA_", "HIP_", "HSA_", "INTEL_")
     env_vars = {k: v for k, v in os.environ.items() if k.startswith(prefixes)}
 
     # gpu_type, gpu_num = get_gpu()

--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -129,6 +129,7 @@ class Model:
             "HIP_VISIBLE_DEVICES": "quay.io/ramalama/rocm",
             "CUDA_VISIBLE_DEVICES": "quay.io/ramalama/cuda",
             "ASAHI_VISIBLE_DEVICES": "quay.io/ramalama/asahi",
+            "INTEL_VISIBLE_DEVICES": "quay.io/ramalama/intel-gpu",
         }
 
         image = images.get(gpu_type, args.image)
@@ -199,6 +200,7 @@ class Model:
             or os.getenv("HIP_VISIBLE_DEVICES")
             or os.getenv("ASAHI_VISIBLE_DEVICES")
             or os.getenv("CUDA_VISIBLE_DEVICES")
+            or os.getenv("INTEL_VISIBLE_DEVICES")
             or (
                 # linux and macOS report aarch64 differently
                 platform.machine() in {"aarch64", "arm64"}


### PR DESCRIPTION
Add logic to detect an Intel GPU and set `INTEL_VISIBLE_DEVICES` if found.

__Note:__ This is preliminary logic that narrowly detects the Intel ARC GPU in the Meteor Lake Core Ultra 7 chipset.

## Summary by Sourcery

Detect Intel ARC GPUs and use them if available.

New Features:
- Enable the use of Intel ARC GPUs on systems with Meteor Lake Core Ultra 7 chipsets.

Tests:
- Update tests to support Intel ARC GPUs.