### PR TITLE
If ngl is not specified

### DIFF
--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -223,6 +223,9 @@ class Model:
                 and os.path.exists("/dev/dri")
             )
         ):
+            if args.ngl < 0:
+                args.ngl = 999
+
             if runner:
                 gpu_args += ["--ngl"]  # double dash
             else:


### PR DESCRIPTION
ngl should default to 999 in all these cases.

## Summary by Sourcery

Bug Fixes:
- Set ngl to 999 if it is less than 0 to resolve issues caused by unspecified ngl values.