### PR TITLE
feat: display emoji of the engine for the run in the prompt

### DIFF
--- a/container-images/scripts/build_llama_and_whisper.sh
+++ b/container-images/scripts/build_llama_and_whisper.sh
@@ -111,7 +111,7 @@ clone_and_build_whisper_cpp() {
 }
 
 clone_and_build_llama_cpp() {
-  local llama_cpp_sha="4078c77f9891831f29ffc7c315c8ec6695ba5ce7"
+  local llama_cpp_sha="7ad0779f5de84a68143b2c00ab5dc94a948925d3"
 
   git clone https://github.com/ggml-org/llama.cpp
   cd llama.cpp

--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -187,6 +187,14 @@ class Model:
             container_labels += ["--label", f"ai.ramalama.command={args.subcommand}"]
         conman_args.extend(container_labels)
 
+        # if args.subcommand is run add LLAMA_PROMPT_PREFIX to the container
+        if hasattr(args, "subcommand") and args.subcommand == "run":
+            # if podman
+            if os.path.basename(args.engine) == "podman":
+                conman_args += ["--env", "LLAMA_PROMPT_PREFIX=🦭 > "]
+            elif os.path.basename(args.engine) == "docker":
+                conman_args += ["--env", "LLAMA_PROMPT_PREFIX=🐋 > "]
+
         if os.path.basename(args.engine) == "podman" and args.podman_keep_groups:
             conman_args += ["--group-add", "keep-groups"]
 
@@ -357,6 +365,11 @@ class Model:
 
     def build_exec_args_run(self, args, model_path, prompt):
         exec_model_path = model_path if not args.container else MNT_FILE
+
+        # override prompt if not set to the local call
+        if "LLAMA_PROMPT_PREFIX" not in os.environ:
+            os.environ["LLAMA_PROMPT_PREFIX"] = "🦙 > "
+
         exec_args = ["llama-run", "-c", f"{args.context}", "--temp", f"{args.temp}"]
 
         if args.seed:


### PR DESCRIPTION
Add emoji prompt with the engine

- podman: `🦭 > `
- native: `🦙 > `
- docker: `🐋 > `

I had to bump the sha to build a more recent version of the llama-run for the ramalama image

I checked on macOS and inside a container (docker or podman) but not on Linux natively so 🤷


fixes https://github.com/containers/ramalama/issues/783

## Summary by Sourcery

This pull request introduces an emoji prompt to indicate the engine being used (Podman, Docker, or native) when running the `run` subcommand. It also updates the llama.cpp SHA and fixes an issue with the prompt prefix.

New Features:
- Introduces a new feature that displays an emoji prompt based on the engine used for the run command: Podman (🦭), Docker (🐋), and native (🦙).

Bug Fixes:
- Fixes an issue where the prompt prefix was not being displayed correctly in certain environments.

Build:
- Updates the llama.cpp SHA to build a more recent version for the ramalama image.