### PR TITLE
--version points to git hash and date

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,12 @@ readme = "README.md"
 license = {file = "LICENSE"}
 keywords = ["ramalama", "llama", "AI"]
 
+[build-system]
+requires = ["setuptools", "setuptools_scm"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+
 [project.urls]
 Homepage = "https://github.com/containers/ramalama"
 Documentation = "https://github.com/containers/ramalama/tree/main/docs"

--- a/ramalama/version.py
+++ b/ramalama/version.py
@@ -1,16 +1,9 @@
-import importlib.metadata
-
-"""Version of RamaLamaPy."""
-
+import setuptools_scm
 
 def version():
-    try:
-        return importlib.metadata.version("ramalama")
-    except importlib.metadata.PackageNotFoundError:
-        return "0"
+    """Returns the package version dynamically from Git."""
+    return setuptools_scm.get_version()
 
-    return "0"
-
-
-def print_version(args):
-    print("ramalama version %s" % version())
+def print_version(args=None):
+    """Prints the current version of the package."""
+    print(f"ramalama version {version()}")

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ class build_py(build_py_orig):
 
 setuptools.setup(
     name="ramalama",
-    version="0.5.5",
+    use_scm_version=True,
     packages=find_packages(),
     cmdclass={"build_py": build_py},
     scripts=["bin/ramalama"],


### PR DESCRIPTION
Today ramalama just share version 0.5.5 (as example) but don't tell users and developer which commit it's using.

Resolves: https://github.com/containers/ramalama/issues/754

## Summary by Sourcery

Update the versioning scheme to use setuptools_scm, dynamically deriving the version from Git.

Build:
- Use setuptools_scm for version management.

Chores:
- Remove the hardcoded version and replace it with dynamic versioning.