### PR TITLE
Upgrade from 6.3.1 to 6.3.2

### DIFF
--- a/container-images/rocm/amdgpu.repo
+++ b/container-images/rocm/amdgpu.repo
@@ -1,6 +1,6 @@
 [amdgpu]
 name=amdgpu
-baseurl=https://repo.radeon.com/amdgpu/6.3.1/rhel/9.5/main/x86_64/
+baseurl=https://repo.radeon.com/amdgpu/6.3.2/rhel/9.5/main/x86_64/
 enabled=1
 priority=50
 gpgcheck=1

--- a/container-images/rocm/rocm.repo
+++ b/container-images/rocm/rocm.repo
@@ -1,6 +1,6 @@
 [ROCm]
 name=ROCm
-baseurl=https://repo.radeon.com/rocm/rhel9/6.3.1/main
+baseurl=https://repo.radeon.com/rocm/rhel9/6.3.2/main
 enabled=1
 priority=50
 gpgcheck=1


### PR DESCRIPTION
For ROCm and AMD drivers

## Summary by Sourcery

Chores:
- Upgrade ROCm and AMD drivers from 6.3.1 to 6.3.2