### PR TITLE
Check if file exists before sorting them into a list

### DIFF
--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -429,7 +429,7 @@ def human_duration(d):
         return f"{d // 31536000} years"
 
 
-def list_files_by_modification():
+def list_files_by_modification(args):
     paths = Path().rglob("*")
     models = []
     for path in paths:
@@ -440,6 +440,9 @@ def list_files_by_modification():
                 continue
         if os.path.exists(path):
             models.append(path)
+        else:
+            print(f"Broken symlink found in: {args.store}/models/{path} \nAttempting removal")
+            New(str(path).replace("/", "://", 1), args).remove(args)
 
     return sorted(models, key=lambda p: os.path.getmtime(p), reverse=True)
 
@@ -537,7 +540,7 @@ def _list_models(args):
     models = []
 
     # Collect model data
-    for path in list_files_by_modification():
+    for path in list_files_by_modification(args):
         if path.is_symlink():
             if str(path).startswith("file/"):
                 name = str(path).replace("/", ":///", 1)

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -438,7 +438,8 @@ def list_files_by_modification():
                 path = str(path).replace("file/", "file:///")
                 perror(f"{path} does not exist")
                 continue
-        models.append(path)
+        if os.path.exists(path):
+            models.append(path)
 
     return sorted(models, key=lambda p: os.path.getmtime(p), reverse=True)
 


### PR DESCRIPTION
A dangling symlink can cause `ramalama ls` to fail with:
```
$ ramalama ls            
Error: [Errno 2] No such file or directory: 'ollama/qwen:1.8b
```

So checking to see if the file exists before appending it into a list to be sorted fixes this:
```
$ ramalama ls
NAME                       MODIFIED     SIZE    
ollama://starcoder2:3b     1 hour ago   1.59 GB 
ollama://deepseek-r1:32b   12 hours ago 18.49 GB
ollama://qwen2.5-coder:32b 12 hours ago 18.49 GB
```

Root cause could be solved by creating a hard link instead of symbolic from to ollama model blob to the ramalama blob store

## Summary by Sourcery

Bug Fixes:
- Fix an error where a dangling symlink could cause `ramalama ls` to fail.