### PR TITLE
README: Fix typo 

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ When both Podman and Docker are installed, RamaLama defaults to Podman, The `RAM
 
 ### Test and run your models more securely
 
-Because RamaLama defaults to running AI models inside of rootless containers using Podman on Docker. These containers isolate the AI models from information on the underlying host. With RamaLama containers, the AI model is mounted as a volume into the container in read/only mode. This results in the process running the model, llama.cpp or vLLM, being isolated from the host.  In addition, since `ramalama run` uses the --network=none option, the container can not reach the network and leak any information out of the system. Finally, containers are run with --rm options which means that any content written during the running of the container is wiped out when the application exits.
+Because RamaLama defaults to running AI models inside of rootless containers using Podman or Docker. These containers isolate the AI models from information on the underlying host. With RamaLama containers, the AI model is mounted as a volume into the container in read/only mode. This results in the process running the model, llama.cpp or vLLM, being isolated from the host.  In addition, since `ramalama run` uses the --network=none option, the container can not reach the network and leak any information out of the system. Finally, containers are run with --rm options which means that any content written during the running of the container is wiped out when the application exits.
 
 ### Here’s how RamaLama delivers a robust security footprint:
 


### PR DESCRIPTION
## Changes Made
On Line 24 in README
```diff
- ...rootless containers using Podman on Docker.
+ ...rootless containers using Podman or Docker.
```

## Summary by Sourcery

Documentation:
- Fix typo in the README regarding the use of Podman or Docker for rootless containers