### PR TITLE
chore: use absolute link for the RamaLama logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![RAMALAMA logo](logos/PNG/ramalama-logo-full-vertical-added-bg.png)
+![RAMALAMA logo](https://github.com/containers/ramalama/raw/main/logos/PNG/ramalama-logo-full-vertical-added-bg.png)
 
 # RamaLama
 


### PR DESCRIPTION
allow proper rendering when README is rendered outside of GitHub

example:
https://pypi.org/project/ramalama/

## Summary by Sourcery

Chores:
- Render the logo correctly when README is rendered outside of GitHub, such as on PyPI.