### PR TITLE
Change --network-mode to --network

### DIFF
--- a/docs/ramalama-bench.1.md
+++ b/docs/ramalama-bench.1.md
@@ -28,7 +28,7 @@ URL support means if a model is on a web site or even on your local system, you 
 #### **--help**, **-h**
 show this help message and exit
 
-#### **--network-mode**=*none*
+#### **--network**=*none*
 set the network mode for the container
 
 ## DESCRIPTION

--- a/docs/ramalama-convert.1.md
+++ b/docs/ramalama-convert.1.md
@@ -16,7 +16,7 @@ The model can be from RamaLama model storage in Huggingface, Ollama, or local mo
 #### **--help**, **-h**
 Print usage message
 
-#### **--network-mode**=*none*
+#### **--network**=*none*
 sets the configuration for network namespaces when handling RUN instructions
 
 #### **--type**=*raw* | *car*

--- a/docs/ramalama-push.1.md
+++ b/docs/ramalama-push.1.md
@@ -22,7 +22,7 @@ path of the authentication file for OCI registries
 #### **--help**, **-h**
 Print usage message
 
-#### **--network-mode**=*none*
+#### **--network**=*none*
 sets the configuration for network namespaces when handling RUN instructions
 
 #### **--tls-verify**=*true*

--- a/docs/ramalama-rag.1.md
+++ b/docs/ramalama-rag.1.md
@@ -22,7 +22,7 @@ positional arguments:
 #### **--help**, **-h**
 Print usage message
 
-#### **--network-mode**=*none*
+#### **--network**=*none*
 sets the configuration for network namespaces when handling RUN instructions
 
 ## EXAMPLES

--- a/docs/ramalama-run.1.md
+++ b/docs/ramalama-run.1.md
@@ -40,7 +40,7 @@ duration to keep a model loaded (e.g. 5m)
 #### **--name**, **-n**
 name of the container to run the Model in
 
-#### **--network-mode**=*none*
+#### **--network**=*none*
 set the network mode for the container
 
 #### **--seed**=

--- a/docs/ramalama-serve.1.md
+++ b/docs/ramalama-serve.1.md
@@ -64,7 +64,7 @@ IP address for llama.cpp to listen on.
 #### **--name**, **-n**
 Name of the container to run the Model in.
 
-#### **--network-mode**=*""*
+#### **--network**=*""*
 set the network mode for the container
 
 #### **--port**, **-p**

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -457,7 +457,7 @@ def bench_cli(args):
 def bench_parser(subparsers):
     parser = subparsers.add_parser("bench", aliases=["benchmark"], help="benchmark specified AI Model")
     parser.add_argument(
-        "--network-mode",
+        "--network",
         type=str,
         default="none",
         help="set the network mode for the container",
@@ -687,7 +687,7 @@ Model "raw" contains the model and a link file model.file to it stored at /.""",
     )
     # https://docs.podman.io/en/latest/markdown/podman-build.1.html#network-mode-net
     parser.add_argument(
-        "--network-mode",
+        "--network",
         type=str,
         default="none",
         help="sets the configuration for network namespaces when handling RUN instructions",
@@ -723,7 +723,7 @@ def push_parser(subparsers):
         help=argparse.SUPPRESS,
     )
     parser.add_argument(
-        "--network-mode",
+        "--network",
         type=str,
         default="none",
         help="set the network mode for the container",
@@ -806,7 +806,7 @@ def _run(parser):
     # podman if needed:
     # https://docs.podman.io/en/latest/markdown/podman-run.1.html#network-mode-net
     parser.add_argument(
-        "--network-mode",
+        "--network",
         type=str,
         default="none",
         help="set the network mode for the container",
@@ -926,7 +926,7 @@ def rag_parser(subparsers):
         help="generate and convert retrieval augmented generation (RAG) data from provided documents into an OCI Image",
     )
     parser.add_argument(
-        "--network-mode",
+        "--network",
         type=str,
         default="none",
         help="set the network mode for the container",

--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -205,8 +205,8 @@ class Model:
                 if k == "CUDA_VISIBLE_DEVICES":
                     conman_args += ["--device", "nvidia.com/gpu=all"]
                 conman_args += ["-e", f"{k}={v}"]
-        if args.network_mode != "":
-            conman_args += ["--network", args.network_mode]
+        if args.network != "":
+            conman_args += ["--network", args.network]
         return conman_args
 
     def gpu_args(self, args, runner=False):

--- a/ramalama/oci.py
+++ b/ramalama/oci.py
@@ -179,7 +179,7 @@ LABEL {ociimage_car}
                     self.conman,
                     "build",
                     "--no-cache",
-                    f"--network={args.network_mode}",
+                    f"--network={args.network}",
                     "-q",
                     "-f",
                     containerfile.name,

--- a/ramalama/rag.py
+++ b/ramalama/rag.py
@@ -31,7 +31,7 @@ COPY {base} /vector.db
                     args.engine,
                     "build",
                     "--no-cache",
-                    f"--network={args.network_mode}",
+                    f"--network={args.network}",
                     "-q",
                     "-t",
                     target,
@@ -58,8 +58,8 @@ COPY {base} /vector.db
         rag_image = ":".join(s)
 
         exec_args = [args.engine, "run", "--rm"]
-        if args.network_mode != "":
-            exec_args += ["--network", args.network_mode]
+        if args.network != "":
+            exec_args += ["--network", args.network]
         for path in args.PATH:
             if os.path.exists(path):
                 fpath = os.path.realpath(path)


### PR DESCRIPTION
So users can easily understand what podman/docker CLI this maps to.

## Summary by Sourcery

Documentation:
- Update CLI documentation to reflect the argument name change from `--network-mode` to `--network`.