### PR TITLE
Add Intel ARC 155H to list of supported hardware

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ curl -fsSL https://raw.githubusercontent.com/containers/ramalama/s/install.sh | 
 | Nvidia GPU (cuda)                  | :white_check_mark: |
 | AMD GPU (rocm)                     | :white_check_mark: |
 | Ascend NPU (Linux)                 | :white_check_mark: |
+| Intel ARC GPU (Meteor Lake 155H)   | :white_check_mark: |
+
 ## COMMANDS
 
 | Command                                                | Description                                                |


### PR DESCRIPTION
Small change to add Intel Meteor Lake with ARC GPU to the list of hardware in readme.md.

## Summary by Sourcery

Documentation:
- Adds Intel ARC GPU (Meteor Lake 155H) to the list of supported hardware in the README.