### PR TITLE
chore: fix links of llama.cpp repository

### DIFF
--- a/container-images/scripts/build_llama_and_whisper.sh
+++ b/container-images/scripts/build_llama_and_whisper.sh
@@ -113,7 +113,7 @@ clone_and_build_whisper_cpp() {
 clone_and_build_llama_cpp() {
   local llama_cpp_sha="4078c77f9891831f29ffc7c315c8ec6695ba5ce7"
 
-  git clone https://github.com/ggerganov/llama.cpp
+  git clone https://github.com/ggml-org/llama.cpp
   cd llama.cpp
   git submodule update --init --recursive
   git reset --hard "$llama_cpp_sha"

--- a/docs/ramalama-serve.1.md
+++ b/docs/ramalama-serve.1.md
@@ -30,7 +30,7 @@ URL support means if a model is on a web site or even on your local system, you 
 ## REST API ENDPOINTS
 Under the hood, `ramalama-serve` uses the `LLaMA.cpp` HTTP server by default.
 
-For REST API endpoint documentation, see: [https://github.com/ggerganov/llama.cpp/blob/master/examples/server/README.md#api-endpoints](https://github.com/ggerganov/llama.cpp/blob/master/examples/server/README.md#api-endpoints)
+For REST API endpoint documentation, see: [https://github.com/ggml-org/llama.cpp/blob/master/examples/server/README.md#api-endpoints](https://github.com/ggml-org/llama.cpp/blob/master/examples/server/README.md#api-endpoints)
 
 ## OPTIONS
 

--- a/ramalama/gguf_parser.py
+++ b/ramalama/gguf_parser.py
@@ -8,7 +8,7 @@ from ramalama.model_inspect import GGUFModelInfo, Tensor
 
 
 # Based on ggml_type in
-# https://github.com/ggerganov/ggml/blob/master/docs/gguf.md#file-structure
+# https://github.com/ggml-org/ggml/blob/master/docs/gguf.md#file-structure
 class GGML_TYPE(IntEnum):
     GGML_TYPE_F32 = (0,)
     GGML_TYPE_F16 = (1,)
@@ -43,7 +43,7 @@ class GGML_TYPE(IntEnum):
 
 
 # Based on gguf_metadata_value_type in
-# https://github.com/ggerganov/ggml/blob/master/docs/gguf.md#file-structure
+# https://github.com/ggml-org/ggml/blob/master/docs/gguf.md#file-structure
 class GGUFValueType(IntEnum):
     UINT8 = (0,)  # 8-bit unsigned integer
     INT8 = (1,)  # 8-bit signed integer


### PR DESCRIPTION
repository has moved: https://github.com/ggml-org/llama.cpp/discussions/11801

## Summary by Sourcery

Update the llama.cpp repository URL to ggml-org/llama.cpp in the build script, gguf_parser.py, and documentation.

Build:
- Update the llama.cpp repository URL in the build script to ggml-org/llama.cpp

Documentation:
- Update the llama.cpp repository URL in the documentation to ggml-org/llama.cpp

Chores:
- Update the llama.cpp repository URL to ggml-org/llama.cpp in the gguf_parser.py and documentation