### PR TITLE
Added support for mac cpu and clear warning message

### DIFF
--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -265,7 +265,7 @@ class Model(ModelBase):
             for device_arg in args.device:
                 conman_args += ["--device", device_arg]
         else:
-            if (sys.platform == "darwin" and os.path.basename(args.engine) != "docker") or os.path.exists("/dev/dri"):
+            if os.getenv("LIBKRUN") == "True" or os.path.exists("/dev/dri"):
                 conman_args += ["--device", "/dev/dri"]
 
             if os.path.exists("/dev/kfd"):
@@ -316,7 +316,7 @@ class Model(ModelBase):
             or (
                 # linux and macOS report aarch64 differently, on Apple Silicon
                 # (arm64), we should have acceleration on regardless.
-                machine == "arm64"
+                (os.getenv("LIBKRUN") == "True")
                 or (machine == "aarch64" and os.path.exists("/dev/dri"))
             )
         ):


### PR DESCRIPTION
Address issue https://github.com/containers/ramalama/issues/895

My thought process is if we're going to give a error sign to the user for not having libkrun we can give them the option to use cpu as well given they know it doesnt have gpu support!

## Summary by Sourcery

Adds support for running on macOS with the CPU by prompting the user to proceed without GPU support if the 'applehv' provider is being used. Modifies GPU arguments to account for the absence of /dev/dri when not using libkrun.