### PR TITLE
Added support for apple hypervisor support on macos

### DIFF
--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -36,7 +36,7 @@ def get_engine():
     if engine is not None:
         return engine
 
-    if available("podman") and (sys.platform != "darwin" or is_podman_machine_running_with_krunkit()):
+    if available("podman"):
         return "podman"
 
     if available("docker") and sys.platform != "darwin":
@@ -55,7 +55,7 @@ def container_manager():
     return _engine
 
 
-def is_podman_machine_running_with_krunkit():
+def krunkit():
     podman_machine_list = ["podman", "machine", "list", "--all-providers"]
     try:
         output = run_cmd(podman_machine_list, ignore_stderr=True).stdout.decode("utf-8").strip()

--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -11,6 +11,7 @@ from ramalama.common import (
     genname,
     get_env_vars,
     get_gpu,
+    krunkit,
     run_cmd,
 )
 from ramalama.gguf_parser import GGUFInfoParser
@@ -211,7 +212,7 @@ class Model:
             for device_arg in args.device:
                 conman_args += ["--device", device_arg]
         else:
-            if (sys.platform == "darwin" and os.path.basename(args.engine) != "docker") or os.path.exists("/dev/dri"):
+            if os.path.exists("/dev/dri") or krunkit():
                 conman_args += ["--device", "/dev/dri"]
 
             if os.path.exists("/dev/kfd"):
@@ -237,8 +238,8 @@ class Model:
             or (
                 # linux and macOS report aarch64 differently, on Apple Silicon
                 # (arm64), we should have acceleration on regardless.
-                machine == "arm64"
-                or (machine == "aarch64" and os.path.exists("/dev/dri"))
+                machine
+                in {"arm64", "aarch64"}
             )
         ):
             if args.ngl < 0:


### PR DESCRIPTION
Slightly reworked the way krunkit is being detected so ramalama can use apple hyper v (the default apple vm for podman desktop) as well. 

Even though this is a niche use case I think its useful if the default VM can spin up ramalama too!

## Summary by Sourcery

This pull request enables ramalama to run on macOS using the Apple hypervisor (the default VM for Podman Desktop) by adjusting krunkit detection logic. It also ensures that GPU acceleration is enabled on Apple Silicon machines.

New Features:
- Adds support for the Apple hypervisor in macOS environments when using Podman Desktop.

Enhancements:
- Refactors the logic for detecting krunkit to enable its usage with the Apple hypervisor.