### PR TITLE
Fix handling of --privileged flag

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -2,7 +2,7 @@
 [codespell]
 
 # Comma-separated list of files to skip.
-skip = ./logos,./vendor,./.git #,bin,vendor,.git,go.sum,changelog.txt,.cirrus.yml,"RELEASE_NOTES.md,*.xz,*.gz,*.tar,*.tgz,bin2img,*ico,*.png,*.1,*.5,copyimg,*.orig,apidoc.go"
+skip = ./logos,./vendor,./.git #,bin,vendor,.git,go.sum,changelog.txt,.cirrus.yml,"RELEASE_NOTES.md,*.xz,*.gz,*.tar,*.tgz,bin2img,*ico,*.png,*.1,*.5,*.7,copyimg,*.orig,apidoc.go"
 
 # Comma separated list of words to be ignored. Words must be lowercased.
 ignore-words-list = clos,creat,ro,hastable,shouldnot,mountns,passt


### PR DESCRIPTION
## Summary by Sourcery

Allow the use of the `--privileged` flag to run containers with elevated privileges. Update the validation logic to prevent conflicts between the `--nocontainer` flag and the `--name` or `--privileged` flags.

Bug Fixes:
- Correctly handle the --privileged flag when starting a container, ensuring that security options are configured appropriately based on its value.
- Fix conflict between `--nocontainer` and `--privileged` options when running or serving a model.
- Fix conflict between `--nocontainer` and `--name` options when running or serving a model.

Tests:
- Add tests to verify that the `--privileged` flag is handled correctly and that conflicts with the `--nocontainer` flag are detected.