### PR TITLE
Changes to "apt" command syntax in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -43,9 +43,9 @@ apt_install() {
     $sudo apt-get update || true
 
     # only install docker if podman can't be
-    if ! $sudo apt install -y podman; then
+    if ! $sudo apt install podman; then
       if ! available docker; then
-        $sudo apt install -y docker || true
+        $sudo apt install docker || true
       fi
     fi
   fi

--- a/install.sh
+++ b/install.sh
@@ -43,9 +43,9 @@ apt_install() {
     $sudo apt-get update -qq || true
 
     # only install docker if podman can't be
-    if ! $sudo apt_get_install podman; then
+    if ! $sudo apt install -y podman; then
       if ! available docker; then
-        $sudo apt_get_install docker || true
+        $sudo apt install -y docker || true
       fi
     fi
   fi


### PR DESCRIPTION
Original install.sh had incorrect syntax as shown below

`apt_get_install`

Changed to 
`apt install`

Had a `-y `in my changes orginally, but removed as that would actually install the package, and the offending line was only a "test if true"

NOTE: `apt-get install `would also be correct, but `apt install` is newer and not many still use `apt-get`

## Summary by Sourcery

Bug Fixes:
- Fix the syntax of the `apt` command used for installing packages in `install.sh` script. The incorrect `apt_get_install` and `apt-get install` was replaced with `apt install`