### PR TITLE
Introduced a model store

### DIFF
--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -1007,21 +1007,21 @@ def rm_cli(args):
 
 def New(model, args):
     if model.startswith("huggingface://") or model.startswith("hf://") or model.startswith("hf.co/"):
-        return Huggingface(model)
+        return Huggingface(model, args.store)
     if model.startswith("ollama://") or "ollama.com/library/" in model:
-        return Ollama(model)
+        return Ollama(model, args.store)
     if model.startswith("oci://") or model.startswith("docker://"):
-        return OCI(model, args.engine)
+        return OCI(model, args.engine, args.store)
     if model.startswith("http://") or model.startswith("https://") or model.startswith("file://"):
-        return URL(model)
+        return URL(model, args.store)
 
     transport = config.get("transport", "ollama")
     if transport == "huggingface":
-        return Huggingface(model)
+        return Huggingface(model, args.store)
     if transport == "ollama":
-        return Ollama(model)
+        return Ollama(model, args.store)
     if transport == "oci":
-        return OCI(model, args.engine)
+        return OCI(model, args.engine, args.store)
 
     raise KeyError(f'transport "{transport}" not supported. Must be oci, huggingface, or ollama.')
 

--- a/ramalama/http_client.py
+++ b/ramalama/http_client.py
@@ -43,7 +43,7 @@ class HttpClient:
         try:
             self.response = urllib.request.urlopen(request)
         except urllib.error.HTTPError as e:
-            raise IOError(f"Request failed: {e.code}") from e
+            raise e
         except urllib.error.URLError as e:
             raise IOError(f"Network error: {e.reason}") from e
 

--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -17,6 +17,7 @@ from ramalama.kube import Kube
 from ramalama.common import MNT_DIR, MNT_FILE
 from ramalama.model_inspect import GGUFModelInfo, ModelInfoBase
 from ramalama.gguf_parser import GGUFInfoParser
+from ramalama.model_store import ModelStore
 
 MODEL_TYPES = ["file", "https", "http", "oci", "huggingface", "hf", "ollama"]
 
@@ -41,11 +42,17 @@ class Model:
     model = ""
     type = "Model"
 
-    def __init__(self, model):
+    def __init__(self, model, store_path="", model_registry=""):
         self.model = model
+        self.model_tag = "latest"
+        if ":" in model:
+            self.model, self.model_tag = model.split(":", 1)
+
         split = self.model.rsplit("/", 1)
         self.directory = split[0] if len(split) > 1 else ""
         self.filename = split[1] if len(split) > 1 else split[0]
+
+        self.store = ModelStore(store_path, self.filename, self.directory, model_registry)
 
     def login(self, args):
         raise NotImplementedError(f"ramalama login for {self.type} not implemented")

--- a/ramalama/model_store.py
+++ b/ramalama/model_store.py
@@ -1,0 +1,184 @@
+import os
+import urllib
+from pathlib import Path
+
+from enum import StrEnum
+from dataclasses import dataclass
+from typing import Dict, Tuple
+
+
+from ramalama.common import verify_checksum, download_file
+
+
+class ModelRegistry(StrEnum):
+    HUGGINGFACE = "huggingface"
+    OLLAMA = "ollama"
+    OCI = "oci"
+    URL = "url"
+
+
+@dataclass
+class SnapshotFile:
+    url: str
+    header: Dict
+    hash: str
+    name: str
+    should_show_progress: bool
+    should_verify_checksum: bool
+    required: bool = True
+
+
+class RefFile:
+
+    def __init__(self):
+        self.hash: str = ""
+        self.filenames: list[str] = []
+
+    def from_path(path: str) -> "RefFile":
+        ref_file = RefFile()
+        with open(path, "r") as file:
+            ref_file.hash = file.readline().strip()
+            filename = file.readline().strip()
+            while filename != "":
+                ref_file.filenames.append(filename)
+                filename = file.readline().strip()
+        return ref_file
+
+
+class ModelStore:
+
+    def __init__(
+        self,
+        base_path: Path,
+        model_name: str,
+        model_organization: str,
+        model_registry: ModelRegistry,
+    ):
+        self._store_base_path = os.path.join(base_path, "store")
+        self._model_name = model_name
+        self._model_organization = model_organization
+        self._model_registry = model_registry
+
+    @property
+    def store_path(self) -> str:
+        return self._store_base_path
+
+    @property
+    def model_name(self) -> str:
+        return self._model_name
+
+    @property
+    def model_organization(self) -> str:
+        return self._model_organization if self._model_organization != "" else self._model_name
+
+    @property
+    def model_registry(self) -> ModelRegistry:
+        return self._model_registry
+
+    @property
+    def model_base_directory(self) -> str:
+        return os.path.join(self.store_path, self.model_registry, self.model_organization)
+
+    @property
+    def blob_directory(self) -> str:
+        return os.path.join(self.model_base_directory, "blobs")
+
+    @property
+    def ref_directory(self) -> str:
+        return os.path.join(self.model_base_directory, "refs")
+
+    @property
+    def snapshot_directory(self) -> str:
+        return os.path.join(self.model_base_directory, "snapshots")
+
+    def get_ref_file_path(self, model_tag: str) -> str:
+        return os.path.join(self.ref_directory, model_tag)
+
+    def get_snapshot_directory(self, hash: str) -> str:
+        return os.path.join(self.snapshot_directory, hash)
+
+    def get_blob_file_path(self, hash: str) -> str:
+        return os.path.join(self.blob_directory, hash)
+
+    def get_snapshot_file_path(self, hash: str, filename: str) -> str:
+        return os.path.join(self.get_snapshot_directory(hash), filename)
+
+    def resolve_model_directory(self, model_tag: str) -> str:
+        ref_file_path = self.get_ref_file_path(model_tag)
+        if not self.exists(ref_file_path):
+            return ""
+
+        ref_file = RefFile(ref_file_path)
+        return self.get_snapshot_directory(ref_file.hash)
+
+    def ensure_directory_setup(self) -> None:
+        os.makedirs(self.blob_directory, exist_ok=True)
+        os.makedirs(self.ref_directory, exist_ok=True)
+        os.makedirs(self.snapshot_directory, exist_ok=True)
+
+    def exists(self, model_tag: str) -> bool:
+        return os.path.exists(self.get_ref_file_path(model_tag))
+
+    def get_cached_files(self, model_tag: str) -> Tuple[str, list[str], bool]:
+        cached_files = []
+
+        ref_file_path = self.get_ref_file_path(model_tag)
+        if not self.exists(ref_file_path):
+            return ("", cached_files, False)
+
+        ref_file: RefFile = RefFile.from_path(ref_file_path)
+        for file in ref_file.filenames:
+            path = self.get_snapshot_file_path(ref_file.hash, file)
+            if os.path.exists(path):
+                cached_files.append(file)
+
+        return (ref_file.hash, cached_files, len(cached_files) == len(ref_file.filenames))
+
+    def prepare_new_snapshot(self, model_tag: str, snapshot_hash: str, snapshot_files: list[SnapshotFile]):
+        self.ensure_directory_setup()
+
+        ref_file = self.get_ref_file_path(model_tag)
+        if not os.path.exists(ref_file):
+            with open(ref_file, "w") as ref_file:
+                ref_file.write(f"{snapshot_hash}")
+                for file in snapshot_files:
+                    ref_file.write(f"\n{file.name}")
+
+                ref_file.flush()
+
+        snapshot_directory = self.get_snapshot_directory(snapshot_hash)
+        os.makedirs(snapshot_directory, exist_ok=True)
+
+
+    def new_snapshot(self, model_tag: str, snapshot_hash: str, snapshot_files: list[SnapshotFile]):
+        self.prepare_new_snapshot(model_tag, snapshot_hash, snapshot_files)
+
+        for file in snapshot_files:
+            dest_path = self.get_blob_file_path(file.hash)
+            try:
+                download_file(
+                    url=file.url,
+                    headers=file.header,
+                    dest_path=dest_path,
+                    show_progress=file.should_show_progress,
+                )
+            except urllib.error.HTTPError as e:
+                if file.required:
+                    raise
+                continue
+
+            if file.should_verify_checksum:
+                if not verify_checksum(dest_path):
+                    print(f"Checksum mismatch for blob {dest_path}, retrying download...")
+                    os.remove(dest_path)
+                    download_file(
+                        url=file.url,
+                        headers=file.header,
+                        dest_path=dest_path,
+                        show_progress=file.should_show_progress,
+                    )
+                    if not verify_checksum(dest_path):
+                        raise ValueError(f"Checksum verification failed for blob {dest_path}")
+
+            relative_target_path = os.path.relpath(dest_path, start=self.get_snapshot_directory(snapshot_hash))
+            os.symlink(relative_target_path, self.get_snapshot_file_path(snapshot_hash, file.name))

--- a/ramalama/oci.py
+++ b/ramalama/oci.py
@@ -12,6 +12,7 @@ from ramalama.common import (
     perror,
     run_cmd,
 )
+from ramalama.model_store import ModelRegistry
 
 prefix = "oci://"
 
@@ -102,8 +103,9 @@ def list_models(args):
 
 
 class OCI(Model):
-    def __init__(self, model, conman):
-        super().__init__(model.removeprefix(prefix).removeprefix("docker://"))
+    def __init__(self, model, conman, store_path=""):
+        model_name = model.removeprefix(prefix).removeprefix("docker://")
+        super().__init__(model_name, store_path, ModelRegistry.OCI)
         for t in MODEL_TYPES:
             if self.model.startswith(t + "://"):
                 raise ValueError(f"{model} invalid: Only OCI Model types supported")

--- a/ramalama/url.py
+++ b/ramalama/url.py
@@ -2,13 +2,14 @@ import os
 from ramalama.common import download_file
 from ramalama.model import Model, rm_until_substring
 from urllib.parse import urlparse
+from ramalama.model_store import ModelRegistry
 
 
 class URL(Model):
-    def __init__(self, model):
+    def __init__(self, model, store_path=""):
         self.type = urlparse(model).scheme
         model = rm_until_substring(model, "://")
-        super().__init__(model)
+        super().__init__(model, store_path,ModelRegistry.URL)
         split = self.model.rsplit("/", 1)
         self.directory = split[0].removeprefix("/") if len(split) > 1 else ""
 


### PR DESCRIPTION
Added a model store to standardize pulling, storing and using models across the different repositories.

A key goal of this store is to support downloading multiple files, e.g. the chat template from ollama models or additional metadata from non-GGUF models. In addition, this is probably a first step towards enabling the usage of safetensors (https://github.com/containers/ramalama/issues/642) where a model consists of multiple files. 

The proposed structure is inspired by how the huggingface-cli stores its files and extends it for the multi-source usage in ramalama. 

The proposed storage structure looks like this after running 
- `ramalama pull ollama://tinyllama`
- `ramalama pull hf://ibm-granite/granite-3b-code-base-2k-GGUF/granite-3b-code-base.Q4_K_M.gguf`
```
~/.local/share/ramalama/store
   |-- ollama
   |   |-- tinyllama
   |   |   |-- blobs
   |   |   |   |-- sha256:2af3b81862c6be03c769683af18efdadb2c33f60ff32ab6f83e42c043d6c7816
   |   |   |   |-- sha256:6331358be52a6ebc2fd0755a51ad1175734fd17a628ab5ea6897109396245362
   |   |   |   |-- sha256:af0ddbdaaa26f30d54d727f9dd944b76bdb926fdaf9a58f63f78c532f57c191f
   |   |   |-- refs
   |   |   |   |-- latest
   |   |   |-- snapshots
   |   |   |   |-- sha256:6331358be52a6ebc2fd0755a51ad1175734fd17a628ab5ea6897109396245362
   |   |   |   |   |-- chat_template -> ../../blobs/sha256:af0ddbdaaa26f30d54d727f9dd944b76bdb926fdaf9a58f63f78c532f57c191f
   |   |   |   |   |-- config.json -> ../../blobs/sha256:6331358be52a6ebc2fd0755a51ad1175734fd17a628ab5ea6897109396245362
   |   |   |   |   |-- tinyllama -> ../../blobs/sha256:2af3b81862c6be03c769683af18efdadb2c33f60ff32ab6f83e42c043d6c7816
   |-- huggingface
   |   |-- ibm-granite
   |   |   |-- granite-3b-code-base-2k-GGUF
   |   |   |   |-- blobs
   |   |   |   |   |-- sha256:c803a9bb910be0699501319140329ba0d2850aeb8827389e38f24e8370f04293
   |   |   |   |-- refs
   |   |   |   |   |-- latest
   |   |   |   |-- snapshots
   |   |   |   |   |-- sha256:c803a9bb910be0699501319140329ba0d2850aeb8827389e38f24e8370f04293
   |   |   |   |   |   |-- granite-3b-code-base.Q4_K_M.gguf -> ../../blobs/sha256:c803a9bb910be0699501319140329ba0d2850aeb8827389e38f24e8370f04293
```

## Summary by Sourcery

New Features:
- Add a model store to handle pulling, storing, and accessing models across repositories.