### PR TITLE
Change rune to run

### DIFF
--- a/docs/demo/ramalama.sh
+++ b/docs/demo/ramalama.sh
@@ -79,7 +79,7 @@ run() {
     exec_color "ramalama --dryrun run granite | grep --color -- --network.*none"
     echo ""
 
-    echo_color "run granite via RamaLama rune"
+    echo_color "run granite via RamaLama run"
     exec_color "ramalama run --ngl 0 granite"
     echo ""
 


### PR DESCRIPTION
Spotted this typo during demo

## Summary by Sourcery

Corrected a typo in the demo script, changing 'rune' to 'run'.

Bug Fixes:
- Fixed a typo in the demo script, changing 'rune' to 'run'.

Documentation:
- Corrected a typo in the demo script within the documentation.