### PR TITLE
fix: handling of date with python 3.8/3.9/3.10

### DIFF
--- a/ramalama/oci.py
+++ b/ramalama/oci.py
@@ -115,7 +115,9 @@ def list_models(args):
     models += list_manifests(args)
     for model in models:
         # Convert to ISO 8601 format
-        parsed_date = datetime.fromisoformat(model["modified"].replace(" UTC", "").replace(" ", "T"))
+        parsed_date = datetime.fromisoformat(
+            model["modified"].replace(" UTC", "").replace("+0000", "+00:00").replace(" ", "T")
+        )
         model["modified"] = parsed_date.isoformat()
 
     return models


### PR DESCRIPTION
use a function working on 3.8+

it was working with python 3.11+

## Summary by Sourcery

Bug Fixes:
- Fixes date parsing to be compatible with Python 3.8+