### PR TITLE
Some tests around --network, --net options

### DIFF
--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -17,13 +17,13 @@ EOF
 	verify_begin="${conman} run --rm -i --label ai.ramalama --name"
 
 	run_ramalama --dryrun run ${model}
-	is "$output" "${verify_begin} ramalama_.*" "dryrun correct"
+	is "$output" "${verify_begin} ramalama_.*--network none.*" "dryrun correct"
 	is "$output" ".*${model}" "verify model name"
 	is "$output" ".*-c 2048" "verify model name"
 	assert "$output" !~ ".*--seed" "assert seed does not show by default"
 
-	run_ramalama --dryrun run --seed 9876 -c 4096 --name foobar ${model}
-	is "$output" "${verify_begin} foobar .*" "dryrun correct with --name"
+	run_ramalama --dryrun run --seed 9876 -c 4096 --net bridge --name foobar ${model}
+	is "$output" "${verify_begin} foobar.*--network bridge.*" "dryrun correct with --name"
 	is "$output" ".*${model}" "verify model name"
 	is "$output" ".*-c 4096" "verify ctx-size is set"
 	is "$output" ".*--temp 0.8" "verify temp is set"

--- a/test/system/040-serve.bats
+++ b/test/system/040-serve.bats
@@ -16,12 +16,13 @@ verify_begin=".*run --rm -i --label ai.ramalama --name"
 
 	run_ramalama --dryrun serve --name foobar ${model}
 	is "$output" "${verify_begin} foobar .*" "dryrun correct with --name"
+	assert "$output" !~ ".*--network" "--network is not part of the output"
 	assert "$output" =~ ".*--host 0.0.0.0" "verify host 0.0.0.0 is added when run within container"
 	is "$output" ".*${model}" "verify model name"
 	assert "$output" !~ ".*--seed" "assert seed does not show by default"
 
-	run_ramalama --dryrun serve --host 127.1.2.3 --name foobar ${model}
-	assert "$output" =~ ".*--host 127.1.2.3" "verify --host is modified when run within container"
+	run_ramalama --dryrun serve --network bridge --host 127.1.2.3 --name foobar ${model}
+	assert "$output" =~ "--network bridge.*--host 127.1.2.3" "verify --host is modified when run within container"
 	is "$output" ".*${model}" "verify model name"
 	is "$output" ".*--temp 0.8" "verify temp is set"
 


### PR DESCRIPTION
For run and serve commands.

## Summary by Sourcery

Tests:
- Added system tests to verify the behavior of the `--network` and `--net` options with the `run` and `serve` commands.