### PR TITLE
HuggingFace Cache Implementation

### DIFF
--- a/ramalama/huggingface.py
+++ b/ramalama/huggingface.py
@@ -71,7 +71,7 @@ class Huggingface(Model):
                 return self.hf_pull(args, model_path, directory_path)
             perror("URL pull failed and huggingface-cli not available")
             raise KeyError(f"Failed to pull model: {str(e)}")
-        
+
     def _fetch_snapshot_path(self, cache_dir, namespace, repo):
         cache_path = os.path.join(cache_dir, f'models--{namespace}--{repo}')
         main_ref_path = os.path.join(cache_path, 'refs', 'main')
@@ -89,26 +89,25 @@ class Huggingface(Model):
         default_hf_caches = [os.path.join(os.environ['HOME'], '.cache/huggingface/hub')]
         namespace, repo = os.path.split(str(self.directory))
 
-
         for cache_dir in default_hf_caches:
-                snapshot_path, cache_path = self._fetch_snapshot_path(cache_dir, namespace, repo)
-                if not snapshot_path or not os.path.exists(snapshot_path):
-                    continue
+            snapshot_path, cache_path = self._fetch_snapshot_path(cache_dir, namespace, repo)
+            if not snapshot_path or not os.path.exists(snapshot_path):
+                continue
 
-                file_path = os.path.join(snapshot_path, self.filename)
-                if not os.path.exists(file_path):
-                    continue
+            file_path = os.path.join(snapshot_path, self.filename)
+            if not os.path.exists(file_path):
+                continue
 
-                blob_path = pathlib.Path(file_path).resolve()
-                if not os.path.exists(blob_path):
-                    continue
+            blob_path = pathlib.Path(file_path).resolve()
+            if not os.path.exists(blob_path):
+                continue
 
-                blob_file = os.path.relpath(blob_path, start=os.path.join(cache_path, 'blobs'))
-                if str(blob_file) != str(sha256_checksum):
-                    continue
+            blob_file = os.path.relpath(blob_path, start=os.path.join(cache_path, 'blobs'))
+            if str(blob_file) != str(sha256_checksum):
+                continue
 
-                os.symlink(blob_path, target_path)
-                return True
+            os.symlink(blob_path, target_path)
+            return True
         return False
 
     def hf_pull(self, args, model_path, directory_path):


### PR DESCRIPTION
Adding similar cache-checking functionality that Ollama has for HuggingFace

```
$ huggingface-cli download DevQuasar/ibm-granite.granite-3.2-8b-instruct-preview-GGUF ibm-granite.granite-3.2-8b-instruct-preview.Q4_K_M.gguf
/Users/kugupta/.cache/huggingface/hub/models--DevQuasar--ibm-granite.granite-3.2-8b-instruct-preview-GGUF/snapshots/67a9b8b00464fce66686bdabc0f5d1fc2a63d8b8/ibm-granite.granite-3.2-8b-instruct-preview.Q4_K_M.gguf

$ huggingface-cli scan-cache        
REPO ID                                                    REPO TYPE SIZE ON DISK NB FILES LAST_ACCESSED LAST_MODIFIED REFS LOCAL PATH                                                                                                
---------------------------------------------------------- --------- ------------ -------- ------------- ------------- ---- --------------------------------------------------------------------------------------------------------- 
DevQuasar/ibm-granite.granite-3.2-8b-instruct-preview-GGUF model             4.9G        1 2 minutes ago 3 minutes ago main /Users/kugupta/.cache/huggingface/hub/models--DevQuasar--ibm-granite.granite-3.2-8b-instruct-preview-GGUF 

$ ramalama ls
NAME MODIFIED SIZE

$ ramalama pull hf://DevQuasar/ibm-granite.granite-3.2-8b-instruct-preview-GGUF/ibm-granite.granite-3.2-8b-instruct-preview.Q4_K_M.gguf

$ ramalama ls
NAME                                                                                                                             MODIFIED      SIZE  
huggingface://DevQuasar/ibm-granite.granite-3.2-8b-instruct-preview-GGUF/ibm-granite.granite-3.2-8b-instruct-preview.Q4_K_M.gguf 2 seconds ago 4.6 GB

$ ls -la ~/.local/share/ramalama/models/huggingface/DevQuasar/ibm-granite.granite-3.2-8b-instruct-preview-GGUF/ibm-granite.granite-3.2-8b-instruct-preview.Q4_K_M.gguf
lrwxr-xr-x@ 1 kugupta  staff  216 Feb 16 19:11 /Users/kugupta/.local/share/ramalama/models/huggingface/DevQuasar/ibm-granite.granite-3.2-8b-instruct-preview-GGUF/ibm-granite.granite-3.2-8b-instruct-preview.Q4_K_M.gguf -> ../../../../repos/huggingface/DevQuasar/ibm-granite.granite-3.2-8b-instruct-preview-GGUF/ibm-granite.granite-3.2-8b-instruct-preview.Q4_K_M.gguf/sha256:984041b0d5e851c3c1199d67c74b067289cbd7299d009f6a66dce843c960c3d3

$ ls -la ~/.local/share/ramalama/repos/huggingface/DevQuasar/ibm-granite.granite-3.2-8b-instruct-preview-GGUF/ibm-granite.granite-3.2-8b-instruct-preview.Q4_K_M.gguf 
lrwxr-xr-x@ 1 kugupta  staff  176 Feb 16 19:11 sha256:984041b0d5e851c3c1199d67c74b067289cbd7299d009f6a66dce843c960c3d3 -> /Users/kugupta/.cache/huggingface/hub/models--DevQuasar--ibm-granite.granite-3.2-8b-instruct-preview-GGUF/blobs/984041b0d5e851c3c1199d67c74b067289cbd7299d009f6a66dce843c960c3d3

$ ramalama run hf://DevQuasar/ibm-granite.granite-3.2-8b-instruct-preview-GGUF/ibm-granite.granite-3.2-8b-instruct-preview.Q4_K_M.gguf
> Working model loaded from a huggingface hub cache      
```

## Summary by Sourcery

Implement Hugging Face model caching. Check the Hugging Face cache for existing models before attempting to download them.

New Features:
- Add caching for Hugging Face models.
- Check the Hugging Face cache for models before downloading them.