### PR TITLE
Add @github-copilot to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # Default to all maintainers if nothing more specific matches
-* @rhatdan @ericcurtin @bmahabirbu @maxamillion @dougsland @swarajpande5 @jhjaggars @cgruver @slp @engelmi
+* @rhatdan @ericcurtin @bmahabirbu @maxamillion @dougsland @swarajpande5 @jhjaggars @cgruver @slp @engelmi @github-copilot


### PR DESCRIPTION
Hoping this adds code reviews from the copilot bot.

## Summary by Sourcery

Chores:
- Add @github-copilot to CODEOWNERS