### PR TITLE
Change RAMALAMA_GPU_DEVICE to RAMALAMA_DEVICE for AI accelerator device override

### DIFF
--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -186,9 +186,9 @@ class Model:
         if hasattr(args, "port"):
             conman_args += ["-p", f"{args.port}:{args.port}"]
 
-        # Check for env var RAMALAMA_GPU_DEVICE to explicitly declare the GPU device path
+        # Check for env var RAMALAMA_DEVICE to explicitly declare the GPU device path
         device_override=0
-        gpu_device = os.environ.get("RAMALAMA_GPU_DEVICE")
+        gpu_device = os.environ.get("RAMALAMA_DEVICE")
         if gpu_device:
             conman_args += ["--device", gpu_device]
             device_override=1


### PR DESCRIPTION
Per @ericcurtin suggestion, making the env ver for device override more generic to accelerator type.

## Summary by Sourcery

Enhancements:
- Use a more generic environment variable name for overriding AI accelerator devices.