### PR TITLE
Remove reference to non-existent docs in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ This section describes how to make a contribution to RamaLama.
 
 ### Prepare your environment
 
-The minimum version of Python required to use RamaLama is PYTHON 3.12
+The minimum version of Python required to use RamaLama is Python 3.12
 
 ### Fork and clone RamaLama
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,12 +53,6 @@ This section describes how to make a contribution to RamaLama.
 
 ### Prepare your environment
 
-Read the [install documentation to see how to install dependencies](https://ramalama.io/getting-started/installation#build-and-run-dependencies).
-
-The install documentation will illustrate the following steps:
-- Installation of required tools
-- Installing RamaLama from source
-
 The minimum version of Python required to use RamaLama is PYTHON 3.12
 
 ### Fork and clone RamaLama

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Supported transports:
 | HuggingFace   | [`huggingface.co`](https://www.huggingface.co)      |
 | Ollama        | [`ollama.com`](https://www.ollama.com)              |
 | OCI Container Registries | [`opencontainers.org`](https://opencontainers.org)|
-||Examples: [`quay.io`](https://quay.io),  [`Docker Hub`](https://docker.io), and [`Artifactory`](https://artifactory.com)|
+||Examples: [`quay.io`](https://quay.io),  [`Docker Hub`](https://docker.io), [`Pulp`](https://pulpproject.org), and [`Artifactory`](https://artifactory.com)|
 
 RamaLama uses the Ollama registry transport by default. Use the RAMALAMA_TRANSPORTS environment variable to modify the default. `export RAMALAMA_TRANSPORT=huggingface` Changes RamaLama to use huggingface transport.
 

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -197,7 +197,7 @@ The RAMALAMA_CONTAINER_ENGINE environment variable modifies default behaviour.""
         dest="ngl",
         type=int,
         default=config.get("ngl", -1),
-        help="Number of layers to offload to the gpu, if available"
+        help="Number of layers to offload to the gpu, if available",
     )
     parser.add_argument(
         "--keep-groups",

--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -23,7 +23,8 @@ MNT_DIR = "/mnt/models"
 MNT_FILE = f"{MNT_DIR}/model.file"
 HTTP_RANGE_NOT_SATISFIABLE = 416
 
-DEFAULT_IMAGE="quay.io/ramalama/ramalama"
+DEFAULT_IMAGE = "quay.io/ramalama/ramalama"
+
 
 def container_manager():
     engine = os.getenv("RAMALAMA_CONTAINER_ENGINE")

--- a/ramalama/http_client.py
+++ b/ramalama/http_client.py
@@ -59,6 +59,8 @@ class HttpClient:
         self.total_to_download += self.file_size
         self.now_downloaded = 0
         self.start_time = time.time()
+        accumulated_size = 0
+        last_update_time = time.time()
         while True:
             data = self.response.read(1024)
             if not data:
@@ -66,7 +68,12 @@ class HttpClient:
 
             size = file.write(data)
             if progress:
-                self.update_progress(size)
+                accumulated_size += size
+                if time.time() - last_update_time >= 0.1:
+                    self.now_downloaded += accumulated_size
+                    self.update_progress(self.now_downloaded, self.total_to_download)
+                    accumulated_size = 0
+                    last_update_time = time.time()
 
     def human_readable_time(self, seconds):
         hrs = int(seconds) // 3600


### PR DESCRIPTION
CONTRIBUTING.md has a reference to ramalama.io which does not exist yet.

This PR resolves #743

## Summary by Sourcery

Documentation:
- Remove the reference to the non-existent ramalama.io URL from the contributing documentation.