### PR TITLE
Attempt to use build_llama_and_whisper.sh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,14 +60,9 @@ jobs:
         shell: bash
         run: |
            sudo apt-get update
-           sudo apt-get install podman bats bash codespell python3-argcomplete pipx git cmake
+           sudo apt-get install podman bats bash codespell python3-argcomplete pipx git cmake libcurl4-openssl-dev
            make install-requirements
-           git clone https://github.com/ggerganov/llama.cpp
-           cd llama.cpp
-           git submodule update --init --recursive
-           cmake -B build -DGGML_NATIVE=OFF
-           cmake --build build --config Release
-           sudo cmake --install build
+           sudo ./container-images/scripts/build_llama_and_whisper.sh
 
       - name: Upgrade to podman 5
         run: |

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ build_multi_arch:
 
 .PHONY: build-rag
 build-rag:
-	podman build --build-arg IMAGE=${IMAGE} --build-arg GPU=${GPU} -t ${IMAGE}-rag container-images/pragmatic
+	podman build --no-cache --build-arg IMAGE=${IMAGE} --build-arg GPU=${GPU} -t ${IMAGE}-rag container-images/pragmatic
 
 .PHONY: install-docs
 install-docs: docs


### PR DESCRIPTION
## Summary by Sourcery

Use a script to build llama.cpp and whisper.cpp in the CI workflow.

Enhancements:
- Improve the build process for llama.cpp and whisper.cpp.

CI:
- Build llama.cpp and whisper.cpp using the `build_llama_and_whisper.sh` script instead of building them directly in the workflow.
- Run `dnf_install` and `dnf -y clean all` only if `dnf` is available.