### PR TITLE
Build a non-kompute Vulkan container image

### DIFF
--- a/container-images/vulkan/Containerfile
+++ b/container-images/vulkan/Containerfile
@@ -4,5 +4,5 @@ ENV MODEL_PATH=/mnt/models/model.file
 
 COPY --chmod=755 ../scripts /usr/bin
 
-RUN /usr/bin/build_llama_and_whisper.sh "ramalama"
+RUN /usr/bin/build_llama_and_whisper.sh "vulkan"
 


### PR DESCRIPTION
There's no image to pull to play around with this backend right now.

## Summary by Sourcery

Chores:
- Build a container image for the Vulkan backend.