### PR TITLE
--version points to git hash

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -100,6 +100,29 @@ check_platform() {
   return 0
 }
 
+setup_version_file() {
+  local config_dir="$HOME/.config/ramalama"
+  local version_file="$config_dir/version"
+
+  # Ensure ~/.config/ramalama/ exists
+  mkdir -p "$config_dir"
+
+  version="0.0.0"
+  # Try to get version from Git
+  if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    version=$(git describe --tags --long --always)
+    # Format version properly (strip 'g' from commit hash)
+    if [[ "$version" =~ ([0-9]+\.[0-9]+\.[0-9]+)-([0-9]+)-g([a-f0-9]+) ]]; then
+      version="${BASH_REMATCH[1]}.dev${BASH_REMATCH[2]}+${BASH_REMATCH[3]}"
+    fi
+  fi
+
+  # Save version to file
+  echo "$version" > "$version_file"
+
+  echo "Saved version: $version in $version_file"
+}
+
 setup_ramalama() {
   local binfile="ramalama"
   local from_file="${binfile}"
@@ -181,7 +204,7 @@ main() {
   trap cleanup EXIT
 
   setup_ramalama "$bindir"
+  setup_version_file
 }
 
 main "$@"
-

--- a/ramalama/version.py
+++ b/ramalama/version.py
@@ -1,16 +1,19 @@
-import importlib.metadata
+import os
 
-"""Version of RamaLamaPy."""
-
+CONFIG_DIR = os.path.expanduser("~/.config/ramalama")
+VERSION_FILE = os.path.join(CONFIG_DIR, "version")
 
 def version():
-    try:
-        return importlib.metadata.version("ramalama")
-    except importlib.metadata.PackageNotFoundError:
-        return "0"
+    """Reads the version from ~/.config/ramalama/version."""
+    if os.path.exists(VERSION_FILE):
+        try:
+            with open(VERSION_FILE, "r") as f:
+                return f.read().strip()
+        except (IOError, OSError) as e:
+            return f"Error reading version file: {VERSION_FILE}. Ensure you have the correct permissions. Details: {e}"
 
-    return "0"
+    return f"cannot be detected, see if exists {VERSION_FILE}. Please run sudo ./install.sh"
 
-
-def print_version(args):
-    print("ramalama version %s" % version())
+def print_version(args=None):
+    """Prints the current version of the package."""
+    print(f"ramalama version {version()}")


### PR DESCRIPTION
Today ramalama just share version 0.5.5 (as example) but don't tell users and developer which commit it's using.

Resolves: https://github.com/containers/ramalama/issues/754

## Summary by Sourcery

Update the version reporting to use the Git commit hash if available, falling back to a file-based version if not in a Git repository.

New Features:
- Add the ability to determine the version from the git hash.

Enhancements:
- Improve version reporting to provide more context.