### PR TITLE
Reuse Ollama cached image when available

### DIFF
--- a/ramalama/ollama.py
+++ b/ramalama/ollama.py
@@ -1,7 +1,7 @@
 import os
 import urllib.request
 import json
-from ramalama.common import run_cmd, verify_checksum, download_file
+from ramalama.common import run_cmd, verify_checksum, download_file, available
 from ramalama.model import Model, rm_until_substring
 
 
@@ -30,15 +30,18 @@ def pull_blob(repos, layer_digest, accept, registry_head, models, model_name, mo
     layer_blob_path = os.path.join(repos, "blobs", layer_digest)
     url = f"{registry_head}/blobs/{layer_digest}"
     headers = {"Accept": accept}
-    download_file(url, layer_blob_path, headers=headers, show_progress=True)
-
-    # Verify checksum after downloading the blob
-    if not verify_checksum(layer_blob_path):
-        print(f"Checksum mismatch for blob {layer_blob_path}, retrying download...")
-        os.remove(layer_blob_path)
+    local_blob = in_existing_cache(model_name, model_tag)
+    if local_blob is not None:
+        run_cmd(["ln", "-sf", local_blob, layer_blob_path])
+    else:
         download_file(url, layer_blob_path, headers=headers, show_progress=True)
+        # Verify checksum after downloading the blob
         if not verify_checksum(layer_blob_path):
-            raise ValueError(f"Checksum verification failed for blob {layer_blob_path}")
+            print(f"Checksum mismatch for blob {layer_blob_path}, retrying download...")
+            os.remove(layer_blob_path)
+            download_file(url, layer_blob_path, headers=headers, show_progress=True)
+            if not verify_checksum(layer_blob_path):
+                raise ValueError(f"Checksum verification failed for blob {layer_blob_path}")
 
     os.makedirs(models, exist_ok=True)
     relative_target_path = os.path.relpath(layer_blob_path, start=os.path.dirname(model_path))
@@ -57,6 +60,27 @@ def init_pull(repos, accept, registry_head, model_name, model_tag, models, model
 
     return model_path
 
+
+def in_existing_cache(model_name, model_tag):
+    if not available("ollama"):
+        return None
+    default_ollama_caches=[
+        os.path.join(os.environ['HOME'], '.ollama/models'),
+        '/usr/share/ollama/.ollama/models'
+        f'C:\\Users\\{os.getlogin()}\\.ollama\\models'
+    ]
+
+    for cache_dir in default_ollama_caches:
+        manifest_path = os.path.join(cache_dir, 'manifests', 'registry.ollama.ai', model_name, model_tag)
+        if os.path.exists(manifest_path):
+            with open(manifest_path, 'r') as file:
+                manifest_data = json.load(file)
+                for layer in manifest_data["layers"]:
+                    if layer["mediaType"] == "application/vnd.ollama.image.model":
+                        layer_digest = layer["digest"]
+                        ollama_digest_path = os.path.join(cache_dir, 'blobs', layer_digest)
+                        return str(ollama_digest_path).replace(':','-')
+    return None
 
 class Ollama(Model):
     def __init__(self, model):


### PR DESCRIPTION
Created a new function called in_existing_cache to take in a model name and tag, search a default Ollama cache and see if there's a matching model layer to symlink in the ramalama store.

Allows the process of someone running ollama to use ramalama with no model pulls!
```
$ ollama ls
NAME                                   ID              SIZE      MODIFIED      
starcoder2:3b                          9f4ae0aff61e    1.7 GB    9 minutes ago    
sroecker/nuextract-tiny-v1.5:latest    be09317bfbbb    994 MB    7 hours ago      
deepseek-r1:32b                        38056bbcbb2d    19 GB     3 weeks ago      
qwen2.5-coder:32b                      4bd6cbf2d094    19 GB     2 months ago     
nomic-embed-text:latest                0a109f422b47    274 MB    8 months ago     

$ ramalama ls
NAME MODIFIED SIZE

$ ramalama run starcoder2:3b 
> We have a cache and didn't have to pull the model down
...

$ ramalama ls
NAME                   MODIFIED       SIZE   
ollama://starcoder2:3b 15 seconds ago 1.59 GB
```
