### PR TITLE
chore: do not format size for --json export in list command

### DIFF
--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -533,7 +533,7 @@ def human_readable_size(size):
 
 
 def get_size(file):
-    return human_readable_size(os.path.getsize(file))
+    return os.path.getsize(file)
 
 
 def _list_models(args):
@@ -612,6 +612,8 @@ def list_cli(args):
             modified = human_duration(model["modified"]) + " ago"
         except TypeError:
             modified = model["modified"]
+        # update the size to be human readable
+        model["size"] = human_readable_size(model["size"])
         name_width = max(name_width, len(model["name"]))
         modified_width = max(modified_width, len(modified))
         size_width = max(size_width, len(model["size"]))


### PR DESCRIPTION
fixes https://github.com/containers/ramalama/issues/869

## Summary by Sourcery

This pull request fixes an issue where the size of models was being formatted when exporting in JSON format. The size is now only formatted for human readability when printing to the console.

Bug Fixes:
- Fixes an issue where the size of models was being formatted when exporting in JSON format, which is not desired.

Enhancements:
- The size of the model is now formatted for human readability only when printing to the console, and not when exporting to JSON.