### PR TITLE
Removed error wrapping in urlopen

### DIFF
--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -21,7 +21,9 @@ logging.basicConfig(level=logging.WARNING, format="%(asctime)s - %(levelname)s -
 
 MNT_DIR = "/mnt/models"
 MNT_FILE = f"{MNT_DIR}/model.file"
-HTTP_RANGE_NOT_SATISFIABLE = 416
+
+HTTP_NOT_FOUND = 404
+HTTP_RANGE_NOT_SATISFIABLE = 416  # "Range Not Satisfiable" error (file already downloaded)
 
 DEFAULT_IMAGE = "quay.io/ramalama/ramalama"
 
@@ -199,7 +201,7 @@ def download_file(url, dest_path, headers=None, show_progress=True):
             return  # Exit function if successful
 
         except urllib.error.HTTPError as e:
-            if e.code == HTTP_RANGE_NOT_SATISFIABLE:  # "Range Not Satisfiable" error (file already downloaded)
+            if e.code in [HTTP_RANGE_NOT_SATISFIABLE, HTTP_NOT_FOUND]:
                 return  # No need to retry
 
         except urllib.error.URLError as e:

--- a/ramalama/http_client.py
+++ b/ramalama/http_client.py
@@ -40,12 +40,7 @@ class HttpClient:
     def urlopen(self, url, headers):
         headers["Range"] = f"bytes={self.file_size}-"
         request = urllib.request.Request(url, headers=headers)
-        try:
-            self.response = urllib.request.urlopen(request)
-        except urllib.error.HTTPError as e:
-            raise IOError(f"Request failed: {e.code}") from e
-        except urllib.error.URLError as e:
-            raise IOError(f"Network error: {e.reason}") from e
+        self.response = urllib.request.urlopen(request)
 
         if self.response.status not in (200, 206):
             raise IOError(f"Request failed: {self.response.status}")


### PR DESCRIPTION
By wrapping the raised error from urlopen() in an IOError, the caller can not accurately handle that error anymore as its missing the http response code for http errors, for example. Instead, we do not handle any error at all in the HTTPClient for urlopen and let the error bubble up. This way the caller such as the download_file() can properly handle errors such as skipping retries for 404.