### PR TITLE
Just one add_argument call for --dryrun/--dry-run

### DIFF
--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -166,9 +166,12 @@ def configure_arguments(parser):
 The RAMALAMA_IN_CONTAINER environment variable modifies default behaviour.""",
     )
     parser.add_argument(
-        "--dryrun", dest="dryrun", action="store_true", help="show container runtime command without executing it"
+        "--dryrun",
+        "--dry-run",
+        dest="dryrun",
+        action="store_true",
+        help="show container runtime command without executing it",
     )
-    parser.add_argument("--dry-run", dest="dryrun", action="store_true", help=argparse.SUPPRESS)  # Alternative spelling
     parser.add_argument(
         "--engine",
         dest="engine",


### PR DESCRIPTION
Just alias a single function call, rather than calling the function twice

## Summary by Sourcery

Enhancements:
- The `--dry-run` argument is now an alias for `--dryrun`, instead of being a separate argument.