### PR TITLE
Try to choose a free port on serve if default one is not available

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,9 @@ $ ramalama stop mylama
 
 To use a UI, run a `ramalama serve` command, then connect via your browser at:
 
-127.0.0.1:8080
+127.0.0.1:<port>
+
+The default serving port will be 8080 if available, otherwise a free random port in the range 8081-8090. If you wish, you can specify a port to use with `--port/-p`.
 
 ## Diagram
 

--- a/docs/ramalama-serve.1.md
+++ b/docs/ramalama-serve.1.md
@@ -81,7 +81,8 @@ number of gpu layers, 0 means CPU inferencing, 999 means use max layers (default
 The default -1, means use whatever is automatically deemed appropriate (0 or 999)
 
 #### **--port**, **-p**
-port for AI Model server to listen on
+port for AI Model server to listen on. It must be available. If not specified, 
+the serving port will be 8080 if available, otherwise a free port in 8081-8090 range.
 
 #### **--privileged**
 By  default, RamaLama containers are unprivileged (=false) and cannot, for

--- a/ramalama/config.py
+++ b/ramalama/config.py
@@ -5,6 +5,8 @@ from typing import Any, Dict
 from ramalama.common import container_manager, default_image
 from ramalama.toml_parser import TOMLParser
 
+DEFAULT_PORT_RANGE = (8080, 8090)
+
 
 def get_store():
     if os.geteuid() == 0:
@@ -60,6 +62,10 @@ def load_config_from_env(config: Dict[str, Any], env: Dict):
     config['transport'] = env.get('RAMALAMA_TRANSPORT', config.get('transport', "ollama"))
 
 
+def int_tuple_as_str(input: tuple) -> str:
+    return '-'.join(map(str, input))
+
+
 def load_config_defaults(config: Dict[str, Any]):
     """Set configuration defaults if these are not yet set."""
     config['nocontainer'] = config.get('nocontainer', False)
@@ -71,7 +77,8 @@ def load_config_defaults(config: Dict[str, Any]):
     config['pull'] = config.get('pull', "newer")
     config['temp'] = config.get('temp', "0.8")
     config['host'] = config.get('host', "0.0.0.0")
-    config['port'] = config.get('port', "8080")
+    # print tuple as a range to avoid confusion
+    config['port'] = config.get('port', int_tuple_as_str(DEFAULT_PORT_RANGE))
     config['use_model_store'] = config.get('use_model_store', False)
 
 

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -2,7 +2,7 @@ import json
 
 import pytest
 
-from ramalama.config import load_config_defaults, load_config_from_env
+from ramalama.config import DEFAULT_PORT_RANGE, int_tuple_as_str, load_config_defaults, load_config_from_env
 
 
 @pytest.mark.parametrize(
@@ -64,8 +64,8 @@ def test_load_config_from_env(env, config, expected):
                 "pull": "newer",
                 "temp": "0.8",
                 "host": "0.0.0.0",
-                "port": "8080",
                 "use_model_store": False,
+                "port": int_tuple_as_str(DEFAULT_PORT_RANGE),
             },
         ),
         (
@@ -82,8 +82,8 @@ def test_load_config_from_env(env, config, expected):
                 "pull": "newer",
                 "temp": "0.8",
                 "host": "0.0.0.0",
-                "port": "8080",
                 "use_model_store": False,
+                "port": int_tuple_as_str(DEFAULT_PORT_RANGE),
             },
         ),
     ],

--- a/test/unit/test_model.py
+++ b/test/unit/test_model.py
@@ -1,5 +1,9 @@
+import socket
+from unittest.mock import MagicMock, Mock, patch
+
 import pytest
 
+from ramalama.model import compute_serving_port
 from ramalama.model_factory import ModelFactory
 
 hf_granite_blob = "https://huggingface.co/ibm-granite/granite-3b-code-base-2k-GGUF/blob"
@@ -52,3 +56,50 @@ def test_extract_model_identifiers(model_input: str, expected_name: str, expecte
     assert name == expected_name
     assert tag == expected_tag
     assert orga == expected_orga
+
+
+@pytest.mark.parametrize(
+    "inputPort,expectedRandomizedResult,expectedRandomPortsAvl,expectedOutput,expectedErr",
+    [
+        ("", [], [None], "8999", IOError),
+        ("8999", [], [None], "8999", None),
+        ("8080", [8080, 8087, 8085, 8086, 8084, 8090, 8088, 8089, 8082, 8081, 8083], [None], "8080", None),
+        (
+            "8080-8090",
+            [8080, 8088, 8090, 8084, 8081, 8087, 8085, 8089, 8082, 8086, 8083],
+            [OSError, None],
+            "8088",
+            None,
+        ),
+        (
+            "8080-8090",
+            [8080, 8090, 8082, 8084, 8088, 8089, 8087, 8081, 8083, 8086, 8085],
+            [OSError, OSError, None],
+            "8082",
+            None,
+        ),
+        (
+            "8080-8090",
+            [8080, 8085, 8090, 8081, 8084, 8088, 8086, 8087, 8083, 8082, 8089],
+            [OSError, OSError, OSError, OSError, OSError, OSError, OSError, OSError, OSError, OSError, OSError],
+            "0",
+            IOError,
+        ),
+    ],
+)
+def test_compute_serving_port(
+    inputPort: str, expectedRandomizedResult: list, expectedRandomPortsAvl: list, expectedOutput: str, expectedErr
+):
+    mock_socket = socket.socket
+    mock_socket.bind = MagicMock(side_effect=expectedRandomPortsAvl)
+    mock_compute_ports = Mock(return_value=expectedRandomizedResult)
+
+    with patch('ramalama.model.compute_ports', mock_compute_ports):
+        with patch('socket.socket', mock_socket):
+            if expectedErr:
+                with pytest.raises(expectedErr):
+                    outputPort = compute_serving_port(inputPort, False)
+                    assert outputPort == expectedOutput
+            else:
+                outputPort = compute_serving_port(inputPort, False)
+                assert outputPort == expectedOutput


### PR DESCRIPTION
This change tries first to find if the default port 8080 is available.
If not, it tries to find an available free port in the range 8081-8090 in random order.
An error is raised if no free port is found.

In case of success, the chosen port is printed out for the user.

This does not apply if the user chooses a port different from 8080.

Note that this check could be still not be enough if the chosen port is taken
by another process after our check, in that case we will still fail at a later phase as today.

Includes unit testing.

## Summary by Sourcery

Tests:
- Add a unit test for the port validation logic.