### PR TITLE
Drop all capablities and run with no-new-privileges

### DIFF
--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -156,6 +156,9 @@ class Model:
             "--security-opt=label=disable",
             "--name",
             name,
+            "--env=HOME=/tmp",
+            "--cap-drop=all",
+            "--security-opt=no-new-privileges",
         ]
 
         if os.path.basename(args.engine) == "podman":


### PR DESCRIPTION
llama-run attempts to write to $HOME. Since we are running as root inside of the container, the process tries to write to /root which is has permissions 500, which means even root procesess can not write their without CAP_DAC_OVERRIDE, since we don't want to give that CAP, we modify HOME to be /tmp/

## Summary by Sourcery

Enhancements:
- Prevent the container from writing to /root by setting the HOME environment variable to /tmp. This avoids the need for the CAP_DAC_OVERRIDE capability.