### PR TITLE
Modify GPU detection to match against env var value instead of prefix

### DIFF
--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -371,14 +371,13 @@ def get_gpu():
 def get_env_vars():
     gpu_vars = (
         "ASAHI_VISIBLE_DEVICES",
+        "CANN_VISIBLE_DEVICES",
         "CUDA_VISIBLE_DEVICES",
+        "CUDA_LAUNCH_BLOCKING",
         "HIP_VISIBLE_DEVICES",
         "HSA_VISIBLE_DEVICES",
-        "INTEL_VISIBLE_DEVICES",
-        "CANN_VISIBLE_DEVICES",
-        "CUDA_LAUNCH_BLOCKING",
-        "HIP_SOMETHING",
         "HSA_OVERRIDE_GFX_VERSION",
+        "INTEL_VISIBLE_DEVICES",
     )
     env_vars = {k: v for k, v in os.environ.items() for gpu_var in gpu_vars if k == gpu_var}
 

--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -378,6 +378,7 @@ def get_env_vars():
         "CANN_VISIBLE_DEVICES",
         "CUDA_LAUNCH_BLOCKING",
         "HIP_SOMETHING",
+        "HSA_OVERRIDE_GFX_VERSION",
     )
     env_vars = {k: v for k, v in os.environ.items() for gpu_var in gpu_vars if k == gpu_var}
 

--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -365,15 +365,17 @@ def get_gpu():
 
     if igpu_num:
         os.environ["INTEL_VISIBLE_DEVICES"] = str(igpu_num)
+        return
 
 
 def get_env_vars():
-    prefixes = ("ASAHI_", "CUDA_", "HIP_", "HSA_", "INTEL_", "CANN_")
-    env_vars = {k: v for k, v in os.environ.items() if k.startswith(prefixes)}
-
-    # gpu_type, gpu_num = get_gpu()
-    # if gpu_type not in env_vars and gpu_type in {"HIP_VISIBLE_DEVICES", "ASAHI_VISIBLE_DEVICES"}:
-    #     env_vars[gpu_type] = str(gpu_num)
+    gpu_vars = ("ASAHI_VISIBLE_DEVICES", "CUDA_VISIBLE_DEVICES", "HIP_VISIBLE_DEVICES", "HSA_VISIBLE_DEVICES", "INTEL_VISIBLE_DEVICES", "CANN_VISIBLE_DEVICES")
+    # prefixes = ("ASAHI_", "CUDA_", "HIP_", "HSA_", "INTEL_", "CANN_")
+    env_vars = {
+        k: v for k, v in os.environ.items()
+        for gpu_var in gpu_vars
+            if k == gpu_var
+        }
 
     return env_vars
 

--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -370,12 +370,12 @@ def get_gpu():
 
 def get_env_vars():
     gpu_vars = (
-         "ASAHI_VISIBLE_DEVICES",
-         "CUDA_VISIBLE_DEVICES",
-         "HIP_VISIBLE_DEVICES",
-         "HSA_VISIBLE_DEVICES",
-         "INTEL_VISIBLE_DEVICES",
-         "CANN_VISIBLE_DEVICES",
+        "ASAHI_VISIBLE_DEVICES",
+        "CUDA_VISIBLE_DEVICES",
+        "HIP_VISIBLE_DEVICES",
+        "HSA_VISIBLE_DEVICES",
+        "INTEL_VISIBLE_DEVICES",
+        "CANN_VISIBLE_DEVICES",
     )
     env_vars = {k: v for k, v in os.environ.items() for gpu_var in gpu_vars if k == gpu_var}
 

--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -376,6 +376,8 @@ def get_env_vars():
         "HSA_VISIBLE_DEVICES",
         "INTEL_VISIBLE_DEVICES",
         "CANN_VISIBLE_DEVICES",
+        "CUDA_LAUNCH_BLOCKING",
+        "HIP_SOMETHING",
     )
     env_vars = {k: v for k, v in os.environ.items() for gpu_var in gpu_vars if k == gpu_var}
 

--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -369,13 +369,15 @@ def get_gpu():
 
 
 def get_env_vars():
-    gpu_vars = ("ASAHI_VISIBLE_DEVICES", "CUDA_VISIBLE_DEVICES", "HIP_VISIBLE_DEVICES", "HSA_VISIBLE_DEVICES", "INTEL_VISIBLE_DEVICES", "CANN_VISIBLE_DEVICES")
-    # prefixes = ("ASAHI_", "CUDA_", "HIP_", "HSA_", "INTEL_", "CANN_")
-    env_vars = {
-        k: v for k, v in os.environ.items()
-        for gpu_var in gpu_vars
-            if k == gpu_var
-        }
+    gpu_vars = (
+         "ASAHI_VISIBLE_DEVICES",
+         "CUDA_VISIBLE_DEVICES",
+         "HIP_VISIBLE_DEVICES",
+         "HSA_VISIBLE_DEVICES",
+         "INTEL_VISIBLE_DEVICES",
+         "CANN_VISIBLE_DEVICES",
+    )
+    env_vars = {k: v for k, v in os.environ.items() for gpu_var in gpu_vars if k == gpu_var}
 
     return env_vars
 

--- a/test/system/040-serve.bats
+++ b/test/system/040-serve.bats
@@ -165,11 +165,11 @@ verify_begin=".*run --rm -i --label ai.ramalama --name"
     is "$output" ".*Exec=llama-server --port 1234 -m .*" "Exec line should be correct"
     is "$output" ".*Mount=type=bind,.*tinyllama" "Mount line should be correct"
 
-    HIP_SOMETHING=99 run_ramalama serve --port 1234 --generate=quadlet ${model}
+    HIP_VISIBLE_DEVICES=99 run_ramalama serve --port 1234 --generate=quadlet ${model}
     is "$output" "Generating quadlet file: tinyllama.container" "generate tinllama.container"
 
     run cat tinyllama.container
-    is "$output" ".*Environment=HIP_SOMETHING=99" "Should contain env property"
+    is "$output" ".*Environment=HIP_VISIBLE_DEVICES=99" "Should contain env property"
 
     rm tinyllama.container
     run_ramalama 2 serve --name=${name} --port 1234 --generate=bogus tiny
@@ -260,12 +260,12 @@ verify_begin=".*run --rm -i --label ai.ramalama --name"
     is "$output" ".*command: \[\"llama-server\"\]" "Should command"
     is "$output" ".*containerPort: 1234" "Should container container port"
 
-    HIP_SOMETHING=99 run_ramalama serve --name=${name} --port 1234 --generate=kube ${model}
+    HIP_VISIBLE_DEVICES=99 run_ramalama serve --name=${name} --port 1234 --generate=kube ${model}
     is "$output" ".*Generating Kubernetes YAML file: ${name}.yaml" "generate .yaml file"
 
     run cat $name.yaml
     is "$output" ".*env:" "Should contain env property"
-    is "$output" ".*name: HIP_SOMETHING" "Should contain env name"
+    is "$output" ".*name: HIP_VISIBLE_DEVICES" "Should contain env name"
     is "$output" ".*value: 99" "Should contain env value"
 
     run_ramalama serve --name=${name} --port 1234 --generate=quadlet/kube ${model}
@@ -276,12 +276,12 @@ verify_begin=".*run --rm -i --label ai.ramalama --name"
     is "$output" ".*command: \[\"llama-server\"\]" "Should command"
     is "$output" ".*containerPort: 1234" "Should container container port"
 
-    HIP_SOMETHING=99 run_ramalama serve --name=${name} --port 1234 --generate=quadlet/kube ${model}
+    HIP_VISIBLE_DEVICES=99 run_ramalama serve --name=${name} --port 1234 --generate=quadlet/kube ${model}
     is "$output" ".*Generating Kubernetes YAML file: ${name}.yaml" "generate .yaml file"
 
     run cat $name.yaml
     is "$output" ".*env:" "Should contain env property"
-    is "$output" ".*name: HIP_SOMETHING" "Should contain env name"
+    is "$output" ".*name: HIP_VISIBLE_DEVICES" "Should contain env name"
     is "$output" ".*value: 99" "Should contain env value"
 
     run cat $name.kube


### PR DESCRIPTION
This PR fixes and issue where ramalama will fail to properly detect a GPU if there is an environment variable that has the same prefix as the env vars that ramalama looks for.

i.e. the Intel OneApi dev environment sets `INTEL_PYTHONHOME`

The previous logic will incorrectly return true because it matched agains the prefix of `INTEL_`

## Summary by Sourcery

Bug Fixes:
- Fixes incorrect GPU detection when environment variables share prefixes with GPU-related variables.