### PR TITLE
typo: Add quotes to intel-gpu argument in build llama and whisper script

### DIFF
--- a/container-images/intel-gpu/Containerfile
+++ b/container-images/intel-gpu/Containerfile
@@ -4,7 +4,7 @@ COPY intel-gpu/oneAPI.repo /etc/yum.repos.d/
 COPY scripts/build_llama_and_whisper.sh /
 
 RUN chmod +x /build_llama_and_whisper.sh ; \
-    /build_llama_and_whisper.sh intel-gpu
+    /build_llama_and_whisper.sh "intel-gpu"
 
 FROM quay.io/fedora/fedora:41
 


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Quote the `intel-gpu` argument in the `build_llama_and_whisper.sh` script.