### PR TITLE
Include instructions for installing on Fedora 42+

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,14 @@ $ cat /usr/share/ramalama/shortnames.conf
 
 ## Install
 
+## Install on Fedora
+
+RamaLama is available in [Fedora 40](https://fedoraproject.org/) and later. To install it, run:
+
+```
+sudo dnf install python3-ramalama
+```
+
 ## Install via PyPi
 
 RamaLama is available via PyPi [https://pypi.org/project/ramalama](https://pypi.org/project/ramalama)


### PR DESCRIPTION
This is the easiest and most secure way to install Ramalama.

## Summary by Sourcery

Documentation:
- Add instructions for installing Ramalama on Fedora 42 and later using the `dnf` package manager.