### PR TITLE
Add system tests to pull from the Hugging Face cache

### DIFF
--- a/test/system/050-pull.bats
+++ b/test/system/050-pull.bats
@@ -53,6 +53,29 @@ load setup_suite
 }
 
 # bats test_tags=distro-integration
+@test "ramalama pull huggingface-cli cache" {
+    skip_if_no_hf-cli
+    huggingface-cli download Felladrin/gguf-smollm-360M-instruct-add-basics smollm-360M-instruct-add-basics.IQ2_XXS.gguf
+
+    run_ramalama pull hf://Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS.gguf
+    run_ramalama list
+    is "$output" ".*Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS" "image was actually pulled locally from hf-cli cache"
+    run_ramalama rm hf://Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS.gguf
+
+    run_ramalama pull huggingface://Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS.gguf
+    run_ramalama list
+    is "$output" ".*Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS" "image was actually pulled locally from hf-cli cache"
+    run_ramalama rm huggingface://Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS.gguf
+
+    RAMALAMA_TRANSPORT=huggingface run_ramalama pull Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS.gguf
+    run_ramalama list
+    is "$output" ".*Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS" "image was actually pulled locally from hf-cli cache"
+    run_ramalama rm huggingface://Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS.gguf
+
+    rm -rf ~/.cache/huggingface/hub/models--Felladrin--gguf-smollm-360M-instruct-add-basics
+}
+
+# bats test_tags=distro-integration
 @test "ramalama pull oci" {
     skip "Waiting for podman artiface support" 
     run_ramalama pull oci://quay.io/mmortari/gguf-py-example:v1

--- a/test/system/helpers.bash
+++ b/test/system/helpers.bash
@@ -270,5 +270,12 @@ function skip_if_darwin() {
     fi
 }
 
+function skip_if_no_hf-cli(){
+    if ! command -v huggingface-cli 2>&1 >/dev/null
+    then
+        skip "Not supported without huggingface-cli"
+    fi
+}
+
 # END   miscellaneous tools
 ###############################################################################


### PR DESCRIPTION
Adds a system test to verify that `ramalama pull` can pull images from the Hugging Face cache when using hf://, huggingface://, or setting RAMALAMA_TRANSPORT=huggingface.

Created a new helper function named skip_if_no_hf-cli for local users. Checks if the huggingface-cli command is available, else skips the test.

Having trouble passing through the current tests when Ollama is installed on a Linux box if anyone would like to help assist/debug there: https://github.com/kush-gupt/ramalama/actions/runs/13377020351/job/37358309783

## Summary by Sourcery

Adds a system test to verify that `ramalama pull` can pull images from the Hugging Face cache when using `hf://`, `huggingface://`, or setting `RAMALAMA_TRANSPORT=huggingface`. Also introduces a helper function to skip tests if the `huggingface-cli` command is not available.

Tests:
- Adds a system test to verify that `ramalama pull` can pull images from the Hugging Face cache when using `hf://`, `huggingface://`, or setting `RAMALAMA_TRANSPORT=huggingface`.
- Introduces a helper function `skip_if_no_hf-cli` to skip tests if the `huggingface-cli` command is not available.