### PR TITLE
Add new model store

### DIFF
--- a/docs/ramalama.1.md
+++ b/docs/ramalama.1.md
@@ -141,6 +141,10 @@ The default can be overridden in the ramalama.conf file.
 store AI Models in the specified directory (default rootless: `$HOME/.local/share/ramalama`, default rootful: `/var/lib/ramalama`)
 The default can be overridden in the ramalama.conf file.
 
+#### **--use-model-store**
+Use the recently introduced model store for organizing and storing models.
+It adds support for model versioning and multiple files such as chat templates. In addition, it improves performance through optimized caching and fast model access, enhanced reliability, and simplified maintenance thanks to a centralized, structured directory layout.
+
 ## COMMANDS
 
 | Command                                           | Description                                                |

--- a/install.sh
+++ b/install.sh
@@ -169,10 +169,10 @@ install_ramalama_libs() {
   install_dirs "$sharedir"
   local python_files=("cli.py" "config.py" "rag.py" "gguf_parser.py" \
                       "huggingface.py" "model.py" "model_factory.py" \
-                      "model_inspect.py" "ollama.py" "common.py" "__init__.py" \
-                      "quadlet.py" "kube.py" "oci.py" "version.py" \
-                      "shortnames.py" "toml_parser.py" "file.py" \
-                      "http_client.py" "url.py" "annotations.py" \
+                      "model_store.py" "model_inspect.py" "ollama.py" \
+                      "common.py" "__init__.py" "quadlet.py" "kube.py" \
+                      "oci.py" "version.py" "shortnames.py" "toml_parser.py" \
+                      "file.py" "http_client.py" "url.py" "annotations.py" \
                       "gpu_detector.py" "console.py")
   local job_count=0
   local job_queue=()

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -472,7 +472,7 @@ def get_size(path):
 def _list_models(args):
     mycwd = os.getcwd()
     if args.use_model_store:
-        models = GlobalModelStore(args.store).list_models()
+        models = GlobalModelStore(args.store).list_models(engine=args.engine, debug=args.debug)
         ret = []
         local_timezone = datetime.now().astimezone().tzinfo
 

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -1002,11 +1002,5 @@ def inspect_parser(subparsers):
 
 
 def inspect_cli(args):
-    import traceback
-
-    try:
-        model = New(args.MODEL, args)
-        model.inspect(args)
-    except Exception as ex:
-        print(ex)
-        print(traceback.print_exc())
+    model = New(args.MODEL, args)
+    model.inspect(args)

--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -244,7 +244,8 @@ def download_file(url, dest_path, headers=None, show_progress=True):
 
         except urllib.error.HTTPError as e:
             if e.code in [HTTP_RANGE_NOT_SATISFIABLE, HTTP_NOT_FOUND]:
-                return  # No need to retry
+                raise e
+            retries += 1
 
         except urllib.error.URLError as e:
             console.error(f"Network Error: {e.reason}")
@@ -264,7 +265,7 @@ def download_file(url, dest_path, headers=None, show_progress=True):
 
         except Exception as e:
             console.error(f"Unexpected error: {str(e)}")
-            raise
+            raise e
 
         if retries >= max_retries:
             error_message = (
@@ -274,8 +275,7 @@ def download_file(url, dest_path, headers=None, show_progress=True):
                 "- Server is down or unresponsive\n"
                 "- Firewall or proxy blocking the request\n"
             )
-            console.error(error_message)
-            sys.exit(1)
+            raise Exception(error_message)
 
         time.sleep(2**retries * 0.1)  # Exponential backoff (0.1s, 0.2s, 0.4s...)
 

--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -160,6 +160,21 @@ def find_working_directory():
     return os.path.dirname(__file__)
 
 
+def generate_sha256(to_hash: str) -> str:
+    """
+    Generates a sha256 for a string.
+
+    Args:
+    to_hash (str): The string to generate the sha256 hash for.
+
+    Returns:
+    str: Hex digest of the input appended to the prefix sha256:
+    """
+    h = hashlib.new("sha256")
+    h.update(to_hash.encode("utf-8"))
+    return f"sha256:{h.hexdigest()}"
+
+
 def verify_checksum(filename):
     """
     Verifies if the SHA-256 checksum of a file matches the checksum provided in

--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -176,13 +176,16 @@ def verify_checksum(filename):
     if not os.path.exists(filename):
         return False
 
-    # Check if the filename starts with "sha256:"
+    # Check if the filename starts with "sha256:" or "sha256-" and extract the checksum from filename
+    expected_checksum = ""
     fn_base = os.path.basename(filename)
-    if not fn_base.startswith("sha256:"):
-        raise ValueError(f"filename does not start with 'sha256:': {fn_base}")
+    if fn_base.startswith("sha256:"):
+        expected_checksum = fn_base.split(":")[1]
+    elif fn_base.startswith("sha256-"):
+        expected_checksum = fn_base.split("-")[1]
+    else:
+        raise ValueError(f"filename has to start with 'sha256:' or 'sha256-': {fn_base}")
 
-    # Extract the expected checksum from the filename
-    expected_checksum = fn_base.split(":")[1]
     if len(expected_checksum) != 64:
         raise ValueError("invalid checksum length in filename")
 

--- a/ramalama/config.py
+++ b/ramalama/config.py
@@ -72,6 +72,7 @@ def load_config_defaults(config: Dict[str, Any]):
     config['temp'] = config.get('temp', "0.8")
     config['host'] = config.get('host', "0.0.0.0")
     config['port'] = config.get('port', "8080")
+    config['use_model_store'] = config.get('use_model_store', False)
 
 
 def load_and_merge_config() -> Dict[str, Any]:

--- a/ramalama/huggingface.py
+++ b/ramalama/huggingface.py
@@ -1,10 +1,13 @@
 import json
 import os
 import pathlib
+import shutil
+import tempfile
 import urllib.request
 
-from ramalama.common import available, download_file, exec_cmd, perror, run_cmd, verify_checksum
+from ramalama.common import available, download_file, exec_cmd, generate_sha256, perror, run_cmd, verify_checksum
 from ramalama.model import Model
+from ramalama.model_store import SnapshotFile
 
 missing_huggingface = """
 Optional: Huggingface models require the huggingface-cli module.
@@ -22,15 +25,100 @@ def is_huggingface_cli_available():
         return False
 
 
-def fetch_checksum_from_api(url):
-    """Fetch the SHA-256 checksum from the model's metadata API."""
-    with urllib.request.urlopen(url) as response:
-        data = response.read().decode()
-    # Extract the SHA-256 checksum from the `oid sha256` line
-    for line in data.splitlines():
-        if line.startswith("oid sha256:"):
-            return line.split(":", 1)[1].strip()
-    raise ValueError("SHA-256 checksum not found in the API response.")
+def fetch_checksum_from_api(organization, file):
+    """Fetch the SHA-256 checksum from the model's metadata API for a given file."""
+    checksum_api_url = f"{HuggingfaceRepository.REGISTRY_URL}/{organization}/raw/main/{file}"
+    try:
+        with urllib.request.urlopen(checksum_api_url) as response:
+            data = response.read().decode()
+        # Extract the SHA-256 checksum from the `oid sha256` line
+        for line in data.splitlines():
+            if line.startswith("oid sha256:"):
+                return line.split(":", 1)[1].strip()
+        raise ValueError("SHA-256 checksum not found in the API response.")
+    except urllib.error.HTTPError as e:
+        raise KeyError(f"failed to pull {checksum_api_url}: " + str(e).strip("'"))
+    except urllib.error.URLError as e:
+        raise KeyError(f"failed to pull {checksum_api_url}: " + str(e).strip("'"))
+
+
+class HuggingfaceCLIFile(SnapshotFile):
+
+    def __init__(
+        self, url, header, hash, name, should_show_progress=False, should_verify_checksum=False, required=True
+    ):
+        super().__init__(url, header, hash, name, should_show_progress, should_verify_checksum, required)
+
+    def download(self, blob_file_path, snapshot_dir):
+        # moving from the cached temp directory to blob directory
+        shutil.move(self.url, blob_file_path)
+        return os.path.relpath(blob_file_path, start=snapshot_dir)
+
+
+class HuggingfaceRepository:
+
+    REGISTRY_URL = "https://huggingface.co"
+
+    FILE_NAME_CONFIG = "config.json"
+    FILE_NAME_GENERATION_CONFIG = "generation_config.json"
+    FILE_NAME_TOKENIZER_CONFIG = "tokenizer_config.json"
+
+    def __init__(self, name: str, organization: str):
+        self.name = name
+        self.organization = organization
+
+        self.blob_url = f"{HuggingfaceRepository.REGISTRY_URL}/{self.organization}/resolve/main"
+        self.headers = {}
+
+    def get_file_list(self, cached_files: list[str], snapshot_hash: str) -> list[SnapshotFile]:
+        files = []
+        if self.name not in cached_files:
+            files.append(self.model_file(snapshot_hash))
+        if HuggingfaceRepository.FILE_NAME_CONFIG not in cached_files:
+            files.append(self.config_file())
+        if HuggingfaceRepository.FILE_NAME_GENERATION_CONFIG not in cached_files:
+            files.append(self.generation_config_file())
+        if HuggingfaceRepository.FILE_NAME_TOKENIZER_CONFIG not in cached_files:
+            files.append(self.tokenizer_config_file())
+
+        return files
+
+    def model_file(self, snapshot_hash: str) -> SnapshotFile:
+        return SnapshotFile(
+            url=f"{self.blob_url}/{self.name}",
+            header=self.headers,
+            hash=snapshot_hash,
+            name=self.name,
+            should_show_progress=True,
+            should_verify_checksum=True,
+        )
+
+    def config_file(self) -> SnapshotFile:
+        return SnapshotFile(
+            url=f"{self.blob_url}/{HuggingfaceRepository.FILE_NAME_CONFIG}",
+            header=self.headers,
+            hash=generate_sha256(HuggingfaceRepository.FILE_NAME_CONFIG),
+            name=HuggingfaceRepository.FILE_NAME_CONFIG,
+            required=False,
+        )
+
+    def generation_config_file(self) -> SnapshotFile:
+        return SnapshotFile(
+            url=f"{self.blob_url}/{HuggingfaceRepository.FILE_NAME_GENERATION_CONFIG}",
+            header=self.headers,
+            hash=generate_sha256(HuggingfaceRepository.FILE_NAME_GENERATION_CONFIG),
+            name=HuggingfaceRepository.FILE_NAME_GENERATION_CONFIG,
+            required=False,
+        )
+
+    def tokenizer_config_file(self) -> SnapshotFile:
+        return SnapshotFile(
+            url=f"{self.blob_url}/{HuggingfaceRepository.FILE_NAME_TOKENIZER_CONFIG}",
+            header=self.headers,
+            hash=generate_sha256(HuggingfaceRepository.FILE_NAME_TOKENIZER_CONFIG),
+            name=HuggingfaceRepository.FILE_NAME_TOKENIZER_CONFIG,
+            required=False,
+        )
 
 
 def get_repo_info(repo_name):
@@ -88,6 +176,9 @@ class Huggingface(Model):
         self.exec(conman_args, args)
 
     def pull(self, args):
+        if self.store is not None:
+            return self._pull_with_model_store()
+
         model_path = self.model_path(args)
         directory_path = os.path.join(args.store, "repos", "huggingface", self.directory, self.filename)
         os.makedirs(directory_path, exist_ok=True)
@@ -158,13 +249,7 @@ class Huggingface(Model):
 
     def url_pull(self, args, model_path, directory_path):
         # Fetch the SHA-256 checksum from the API
-        checksum_api_url = f"https://huggingface.co/{self.directory}/raw/main/{self.filename}"
-        try:
-            sha256_checksum = fetch_checksum_from_api(checksum_api_url)
-        except urllib.error.HTTPError as e:
-            raise KeyError(f"failed to pull {checksum_api_url}: " + str(e).strip("'"))
-        except urllib.error.URLError as e:
-            raise KeyError(f"failed to pull {checksum_api_url}: " + str(e).strip("'"))
+        sha256_checksum = fetch_checksum_from_api(self.directory, self.filename)
 
         target_path = os.path.join(directory_path, f"sha256:{sha256_checksum}")
 
@@ -222,3 +307,63 @@ class Huggingface(Model):
             exec_cmd(cmd_args, debug=args.debug)
         except FileNotFoundError as e:
             print(f"{str(e).strip()}\n{missing_huggingface}")
+
+    def _collect_cli_files(self, tempdir: str) -> tuple[str, list[HuggingfaceCLIFile]]:
+        cache_dir = os.path.join(tempdir, ".cache", "huggingface", "download")
+        files: list[HuggingfaceCLIFile] = []
+        snapshot_hash = ""
+        for entry in os.listdir(tempdir):
+            entry_path = os.path.join(tempdir, entry)
+            if os.path.isdir(entry_path) or entry == ".gitattributes":
+                continue
+            sha256 = ""
+            with open(os.path.join(cache_dir, f"{entry}.metadata")) as metafile:
+                metafile.readline()
+                sha256 = f"sha256:{metafile.readline().strip()}"
+            if sha256 == "sha256:":
+                continue
+            if entry.lower() == "readme.md":
+                snapshot_hash = sha256
+                continue
+            files.append(
+                HuggingfaceCLIFile(
+                    url=entry_path,
+                    header={},
+                    hash=sha256,
+                    name=entry,
+                )
+            )
+
+        return snapshot_hash, files
+
+    def _pull_with_model_store(self, debug: bool = False):
+        name, tag, organization = self.extract_model_identifiers()
+        hash, cached_files, all = self.store.get_cached_files(tag)
+        if all:
+            return self.store.get_snapshot_file_path(hash, name)
+
+        try:
+            # Fetch the SHA-256 checksum of model from the API and use as snapshot hash
+            snapshot_hash = f"sha256:{fetch_checksum_from_api(self.organization, self.name)}"
+
+            hf_repo = HuggingfaceRepository(name, organization)
+            files = hf_repo.get_file_list(cached_files, snapshot_hash)
+            self.store.new_snapshot(tag, snapshot_hash, files)
+        except Exception as e:
+            if not self.hf_cli_available:
+                perror("URL pull failed and huggingface-cli not available")
+                raise KeyError(f"Failed to pull model: {str(e)}")
+
+            # Cleanup previously created snapshot
+            self.store.remove_snapshot(tag)
+
+            # Create temporary directory for downloading via huggingface-cli
+            with tempfile.TemporaryDirectory() as tempdir:
+                model = f"{organization}/{name}"
+                conman_args = ["huggingface-cli", "download", "--local-dir", tempdir, model]
+                run_cmd(conman_args, debug=debug)
+
+                snapshot_hash, files = self._collect_cli_files(tempdir)
+                self.store.new_snapshot(tag, snapshot_hash, files)
+
+        return self.store.get_snapshot_file_path(snapshot_hash, self.store.model_name)

--- a/ramalama/huggingface.py
+++ b/ramalama/huggingface.py
@@ -19,10 +19,7 @@ pip install huggingface_hub
 
 def is_huggingface_cli_available():
     """Check if huggingface-cli is available on the system."""
-    if available("huggingface-cli"):
-        return True
-    else:
-        return False
+    return available("huggingface-cli")
 
 
 def fetch_checksum_from_api(organization, file):

--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -85,9 +85,27 @@ class Model(ModelBase):
 
     def __init__(self, model):
         self.model = model
+        self.store = None
+
         split = self.model.rsplit("/", 1)
         self.directory = split[0] if len(split) > 1 else ""
         self.filename = split[1] if len(split) > 1 else split[0]
+
+    def extract_model_identifiers(self):
+        model_name = self.model
+        model_tag = "latest"
+        model_organization = ""
+
+        # extract model tag from name if exists
+        if ":" in model_name:
+            model_name, model_tag = model_name.split(":", 1)
+
+        # extract model organization from name if exists and update name
+        split = model_name.rsplit("/", 1)
+        model_organization = split[0].removeprefix("/") if len(split) > 1 else ""
+        model_name = split[1] if len(split) > 1 else split[0]
+
+        return model_name, model_tag, model_organization
 
     def is_symlink_to(self, file_path, target_path):
         if os.path.islink(file_path):

--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -18,6 +18,7 @@ from ramalama.console import EMOJI
 from ramalama.gguf_parser import GGUFInfoParser
 from ramalama.kube import Kube
 from ramalama.model_inspect import GGUFModelInfo, ModelInfoBase
+from ramalama.model_store import ModelStore
 from ramalama.quadlet import Quadlet
 from ramalama.version import version
 
@@ -85,11 +86,19 @@ class Model(ModelBase):
 
     def __init__(self, model):
         self.model = model
-        self.store = None
 
         split = self.model.rsplit("/", 1)
         self.directory = split[0] if len(split) > 1 else ""
         self.filename = split[1] if len(split) > 1 else split[0]
+
+        self._model_name: str
+        self._model_tag: str
+        self._model_organization: str
+        self._model_type: str
+        self._model_name, self._model_tag, self._model_organization = self.extract_model_identifiers()
+        self._model_type = type(self).__name__.lower()
+
+        self.store: ModelStore = None
 
     def extract_model_identifiers(self):
         model_name = self.model
@@ -106,6 +115,22 @@ class Model(ModelBase):
         model_name = split[1] if len(split) > 1 else split[0]
 
         return model_name, model_tag, model_organization
+
+    @property
+    def name(self) -> str:
+        return self._model_name
+
+    @property
+    def tag(self) -> str:
+        return self._model_tag
+
+    @property
+    def organization(self) -> str:
+        return self._model_organization
+
+    @property
+    def model_type(self) -> str:
+        return self._model_type
 
     def is_symlink_to(self, file_path, target_path):
         if os.path.islink(file_path):
@@ -137,6 +162,11 @@ class Model(ModelBase):
                             print(f"Deleted: {file_path}")
 
     def remove(self, args):
+        if self.store is not None:
+            _, tag, _ = self.extract_model_identifiers()
+            self.store.remove_snapshot(tag)
+            return
+
         model_path = self.model_path(args)
         try:
             os.remove(model_path)
@@ -418,6 +448,22 @@ class Model(ModelBase):
 
         return prompt
 
+    def model_path(self, args):
+        if self.store is not None:
+            _, tag, _ = self.extract_model_identifiers()
+            if self.store.tag_exists(tag):
+                fhash, _, _ = self.store.get_cached_files(tag)
+                return self.store.get_snapshot_file_path(fhash, self.store.model_name)
+
+        return os.path.join(args.store, "models", self.type, self.directory, self.filename)
+
+    def exists(self, args):
+        model_path = self.model_path(args)
+        if not os.path.exists(model_path):
+            return None
+
+        return model_path
+
     def get_model_path(self, args):
         model_path = self.exists(args)
         if model_path:
@@ -604,19 +650,6 @@ class Model(ModelBase):
     def kube(self, model, args, exec_args):
         kube = Kube(model, self.image, args, exec_args)
         kube.generate()
-
-    def path(self, args):
-        return self.model_path(args)
-
-    def model_path(self, args):
-        return os.path.join(args.store, "models", self.type, self.directory, self.filename)
-
-    def exists(self, args):
-        model_path = self.model_path(args)
-        if not os.path.exists(model_path):
-            return None
-
-        return model_path
 
     def check_valid_model_path(self, relative_target_path, model_path):
         return os.path.exists(model_path) and os.readlink(model_path) == relative_target_path

--- a/ramalama/model_factory.py
+++ b/ramalama/model_factory.py
@@ -1,9 +1,10 @@
-from typing import Union
+from typing import Callable, Tuple, Union
 from urllib.parse import urlparse
 
 from ramalama.common import rm_until_substring
 from ramalama.huggingface import Huggingface
 from ramalama.model import MODEL_TYPES
+from ramalama.model_store import ModelStore
 from ramalama.oci import OCI
 from ramalama.ollama import Ollama
 from ramalama.url import URL
@@ -11,19 +12,56 @@ from ramalama.url import URL
 
 class ModelFactory:
 
-    def __init__(self, model: str, transport: str = "ollama", engine: str = "podman", ignore_stderr: bool = False):
+    def __init__(
+        self,
+        model: str,
+        store_path: str,
+        use_model_store: bool,
+        transport: str = "ollama",
+        engine: str = "podman",
+        ignore_stderr: bool = False,
+    ):
         self.model = model
+        self.store_path = store_path
+        self.use_model_store = use_model_store
         self.transport = transport
         self.engine = engine
         self.ignore_stderr = ignore_stderr
 
-    def prune_model_input(self, cls: type[Union[Huggingface, Ollama, OCI, URL]]) -> str:
+        self.model_cls: type[Union[Huggingface, Ollama, OCI, URL]]
+        self.create: Callable[[], Union[Huggingface, Ollama, OCI, URL]]
+        self.model_cls, self.create = self.detect_model_model_type()
+
+        self.pruned_model = self.prune_model_input()
+
+    def detect_model_model_type(
+        self,
+    ) -> Tuple[type[Union[Huggingface, Ollama, OCI, URL]], Callable[[], Union[Huggingface, Ollama, OCI, URL]]]:
+        if self.model.startswith("huggingface://") or self.model.startswith("hf://") or self.model.startswith("hf.co/"):
+            return Huggingface, self.create_huggingface
+        if self.model.startswith("ollama://") or "ollama.com/library/" in self.model:
+            return Ollama, self.create_ollama
+        if self.model.startswith("oci://") or self.model.startswith("docker://"):
+            return OCI, self.create_oci
+        if self.model.startswith("http://") or self.model.startswith("https://") or self.model.startswith("file://"):
+            return URL, self.create_url
+
+        if self.transport == "huggingface":
+            return Huggingface, self.create_huggingface
+        if self.transport == "ollama":
+            return Ollama, self.create_ollama
+        if self.transport == "oci":
+            return OCI, self.create_oci
+
+        raise KeyError(f'transport "{self.transport}" not supported. Must be oci, huggingface, or ollama.')
+
+    def prune_model_input(self) -> str:
         # remove protocol from model input
         pruned_model_input = rm_until_substring(self.model, "://")
 
-        if cls == Huggingface:
+        if self.model_cls == Huggingface:
             pruned_model_input = rm_until_substring(pruned_model_input, "hf.co/")
-        elif cls == Ollama:
+        elif self.model_cls == Ollama:
             pruned_model_input = rm_until_substring(pruned_model_input, "ollama.com/library/")
 
         return pruned_model_input
@@ -36,34 +74,28 @@ class ModelFactory:
             if self.model.startswith(t + "://"):
                 raise ValueError(f"{self.model} invalid: Only OCI Model types supported")
 
+    def set_optional_model_store(self, model: Union[Huggingface, Ollama, OCI, URL]):
+        if self.use_model_store:
+            name, tag, orga = model.extract_model_identifiers()
+            model.store = ModelStore(self.store_path, name, tag, orga)
+
     def create_huggingface(self) -> Huggingface:
-        return Huggingface(self.prune_model_input(Huggingface))
+        model = Huggingface(self.pruned_model)
+        self.set_optional_model_store(model)
+        return model
 
     def create_ollama(self) -> Ollama:
-        return Ollama(self.prune_model_input(Ollama))
+        model = Ollama(self.pruned_model)
+        self.set_optional_model_store(model)
+        return model
 
     def create_oci(self) -> OCI:
         self.validate_oci_model_input()
-        return OCI(self.prune_model_input(OCI), self.engine, self.ignore_stderr)
+        model = OCI(self.pruned_model, self.engine, self.ignore_stderr)
+        self.set_optional_model_store(model)
+        return model
 
     def create_url(self) -> URL:
-        return URL(self.prune_model_input(URL), urlparse(self.model).scheme)
-
-    def create(self) -> Union[Huggingface, Ollama, OCI, URL]:
-        if self.model.startswith("huggingface://") or self.model.startswith("hf://") or self.model.startswith("hf.co/"):
-            return self.create_huggingface()
-        if self.model.startswith("ollama://") or "ollama.com/library/" in self.model:
-            return self.create_ollama()
-        if self.model.startswith("oci://") or self.model.startswith("docker://"):
-            return self.create_oci()
-        if self.model.startswith("http://") or self.model.startswith("https://") or self.model.startswith("file://"):
-            return self.create_url()
-
-        if self.transport == "huggingface":
-            return self.create_huggingface()
-        if self.transport == "ollama":
-            return self.create_ollama()
-        if self.transport == "oci":
-            return self.create_oci()
-
-        raise KeyError(f'transport "{self.transport}" not supported. Must be oci, huggingface, or ollama.')
+        model = URL(self.pruned_model, urlparse(self.model).scheme)
+        self.set_optional_model_store(model)
+        return model

--- a/ramalama/model_factory.py
+++ b/ramalama/model_factory.py
@@ -4,7 +4,7 @@ from urllib.parse import urlparse
 from ramalama.common import rm_until_substring
 from ramalama.huggingface import Huggingface
 from ramalama.model import MODEL_TYPES
-from ramalama.model_store import ModelStore
+from ramalama.model_store import GlobalModelStore, ModelStore
 from ramalama.oci import OCI
 from ramalama.ollama import Ollama
 from ramalama.url import URL
@@ -76,8 +76,8 @@ class ModelFactory:
 
     def set_optional_model_store(self, model: Union[Huggingface, Ollama, OCI, URL]):
         if self.use_model_store:
-            name, tag, orga = model.extract_model_identifiers()
-            model.store = ModelStore(self.store_path, name, tag, orga)
+            name, _, orga = model.extract_model_identifiers()
+            model.store = ModelStore(GlobalModelStore(self.store_path), name, type(model).__name__.lower(), orga)
 
     def create_huggingface(self) -> Huggingface:
         model = Huggingface(self.pruned_model)

--- a/ramalama/model_store.py
+++ b/ramalama/model_store.py
@@ -192,6 +192,9 @@ class ModelStore:
     def get_blob_file_path(self, file_hash: str) -> str:
         return os.path.join(self.blobs_directory, sanitize_hash(file_hash))
 
+    def get_partial_blob_file_path(self, file_hash: str) -> str:
+        return self.get_blob_file_path(file_hash) + ".partial"
+
     def ensure_directory_setup(self) -> None:
         os.makedirs(self.blobs_directory, exist_ok=True)
         os.makedirs(self.refs_directory, exist_ok=True)
@@ -264,8 +267,10 @@ class ModelStore:
         ref_file = self.get_ref_file(model_tag)
 
         # Remove all blobs first
-        for file in ref_file.filenames:
-            self._remove_blob_file(self.get_snapshot_file_path(ref_file.hash, file))
+        if ref_file is not None:
+            for file in ref_file.filenames:
+                self._remove_blob_file(self.get_snapshot_file_path(ref_file.hash, file))
+                self._remove_blob_file(self.get_partial_blob_file_path(ref_file.hash, file))
 
         # Remove snapshot directory
         snapshot_directory = self.get_snapshot_directory_from_tag(model_tag)

--- a/ramalama/model_store.py
+++ b/ramalama/model_store.py
@@ -12,9 +12,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 def sanitize_hash(filename: str) -> str:
-    return filename
-    # TODO: re-enable sanitizing
-    # return filename.replace(":", "-")
+    return filename.replace(":", "-")
 
 
 class SnapshotFile:
@@ -245,7 +243,7 @@ class ModelStore:
 
             if file.should_verify_checksum:
                 if not verify_checksum(dest_path):
-                    print(f"Checksum mismatch for blob {dest_path}, retrying download...")
+                    LOGGER.info(f"Checksum mismatch for blob {dest_path}, retrying download...")
                     os.remove(dest_path)
                     file.download(dest_path, self.get_snapshot_directory(snapshot_hash))
                     if not verify_checksum(dest_path):

--- a/ramalama/model_store.py
+++ b/ramalama/model_store.py
@@ -1,0 +1,198 @@
+import os
+import urllib
+from enum import StrEnum
+from pathlib import Path
+from typing import Dict, Tuple
+
+from ramalama.common import download_file, verify_checksum
+
+
+class ModelRegistry(StrEnum):
+    HUGGINGFACE = "huggingface"
+    OLLAMA = "ollama"
+    OCI = "oci"
+    URL = "url"
+
+
+class SnapshotFile:
+
+    def __init__(
+        self,
+        url: str,
+        header: Dict,
+        hash: str,
+        name: str,
+        should_show_progress: bool = False,
+        should_verify_checksum: bool = False,
+        required: bool = True,
+    ):
+        self.url: str = url
+        self.header: Dict = header
+        self.hash: str = hash
+        self.name: str = name
+        self.should_show_progress: bool = should_show_progress
+        self.should_verify_checksum: bool = should_verify_checksum
+        self.required: bool = required
+
+    def download(self, blob_file_path: str, snapshot_dir: str) -> str:
+        download_file(
+            url=self.url,
+            headers=self.header,
+            dest_path=blob_file_path,
+            show_progress=self.should_show_progress,
+        )
+        return os.path.relpath(blob_file_path, start=snapshot_dir)
+
+
+class RefFile:
+
+    def __init__(self):
+        self.hash: str = ""
+        self.filenames: list[str] = []
+
+    def from_path(path: str) -> "RefFile":
+        ref_file = RefFile()
+        with open(path, "r") as file:
+            ref_file.hash = file.readline().strip()
+            filename = file.readline().strip()
+            while filename != "":
+                ref_file.filenames.append(filename)
+                filename = file.readline().strip()
+        return ref_file
+
+
+class ModelStore:
+
+    def __init__(
+        self,
+        base_path: Path,
+        model_name: str,
+        model_organization: str,
+        model_registry: ModelRegistry,
+    ):
+        self._store_base_path = os.path.join(base_path, "store")
+        self._model_name = model_name
+        self._model_organization = model_organization
+        self._model_registry = model_registry
+
+    @property
+    def store_path(self) -> str:
+        return self._store_base_path
+
+    @property
+    def model_name(self) -> str:
+        return self._model_name
+
+    @property
+    def model_organization(self) -> str:
+        return self._model_organization if self._model_organization != "" else self._model_name
+
+    @property
+    def model_registry(self) -> ModelRegistry:
+        return self._model_registry
+
+    @property
+    def model_base_directory(self) -> str:
+        return os.path.join(self.store_path, self.model_registry, self.model_organization)
+
+    @property
+    def blob_directory(self) -> str:
+        return os.path.join(self.model_base_directory, "blobs")
+
+    @property
+    def ref_directory(self) -> str:
+        return os.path.join(self.model_base_directory, "refs")
+
+    @property
+    def snapshot_directory(self) -> str:
+        return os.path.join(self.model_base_directory, "snapshots")
+
+    @staticmethod
+    def sanitize_filename(filename: str) -> str:
+        return filename.replace(":", "-")
+
+    def get_ref_file_path(self, model_tag: str) -> str:
+        return os.path.join(self.ref_directory, model_tag)
+
+    def get_snapshot_directory(self, hash: str) -> str:
+        return os.path.join(self.snapshot_directory, ModelStore.sanitize_filename(hash))
+
+    def get_blob_file_path(self, hash: str) -> str:
+        return os.path.join(self.blob_directory, ModelStore.sanitize_filename(hash))
+
+    def get_snapshot_file_path(self, hash: str, filename: str) -> str:
+        return os.path.join(self.get_snapshot_directory(ModelStore.sanitize_filename(hash)), filename)
+
+    def resolve_model_directory(self, model_tag: str) -> str:
+        ref_file_path = self.get_ref_file_path(model_tag)
+        if not self.exists(ref_file_path):
+            return ""
+
+        ref_file = RefFile(ref_file_path)
+        return self.get_snapshot_directory(ref_file.hash)
+
+    def ensure_directory_setup(self) -> None:
+        os.makedirs(self.blob_directory, exist_ok=True)
+        os.makedirs(self.ref_directory, exist_ok=True)
+        os.makedirs(self.snapshot_directory, exist_ok=True)
+
+    def exists(self, model_tag: str) -> bool:
+        return os.path.exists(self.get_ref_file_path(model_tag))
+
+    def get_cached_files(self, model_tag: str) -> Tuple[str, list[str], bool]:
+        cached_files = []
+
+        ref_file_path = self.get_ref_file_path(model_tag)
+        if not self.exists(ref_file_path):
+            return ("", cached_files, False)
+
+        ref_file: RefFile = RefFile.from_path(ref_file_path)
+        for file in ref_file.filenames:
+            path = self.get_snapshot_file_path(ref_file.hash, file)
+            if os.path.exists(path):
+                cached_files.append(file)
+
+        return (ref_file.hash, cached_files, len(cached_files) == len(ref_file.filenames))
+
+    def prepare_new_snapshot(self, model_tag: str, snapshot_hash: str, snapshot_files: list[SnapshotFile]):
+        self.ensure_directory_setup()
+
+        ref_file = self.get_ref_file_path(model_tag)
+        if not os.path.exists(ref_file):
+            with open(ref_file, "w") as ref_file:
+                ref_file.write(f"{snapshot_hash}")
+                for file in snapshot_files:
+                    ref_file.write(f"\n{file.name}")
+
+                ref_file.flush()
+
+        snapshot_directory = self.get_snapshot_directory(snapshot_hash)
+        os.makedirs(snapshot_directory, exist_ok=True)
+
+    # TODO: implement - iterating over all symlinks in snapshot dir, check valid
+    def verify_snapshot(self):
+        pass
+
+    def new_snapshot(self, model_tag: str, snapshot_hash: str, snapshot_files: list[SnapshotFile]):
+        snapshot_hash = self.sanitize_filename(snapshot_hash)
+        self.prepare_new_snapshot(model_tag, snapshot_hash, snapshot_files)
+
+        for file in snapshot_files:
+            dest_path = self.get_blob_file_path(file.hash)
+            blob_relative_path = ""
+            try:
+                blob_relative_path = file.download(dest_path, self.get_snapshot_directory(snapshot_hash))
+            except urllib.error.HTTPError as e:
+                if file.required:
+                    raise
+                continue
+
+            if file.should_verify_checksum:
+                if not verify_checksum(dest_path):
+                    print(f"Checksum mismatch for blob {dest_path}, retrying download...")
+                    os.remove(dest_path)
+                    file.download(dest_path, self.get_snapshot_directory(snapshot_hash))
+                    if not verify_checksum(dest_path):
+                        raise ValueError(f"Checksum verification failed for blob {dest_path}")
+
+            os.symlink(blob_relative_path, self.get_snapshot_file_path(snapshot_hash, file.name))

--- a/ramalama/ollama.py
+++ b/ramalama/ollama.py
@@ -282,7 +282,7 @@ class Ollama(Model):
         except urllib.error.HTTPError as e:
             if "Not Found" in e.reason:
                 raise KeyError(f"{name}:{tag} was not found in the Ollama registry")
-            raise KeyError(f"failed to fetch manifest: {str(e).strip("'")}")
+            raise KeyError(f"failed to fetch snapshot files: {str(e).strip("'")}")
 
         # If a model has been downloaded via ollama cli, only create symlink in the snapshots directory
         if is_model_in_ollama_cache:

--- a/ramalama/ollama.py
+++ b/ramalama/ollama.py
@@ -1,9 +1,11 @@
 import json
 import os
 import urllib.request
+from typing import Optional
 
 from ramalama.common import available, download_file, run_cmd, verify_checksum
 from ramalama.model import Model
+from ramalama.model_store import SnapshotFile
 
 
 def fetch_manifest_data(registry_head, model_tag, accept):
@@ -85,6 +87,106 @@ def in_existing_cache(model_name, model_tag):
     return None
 
 
+class OllamaRepository:
+
+    REGISTRY_URL = "https://registry.ollama.ai/v2/library"
+    ACCEPT = "Accept: application/vnd.docker.distribution.manifest.v2+json"
+
+    FILE_NAME_CONFIG = "config.json"
+    FILE_NAME_CHAT_TEMPLATE = "chat_template"
+
+    def __init__(self, name):
+        self.name = name
+        self.registry_head = f"{OllamaRepository.REGISTRY_URL}/{name}"
+        self.blob_url = f"{self.registry_head}/blobs"
+        self.headers = {"Accept": OllamaRepository.ACCEPT}
+
+    def fetch_manifest(self, tag):
+        try:
+            return fetch_manifest_data(self.registry_head, tag, OllamaRepository.ACCEPT)
+        except urllib.error.HTTPError as e:
+            if "Not Found" in e.reason:
+                raise KeyError(f"Manifest for {self.name}:{tag} was not found in the Ollama registry")
+            raise KeyError(f"failed to fetch manifest: {str(e).strip("'")}")
+
+    def get_file_list(self, tag, cached_files, is_model_in_ollama_cache, manifest=None) -> list[SnapshotFile]:
+        if manifest is None:
+            manifest = self.fetch_manifest(tag)
+
+        files = []
+        if self.name not in cached_files and not is_model_in_ollama_cache:
+            model = self.model_file(tag, manifest)
+            if model is not None:
+                files.append(model)
+        if OllamaRepository.FILE_NAME_CONFIG not in cached_files:
+            files.append(self.config_file(tag, manifest))
+        if OllamaRepository.FILE_NAME_CHAT_TEMPLATE not in cached_files:
+            chat_template = self.chat_template_file(tag, manifest)
+            if chat_template is not None:
+                files.append(chat_template)
+
+        return files
+
+    def get_model_hash(self, manifest) -> str:
+        for layer in manifest["layers"]:
+            layer_digest = layer["digest"]
+            if layer["mediaType"] == "application/vnd.ollama.image.model":
+                return layer_digest
+        return ""
+
+    def model_file(self, tag, manifest=None) -> Optional[SnapshotFile]:
+        if manifest is None:
+            manifest = self.fetch_manifest(tag)
+
+        model_digest = self.get_model_hash(manifest)
+        if model_digest == "":
+            return None
+
+        return SnapshotFile(
+            url=f"{self.blob_url}/{model_digest}",
+            header=self.headers,
+            hash=model_digest,
+            name=self.name,
+            should_show_progress=True,
+            should_verify_checksum=True,
+        )
+
+    def config_file(self, tag, manifest=None) -> SnapshotFile:
+        if manifest is None:
+            manifest = self.fetch_manifest(tag)
+
+        config_hash = manifest["config"]["digest"]
+
+        return SnapshotFile(
+            url=f"{self.blob_url}/{config_hash}",
+            header=self.headers,
+            hash=config_hash,
+            name=OllamaRepository.FILE_NAME_CONFIG,
+        )
+
+    def get_chat_template_hash(self, manifest) -> str:
+        for layer in manifest["layers"]:
+            layer_digest = layer["digest"]
+            if layer["mediaType"] == "application/vnd.ollama.image.template":
+                return layer_digest
+        return ""
+
+    def chat_template_file(self, tag, manifest=None) -> Optional[SnapshotFile]:
+        if manifest is None:
+            manifest = self.fetch_manifest(tag)
+
+        chat_template_digest = self.get_chat_template_hash(manifest)
+        if chat_template_digest == "":
+            return None
+
+        return SnapshotFile(
+            url=f"{self.blob_url}/{chat_template_digest}",
+            header=self.headers,
+            hash=chat_template_digest,
+            name=OllamaRepository.FILE_NAME_CHAT_TEMPLATE,
+        )
+
+
 class Ollama(Model):
     def __init__(self, model):
         super().__init__(model)
@@ -124,6 +226,9 @@ class Ollama(Model):
         return model_path
 
     def pull(self, args):
+        if self.store is not None:
+            return self._pull_with_modelstore()
+
         repos = args.store + "/repos/ollama"
         model_path, models, model_base, model_name, model_tag = self._local(args)
         if os.path.exists(model_path):
@@ -158,3 +263,30 @@ class Ollama(Model):
 
         model_base = os.path.basename(model_name)
         return os.path.join(models, f"{model_base}:{model_tag}")
+
+    def _pull_with_modelstore(self):
+        name, tag, _ = self.extract_model_identifiers()
+        hash, cached_files, all = self.store.get_cached_files(tag)
+        if all:
+            return self.store.get_snapshot_file_path(hash, name)
+
+        ollama_repo = OllamaRepository(self.store.model_name)
+        manifest = ollama_repo.fetch_manifest(tag)
+        ollama_cache_path = in_existing_cache(self.name, tag)
+        is_model_in_ollama_cache = ollama_cache_path is not None
+        files: list[SnapshotFile] = ollama_repo.get_file_list(tag, cached_files, is_model_in_ollama_cache)
+
+        model_hash = ollama_repo.get_model_hash(manifest)
+        try:
+            self.store.new_snapshot(tag, model_hash, files)
+        except urllib.error.HTTPError as e:
+            if "Not Found" in e.reason:
+                raise KeyError(f"{name}:{tag} was not found in the Ollama registry")
+            raise KeyError(f"failed to fetch manifest: {str(e).strip("'")}")
+
+        # If a model has been downloaded via ollama cli, only create symlink in the snapshots directory
+        if is_model_in_ollama_cache:
+            snapshot_model_path = self.store.get_snapshot_file_path(model_hash, self.store.model_name)
+            os.symlink(ollama_cache_path, snapshot_model_path)
+
+        return self.store.get_snapshot_file_path(model_hash, self.store.model_name)

--- a/ramalama/url.py
+++ b/ramalama/url.py
@@ -1,7 +1,25 @@
 import os
+import shutil
 
-from ramalama.common import download_file
+from ramalama.common import download_file, generate_sha256
+from ramalama.huggingface import HuggingfaceRepository
 from ramalama.model import Model
+from ramalama.model_store import SnapshotFile
+
+
+class LocalModelFile(SnapshotFile):
+
+    def __init__(
+        self, url, header, hash, name, should_show_progress=False, should_verify_checksum=False, required=True
+    ):
+        super().__init__(url, header, hash, name, should_show_progress, should_verify_checksum, required)
+
+    def download(self, blob_file_path, snapshot_dir):
+        if not os.path.exists(self.url):
+            raise FileNotFoundError(f"No such file: '{self.url}'")
+        # moving from the local location to blob directory so the model store "owns" the data
+        shutil.copy(self.url, blob_file_path)
+        return os.path.relpath(blob_file_path, start=snapshot_dir)
 
 
 class URL(Model):
@@ -20,9 +38,17 @@ class URL(Model):
             model_organization = "/".join(parts[:-2])
             model_tag = parts[-1]
 
+        # handling huggingface specific URLs for more precise identifiers
+        if len(parts) > 2 and HuggingfaceRepository.REGISTRY_URL.endswith(parts[0]) and parts[-2] == "resolve":
+            model_organization = "/".join(parts[:-2])
+            model_tag = parts[-1]
+
         return model_name, model_tag, model_organization
 
     def pull(self, args):
+        if self.store is not None:
+            return self._pull_with_model_store()
+
         model_path = self.model_path(args)
         directory_path = os.path.join(args.store, "repos", self.type, self.directory, self.filename)
         os.makedirs(directory_path, exist_ok=True)
@@ -49,3 +75,37 @@ class URL(Model):
             os.symlink(relative_target_path, model_path)
 
         return model_path
+
+    def _pull_with_model_store(self):
+        name, tag, _ = self.extract_model_identifiers()
+        hash, _, all = self.store.get_cached_files(tag)
+        if all:
+            return self.store.get_snapshot_file_path(hash, name)
+
+        files: list[SnapshotFile] = []
+        snapshot_hash = generate_sha256(name)
+        if self.type == "file":
+            files.append(
+                LocalModelFile(
+                    url=self.model,  # model contains the full path here
+                    header={},
+                    hash=snapshot_hash,
+                    name=name,
+                    required=True,
+                )
+            )
+        else:
+            files.append(
+                SnapshotFile(
+                    url=f"{self.type}://{self.model}",
+                    header={},
+                    hash=snapshot_hash,
+                    name=name,
+                    should_show_progress=True,
+                    required=True,
+                )
+            )
+
+        self.store.new_snapshot(tag, snapshot_hash, files)
+
+        return self.store.get_snapshot_file_path(snapshot_hash, name)

--- a/ramalama/url.py
+++ b/ramalama/url.py
@@ -12,6 +12,16 @@ class URL(Model):
         split = self.model.rsplit("/", 1)
         self.directory = split[0].removeprefix("/") if len(split) > 1 else ""
 
+    def extract_model_identifiers(self):
+        model_name, model_tag, model_organization = super().extract_model_identifiers()
+
+        parts = model_organization.split("/")
+        if len(parts) > 2 and parts[-2] == "blob":
+            model_organization = "/".join(parts[:-2])
+            model_tag = parts[-1]
+
+        return model_name, model_tag, model_organization
+
     def pull(self, args):
         model_path = self.model_path(args)
         directory_path = os.path.join(args.store, "repos", self.type, self.directory, self.filename)

--- a/test/unit/data/verify_checksum/sha256-62fbfd9ed093d6e5ac83190c86eec5369317919f4b149598d2dbb38900e9faef
+++ b/test/unit/data/verify_checksum/sha256-62fbfd9ed093d6e5ac83190c86eec5369317919f4b149598d2dbb38900e9faef
@@ -1,0 +1,6 @@
+{{ if .System }}<|im_start|>system
+{{ .System }}<|im_end|>
+{{ end }}{{ if .Prompt }}<|im_start|>user
+{{ .Prompt }}<|im_end|>
+{{ end }}<|im_start|>assistant
+{{ .Response }}<|im_end|>

--- a/test/unit/data/verify_checksum/sha256:123
+++ b/test/unit/data/verify_checksum/sha256:123
@@ -1,0 +1,1 @@
+RamaLama - make working with AI boring through the use of OCI containers.

--- a/test/unit/data/verify_checksum/sha256:16cd1aa2bd52b0e87ff143e8a8a7bb6fcb0163c624396ca58e7f75ec99ef081f
+++ b/test/unit/data/verify_checksum/sha256:16cd1aa2bd52b0e87ff143e8a8a7bb6fcb0163c624396ca58e7f75ec99ef081f
@@ -1,0 +1,3 @@
+{"model_format":"gguf","model_family":"llama","model_families":["llama"],"model_type":"361.82M","file_type":"Q4_0","architecture":"amd64","os":"linux","rootfs":{"type":"layers","diff_ids":["sha256:f7ae49f9d598730afa2de96fc7dade47f5850446bf813df2e9d739cc8a6c4f29","sha256:62fbfd9ed093d6e5ac83190c86eec5369317919f4b149598d2dbb38900e9faef","sha256:cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30","sha256:ca7a9654b5469dc2d638456f31a51a03367987c54135c089165752d9eeb08cd7"]}}
+
+I have been tampered with

--- a/test/unit/data/verify_checksum/sha256:62fbfd9ed093d6e5ac83190c86eec5369317919f4b149598d2dbb38900e9faef
+++ b/test/unit/data/verify_checksum/sha256:62fbfd9ed093d6e5ac83190c86eec5369317919f4b149598d2dbb38900e9faef
@@ -1,0 +1,6 @@
+{{ if .System }}<|im_start|>system
+{{ .System }}<|im_end|>
+{{ end }}{{ if .Prompt }}<|im_start|>user
+{{ .Prompt }}<|im_end|>
+{{ end }}<|im_start|>assistant
+{{ .Response }}<|im_end|>

--- a/test/unit/test_common.py
+++ b/test/unit/test_common.py
@@ -1,6 +1,9 @@
+import os
+from pathlib import Path
+
 import pytest
 
-from ramalama.common import rm_until_substring
+from ramalama.common import rm_until_substring, verify_checksum
 
 
 @pytest.mark.parametrize(
@@ -25,3 +28,25 @@ from ramalama.common import rm_until_substring
 def test_rm_until_substring(input: str, rm_until: str, expected: str):
     actual = rm_until_substring(input, rm_until)
     assert actual == expected
+
+
+@pytest.mark.parametrize(
+    "input_file,expected_error,expected_result",
+    [
+        ("", ValueError, None),
+        ("invalidname", ValueError, None),
+        ("sha256:123", ValueError, None),
+        ("sha256:62fbfd9ed093d6e5ac83190c86eec5369317919f4b149598d2dbb38900e9faef", None, True),
+        ("sha256-62fbfd9ed093d6e5ac83190c86eec5369317919f4b149598d2dbb38900e9faef", None, True),
+        ("sha256:16cd1aa2bd52b0e87ff143e8a8a7bb6fcb0163c624396ca58e7f75ec99ef081f", None, False),
+    ],
+)
+def test_verify_checksum(input_file: str, expected_error: Exception, expected_result: bool):
+    full_path = os.path.join(Path(__file__).parent, "data", "verify_checksum", input_file)
+
+    if expected_error is None:
+        assert verify_checksum(full_path) == expected_result
+        return
+
+    with pytest.raises(expected_error):
+        verify_checksum(full_path)

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -65,6 +65,7 @@ def test_load_config_from_env(env, config, expected):
                 "temp": "0.8",
                 "host": "0.0.0.0",
                 "port": "8080",
+                "use_model_store": False,
             },
         ),
         (
@@ -82,6 +83,7 @@ def test_load_config_from_env(env, config, expected):
                 "temp": "0.8",
                 "host": "0.0.0.0",
                 "port": "8080",
+                "use_model_store": False,
             },
         ),
     ],

--- a/test/unit/test_model.py
+++ b/test/unit/test_model.py
@@ -1,0 +1,52 @@
+import pytest
+
+from ramalama.model_factory import ModelFactory
+
+
+@pytest.mark.parametrize(
+    "model_input,expected_name,expected_tag,expected_orga",
+    [
+        ("huggingface://granite-code", "granite-code", "latest", ""),
+        ("hf://granite-code", "granite-code", "latest", ""),
+        (
+            "https://huggingface.co/ibm-granite/granite-3b-code-base-2k-GGUF/blob/main/granite-3b-code-base.Q4_K_M.gguf",
+            "granite-3b-code-base.Q4_K_M.gguf",
+            "main",
+            "huggingface.co/ibm-granite/granite-3b-code-base-2k-GGUF",
+        ),
+        (
+            "https://huggingface.co/ibm-granite/granite-3b-code-base-2k-GGUF/blob/8ee52dc636b27b99caf046e717a87fb37ad9f33e/granite-3b-code-base.Q4_K_M.gguf",
+            "granite-3b-code-base.Q4_K_M.gguf",
+            "8ee52dc636b27b99caf046e717a87fb37ad9f33e",
+            "huggingface.co/ibm-granite/granite-3b-code-base-2k-GGUF",
+        ),
+        ("ollama://granite-code", "granite-code", "latest", ""),
+        (
+            "https://ollama.com/huihui_ai/granite3.1-dense-abliterated:2b-instruct-fp16",
+            "granite3.1-dense-abliterated",
+            "2b-instruct-fp16",
+            "ollama.com/huihui_ai",
+        ),
+        ("ollama.com/library/granite-code", "granite-code", "latest", ""),
+        (
+            "huihui_ai/granite3.1-dense-abliterated:2b-instruct-fp16",
+            "granite3.1-dense-abliterated",
+            "2b-instruct-fp16",
+            "huihui_ai",
+        ),
+        ("oci://granite-code", "granite-code", "latest", ""),
+        ("docker://granite-code", "granite-code", "latest", ""),
+        ("docker://granite-code:v1.1.1", "granite-code", "v1.1.1", ""),
+        (
+            "file:///tmp/models/granite-3b-code-base.Q4_K_M.gguf",
+            "granite-3b-code-base.Q4_K_M.gguf",
+            "latest",
+            "tmp/models",
+        ),
+    ],
+)
+def test_extract_model_identifiers(model_input: str, expected_name: str, expected_tag: str, expected_orga: str):
+    name, tag, orga = ModelFactory(model_input, "/tmp/store", False).create().extract_model_identifiers()
+    assert name == expected_name
+    assert tag == expected_tag
+    assert orga == expected_orga


### PR DESCRIPTION
Continuation of #805.

Added a model store to standardize pulling, storing and using models across the different repositories. It tries to add this new concept in a non-breaking way by hiding it behind the `--use-model-store` CLI flag - so existing installations keep working while users can already switch. 

A key goal of this store is to support downloading multiple files, e.g. the chat template from ollama models or additional metadata from non-GGUF models. In addition, this is probably a first step towards enabling the usage of safetensors (https://github.com/containers/ramalama/issues/642) where a model consists of multiple files. 

The proposed structure is inspired by how the huggingface-cli stores its files and extends it for the multi-source usage in ramalama. 

The proposed storage structure looks like this after running 
- `ramalama pull ollama://tinyllama`
- `ramalama pull hf://ibm-granite/granite-3b-code-base-2k-GGUF/granite-3b-code-base.Q4_K_M.gguf`
```
~/.local/share/ramalama/store
   |-- ollama
   |   |-- tinyllama
   |   |   |-- blobs
   |   |   |   |-- sha256-2af3b81862c6be03c769683af18efdadb2c33f60ff32ab6f83e42c043d6c7816
   |   |   |   |-- sha256-6331358be52a6ebc2fd0755a51ad1175734fd17a628ab5ea6897109396245362
   |   |   |   |-- sha256-af0ddbdaaa26f30d54d727f9dd944b76bdb926fdaf9a58f63f78c532f57c191f
   |   |   |-- refs
   |   |   |   |-- latest
   |   |   |-- snapshots
   |   |   |   |-- sha256-6331358be52a6ebc2fd0755a51ad1175734fd17a628ab5ea6897109396245362
   |   |   |   |   |-- chat_template -> ../../blobs/sha256-af0ddbdaaa26f30d54d727f9dd944b76bdb926fdaf9a58f63f78c532f57c191f
   |   |   |   |   |-- config.json -> ../../blobs/sha256-6331358be52a6ebc2fd0755a51ad1175734fd17a628ab5ea6897109396245362
   |   |   |   |   |-- tinyllama -> ../../blobs/sha256-2af3b81862c6be03c769683af18efdadb2c33f60ff32ab6f83e42c043d6c7816
   |-- huggingface
   |   |-- ibm-granite
   |   |   |-- granite-3b-code-base-2k-GGUF
   |   |   |   |-- blobs
   |   |   |   |   |-- sha256-c803a9bb910be0699501319140329ba0d2850aeb8827389e38f24e8370f04293
   |   |   |   |-- refs
   |   |   |   |   |-- latest
   |   |   |   |-- snapshots
   |   |   |   |   |-- sha256-c803a9bb910be0699501319140329ba0d2850aeb8827389e38f24e8370f04293
   |   |   |   |   |   |-- granite-3b-code-base.Q4_K_M.gguf -> ../../blobs/sha256-c803a9bb910be0699501319140329ba0d2850aeb8827389e38f24e8370f04293
```

This PR is still in draft and the following needs to be added:
- [x] Add model store downloading to huggingface, oci and url models
- [ ] Pass chat template file path to llama-run if it exists
- [x] Sanitize the filenames by replacing ":" with "-"
- [ ] Add unit tests
- [ ] Add e2e tests

## Summary by Sourcery

Implements a new model store to standardize pulling, storing, and using models across different repositories. The model store is enabled via the `--use-model-store` CLI flag. It supports downloading multiple files and lays the groundwork for safetensors support. It also adds model store downloading to Hugging Face, OCI, and URL models and sanitizes filenames by replacing ":" with "-".

New Features:
- Introduces a model store for managing models, enabled by the `--use-model-store` flag.
- Adds support for downloading multiple files associated with a model.
- Adds model store downloading to Hugging Face, OCI, and URL models.
- Sanitizes filenames by replacing ":" with "-"