### PR TITLE
readme: fix artifactory link

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Supported transports:
 | HuggingFace   | [`huggingface.co`](https://www.huggingface.co)      |
 | Ollama        | [`ollama.com`](https://www.ollama.com)              |
 | OCI Container Registries | [`opencontainers.org`](https://opencontainers.org)|
-||Examples: [`quay.io`](https://quay.io),  [`Docker Hub`](https://docker.io), [`Pulp`](https://pulpproject.org), and [`Artifactory`](https://artifactory.com)|
+||Examples: [`quay.io`](https://quay.io),  [`Docker Hub`](https://docker.io), [`Pulp`](https://pulpproject.org), and [`Artifactory`](https://jfrog.com/artifactory/)|
 
 RamaLama uses the Ollama registry transport by default. Use the RAMALAMA_TRANSPORTS environment variable to modify the default. `export RAMALAMA_TRANSPORT=huggingface` Changes RamaLama to use huggingface transport.
 


### PR DESCRIPTION
The previous link was to someone with the handle `artifactory`, not JFrog Artifactory.

## Summary by Sourcery

Documentation:
- Correct the Artifactory link in the README to point to jfrog.com/artifactory.