### PR TITLE
Fix up handling of image selection on generate

### DIFF
--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -838,8 +838,17 @@ def run_parser(subparsers):
 
 
 def run_cli(args):
-    model = New(args.MODEL, args)
-    model.run(args)
+    try:
+        model = New(args.MODEL, args)
+        model.run(args)
+
+    except KeyError as e:
+        try:
+            args.quiet = True
+            model = OCI(args.MODEL, args.engine, ignore_stderr=True)
+            model.run(args)
+        except Exception:
+            raise e
 
 
 def serve_parser(subparsers):
@@ -863,8 +872,17 @@ def serve_parser(subparsers):
 def serve_cli(args):
     if not args.container:
         args.detach = False
-    model = New(args.MODEL, args)
-    model.serve(args)
+
+    try:
+        model = New(args.MODEL, args)
+        model.serve(args)
+    except KeyError as e:
+        try:
+            args.quiet = True
+            model = OCI(args.MODEL, args.engine, ignore_stderr=True)
+            model.serve(args)
+        except Exception:
+            raise e
 
 
 def stop_parser(subparsers):
@@ -969,8 +987,8 @@ def _rm_model(models, args):
                         raise e
             try:
                 # attempt to remove as a container image
-                m = OCI(model, args.engine)
-                m.remove(args, ignore_stderr=True)
+                m = OCI(model, args.engine, ignore_stderr=True)
+                m.remove(args)
                 return
             except Exception:
                 pass

--- a/ramalama/kube.py
+++ b/ramalama/kube.py
@@ -5,7 +5,7 @@ from ramalama.version import version
 
 
 class Kube:
-    def __init__(self, model, args, exec_args):
+    def __init__(self, model, image, args, exec_args):
         self.ai_image = model
         if hasattr(args, "MODEL"):
             self.ai_image = args.MODEL
@@ -18,8 +18,7 @@ class Kube:
         self.model = model.removeprefix("oci://")
         self.args = args
         self.exec_args = exec_args
-
-        self.image = args.image
+        self.image = image
 
     def gen_volumes(self):
         mounts = f"""\

--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -485,6 +485,7 @@ class Model(ModelBase):
         return exec_args
 
     def generate_container_config(self, model_path, args, exec_args):
+        self.image = self._image(args)
         if args.generate == "quadlet":
             self.quadlet(model_path, args, exec_args)
         elif args.generate == "kube":
@@ -526,17 +527,17 @@ class Model(ModelBase):
         self.execute_command(model_path, exec_args, args)
 
     def quadlet(self, model, args, exec_args):
-        quadlet = Quadlet(model, args, exec_args)
+        quadlet = Quadlet(model, self.image, args, exec_args)
         quadlet.generate()
 
     def quadlet_kube(self, model, args, exec_args):
-        kube = Kube(model, args, exec_args)
+        kube = Kube(model, self.image, args, exec_args)
         kube.generate()
-        quadlet = Quadlet(model, args, exec_args)
+        quadlet = Quadlet(model, self.image, args, exec_args)
         quadlet.kube()
 
     def kube(self, model, args, exec_args):
-        kube = Kube(model, args, exec_args)
+        kube = Kube(model, self.image, args, exec_args)
         kube.generate()
 
     def path(self, args):

--- a/ramalama/quadlet.py
+++ b/ramalama/quadlet.py
@@ -1,10 +1,10 @@
 import os
 
-from ramalama.common import MNT_DIR, MNT_FILE, default_image, get_env_vars
+from ramalama.common import MNT_DIR, MNT_FILE, get_env_vars
 
 
 class Quadlet:
-    def __init__(self, model, args, exec_args):
+    def __init__(self, model, image, args, exec_args):
         self.ai_image = model
         if hasattr(args, "MODEL"):
             self.ai_image = args.MODEL
@@ -17,6 +17,7 @@ class Quadlet:
         self.model = model.removeprefix("oci://")
         self.args = args
         self.exec_args = exec_args
+        self.image = image
 
     def kube(self):
         outfile = self.name + ".kube"
@@ -64,7 +65,7 @@ After=local-fs.target
 AddDevice=-/dev/dri
 AddDevice=-/dev/kfd
 Exec={" ".join(self.exec_args)}
-Image={default_image()}
+Image={self.image}
 {env_var_string}
 {volume}
 {name_string}

--- a/test/system/040-serve.bats
+++ b/test/system/040-serve.bats
@@ -239,11 +239,11 @@ verify_begin=".*run --rm -i --label ai.ramalama --name"
 	is "$output" ".*command: \[\"--port\"\]" "command is correct"
 	is "$output" ".*args: \['1234', '--model', '/mnt/models/model.file', '--max_model_len', '2048'\]" "args are correct"
 
-	is "$output" ".*image: quay.io/ramalama/ramalama" "image is correct"
 	is "$output" ".*reference: ${ociimage}" "AI image should be created"
 	is "$output" ".*pullPolicy: IfNotPresent" "pullPolicy should exist"
 
 	run_ramalama rm oci://${ociimage}
+	rm $name.yaml
     done
     stop_registry
 }
@@ -257,7 +257,6 @@ verify_begin=".*run --rm -i --label ai.ramalama --name"
     is "$output" ".*Generating Kubernetes YAML file: ${name}.yaml" "generate .yaml file"
 
     run cat $name.yaml
-    is "$output" ".*image: quay.io/ramalama/ramalama" "Should container image"
     is "$output" ".*command: \[\"llama-server\"\]" "Should command"
     is "$output" ".*containerPort: 1234" "Should container container port"
 
@@ -274,7 +273,6 @@ verify_begin=".*run --rm -i --label ai.ramalama --name"
     is "$output" ".*Generating quadlet file: ${name}.kube" "generate .kube file"
 
     run cat $name.yaml
-    is "$output" ".*image: quay.io/ramalama/ramalama" "Should container image"
     is "$output" ".*command: \[\"llama-server\"\]" "Should command"
     is "$output" ".*containerPort: 1234" "Should container container port"
 
@@ -288,6 +286,8 @@ verify_begin=".*run --rm -i --label ai.ramalama --name"
 
     run cat $name.kube
     is "$output" ".*Yaml=$name.yaml" "Should container container port"
+    rm $name.kube
+    rm $name.yaml
 }
 
 # vim: filetype=sh

--- a/test/system/055-convert.bats
+++ b/test/system/055-convert.bats
@@ -37,20 +37,30 @@ load helpers
 
 @test "ramalama convert tiny to image" {
     skip_if_darwin
+    skip_if_docker
     run_ramalama pull tiny
-    run_ramalama convert tiny oci://ramalama/tiny
+    run_ramalama convert tiny oci://quay.io/ramalama/tiny
     run_ramalama list
     is "$output" ".*ramalama/tiny:latest"
-    run_ramalama rm ramalama/tiny
+#    FIXME:  This test will work on all podman 5.3 and greater clients.
+#    right now Ubuntu test suite is stuck on podman 5.0.3 Ubuntu 24.10 support
+#    it bug github is stuck on 24.04.  Should change when 25.04 is released
+#    if is_container and not_docker; then
+#       cname=c_$(safename)
+#       run_podman version
+#       run_ramalama serve -n ${cname} -d quay.io/ramalama/tiny
+#       run_ramalama stop ${cname}
+#    fi
+    run_ramalama rm quay.io/ramalama/tiny
     run_ramalama list
-    assert "$output" !~ ".*ramalama/tiny" "image was removed"
+    assert "$output" !~ ".*quay.io/ramalama/tiny" "image was removed"
 
-    run_ramalama convert ollama://tinyllama oci://ramalama/tiny
+    run_ramalama convert ollama://tinyllama oci://quay.io/ramalama/tinyllama
     run_ramalama list
-    is "$output" ".*ramalama/tiny:latest"
-    run_ramalama rm ramalama/tiny
+    is "$output" ".*quay.io/ramalama/tinyllama:latest"
+    run_ramalama rm quay.io/ramalama/tinyllama
     run_ramalama list
-    assert "$output" !~ ".*ramalama/tiny" "image was removed"
+    assert "$output" !~ ".*ramalama/tinyllama" "image was removed"
 
     podman image prune --force
 }


### PR DESCRIPTION
Also fall back to trying OCI images on ramalama run and serve.

## Summary by Sourcery

This pull request modifies the application to improve image selection and handling, particularly when using `run` and `serve` commands. It introduces a fallback mechanism to attempt using OCI images if the initial image type fails. Additionally, it refactors the `Quadlet` and `Kube` classes to receive the image as a parameter, ensuring correct image usage in container configurations.

Bug Fixes:
- Fixes an issue where the application would not attempt to use OCI images when the initially specified image type failed, specifically in `run` and `serve` commands.

Enhancements:
- Modifies the `Quadlet` and `Kube` classes to receive the image as a parameter during initialization, ensuring the correct image is used for container configuration.
- Improves image handling by ensuring the correct image is used when generating container configurations.