### PR TITLE
Extend make validate check to do more

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,18 +114,18 @@ docs:
 
 .PHONY: lint
 lint:
-	flake8 *.py */*.py
+	flake8 *.py */*.py */*/*.py
 	shellcheck *.sh */*.sh */*/*.sh
 
 .PHONY: check-format
 check-format:
-	black --check --diff *.py */*.py test/unit/*.py
-	isort --check --diff *.py */*.py test/unit/*.py
+	black --check --diff *.py */*.py */*/*.py
+	isort --check --diff *.py */*.py */*/*.py
 
 .PHONY: format
 format:
-	black *.py */*.py test/unit/*.py
-	isort *.py */*.py test/unit/*.py
+	black *.py */*.py */*/*.py
+	isort *.py */*.py */*/*.py
 
 .PHONY: codespell
 codespell:
@@ -137,7 +137,7 @@ test-run:
 	_RAMALAMA_OPTIONS=--nocontainer _RAMALAMA_TEST=local bats -T test/system/030-run.bats
 
 .PHONY: validate
-validate: codespell lint
+validate: codespell lint check-format
 ifeq ($(OS),Linux)
 	hack/man-page-checker
 	hack/xref-helpmsgs-manpages

--- a/ramalama/model_store.py
+++ b/ramalama/model_store.py
@@ -126,7 +126,7 @@ class GlobalModelStore:
         )
         for oci_model in oci_models:
             name, modified, size = (oci_model["name"], oci_model["modified"], oci_model["size"])
-            # ramalama.oci.list_models provides modified as timetamp string, convert it to unix timestamp
+            # ramalama.oci.list_models provides modified as timestamp string, convert it to unix timestamp
             modified_unix = datetime.fromisoformat(modified).timestamp()
             models[name] = [ModelFile(name, modified_unix, size)]
 

--- a/test/unit/test_model.py
+++ b/test/unit/test_model.py
@@ -2,6 +2,8 @@ import pytest
 
 from ramalama.model_factory import ModelFactory
 
+hf_granite_blob = "https://huggingface.co/ibm-granite/granite-3b-code-base-2k-GGUF/blob"
+
 
 @pytest.mark.parametrize(
     "model_input,expected_name,expected_tag,expected_orga",
@@ -9,13 +11,13 @@ from ramalama.model_factory import ModelFactory
         ("huggingface://granite-code", "granite-code", "latest", ""),
         ("hf://granite-code", "granite-code", "latest", ""),
         (
-            "https://huggingface.co/ibm-granite/granite-3b-code-base-2k-GGUF/blob/main/granite-3b-code-base.Q4_K_M.gguf",
+            f"{hf_granite_blob}/main/granite-3b-code-base.Q4_K_M.gguf",
             "granite-3b-code-base.Q4_K_M.gguf",
             "main",
             "huggingface.co/ibm-granite/granite-3b-code-base-2k-GGUF",
         ),
         (
-            "https://huggingface.co/ibm-granite/granite-3b-code-base-2k-GGUF/blob/8ee52dc636b27b99caf046e717a87fb37ad9f33e/granite-3b-code-base.Q4_K_M.gguf",
+            f"{hf_granite_blob}/8ee52dc636b27b99caf046e717a87fb37ad9f33e/granite-3b-code-base.Q4_K_M.gguf",
             "granite-3b-code-base.Q4_K_M.gguf",
             "8ee52dc636b27b99caf046e717a87fb37ad9f33e",
             "huggingface.co/ibm-granite/granite-3b-code-base-2k-GGUF",

--- a/test/unit/test_model_factory.py
+++ b/test/unit/test_model_factory.py
@@ -18,6 +18,9 @@ class Input:
     Engine: str
 
 
+hf_granite_blob = "https://huggingface.co/ibm-granite/granite-3b-code-base-2k-GGUF/blob"
+
+
 @pytest.mark.parametrize(
     "input,expected,error",
     [
@@ -31,7 +34,7 @@ class Input:
         (Input("docker://granite-code", False, "", "podman"), OCI, None),
         (
             Input(
-                "http://huggingface.co/ibm-granite/granite-3b-code-base-2k-GGUF/blob/main/granite-3b-code-base.Q4_K_M.gguf",
+                f"{hf_granite_blob}/main/granite-3b-code-base.Q4_K_M.gguf",
                 False,
                 "",
                 "",
@@ -41,7 +44,7 @@ class Input:
         ),
         (
             Input(
-                "https://huggingface.co/ibm-granite/granite-3b-code-base-2k-GGUF/blob/main/granite-3b-code-base.Q4_K_M.gguf",
+                f"{hf_granite_blob}/main/granite-3b-code-base.Q4_K_M.gguf",
                 False,
                 "",
                 "",
@@ -111,7 +114,7 @@ def test_validate_oci_model_input(input: Input, error):
         (Input("docker://granite-code", False, "", "podman"), "granite-code"),
         (
             Input(
-                "http://huggingface.co/ibm-granite/granite-3b-code-base-2k-GGUF/blob/main/granite-3b-code-base.Q4_K_M.gguf",
+                f"{hf_granite_blob}/main/granite-3b-code-base.Q4_K_M.gguf",
                 False,
                 "",
                 "",
@@ -120,7 +123,7 @@ def test_validate_oci_model_input(input: Input, error):
         ),
         (
             Input(
-                "https://huggingface.co/ibm-granite/granite-3b-code-base-2k-GGUF/blob/main/granite-3b-code-base.Q4_K_M.gguf",
+                f"{hf_granite_blob}/main/granite-3b-code-base.Q4_K_M.gguf",
                 False,
                 "",
                 "",


### PR DESCRIPTION
It also does check-format now.

## Summary by Sourcery

Extends the `make validate` command to include format checking using black and isort. Also, modifies the linting process to include more files and updates test cases to use a constant for the Hugging Face blob URL.

Build:
- Adds `check-format` to the `validate` target in the Makefile, enforcing code formatting standards.
- Extends linting to include more files in subdirectories in the Makefile.
- Updates the Makefile to use black and isort for format checking.