### PR TITLE
There would be one case where this wouldn't work

### DIFF
--- a/ramalama/http_client.py
+++ b/ramalama/http_client.py
@@ -59,7 +59,7 @@ class HttpClient:
         while True:
             data = self.response.read(1024)
             if not data:
-                break
+                return
 
             size = file.write(data)
             if progress:
@@ -69,8 +69,10 @@ class HttpClient:
                     accumulated_size = 0
                     last_update_time = time.time()
 
-        if accumulated_size:
+        if accumulated_size > 0:
             self.update_progress(accumulated_size)
+
+        if progress:
             print("\033[K", end="\r")
 
     def human_readable_time(self, seconds):


### PR DESCRIPTION
When accumulated_size has just been refreshed to zero

## Summary by Sourcery

Bug Fixes:
- Fix an edge case where the download progress was not being updated correctly when the total downloaded size was a multiple of the read buffer size.