### PR TITLE
chore: replace RAMALAMA label by ai.ramalama

### DIFF
--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -480,7 +480,7 @@ def _list_containers(args):
     if conman == "" or conman is None:
         raise ValueError("no container manager (Podman, Docker) found")
 
-    conman_args = [conman, "ps", "-a", "--filter", "label=RAMALAMA"]
+    conman_args = [conman, "ps", "-a", "--filter", "label=ai.ramalama"]
     if hasattr(args, "noheading") and args.noheading:
         conman_args += ["--noheading"]
 

--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -158,7 +158,7 @@ class Model:
             "--rm",
             "-i",
             "--label",
-            "RAMALAMA",
+            "ai.ramalama",
             "--security-opt=label=disable",
             "--name",
             name,

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -9,7 +9,7 @@ load helpers
     if is_container; then
 	run_ramalama info
 	conman=$(jq .Engine.Name <<< $output | tr -d '"' )
-	verify_begin="${conman} run --rm -i --label RAMALAMA --security-opt=label=disable --name"
+	verify_begin="${conman} run --rm -i --label ai.ramalama --security-opt=label=disable --name"
 
 	run_ramalama --dryrun run ${model}
 	is "$output" "${verify_begin} ramalama_.*" "dryrun correct"

--- a/test/system/040-serve.bats
+++ b/test/system/040-serve.bats
@@ -4,7 +4,7 @@ load helpers
 load helpers.registry
 load setup_suite
 
-verify_begin=".*run --rm -i --label RAMALAMA --security-opt=label=disable --name"
+verify_begin=".*run --rm -i --label ai.ramalama --security-opt=label=disable --name"
 
 @test "ramalama --dryrun serve basic output" {
     model=m_$(safename)


### PR DESCRIPTION
make it compliant with 
https://github.com/opencontainers/image-spec/blob/main/annotations.md#rules

fixes https://github.com/containers/ramalama/issues/799

## Summary by Sourcery

Update the container label from `RAMALAMA` to `ai.ramalama` to adhere to OCI image specification rules. This change ensures that container management tools can correctly identify and manage containers created by Ramalama.

Bug Fixes:
- Fix an issue where containers created by ramalama could not be listed reliably using the `label=RAMALAMA` filter due to non-compliance with the Open Container Initiative (OCI) image specification guidelines.

Tests:
- Update system tests to reflect the change in the container label from `RAMALAMA` to `ai.ramalama`.

Chores:
- Replace the `RAMALAMA` label with `ai.ramalama` to comply with OCI image specification guidelines.