### PR TITLE
Add support for llama.cpp engine to use ascend NPU device

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ format:
 
 .PHONY: codespell
 codespell:
-	codespell --dictionary=- -w --skip="*/venv*"
+	codespell --dictionary=-  --ignore-words-list "cann" -w --skip="*/venv*"
 
 .PHONY: test-run
 test-run:

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ curl -fsSL https://raw.githubusercontent.com/containers/ramalama/s/install.sh | 
 | Apple Silicon GPU (podman-machine) | :white_check_mark: |
 | Nvidia GPU (cuda)                  | :white_check_mark: |
 | AMD GPU (rocm)                     | :white_check_mark: |
-
+| Ascend NPU (Linux)                 | :white_check_mark: |
 ## COMMANDS
 
 | Command                                                | Description                                                |

--- a/container-images/cann/Containerfile
+++ b/container-images/cann/Containerfile
@@ -1,0 +1,19 @@
+# Base image with CANN for compilation
+ARG ASCEND_VERSION=cann:8.0.0-910b-openeuler22.03-py3.10
+
+FROM quay.io/ascend/${ASCEND_VERSION} AS builder
+ARG GOLANG_VERSION
+COPY ../scripts /scripts
+RUN chmod +x /scripts/*.sh && \
+    sh -x /scripts/build_llama_and_whisper.sh "cann"
+
+FROM quay.io/ascend/${ASCEND_VERSION}
+# Copy the entire installation directory from the builder
+COPY --from=builder /tmp/install /usr
+ENV MODEL_PATH=/mnt/models/model.file
+COPY --chmod=755 ../scripts /usr/bin
+ENTRYPOINT [ \
+    "/bin/bash", \
+    "-c", \
+    "export LD_LIBRARY_PATH=/usr/lib:${LD_LIBRARY_PATH} && source /usr/local/Ascend/ascend-toolkit/set_env.sh && exec \"$@\"", "--" \
+]

--- a/docs/ramalama-cann.7.md
+++ b/docs/ramalama-cann.7.md
@@ -1,0 +1,63 @@
+% ramalama 7
+
+# Setting Up RamaLama with Ascend NPU Support on Linux systems
+
+This guide walks through the steps required to set up RamaLama with Ascend NPU support.
+ - [Background](#background)
+ - [Hardware](#hardware)
+ - [Docker](#docker)
+ - [HISTORY](#todo)
+
+## Background
+
+**Ascend NPU** is a range of AI processors using Neural Processing Unit. It will efficiently handle matrix-matrix multiplication, dot-product and scalars.
+
+**CANN** (Compute Architecture for Neural Networks) is a heterogeneous computing architecture for AI scenarios, providing support for multiple AI frameworks on the top and serving AI processors and programming at the bottom. It plays a crucial role in bridging the gap between upper and lower layers, and is a key platform for improving the computing efficiency of Ascend AI processors. Meanwhile, it offers a highly efficient and easy-to-use programming interface for diverse application scenarios, allowing users to rapidly build AI applications and services based on the Ascend platform.
+
+## Hardware
+
+### Ascend NPU
+
+**Verified devices**
+
+| Ascend NPU                     | Status  |
+| -----------------------------  | ------- |
+| Atlas A2 Training series       | Support |
+| Atlas 800I A2 Inference series | Support |
+
+*Notes:*
+
+- If you have trouble with Ascend NPU device, please create an issue with **[CANN]** prefix/tag.
+- If you run successfully with your Ascend NPU device, please help update the upper table.
+
+## Docker
+### Install the Ascend driver
+This provides NPU acceleration using the AI cores of your Ascend NPU. And [CANN](https://www.hiascend.com/en/software/cann) is a hierarchical APIs to help you to quickly build AI applications and service based on Ascend NPU.
+
+For more information about Ascend NPU in [Ascend Community](https://www.hiascend.com/en/).
+
+Make sure to have the CANN toolkit installed. You can download it from here: [CANN Toolkit](https://www.hiascend.com/developer/download/community/result?module=cann)
+
+### Build Images
+Go to `ramalama` directory and build using make.
+```bash
+make build IMAGE=cann
+make install
+```
+
+You can test with:
+```bash
+ramalama --image quay.io/ramalama/cann:latest serve -d -p 8080 --device=/dev/davinci0 -name ollama://smollm:135m
+```
+
+In a window see the running podman container.
+```
+$ podman ps
+CONTAINER ID   IMAGE                                                         COMMAND                  CREATED             STATUS             PORTS                                          NAMES
+80fc31c131b0   quay.io/ramalama/cann:latest                                  "/bin/bash -c 'expor…"   About an hour ago   Up About an hour                                                  ame
+```
+
+Other using guides see Ramalama ([README.md](https://github.com/containers/ramalama/blob/main/README.md))
+
+## HISTORY
+Mar 2025, Originally compiled

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -187,6 +187,14 @@ def show_gpus_available_cli(args):
 
     else:  # Linux/Other OS GPU detection
         try:
+            ascend_gpus = gpu_detector.get_ascend_npu()
+            # Since Ascend devices are not required, keep quiet if no Ascend devices are detected
+            if ascend_gpus:
+                gpu_info.extend(ascend_gpus)
+        except Exception as e:
+            errors.append({"Vendor": "Ascend", "INFO": str(e)})
+
+        try:
             nvidia_gpus = gpu_detector.get_nvidia_gpu()
             if nvidia_gpus:
                 gpu_info.extend(nvidia_gpus)

--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -273,6 +273,15 @@ def get_gpu():
     except Exception:
         pass
 
+    # Ascend CASE
+    try:
+        command = ['npu-smi']
+        run_cmd(command).stdout.decode("utf-8")
+        os.environ["CANN_VISIBLE_DEVICES"] = "0"
+        return
+    except Exception:
+        pass
+
     # ROCm/AMD CASE
     i = 0
     gpu_num = 0
@@ -303,7 +312,7 @@ def get_gpu():
 
 
 def get_env_vars():
-    prefixes = ("ASAHI_", "CUDA_", "HIP_", "HSA_", "INTEL_")
+    prefixes = ("ASAHI_", "CUDA_", "HIP_", "HSA_", "INTEL_", "CANN_")
     env_vars = {k: v for k, v in os.environ.items() if k.startswith(prefixes)}
 
     # gpu_type, gpu_num = get_gpu()

--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -158,6 +158,7 @@ class Model(ModelBase):
             "CUDA_VISIBLE_DEVICES": "quay.io/ramalama/cuda",
             "ASAHI_VISIBLE_DEVICES": "quay.io/ramalama/asahi",
             "INTEL_VISIBLE_DEVICES": "quay.io/ramalama/intel-gpu",
+            "CANN_VISIBLE_DEVICES": "quay.io/ramalama/cann",
         }
 
         image = images.get(gpu_type, args.image)
@@ -271,6 +272,9 @@ class Model(ModelBase):
             if os.path.exists("/dev/kfd"):
                 conman_args += ["--device", "/dev/kfd"]
 
+            if os.path.exists("/dev/davinci0"):
+                conman_args += ["--device", "/dev/davinci0"]
+
             for k, v in get_env_vars().items():
                 # Special case for Cuda
                 if k == "CUDA_VISIBLE_DEVICES":
@@ -313,6 +317,7 @@ class Model(ModelBase):
             or os.getenv("ASAHI_VISIBLE_DEVICES")
             or os.getenv("CUDA_VISIBLE_DEVICES")
             or os.getenv("INTEL_VISIBLE_DEVICES")
+            or os.getenv("CANN_VISIBLE_DEVICES")
             or (
                 # linux and macOS report aarch64 differently, on Apple Silicon
                 # (arm64), we should have acceleration on regardless.


### PR DESCRIPTION
Add support for llama.cpp engine to use ascend NPU device.
[Ascend NPU](https://www.hiascend.com/en/) is an AI processor that has supports LLM inference engines such as [vllm](https://github.com/vllm-project/vllm-ascend), [llama.cpp](https://github.com/ggml-org/llama.cpp), [onnxruntime](https://github.com/microsoft/onnxruntime).

Corresponding Feature Request is #885.

## Summary by Sourcery

Adds support for Ascend NPU devices to the llama.cpp engine, enabling the use of Ascend NPUs for accelerated inference. This includes changes to detect Ascend NPUs, configure the build environment, and set necessary environment variables.

New Features:
- Adds support for Ascend NPU devices to the llama.cpp engine.
- Detects Ascend NPUs using the `npu-smi` command.
- Adds a new containerfile for building images with CANN support.
- Adds documentation for setting up RamaLama with Ascend NPU support on Linux systems