### PR TITLE
Remove LICENSE header from gpu_detector.py

### DIFF
--- a/ramalama/gpu_detector.py
+++ b/ramalama/gpu_detector.py
@@ -1,19 +1,3 @@
-"""
-MIT License
-
-(C) 2024-2025 ramalama developers
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-"""
-
 import glob
 import logging
 import platform


### PR DESCRIPTION
It doesn't make sense to have a license header just for this file.

Removing, it's easier just to maintain one license file.

## Summary by Sourcery

Chores:
- Removed the redundant LICENSE header from `gpu_detector.py`.