### PR TITLE
Pin dev dependencies to major version and improve formatting + linting

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+max-line-length = 120
+# E203,E221,E231 conflict with black formatting
+extend-ignore = E203,E221,E231,E702

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,14 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y bash codespell python3-argcomplete pipx
           make install-requirements
+
+      - name: Run format check
+        run: |
+          make check-format
+
       - name: Run lint
-        shell: bash
-        run: make lint
+        run: |
+          make lint
 
   bats:
     runs-on: ubuntu-24.04

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,13 @@ help:
 
 .PHONY: install-requirements
 install-requirements:
-	pipx install black flake8 argcomplete wheel huggingface_hub codespell
+	pipx install \
+			black~=25.0 \
+			flake8~=7.0 \
+			argcomplete~=3.0 \
+			wheel~=0.45.0 \
+			huggingface_hub~=0.28.0 \
+			codespell~=2.0
 
 .PHONY: install-completions
 install-completions: completions

--- a/Makefile
+++ b/Makefile
@@ -45,12 +45,13 @@ help:
 .PHONY: install-requirements
 install-requirements:
 	pipx install \
-			black~=25.0 \
-			flake8~=7.0 \
 			argcomplete~=3.0 \
-			wheel~=0.45.0 \
+			black~=25.0 \
+			codespell~=2.0 \
+			flake8~=7.0 \
 			huggingface_hub~=0.28.0 \
-			codespell~=2.0
+			isort~=6.0 \
+			wheel~=0.45.0 \
 
 .PHONY: install-completions
 install-completions: completions
@@ -117,10 +118,12 @@ lint:
 .PHONY: check-format
 check-format:
 	black --check --diff *.py ramalama/*.py
+	isort --check --diff *.py ramalama/*.py
 
 .PHONY: format
 format:
 	black *.py ramalama/*.py
+	isort *.py ramalama/*.py
 
 .PHONY: codespell
 codespell:

--- a/Makefile
+++ b/Makefile
@@ -112,8 +112,15 @@ docs:
 
 .PHONY: lint
 lint:
-	black --line-length 120 --exclude 'venv/*' *.py ramalama/*.py  # Format the code
-	flake8 --max-line-length=120 --exclude=venv *.py ramalama/*.py  # Check for any inconsistencies
+	flake8 *.py ramalama/*.py
+
+.PHONY: check-format
+check-format:
+	black --check --diff *.py ramalama/*.py
+
+.PHONY: format
+format:
+	black *.py ramalama/*.py
 
 .PHONY: codespell
 codespell:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ Repository = "https://github.com/containers/ramalama"
 Issues = "https://github.com/containers/ramalama/issues"
 
 [tool.black]
-line-length = 100
+line-length = 120
 skip-string-normalization = true
 preview = true
 target-version = ["py36"]
@@ -36,11 +36,16 @@ exclude = '''
   | dist
   | docs
   | hack
+  | venv
 )/
 '''
 [tool.isort]
 profile = "black"
-line_length = 100
+line_length = 120
+
+[tool.flake8]
+max-line-length = 120
+
 [tool.pytest.ini_options]
 log_cli = true
 log_cli_level = "DEBUG"

--- a/ramalama/__init__.py
+++ b/ramalama/__init__.py
@@ -1,8 +1,9 @@
 """ramalama client module."""
 
-from ramalama.common import perror
-from ramalama.cli import init_cli, print_version, HelpException
 import sys
+
+from ramalama.cli import HelpException, init_cli, print_version
+from ramalama.common import perror
 
 assert sys.version_info >= (3, 6), "Python 3.6 or greater is required."
 

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -1,29 +1,24 @@
-from pathlib import Path
 import argparse
 import glob
 import json
 import os
-import subprocess
 import platform
+import subprocess
 import time
+from pathlib import Path
+
 import ramalama.oci
 import ramalama.rag
-
+from ramalama.common import container_manager, default_image, perror, run_cmd
+from ramalama.gpu_detector import GPUDetector
 from ramalama.huggingface import Huggingface
-from ramalama.common import (
-    container_manager,
-    default_image,
-    perror,
-    run_cmd,
-)
 from ramalama.model import MODEL_TYPES
 from ramalama.oci import OCI
 from ramalama.ollama import Ollama
-from ramalama.url import URL
 from ramalama.shortnames import Shortnames
 from ramalama.toml_parser import TOMLParser
-from ramalama.version import version, print_version
-from ramalama.gpu_detector import GPUDetector
+from ramalama.url import URL
+from ramalama.version import print_version, version
 
 shortnames = Shortnames()
 
@@ -795,16 +790,9 @@ def _run(parser):
         help="size of the prompt context (0 = loaded from model)",
     )
     parser.add_argument(
-        "--device",
-        dest="device",
-        action='append',
-        type=str,
-        help="Device to leak in to the running container")
-    parser.add_argument(
-        "-n", 
-        "--name",
-        dest="name",
-        help="name of container in which the Model will be run")
+        "--device", dest="device", action='append', type=str, help="Device to leak in to the running container"
+    )
+    parser.add_argument("-n", "--name", dest="name", help="name of container in which the Model will be run")
     # Disable network access by default, and give the option to pass any supported network mode into
     # podman if needed:
     # https://docs.podman.io/en/latest/markdown/podman-run.1.html#network-mode-net
@@ -822,14 +810,9 @@ def _run(parser):
         help="Number of layers to offload to the gpu, if available",
     )
     parser.add_argument(
-        "--privileged",
-        dest="privileged",
-        action="store_true",
-        help="give extended privileges to container"
+        "--privileged", dest="privileged", action="store_true", help="give extended privileges to container"
     )
-    parser.add_argument(
-        "--seed", 
-        help="override random seed")
+    parser.add_argument("--seed", help="override random seed")
     parser.add_argument(
         "--temp", default=config.get('temp', "0.8"), help="temperature of the response from the AI model"
     )

--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -2,19 +2,19 @@
 
 import glob
 import hashlib
-import os
-import re
-import random
 import logging
+import os
+import random
+import re
 import shutil
 import string
 import subprocess
-import time
 import sys
-import urllib.request
+import time
 import urllib.error
-import ramalama.console as console
+import urllib.request
 
+import ramalama.console as console
 from ramalama.http_client import HttpClient
 
 logging.basicConfig(level=logging.WARNING, format="%(asctime)s - %(levelname)s - %(message)s")

--- a/ramalama/console.py
+++ b/ramalama/console.py
@@ -1,5 +1,5 @@
-import os
 import logging
+import os
 
 
 def is_locale_utf8():

--- a/ramalama/gguf_parser.py
+++ b/ramalama/gguf_parser.py
@@ -1,8 +1,7 @@
 import io
 import struct
-
 from enum import IntEnum
-from typing import Dict, Any
+from typing import Any, Dict
 
 import ramalama.console as console
 from ramalama.model_inspect import GGUFModelInfo, Tensor

--- a/ramalama/gpu_detector.py
+++ b/ramalama/gpu_detector.py
@@ -14,10 +14,10 @@ The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.
 """
 
-import subprocess
 import glob
-import platform
 import logging
+import platform
+import subprocess
 
 logging.basicConfig(level=logging.WARNING, format="%(asctime)s - %(levelname)s - %(message)s")
 

--- a/ramalama/http_client.py
+++ b/ramalama/http_client.py
@@ -3,8 +3,9 @@
 import os
 import shutil
 import time
-import urllib.request
 import urllib.error
+import urllib.request
+
 from ramalama.file import File
 
 

--- a/ramalama/huggingface.py
+++ b/ramalama/huggingface.py
@@ -1,7 +1,8 @@
 import os
 import pathlib
 import urllib.request
-from ramalama.common import available, run_cmd, exec_cmd, download_file, verify_checksum, perror
+
+from ramalama.common import available, download_file, exec_cmd, perror, run_cmd, verify_checksum
 from ramalama.model import Model, rm_until_substring
 
 missing_huggingface = """

--- a/ramalama/kube.py
+++ b/ramalama/kube.py
@@ -1,8 +1,7 @@
 import os
 
-
+from ramalama.common import MNT_DIR, genname, get_env_vars
 from ramalama.version import version
-from ramalama.common import genname, MNT_DIR, get_env_vars
 
 
 class Kube:

--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -1,22 +1,23 @@
 import os
-import sys
 import platform
+import sys
 
 from ramalama.common import (
-    container_manager,
     DEFAULT_IMAGE,
+    MNT_DIR,
+    MNT_FILE,
+    container_manager,
     exec_cmd,
     genname,
-    run_cmd,
-    get_gpu,
     get_env_vars,
+    get_gpu,
+    run_cmd,
 )
-from ramalama.version import version
-from ramalama.quadlet import Quadlet
-from ramalama.kube import Kube
-from ramalama.common import MNT_DIR, MNT_FILE
-from ramalama.model_inspect import GGUFModelInfo, ModelInfoBase
 from ramalama.gguf_parser import GGUFInfoParser
+from ramalama.kube import Kube
+from ramalama.model_inspect import GGUFModelInfo, ModelInfoBase
+from ramalama.quadlet import Quadlet
+from ramalama.version import version
 
 MODEL_TYPES = ["file", "https", "http", "oci", "huggingface", "hf", "ollama"]
 

--- a/ramalama/model_inspect.py
+++ b/ramalama/model_inspect.py
@@ -1,9 +1,8 @@
-import sys
-import shutil
 import json
-
-from typing import Dict, Any
+import shutil
+import sys
 from dataclasses import dataclass
+from typing import Any, Dict
 
 
 def get_terminal_width():

--- a/ramalama/oci.py
+++ b/ramalama/oci.py
@@ -4,14 +4,8 @@ import subprocess
 import tempfile
 
 import ramalama.annotations as annotations
-from ramalama.model import Model, MODEL_TYPES
-from ramalama.common import (
-    engine_version,
-    exec_cmd,
-    MNT_FILE,
-    perror,
-    run_cmd,
-)
+from ramalama.common import MNT_FILE, engine_version, exec_cmd, perror, run_cmd
+from ramalama.model import MODEL_TYPES, Model
 
 prefix = "oci://"
 

--- a/ramalama/ollama.py
+++ b/ramalama/ollama.py
@@ -1,7 +1,8 @@
+import json
 import os
 import urllib.request
-import json
-from ramalama.common import run_cmd, verify_checksum, download_file, available
+
+from ramalama.common import available, download_file, run_cmd, verify_checksum
 from ramalama.model import Model, rm_until_substring
 
 

--- a/ramalama/quadlet.py
+++ b/ramalama/quadlet.py
@@ -1,6 +1,6 @@
 import os
 
-from ramalama.common import default_image, MNT_DIR, MNT_FILE, get_env_vars
+from ramalama.common import MNT_DIR, MNT_FILE, default_image, get_env_vars
 
 
 class Quadlet:

--- a/ramalama/url.py
+++ b/ramalama/url.py
@@ -1,7 +1,8 @@
 import os
+from urllib.parse import urlparse
+
 from ramalama.common import download_file
 from ramalama.model import Model, rm_until_substring
-from urllib.parse import urlparse
 
 
 class URL(Model):

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
-import setuptools
 import os
+
+import setuptools
 from setuptools import find_packages
 from setuptools.command.build_py import build_py as build_py_orig
 


### PR DESCRIPTION
### Pin versions of the development tools to major version
    
By pinning the version of the development tools, the risk of accidental upgrades and breaking changes leading are mitigated.

### Refined formatting and linting
    
Split make target lint into lint, format and check-format and updated the CI steps accordingly. Also moved configuration of black to pyproject.toml and flake8 to .flake8 file.

### Introduced isort in the format make targets

Introduced isort in the format make targets

### Applied formatting changes from black and isort

Applied formatting changes from black and isort

## Summary by Sourcery

Pin dependencies, update linting and formatting, and update CI.

Build:
- Pin development dependencies to their major versions.
- Split the `lint` make target into `lint`, `format`, and `check-format` targets.
- Move the configuration of Black to `pyproject.toml` and Flake8 to `.flake8`.
- Introduce isort to the format make targets

CI:
- Update CI steps to reflect the new lint, format, and check-format targets

Chores:
- Apply formatting changes from Black and isort