### PR TITLE
benchmark failing because of lack of flag

### DIFF
--- a/docs/ramalama-bench.1.md
+++ b/docs/ramalama-bench.1.md
@@ -25,8 +25,21 @@ URL support means if a model is on a web site or even on your local system, you 
 
 ## OPTIONS
 
+#### **--authfile**=*password*
+path of the authentication file for OCI registries
+
+#### **--device**
+Add a host device to the container. Optional permissions parameter  can
+be  used  to  specify device permissions by combining r for read, w for
+write, and m for mknod(2).
+
+Example: --device=/dev/dri/renderD128:/dev/xvdc:rwm
+
 #### **--help**, **-h**
 show this help message and exit
+
+#### **--name**, **-n**
+name of the container to run the Model in
 
 #### **--network**=*none*
 set the network mode for the container
@@ -34,6 +47,47 @@ set the network mode for the container
 #### **--ngl**
 number of gpu layers, 0 means CPU inferencing, 999 means use max layers (default: -1)
 The default -1, means use whatever is automatically deemed appropriate (0 or 999)
+
+#### **--privileged**
+By  default, RamaLama containers are unprivileged (=false) and cannot, for
+example, modify parts of the operating system. This is  because  by  de‐
+fault  a  container is only allowed limited access to devices. A "privi‐
+leged" container is given the same access to devices as the user launch‐
+ing the container, with the exception of virtual consoles  (/dev/tty\d+)
+when running in systemd mode (--systemd=always).
+
+A  privileged container turns off the security features that isolate the
+container from the host. Dropped Capabilities,  limited  devices,  read-
+only  mount points, Apparmor/SELinux separation, and Seccomp filters are
+all disabled.  Due to the disabled  security  features,  the  privileged
+field  should  almost never be set as containers can easily break out of
+confinement.
+
+Containers running in a user namespace (e.g., rootless containers)  can‐
+not have more privileges than the user that launched them.
+
+#### **--pull**=*policy*
+
+- **always**: Always pull the image and throw an error if the pull fails.
+- **missing**: Only pull the image when it does not exist in the local containers storage.  Throw an error if no image is found and the pull fails.
+- **never**: Never pull the image but use the one from the local containers storage.  Throw an error when no image is found.
+- **newer**: Pull if the image on the registry is newer than the one in the local containers storage.  An image is considered to be newer when the digests are different.  Comparing the time stamps is prone to errors.  Pull errors are suppressed if a local image was found.
+
+#### **--seed**=
+Specify seed rather than using random seed model interaction
+
+#### **--temp**="0.8"
+Temperature of the response from the AI Model
+llama.cpp explains this as:
+
+    The lower the number is, the more deterministic the response.
+
+    The higher the number is the more creative the response is, but more likely to hallucinate when set too high.
+
+        Usage: Lower numbers are good for virtual assistants where we need deterministic responses. Higher numbers are good for roleplay or creative tasks like editing stories
+
+#### **--tls-verify**=*true*
+require HTTPS and verify certificates when contacting OCI registries
 
 ## DESCRIPTION
 Benchmark specified AI Model.

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -378,14 +378,8 @@ def add_network_argument(parser, dflt="none"):
 
 def bench_parser(subparsers):
     parser = subparsers.add_parser("bench", aliases=["benchmark"], help="benchmark specified AI Model")
+    bench_run_serve_perplexity_args(parser)
     add_network_argument(parser)
-    parser.add_argument(
-        "--ngl",
-        dest="ngl",
-        type=int,
-        default=CONFIG["ngl"],
-        help="number of layers to offload to the gpu, if available",
-    )
     parser.add_argument("MODEL")  # positional argument
     parser.set_defaults(func=bench_cli)
 
@@ -707,7 +701,7 @@ def push_cli(args):
 
 
 def run_serve_perplexity_args(parser):
-    parser.add_argument("--authfile", help="path of the authentication file")
+    bench_run_serve_perplexity_args(parser)
     parser.add_argument(
         "-c",
         "--ctx-size",
@@ -715,6 +709,10 @@ def run_serve_perplexity_args(parser):
         default=CONFIG['ctx_size'],
         help="size of the prompt context (0 = loaded from model)",
     )
+
+
+def bench_run_serve_perplexity_args(parser):
+    parser.add_argument("--authfile", help="path of the authentication file")
     parser.add_argument(
         "--device", dest="device", action='append', type=str, help="device to leak in to the running container"
     )

--- a/test/system/002-bench.bats
+++ b/test/system/002-bench.bats
@@ -1,0 +1,22 @@
+#!/usr/bin/env bats
+#
+# Simplest set of ramalama tests. If any of these fail, we have serious problems.
+#
+
+load helpers
+
+# Override standard setup! We don't yet trust ramalama-images or ramalama-rm
+function setup() {
+    # Makes test logs easier to read
+    BATS_TEST_NAME_PREFIX="[002] "
+}
+
+#### DO NOT ADD ANY TESTS HERE! ADD NEW TESTS AT BOTTOM!
+
+# bats test_tags=distro-integration
+@test "ramalama bench" {
+    run_ramalama bench smollm:135m
+    is "$output" ".*model.*size.*" "model and size in output"
+}
+
+# vim: filetype=sh


### PR DESCRIPTION
Specifically priviledged because it's not present in the args object.

## Summary by Sourcery

Fixes a bug where the `bench` command was missing some arguments. This change introduces a new function `bench_run_serve_perplexity_args` to define arguments shared between `bench`, `run` and `serve` commands. The `ngl` argument was removed from the `bench` command and is now loaded from the model.