### PR TITLE
Use vllm-openai upstream image

### DIFF
--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -148,10 +148,7 @@ class Model(ModelBase):
             gpu_type, _ = next(iter(env_vars.items()))
 
         if args.runtime == "vllm":
-            if gpu_type == "HIP_VISIBLE_DEVICES":
-                return "quay.io/modh/vllm:rhoai-2.18-rocm"
-
-            return "quay.io/modh/vllm:rhoai-2.18-cuda"
+            return "docker.io/vllm/vllm-openai"
 
         split = version().split(".")
         vers = ".".join(split[:2])


### PR DESCRIPTION
The one we are currently using is old and doesn't have .gguf compatibility.

## Summary by Sourcery

Enhancements:
- Update the vLLM image to the upstream vllm-openai image, providing compatibility with the .gguf format.