### PR TITLE
Align runtime arguments with run, serve, bench, and perplexity

### DIFF
--- a/docs/ramalama-bench.1.md
+++ b/docs/ramalama-bench.1.md
@@ -31,6 +31,10 @@ show this help message and exit
 #### **--network**=*none*
 set the network mode for the container
 
+#### **--ngl**
+number of gpu layers, 0 means CPU inferencing, 999 means use max layers (default: -1)
+The default -1, means use whatever is automatically deemed appropriate (0 or 999)
+
 ## DESCRIPTION
 Benchmark specified AI Model.
 

--- a/docs/ramalama-perplexity.1.md
+++ b/docs/ramalama-perplexity.1.md
@@ -71,6 +71,9 @@ confinement.
 Containers running in a user namespace (e.g., rootless containers)  can‐
 not have more privileges than the user that launched them.
 
+#### **--seed**=
+Specify seed rather than using random seed model interaction
+
 #### **--temp**="0.8"
 Temperature of the response from the AI Model
 llama.cpp explains this as:
@@ -80,6 +83,9 @@ llama.cpp explains this as:
     The higher the number is the more creative the response is, but more likely to hallucinate when set too high.
 
         Usage: Lower numbers are good for virtual assistants where we need deterministic responses. Higher numbers are good for roleplay or creative tasks like editing stories
+
+#### **--tls-verify**=*true*
+require HTTPS and verify certificates when contacting OCI registries
 
 ## DESCRIPTION
 Calculate the perplexity of an AI Model. Perplexity measures how well the model can predict the next token with lower values being better.

--- a/docs/ramalama-perplexity.1.md
+++ b/docs/ramalama-perplexity.1.md
@@ -25,6 +25,9 @@ URL support means if a model is on a web site or even on your local system, you 
 
 ## OPTIONS
 
+#### **--authfile**=*password*
+path of the authentication file for OCI registries
+
 #### **--ctx-size**, **-c**
 size of the prompt context (default: 2048, 0 = loaded from model)
 
@@ -39,6 +42,12 @@ The device specification is passed directly to the underlying container engine. 
 
 #### **--help**, **-h**
 show this help message and exit
+
+#### **--name**, **-n**
+name of the container to run the Model in
+
+#### **--network**=*none*
+set the network mode for the container
 
 #### **--ngl**
 number of gpu layers, 0 means CPU inferencing, 999 means use max layers (default: -1)

--- a/docs/ramalama-perplexity.1.md
+++ b/docs/ramalama-perplexity.1.md
@@ -25,8 +25,52 @@ URL support means if a model is on a web site or even on your local system, you 
 
 ## OPTIONS
 
+#### **--ctx-size**, **-c**
+size of the prompt context (default: 2048, 0 = loaded from model)
+
+#### **--device**
+Add a host device to the container. Optional permissions parameter  can
+be  used  to  specify device permissions by combining r for read, w for
+write, and m for mknod(2).
+
+Example: --device=/dev/dri/renderD128:/dev/xvdc:rwm
+
+The device specification is passed directly to the underlying container engine.  See documentation of the supported container engine for more information.
+
 #### **--help**, **-h**
 show this help message and exit
+
+#### **--ngl**
+number of gpu layers, 0 means CPU inferencing, 999 means use max layers (default: -1)
+The default -1, means use whatever is automatically deemed appropriate (0 or 999)
+
+#### **--privileged**
+By  default, RamaLama containers are unprivileged (=false) and cannot, for
+example, modify parts of the operating system. This is  because  by  de‐
+fault  a  container is only allowed limited access to devices. A "privi‐
+leged" container is given the same access to devices as the user launch‐
+ing the container, with the exception of virtual consoles  (/dev/tty\d+)
+when running in systemd mode (--systemd=always).
+
+A  privileged container turns off the security features that isolate the
+container from the host. Dropped Capabilities,  limited  devices,  read-
+only  mount points, Apparmor/SELinux separation, and Seccomp filters are
+all disabled.  Due to the disabled  security  features,  the  privileged
+field  should  almost never be set as containers can easily break out of
+confinement.
+
+Containers running in a user namespace (e.g., rootless containers)  can‐
+not have more privileges than the user that launched them.
+
+#### **--temp**="0.8"
+Temperature of the response from the AI Model
+llama.cpp explains this as:
+
+    The lower the number is, the more deterministic the response.
+
+    The higher the number is the more creative the response is, but more likely to hallucinate when set too high.
+
+        Usage: Lower numbers are good for virtual assistants where we need deterministic responses. Higher numbers are good for roleplay or creative tasks like editing stories
 
 ## DESCRIPTION
 Calculate the perplexity of an AI Model. Perplexity measures how well the model can predict the next token with lower values being better.

--- a/docs/ramalama-run.1.md
+++ b/docs/ramalama-run.1.md
@@ -38,7 +38,7 @@ write, and m for mknod(2).
 
 Example: --device=/dev/dri/renderD128:/dev/xvdc:rwm
 
-The device specifiaction is passed directly to the underlying container engine.  See documentation of the supported container engine for more information.
+The device specification is passed directly to the underlying container engine.  See documentation of the supported container engine for more information.
 
 #### **--help**, **-h**
 show this help message and exit
@@ -51,6 +51,10 @@ name of the container to run the Model in
 
 #### **--network**=*none*
 set the network mode for the container
+
+#### **--ngl**
+number of gpu layers, 0 means CPU inferencing, 999 means use max layers (default: -1)
+The default -1, means use whatever is automatically deemed appropriate (0 or 999)
 
 #### **--privileged**
 By  default, RamaLama containers are unprivileged (=false) and cannot, for

--- a/docs/ramalama-serve.1.md
+++ b/docs/ramalama-serve.1.md
@@ -53,7 +53,7 @@ write, and m for mknod(2).
 
 Example: --device=/dev/dri/renderD128:/dev/xvdc:rwm
 
-The device specifiaction is passed directly to the underlying container engine.  See documentation of the supported container engine for more information.
+The device specification is passed directly to the underlying container engine.  See documentation of the supported container engine for more information.
 
 #### **--generate**=type
 Generate specified configuration format for running the AI Model as a service
@@ -75,6 +75,10 @@ Name of the container to run the Model in.
 
 #### **--network**=*""*
 set the network mode for the container
+
+#### **--ngl**
+number of gpu layers, 0 means CPU inferencing, 999 means use max layers (default: -1)
+The default -1, means use whatever is automatically deemed appropriate (0 or 999)
 
 #### **--port**, **-p**
 port for AI Model server to listen on

--- a/docs/ramalama.1.md
+++ b/docs/ramalama.1.md
@@ -110,9 +110,6 @@ show container runtime command without executing it (default: False)
 run RamaLama using the specified container engine. Default is `podman` if installed otherwise docker.
 The default can be overridden in the ramalama.conf file or via the RAMALAMA_CONTAINER_ENGINE environment variable.
 
-#### **--gpu**
-offload the workload to the GPU (default: False)
-
 #### **--help**, **-h**
 show this help message and exit
 
@@ -128,10 +125,6 @@ RamaLama to use the `quay.io/ramalama/aiimage:latest` image.
 #### **--keep-groups**
 pass --group-add keep-groups to podman (default: False)
 Needed to access the gpu on some systems, but has an impact on security, use with caution.
-
-#### **--ngl**
-number of gpu layers, 0 means CPU inferencing, 999 means use max layers (default: -1)
-The default -1, means use whatever is automatically deemed appropriate (0 or 999)
 
 #### **--nocontainer**
 do not run RamaLama in the default container (default: False)

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -187,20 +187,6 @@ The RAMALAMA_IN_CONTAINER environment variable modifies default behaviour.""",
 The RAMALAMA_CONTAINER_ENGINE environment variable modifies default behaviour.""",
     )
     parser.add_argument(
-        "--gpu",
-        dest="gpu",
-        default=False,
-        action="store_true",
-        help="offload the workload to the GPU",
-    )
-    parser.add_argument(
-        "--ngl",
-        dest="ngl",
-        type=int,
-        default=config.get("ngl", -1),
-        help="Number of layers to offload to the gpu, if available",
-    )
-    parser.add_argument(
         "--keep-groups",
         dest="podman_keep_groups",
         default=config.get("keep_groups", False),
@@ -461,6 +447,13 @@ def bench_parser(subparsers):
         type=str,
         default="none",
         help="set the network mode for the container",
+    )
+    parser.add_argument(
+        "--ngl",
+        dest="ngl",
+        type=int,
+        default=config.get("ngl", -1),
+        help="Number of layers to offload to the gpu, if available",
     )
     parser.add_argument("MODEL")  # positional argument
     parser.set_defaults(func=bench_cli)
@@ -815,7 +808,17 @@ def _run(parser):
         help="set the network mode for the container",
     )
     parser.add_argument(
-        "--privileged", dest="privileged", action="store_true", help="give extended privileges to container"
+        "--ngl",
+        dest="ngl",
+        type=int,
+        default=config.get("ngl", -1),
+        help="Number of layers to offload to the gpu, if available",
+    )
+    parser.add_argument(
+        "--privileged",
+        dest="privileged",
+        action="store_true",
+        help="give extended privileges to container"
     )
     parser.add_argument("--seed", help="override random seed")
     parser.add_argument(
@@ -1023,6 +1026,7 @@ def New(model, args):
 
 def perplexity_parser(subparsers):
     parser = subparsers.add_parser("perplexity", help="calculate perplexity for specified AI Model")
+    _run(parser)
     parser.add_argument("MODEL")  # positional argument
     parser.set_defaults(func=perplexity_cli)
 

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -795,9 +795,16 @@ def _run(parser):
         help="size of the prompt context (0 = loaded from model)",
     )
     parser.add_argument(
-        "--device", dest="device", action='append', type=str, help="Device to leak in to the running container"
-    )
-    parser.add_argument("-n", "--name", dest="name", help="name of container in which the Model will be run")
+        "--device",
+        dest="device",
+        action='append',
+        type=str,
+        help="Device to leak in to the running container")
+    parser.add_argument(
+        "-n", 
+        "--name",
+        dest="name",
+        help="name of container in which the Model will be run")
     # Disable network access by default, and give the option to pass any supported network mode into
     # podman if needed:
     # https://docs.podman.io/en/latest/markdown/podman-run.1.html#network-mode-net
@@ -820,7 +827,9 @@ def _run(parser):
         action="store_true",
         help="give extended privileges to container"
     )
-    parser.add_argument("--seed", help="override random seed")
+    parser.add_argument(
+        "--seed", 
+        help="override random seed")
     parser.add_argument(
         "--temp", default=config.get('temp', "0.8"), help="temperature of the response from the AI model"
     )

--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -222,8 +222,7 @@ class Model:
     def gpu_args(self, args, runner=False):
         gpu_args = []
         if (
-            args.gpu > 0
-            or os.getenv("HIP_VISIBLE_DEVICES")
+            os.getenv("HIP_VISIBLE_DEVICES")
             or os.getenv("ASAHI_VISIBLE_DEVICES")
             or os.getenv("CUDA_VISIBLE_DEVICES")
             or os.getenv("INTEL_VISIBLE_DEVICES")


### PR DESCRIPTION
Removed the global argument `--gpu`

Aligned the runtime argument `--ngl` with the subcommands `bench`, `perplexity`, `run`, `serve`

Added arguments to the subcommand perplexity to align it with common arguments of `run` and `serve`

## Summary by Sourcery

Remove the global `--gpu` argument and introduce new runtime arguments for the `perplexity` subcommand, aligning it with the `run` and `serve` subcommands. Standardize the `--ngl` argument across all relevant subcommands. Update the documentation to reflect these changes.

Enhancements:
- Remove the global `--gpu` argument.
- Standardize the `--ngl` runtime argument across `bench`, `perplexity`, `run`, and `serve` subcommands.
- Align the `perplexity` subcommand with `run` and `serve` by adding common runtime arguments.

Documentation:
- Update documentation for `perplexity`, `run`, `serve`, and `bench` commands to reflect the addition of new runtime arguments and removal of the global `--gpu` argument.
- Document new runtime arguments, including `--authfile`, `--ctx-size`, `--device`, `--name`, `--network`, `--ngl`, `--privileged`, `--seed`, `--temp`, and `--tls-verify`.
- Clarify the device specification for the `--device` argument in the documentation for `run` and `serve` commands.
- Correct a typo in the device specification description for the `run` command documentation.