### PR TITLE
Detect & get info on hugging face repos, fix sizing of symlinked directories

### DIFF
--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -449,8 +449,16 @@ def human_readable_size(size):
     return f"{size} PB"
 
 
-def get_size(file):
-    return os.path.getsize(file)
+def get_size(path):
+    if os.path.isdir(path):
+        size = 0
+        for dirpath, dirnames, filenames in os.walk(path, followlinks=True):
+            for file in filenames:
+                filepath = os.path.join(dirpath, file)
+                if not os.path.islink(filepath):
+                    size += os.path.getsize(filepath)
+        return size
+    return os.path.getsize(path)
 
 
 def _list_models(args):


### PR DESCRIPTION
Adds functionality to detect and provide information about Hugging Face repositories, including warnings for Safetensor models and multiple GGUF files. Also fixes the get_size method to correctly calculate the size of directories.

Currently just prints out warnings when detecting models ramalama can't run in an ordinary/expected way, could be adjusted to do different things when trying to run or convert from safetensors in the future.

For the future convert hf to gguf implementation, the llama.cpp script [requires](https://github.com/ggml-org/llama.cpp/blob/master/convert_hf_to_gguf.py) torch and some other dependencies that would increase the container size by ~700 MB, so it might make sense to have a seperate convert container to run the [convert_hf_to_gguf.py](https://github.com/ggml-org/llama.cpp/blob/master/convert_hf_to_gguf.py) script and then [quantize](https://github.com/ggml-org/llama.cpp/blob/master/examples/quantize/README.md) down into the user selected quant.

Still not sure where to store the final/quantized model though, the file model/repo directories make the most sense to me but would probably need to prompt the user that it's under file and not huggingface for the commands.

Example:
```
$ ramalama ls   
NAME MODIFIED SIZE

$ ramalama pull hf://ibm-granite/granite-3.2-2b-instruct

llama.cpp does not support running safetensor models, please use a/convert to the GGUF format using:
- https://huggingface.co/models?other=base_model:quantized:ibm-granite/granite-3.2-2b-instruct 
- https://huggingface.co/spaces/ggml-org/gguf-my-repo


Fetching 13 files: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 13/13 [00:00<00:00, 5946.77it/s]

$ ramalama pull hf://lmstudio-community/granite-3.2-2b-instruct-GGUF 
There are GGUF files to choose from in this repo, use one of the following commands to run one:

- ramalama run hf://lmstudio-community/granite-3.2-2b-instruct-GGUF/granite-3.2-2b-instruct-Q3_K_L.gguf
- ramalama run hf://lmstudio-community/granite-3.2-2b-instruct-GGUF/granite-3.2-2b-instruct-Q4_K_M.gguf
- ramalama run hf://lmstudio-community/granite-3.2-2b-instruct-GGUF/granite-3.2-2b-instruct-Q6_K.gguf
- ramalama run hf://lmstudio-community/granite-3.2-2b-instruct-GGUF/granite-3.2-2b-instruct-Q8_0.gguf


Fetching 6 files:
...

$ ramalama ls
NAME                                                          MODIFIED      SIZE   
huggingface://lmstudio-community/granite-3.2-2b-instruct-GGUF 8 seconds ago 7.15 GB
huggingface://ibm-granite/granite-3.2-2b-instruct             2 minutes ago 4.72 GB
```

Should help fix #691 and related issues

## Summary by Sourcery

Enhance Hugging Face repository handling by adding functionality to detect and provide information about Hugging Face repositories, including warnings for Safetensor models and multiple GGUF files, and fix the get_size method to correctly calculate the size of directories.

Enhancements:
- Improve Hugging Face repository handling by adding functionality to detect and provide information about Hugging Face repositories, including warnings for Safetensor models and multiple GGUF files.
- Fix the get_size method to correctly calculate the size of directories.