### PR TITLE
Inject config to cli functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,13 +119,13 @@ lint:
 
 .PHONY: check-format
 check-format:
-	black --check --diff *.py ramalama/*.py
-	isort --check --diff *.py ramalama/*.py
+	black --check --diff *.py ramalama/*.py test/unit/*.py
+	isort --check --diff *.py ramalama/*.py test/unit/*.py
 
 .PHONY: format
 format:
-	black *.py ramalama/*.py
-	isort *.py ramalama/*.py
+	black *.py ramalama/*.py test/unit/*.py
+	isort *.py ramalama/*.py test/unit/*.py
 
 .PHONY: codespell
 codespell:

--- a/install.sh
+++ b/install.sh
@@ -141,7 +141,7 @@ install_ramalama_bin() {
 }
 
 install_ramalama_libs() {
-  local python_files=("cli.py" "rag.py" "gguf_parser.py" "huggingface.py" \
+  local python_files=("cli.py" "config.py" "rag.py" "gguf_parser.py" "huggingface.py" \
                       "model.py" "model_factory.py" "model_inspect.py" \
                       "ollama.py" "common.py" "__init__.py" "quadlet.py" \
                       "kube.py" "oci.py" "version.py" "shortnames.py" \

--- a/ramalama/config.py
+++ b/ramalama/config.py
@@ -1,0 +1,88 @@
+import os
+from pathlib import Path
+from typing import Any, Dict
+
+from ramalama.common import container_manager, default_image
+from ramalama.toml_parser import TOMLParser
+
+
+def get_store():
+    if os.geteuid() == 0:
+        return "/var/lib/ramalama"
+
+    return os.path.expanduser("~/.local/share/ramalama")
+
+
+def use_container():
+    use_container = os.getenv("RAMALAMA_IN_CONTAINER")
+    if use_container:
+        return use_container.lower() == "true"
+
+    conman = container_manager()
+    return conman is not None
+
+
+def load_config() -> Dict[str, Any]:
+    """Load configuration from a list of paths, in priority order."""
+    parser = TOMLParser()
+    config_path = os.getenv("RAMALAMA_CONFIG")
+    if config_path:
+        return parser.parse_file(config_path)
+
+    config = {}
+    config_paths = [
+        "/usr/share/ramalama/ramalama.conf",
+        "/usr/local/share/ramalama/ramalama.conf",
+        "/etc/ramalama/ramalama.conf",
+    ]
+    config_home = os.getenv("XDG_CONFIG_HOME", os.path.join("~", ".config"))
+    config_paths.extend([os.path.expanduser(os.path.join(config_home, "ramalama", "ramalama.conf"))])
+
+    # Load configuration from each path
+    for path in config_paths:
+        if os.path.exists(path):
+            # Load the main config file
+            config = parser.parse_file(path)
+        if os.path.isdir(path + ".d"):
+            # Load all .conf files in ramalama.conf.d directory
+            for conf_file in sorted(Path(path + ".d").glob("*.conf")):
+                config = parser.parse_file(conf_file)
+
+    return config
+
+
+def load_config_from_env(config: Dict[str, Any], env: Dict):
+    """Load configuration from environment variables."""
+    config['container'] = env.get('RAMALAMA_IN_CONTAINER', config.get('container', use_container()))
+    config['engine'] = env.get('RAMALAMA_CONTAINER_ENGINE', config.get('engine', container_manager()))
+    config['image'] = env.get('RAMALAMA_IMAGE', config.get('image', default_image()))
+    config['store'] = env.get('RAMALAMA_STORE', config.get('store', get_store()))
+    config['transport'] = env.get('RAMALAMA_TRANSPORT', config.get('transport', "ollama"))
+
+
+def load_config_defaults(config: Dict[str, Any]):
+    """Set configuration defaults if these are not yet set."""
+    config['nocontainer'] = config.get('nocontainer', False)
+    config['carimage'] = config.get('carimage', "registry.access.redhat.com/ubi9-micro:latest")
+    config['runtime'] = config.get('runtime', 'llama.cpp')
+    config['ngl'] = config.get('ngl', -1)
+    config['keep_groups'] = config.get('keep_groups', False)
+    config['ctx_size'] = config.get('ctx_size', 2048)
+    config['pull'] = config.get('pull', "newer")
+    config['temp'] = config.get('temp', "0.8")
+    config['host'] = config.get('host', "0.0.0.0")
+    config['port'] = config.get('port', "8080")
+
+
+def load_and_merge_config() -> Dict[str, Any]:
+    """Load configuration from files, merge with environment variables and set defaults for options not set."""
+    config = load_config()
+
+    ramalama_config = config.setdefault('ramalama', {})
+    load_config_from_env(ramalama_config, os.environ)
+    load_config_defaults(ramalama_config)
+
+    return ramalama_config
+
+
+CONFIG = load_and_merge_config()

--- a/test/unit/test_common.py
+++ b/test/unit/test_common.py
@@ -2,16 +2,25 @@ import pytest
 
 from ramalama.common import rm_until_substring
 
+
 @pytest.mark.parametrize(
-        "input,rm_until,expected", 
-        [
-            ("", "", ""),
-            ("huggingface://granite-code", "://", "granite-code"),
-            ("hf://granite-code", "://", "granite-code"),
-            ("hf.co/granite-code", "hf.co/", "granite-code"),
-            ("http://huggingface.co/ibm-granite/granite-3b-code-base-2k-GGUF/blob/main/granite-3b-code-base.Q4_K_M.gguf", ".co/", "ibm-granite/granite-3b-code-base-2k-GGUF/blob/main/granite-3b-code-base.Q4_K_M.gguf"),
-            ("file:///tmp/models/granite-3b-code-base.Q4_K_M.gguf", "", "file:///tmp/models/granite-3b-code-base.Q4_K_M.gguf"),
-        ]
+    "input,rm_until,expected",
+    [
+        ("", "", ""),
+        ("huggingface://granite-code", "://", "granite-code"),
+        ("hf://granite-code", "://", "granite-code"),
+        ("hf.co/granite-code", "hf.co/", "granite-code"),
+        (
+            "http://huggingface.co/ibm-granite/granite-3b-code-base-2k-GGUF/blob/main/granite-3b-code-base.Q4_K_M.gguf",
+            ".co/",
+            "ibm-granite/granite-3b-code-base-2k-GGUF/blob/main/granite-3b-code-base.Q4_K_M.gguf",
+        ),
+        (
+            "file:///tmp/models/granite-3b-code-base.Q4_K_M.gguf",
+            "",
+            "file:///tmp/models/granite-3b-code-base.Q4_K_M.gguf",
+        ),
+    ],
 )
 def test_rm_until_substring(input: str, rm_until: str, expected: str):
     actual = rm_until_substring(input, rm_until)

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -1,0 +1,91 @@
+import json
+
+import pytest
+
+from ramalama.config import load_config_defaults, load_config_from_env
+
+
+@pytest.mark.parametrize(
+    "env,config,expected",
+    [
+        (
+            {
+                "RAMALAMA_IN_CONTAINER": "true",
+                "RAMALAMA_CONTAINER_ENGINE": "podman",
+                "RAMALAMA_IMAGE": "image",
+                "RAMALAMA_STORE": "~/.local/share/ramalama",
+                "RAMALAMA_TRANSPORT": "ollama",
+            },
+            {},
+            {
+                "container": "true",
+                "engine": "podman",
+                "image": "image",
+                "store": "~/.local/share/ramalama",
+                "transport": "ollama",
+            },
+        ),
+        (
+            {},
+            {
+                "container": "true",
+                "engine": "podman",
+                "image": "image",
+                "store": "~/.local/share/ramalama",
+                "transport": "ollama",
+            },
+            {
+                "container": "true",
+                "engine": "podman",
+                "image": "image",
+                "store": "~/.local/share/ramalama",
+                "transport": "ollama",
+            },
+        ),
+    ],
+)
+def test_load_config_from_env(env, config, expected):
+    load_config_from_env(config, env)
+    assert json.dumps(config, sort_keys=True) == json.dumps(expected, sort_keys=True)
+
+
+@pytest.mark.parametrize(
+    "config,expected",
+    [
+        (
+            {},
+            {
+                "nocontainer": False,
+                "carimage": "registry.access.redhat.com/ubi9-micro:latest",
+                "runtime": "llama.cpp",
+                "ngl": -1,
+                "keep_groups": False,
+                "ctx_size": 2048,
+                "pull": "newer",
+                "temp": "0.8",
+                "host": "0.0.0.0",
+                "port": "8080",
+            },
+        ),
+        (
+            {
+                "nocontainer": True,
+            },
+            {
+                "nocontainer": True,
+                "carimage": "registry.access.redhat.com/ubi9-micro:latest",
+                "runtime": "llama.cpp",
+                "ngl": -1,
+                "keep_groups": False,
+                "ctx_size": 2048,
+                "pull": "newer",
+                "temp": "0.8",
+                "host": "0.0.0.0",
+                "port": "8080",
+            },
+        ),
+    ],
+)
+def test_load_config_defaults(config, expected):
+    load_config_defaults(config)
+    assert json.dumps(config, sort_keys=True) == json.dumps(expected, sort_keys=True)

--- a/test/unit/test_model_factory.py
+++ b/test/unit/test_model_factory.py
@@ -1,37 +1,56 @@
+from dataclasses import dataclass
+from typing import Union
+
 import pytest
-from ramalama.model_factory import ModelFactory
+
 from ramalama.huggingface import Huggingface
+from ramalama.model_factory import ModelFactory
 from ramalama.oci import OCI
 from ramalama.ollama import Ollama
 from ramalama.url import URL
 
-from dataclasses import dataclass
-from typing import Union
 
 @dataclass
-class Input():
+class Input:
     Model: str
     Transport: str
     Engine: str
 
+
 @pytest.mark.parametrize(
-        "input,expected,error", 
-        [
-            (Input("", "", ""), None, KeyError),
-            (Input("huggingface://granite-code", "", ""), Huggingface, None),
-            (Input("hf://granite-code", "", ""), Huggingface, None),
-            (Input("hf.co/granite-code", "", ""), Huggingface, None),
-            (Input("ollama://granite-code", "", ""), Ollama, None),
-            (Input("ollama.com/library/granite-code", "", ""), Ollama, None),
-            (Input("oci://granite-code", "", "podman"), OCI, None),
-            (Input("docker://granite-code", "", "podman"), OCI, None),
-            (Input("http://huggingface.co/ibm-granite/granite-3b-code-base-2k-GGUF/blob/main/granite-3b-code-base.Q4_K_M.gguf", "", ""), URL, None),
-            (Input("https://huggingface.co/ibm-granite/granite-3b-code-base-2k-GGUF/blob/main/granite-3b-code-base.Q4_K_M.gguf", "", ""), URL, None),
-            (Input("file:///tmp/models/granite-3b-code-base.Q4_K_M.gguf", "", ""), URL, None),
-            (Input("granite-code", "huggingface", ""), Huggingface, None),
-            (Input("granite-code", "ollama", ""), Ollama, None),
-            (Input("granite-code", "oci", ""), OCI, None),
-        ]
+    "input,expected,error",
+    [
+        (Input("", "", ""), None, KeyError),
+        (Input("huggingface://granite-code", "", ""), Huggingface, None),
+        (Input("hf://granite-code", "", ""), Huggingface, None),
+        (Input("hf.co/granite-code", "", ""), Huggingface, None),
+        (Input("ollama://granite-code", "", ""), Ollama, None),
+        (Input("ollama.com/library/granite-code", "", ""), Ollama, None),
+        (Input("oci://granite-code", "", "podman"), OCI, None),
+        (Input("docker://granite-code", "", "podman"), OCI, None),
+        (
+            Input(
+                "http://huggingface.co/ibm-granite/granite-3b-code-base-2k-GGUF/blob/main/granite-3b-code-base.Q4_K_M.gguf",
+                "",
+                "",
+            ),
+            URL,
+            None,
+        ),
+        (
+            Input(
+                "https://huggingface.co/ibm-granite/granite-3b-code-base-2k-GGUF/blob/main/granite-3b-code-base.Q4_K_M.gguf",
+                "",
+                "",
+            ),
+            URL,
+            None,
+        ),
+        (Input("file:///tmp/models/granite-3b-code-base.Q4_K_M.gguf", "", ""), URL, None),
+        (Input("granite-code", "huggingface", ""), Huggingface, None),
+        (Input("granite-code", "ollama", ""), Ollama, None),
+        (Input("granite-code", "oci", ""), OCI, None),
+    ],
 )
 def test_model_factory_create(input: Input, expected: type[Union[Huggingface, Ollama, URL, OCI]], error):
     if error is not None:
@@ -41,49 +60,78 @@ def test_model_factory_create(input: Input, expected: type[Union[Huggingface, Ol
         model = ModelFactory(input.Model, input.Transport, input.Engine).create()
         assert isinstance(model, expected)
 
+
 @pytest.mark.parametrize(
-        "input,error", 
-        [
-            (Input("", "", ""), None),
-            (Input("oci://granite-code", "", "podman"), None),
-            (Input("docker://granite-code", "", "podman"), None),
-            (Input("file:///tmp/models/granite-3b-code-base.Q4_K_M.gguf", "", ""), ValueError),
-            (Input("huggingface://granite-code", "", ""), ValueError),
-            (Input("hf://granite-code", "", ""), ValueError),
-            (Input("hf.co/granite-code", "", ""), None),
-            (Input("ollama://granite-code", "", ""), ValueError),
-            (Input("ollama.com/library/granite-code", "", ""), None),
-            (Input("granite-code", "", ""), None),
-        ]
+    "input,error",
+    [
+        (Input("", "", ""), None),
+        (Input("oci://granite-code", "", "podman"), None),
+        (Input("docker://granite-code", "", "podman"), None),
+        (Input("file:///tmp/models/granite-3b-code-base.Q4_K_M.gguf", "", ""), ValueError),
+        (Input("huggingface://granite-code", "", ""), ValueError),
+        (Input("hf://granite-code", "", ""), ValueError),
+        (Input("hf.co/granite-code", "", ""), None),
+        (Input("ollama://granite-code", "", ""), ValueError),
+        (Input("ollama.com/library/granite-code", "", ""), None),
+        (Input("granite-code", "", ""), None),
+    ],
 )
 def test_validate_oci_model_input(input: Input, error):
     if error is not None:
         with pytest.raises(error):
             ModelFactory(input.Model, input.Transport, input.Engine).validate_oci_model_input()
         return
-    
+
     ModelFactory(input.Model, input.Transport, input.Engine).validate_oci_model_input()
 
 
 @pytest.mark.parametrize(
-        "input,cls,expected", 
-        [
-            (Input("huggingface://granite-code", "", ""), Huggingface, "granite-code"),
-            (Input("huggingface://ibm-granite/granite-3b-code-base-2k-GGUF/granite-code", "", ""), Huggingface, "ibm-granite/granite-3b-code-base-2k-GGUF/granite-code"),
-            (Input("hf://granite-code", "", ""), Huggingface, "granite-code"),
-            (Input("hf.co/granite-code", "", ""), Huggingface, "granite-code"),
-            (Input("ollama://granite-code", "", ""), Ollama, "granite-code"),
-            (Input("ollama.com/library/granite-code", "", ""), Ollama, "granite-code"),
-            (Input("ollama.com/library/ibm-granite/granite-3b-code-base-2k-GGUF/granite-code", "", ""), Ollama, "ibm-granite/granite-3b-code-base-2k-GGUF/granite-code"),
-            (Input("oci://granite-code", "", "podman"), OCI, "granite-code"),
-            (Input("docker://granite-code", "", "podman"), OCI, "granite-code"),
-            (Input("http://huggingface.co/ibm-granite/granite-3b-code-base-2k-GGUF/blob/main/granite-3b-code-base.Q4_K_M.gguf", "", ""), URL, "huggingface.co/ibm-granite/granite-3b-code-base-2k-GGUF/blob/main/granite-3b-code-base.Q4_K_M.gguf"),
-            (Input("https://huggingface.co/ibm-granite/granite-3b-code-base-2k-GGUF/blob/main/granite-3b-code-base.Q4_K_M.gguf", "", ""), URL, "huggingface.co/ibm-granite/granite-3b-code-base-2k-GGUF/blob/main/granite-3b-code-base.Q4_K_M.gguf"),
-            (Input("file:///tmp/models/granite-3b-code-base.Q4_K_M.gguf", "", ""), URL, "/tmp/models/granite-3b-code-base.Q4_K_M.gguf"),
-            (Input("granite-code", "huggingface", ""), Huggingface, "granite-code"),
-            (Input("granite-code", "ollama", ""), Ollama, "granite-code"),
-            (Input("granite-code", "oci", ""), OCI, "granite-code"),
-        ]
+    "input,cls,expected",
+    [
+        (Input("huggingface://granite-code", "", ""), Huggingface, "granite-code"),
+        (
+            Input("huggingface://ibm-granite/granite-3b-code-base-2k-GGUF/granite-code", "", ""),
+            Huggingface,
+            "ibm-granite/granite-3b-code-base-2k-GGUF/granite-code",
+        ),
+        (Input("hf://granite-code", "", ""), Huggingface, "granite-code"),
+        (Input("hf.co/granite-code", "", ""), Huggingface, "granite-code"),
+        (Input("ollama://granite-code", "", ""), Ollama, "granite-code"),
+        (Input("ollama.com/library/granite-code", "", ""), Ollama, "granite-code"),
+        (
+            Input("ollama.com/library/ibm-granite/granite-3b-code-base-2k-GGUF/granite-code", "", ""),
+            Ollama,
+            "ibm-granite/granite-3b-code-base-2k-GGUF/granite-code",
+        ),
+        (Input("oci://granite-code", "", "podman"), OCI, "granite-code"),
+        (Input("docker://granite-code", "", "podman"), OCI, "granite-code"),
+        (
+            Input(
+                "http://huggingface.co/ibm-granite/granite-3b-code-base-2k-GGUF/blob/main/granite-3b-code-base.Q4_K_M.gguf",
+                "",
+                "",
+            ),
+            URL,
+            "huggingface.co/ibm-granite/granite-3b-code-base-2k-GGUF/blob/main/granite-3b-code-base.Q4_K_M.gguf",
+        ),
+        (
+            Input(
+                "https://huggingface.co/ibm-granite/granite-3b-code-base-2k-GGUF/blob/main/granite-3b-code-base.Q4_K_M.gguf",
+                "",
+                "",
+            ),
+            URL,
+            "huggingface.co/ibm-granite/granite-3b-code-base-2k-GGUF/blob/main/granite-3b-code-base.Q4_K_M.gguf",
+        ),
+        (
+            Input("file:///tmp/models/granite-3b-code-base.Q4_K_M.gguf", "", ""),
+            URL,
+            "/tmp/models/granite-3b-code-base.Q4_K_M.gguf",
+        ),
+        (Input("granite-code", "huggingface", ""), Huggingface, "granite-code"),
+        (Input("granite-code", "ollama", ""), Ollama, "granite-code"),
+        (Input("granite-code", "oci", ""), OCI, "granite-code"),
+    ],
 )
 def test_prune_model_input(input: Input, cls: type[Union[Huggingface, Ollama, URL, OCI]], expected: str):
     pruned_model_input = ModelFactory(input.Model, input.Transport, input.Engine).prune_model_input(cls)


### PR DESCRIPTION
In cli.py we already load and merge configuration from various sources and set defaults in the load_and_merge_config(). However, we still define defaults when getting config values in various places. In order to streamline this, the merged config is being injected to all cli functions and access is not done via .get but via index since a missing key is a bug and should throw an error. It also moves the configuration part to a dedicated file.

## Summary by Sourcery

Streamline configuration management by injecting the merged configuration into CLI functions and centralizing configuration logic.

Enhancements:
- Refactor the configuration loading and merging logic into a dedicated `config.py` file.
- Inject the merged configuration into all CLI functions, accessing config values via indexing instead of `.get()` to ensure that missing keys raise errors, highlighting potential bugs.

Tests:
- Add unit tests for the new configuration loading and merging logic.