### PR TITLE
Add passing of environment variables to ramalama commands

### DIFF
--- a/docs/ramalama-bench.1.md
+++ b/docs/ramalama-bench.1.md
@@ -29,11 +29,20 @@ URL support means if a model is on a web site or even on your local system, you 
 path of the authentication file for OCI registries
 
 #### **--device**
-Add a host device to the container. Optional permissions parameter  can
-be  used  to  specify device permissions by combining r for read, w for
+Add a host device to the container. Optional permissions parameter can
+be used to specify device permissions by combining r for read, w for
 write, and m for mknod(2).
 
 Example: --device=/dev/dri/renderD128:/dev/xvdc:rwm
+
+#### **--env**=
+
+Set environment variables inside of the container.
+
+This option allows arbitrary environment variables that are available for the
+process to be launched inside of the container. If an environment variable is
+specified without a value, the container engine checks the host environment
+for a value and set the variable only if it is set on the host.
 
 #### **--help**, **-h**
 show this help message and exit
@@ -49,29 +58,29 @@ number of gpu layers, 0 means CPU inferencing, 999 means use max layers (default
 The default -1, means use whatever is automatically deemed appropriate (0 or 999)
 
 #### **--privileged**
-By  default, RamaLama containers are unprivileged (=false) and cannot, for
-example, modify parts of the operating system. This is  because  by  de‐
-fault  a  container is only allowed limited access to devices. A "privi‐
+By default, RamaLama containers are unprivileged (=false) and cannot, for
+example, modify parts of the operating system. This is because by de‐
+fault a container is only allowed limited access to devices. A "privi‐
 leged" container is given the same access to devices as the user launch‐
-ing the container, with the exception of virtual consoles  (/dev/tty\d+)
+ing the container, with the exception of virtual consoles (/dev/tty\d+)
 when running in systemd mode (--systemd=always).
 
-A  privileged container turns off the security features that isolate the
-container from the host. Dropped Capabilities,  limited  devices,  read-
-only  mount points, Apparmor/SELinux separation, and Seccomp filters are
-all disabled.  Due to the disabled  security  features,  the  privileged
-field  should  almost never be set as containers can easily break out of
+A privileged container turns off the security features that isolate the
+container from the host. Dropped Capabilities, limited devices, read-
+only mount points, Apparmor/SELinux separation, and Seccomp filters are
+all disabled. Due to the disabled security features, the privileged
+field should almost never be set as containers can easily break out of
 confinement.
 
-Containers running in a user namespace (e.g., rootless containers)  can‐
+Containers running in a user namespace (e.g., rootless containers) can‐
 not have more privileges than the user that launched them.
 
 #### **--pull**=*policy*
 
 - **always**: Always pull the image and throw an error if the pull fails.
-- **missing**: Only pull the image when it does not exist in the local containers storage.  Throw an error if no image is found and the pull fails.
-- **never**: Never pull the image but use the one from the local containers storage.  Throw an error when no image is found.
-- **newer**: Pull if the image on the registry is newer than the one in the local containers storage.  An image is considered to be newer when the digests are different.  Comparing the time stamps is prone to errors.  Pull errors are suppressed if a local image was found.
+- **missing**: Only pull the image when it does not exist in the local containers storage. Throw an error if no image is found and the pull fails.
+- **never**: Never pull the image but use the one from the local containers storage. Throw an error when no image is found.
+- **newer**: Pull if the image on the registry is newer than the one in the local containers storage. An image is considered to be newer when the digests are different. Comparing the time stamps is prone to errors. Pull errors are suppressed if a local image was found.
 
 #### **--seed**=
 Specify seed rather than using random seed model interaction

--- a/docs/ramalama-perplexity.1.md
+++ b/docs/ramalama-perplexity.1.md
@@ -32,13 +32,22 @@ path of the authentication file for OCI registries
 size of the prompt context (default: 2048, 0 = loaded from model)
 
 #### **--device**
-Add a host device to the container. Optional permissions parameter  can
-be  used  to  specify device permissions by combining r for read, w for
+Add a host device to the container. Optional permissions parameter can
+be used to specify device permissions by combining r for read, w for
 write, and m for mknod(2).
 
 Example: --device=/dev/dri/renderD128:/dev/xvdc:rwm
 
-The device specification is passed directly to the underlying container engine.  See documentation of the supported container engine for more information.
+The device specification is passed directly to the underlying container engine. See documentation of the supported container engine for more information.
+
+#### **--env**=
+
+Set environment variables inside of the container.
+
+This option allows arbitrary environment variables that are available for the
+process to be launched inside of the container. If an environment variable is
+specified without a value, the container engine checks the host environment
+for a value and set the variable only if it is set on the host.
 
 #### **--help**, **-h**
 show this help message and exit
@@ -54,29 +63,29 @@ number of gpu layers, 0 means CPU inferencing, 999 means use max layers (default
 The default -1, means use whatever is automatically deemed appropriate (0 or 999)
 
 #### **--privileged**
-By  default, RamaLama containers are unprivileged (=false) and cannot, for
-example, modify parts of the operating system. This is  because  by  de‐
-fault  a  container is only allowed limited access to devices. A "privi‐
+By default, RamaLama containers are unprivileged (=false) and cannot, for
+example, modify parts of the operating system. This is because by de‐
+fault a container is only allowed limited access to devices. A "privi‐
 leged" container is given the same access to devices as the user launch‐
-ing the container, with the exception of virtual consoles  (/dev/tty\d+)
+ing the container, with the exception of virtual consoles (/dev/tty\d+)
 when running in systemd mode (--systemd=always).
 
-A  privileged container turns off the security features that isolate the
-container from the host. Dropped Capabilities,  limited  devices,  read-
-only  mount points, Apparmor/SELinux separation, and Seccomp filters are
-all disabled.  Due to the disabled  security  features,  the  privileged
-field  should  almost never be set as containers can easily break out of
+A privileged container turns off the security features that isolate the
+container from the host. Dropped Capabilities, limited devices, read-
+only mount points, Apparmor/SELinux separation, and Seccomp filters are
+all disabled. Due to the disabled security features, the privileged
+field should almost never be set as containers can easily break out of
 confinement.
 
-Containers running in a user namespace (e.g., rootless containers)  can‐
+Containers running in a user namespace (e.g., rootless containers) can‐
 not have more privileges than the user that launched them.
 
 #### **--pull**=*policy*
 
 - **always**: Always pull the image and throw an error if the pull fails.
-- **missing**: Only pull the image when it does not exist in the local containers storage.  Throw an error if no image is found and the pull fails.
-- **never**: Never pull the image but use the one from the local containers storage.  Throw an error when no image is found.
-- **newer**: Pull if the image on the registry is newer than the one in the local containers storage.  An image is considered to be newer when the digests are different.  Comparing the time stamps is prone to errors.  Pull errors are suppressed if a local image was found.
+- **missing**: Only pull the image when it does not exist in the local containers storage. Throw an error if no image is found and the pull fails.
+- **never**: Never pull the image but use the one from the local containers storage. Throw an error when no image is found.
+- **newer**: Pull if the image on the registry is newer than the one in the local containers storage. An image is considered to be newer when the digests are different. Comparing the time stamps is prone to errors. Pull errors are suppressed if a local image was found.
 
 #### **--seed**=
 Specify seed rather than using random seed model interaction

--- a/docs/ramalama-run.1.md
+++ b/docs/ramalama-run.1.md
@@ -40,6 +40,15 @@ Example: --device=/dev/dri/renderD128:/dev/xvdc:rwm
 
 The device specification is passed directly to the underlying container engine.  See documentation of the supported container engine for more information.
 
+#### **--env**=
+
+Set environment variables inside of the container.
+
+This option allows arbitrary environment variables that are available for the
+process to be launched inside of the container. If an environment variable is
+specified without a value, the container engine checks the host environment
+for a value and set the variable only if it is set on the host.
+
 #### **--help**, **-h**
 show this help message and exit
 
@@ -59,29 +68,29 @@ The default -1, means use whatever is automatically deemed appropriate (0 or 999
 Pull image policy. The default is **missing**.
 
 #### **--privileged**
-By  default, RamaLama containers are unprivileged (=false) and cannot, for
-example, modify parts of the operating system. This is  because  by  de‐
-fault  a  container is only allowed limited access to devices. A "privi‐
+By default, RamaLama containers are unprivileged (=false) and cannot, for
+example, modify parts of the operating system. This is because by de‐
+fault a container is only allowed limited access to devices. A "privi‐
 leged" container is given the same access to devices as the user launch‐
-ing the container, with the exception of virtual consoles  (/dev/tty\d+)
+ing the container, with the exception of virtual consoles (/dev/tty\d+)
 when running in systemd mode (--systemd=always).
 
-A  privileged container turns off the security features that isolate the
-container from the host. Dropped Capabilities,  limited  devices,  read-
-only  mount points, Apparmor/SELinux separation, and Seccomp filters are
-all disabled.  Due to the disabled  security  features,  the  privileged
-field  should  almost never be set as containers can easily break out of
+A privileged container turns off the security features that isolate the
+container from the host. Dropped Capabilities, limited devices, read-
+only mount points, Apparmor/SELinux separation, and Seccomp filters are
+all disabled. Due to the disabled security features, the privileged
+field should almost never be set as containers can easily break out of
 confinement.
 
-Containers running in a user namespace (e.g., rootless containers)  can‐
+Containers running in a user namespace (e.g., rootless containers) can‐
 not have more privileges than the user that launched them.
 
 #### **--pull**=*policy*
 
 - **always**: Always pull the image and throw an error if the pull fails.
-- **missing**: Only pull the image when it does not exist in the local containers storage.  Throw an error if no image is found and the pull fails.
-- **never**: Never pull the image but use the one from the local containers storage.  Throw an error when no image is found.
-- **newer**: Pull if the image on the registry is newer than the one in the local containers storage.  An image is considered to be newer when the digests are different.  Comparing the time stamps is prone to errors.  Pull errors are suppressed if a local image was found.
+- **missing**: Only pull the image when it does not exist in the local containers storage. Throw an error if no image is found and the pull fails.
+- **never**: Never pull the image but use the one from the local containers storage. Throw an error when no image is found.
+- **newer**: Pull if the image on the registry is newer than the one in the local containers storage. An image is considered to be newer when the digests are different. Comparing the time stamps is prone to errors. Pull errors are suppressed if a local image was found.
 
 #### **--seed**=
 Specify seed rather than using random seed model interaction
@@ -90,11 +99,11 @@ Specify seed rather than using random seed model interaction
 Temperature of the response from the AI Model
 llama.cpp explains this as:
 
-    The lower the number is, the more deterministic the response.
+  The lower the number is, the more deterministic the response.
 
-    The higher the number is the more creative the response is, but more likely to hallucinate when set too high.
+  The higher the number is the more creative the response is, but more likely to hallucinate when set too high.
 
-        Usage: Lower numbers are good for virtual assistants where we need deterministic responses. Higher numbers are good for roleplay or creative tasks like editing stories
+    Usage: Lower numbers are good for virtual assistants where we need deterministic responses. Higher numbers are good for roleplay or creative tasks like editing stories
 
 #### **--tls-verify**=*true*
 require HTTPS and verify certificates when contacting OCI registries

--- a/docs/ramalama-serve.1.md
+++ b/docs/ramalama-serve.1.md
@@ -47,13 +47,22 @@ The default is TRUE. The --nocontainer option forces this option to False.
 Use the `ramalama stop` command to stop the container running the served ramalama Model.
 
 #### **--device**
-Add a host device to the container. Optional permissions parameter  can
-be  used  to  specify device permissions by combining r for read, w for
+Add a host device to the container. Optional permissions parameter can
+be used to specify device permissions by combining r for read, w for
 write, and m for mknod(2).
 
 Example: --device=/dev/dri/renderD128:/dev/xvdc:rwm
 
-The device specification is passed directly to the underlying container engine.  See documentation of the supported container engine for more information.
+The device specification is passed directly to the underlying container engine. See documentation of the supported container engine for more information.
+
+#### **--env**=
+
+Set environment variables inside of the container.
+
+This option allows arbitrary environment variables that are available for the
+process to be launched inside of the container. If an environment variable is
+specified without a value, the container engine checks the host environment
+for a value and set the variable only if it is set on the host.
 
 #### **--generate**=type
 Generate specified configuration format for running the AI Model as a service
@@ -85,29 +94,29 @@ port for AI Model server to listen on. It must be available. If not specified,
 the serving port will be 8080 if available, otherwise a free port in 8081-8090 range.
 
 #### **--privileged**
-By  default, RamaLama containers are unprivileged (=false) and cannot, for
-example, modify parts of the operating system. This is  because  by  de‐
-fault  a  container is only allowed limited access to devices. A "privi‐
+By default, RamaLama containers are unprivileged (=false) and cannot, for
+example, modify parts of the operating system. This is because by de‐
+fault a container is only allowed limited access to devices. A "privi‐
 leged" container is given the same access to devices as the user launch‐
-ing the container, with the exception of virtual consoles  (/dev/tty\d+)
+ing the container, with the exception of virtual consoles (/dev/tty\d+)
 when running in systemd mode (--systemd=always).
 
-A  privileged container turns off the security features that isolate the
-container from the host. Dropped Capabilities,  limited  devices,  read-
-only  mount points, Apparmor/SELinux separation, and Seccomp filters are
-all disabled.  Due to the disabled  security  features,  the  privileged
-field  should  almost never be set as containers can easily break out of
+A privileged container turns off the security features that isolate the
+container from the host. Dropped Capabilities, limited devices, read-
+only mount points, Apparmor/SELinux separation, and Seccomp filters are
+all disabled. Due to the disabled security features, the privileged
+field should almost never be set as containers can easily break out of
 confinement.
 
-Containers running in a user namespace (e.g., rootless containers)  can‐
+Containers running in a user namespace (e.g., rootless containers) can‐
 not have more privileges than the user that launched them.
 
 #### **--pull**=*policy*
 
 - **always**: Always pull the image and throw an error if the pull fails.
-- **missing**: Only pull the image when it does not exist in the local containers storage.  Throw an error if no image is found and the pull fails.
-- **never**: Never pull the image but use the one from the local containers storage.  Throw an error when no image is found.
-- **newer**: Pull if the image on the registry is newer than the one in the local containers storage.  An image is considered to be newer when the digests are different.  Comparing the time stamps is prone to errors.  Pull errors are suppressed if a local image was found.
+- **missing**: Only pull the image when it does not exist in the local containers storage. Throw an error if no image is found and the pull fails.
+- **never**: Never pull the image but use the one from the local containers storage. Throw an error when no image is found.
+- **newer**: Pull if the image on the registry is newer than the one in the local containers storage. An image is considered to be newer when the digests are different. Comparing the time stamps is prone to errors. Pull errors are suppressed if a local image was found.
 
 #### **--seed**=
 Specify seed rather than using random seed model interaction
@@ -164,7 +173,7 @@ PublishPort=8080
 # Start by default on boot
 WantedBy=multi-user.target default.target
 
-$ mv  MyGraniteServer.container $HOME/.config/containers/systemd/
+$ mv MyGraniteServer.container $HOME/.config/containers/systemd/
 $ systemctl --user daemon-reload
 $ systemctl start --user MyGraniteServer
 $ systemctl status --user MyGraniteServer

--- a/docs/ramalama.conf
+++ b/docs/ramalama.conf
@@ -36,6 +36,10 @@
 # Valid options (Podman, Docker)
 #engine = "podman"
 
+# Environment variables to be added when running model within a container
+#
+#env = []
+
 # OCI container image to run with the specified AI model
 #
 #image = "quay.io/ramalama/ramalama:latest"

--- a/docs/ramalama.conf.5.md
+++ b/docs/ramalama.conf.5.md
@@ -72,6 +72,10 @@ RAMALAMA_IN_CONTAINER environment variable overrides this field.
 
 Size of the prompt context (0 = loaded from model)
 
+**env=[]
+
+Environment variables to be added to the environment used when running in a container engine (e.g., Podman, Docker). For example "LLAMA_ARG_THREADS=10".
+
 **engine**="podman"
 
 Run RamaLama using the specified container engine.
@@ -104,9 +108,9 @@ Specify default port for services to listen on
 **pull**="newer"
 
 - **always**: Always pull the image and throw an error if the pull fails.
-- **missing**: Only pull the image when it does not exist in the local containers storage.  Throw an error if no image is found and the pull fails.
-- **never**: Never pull the image but use the one from the local containers storage.  Throw an error when no image is found.
-- **newer**: Pull if the image on the registry is newer than the one in the local containers storage.  An image is considered to be newer when the digests are different.  Comparing the time stamps is prone to errors.  Pull errors are suppressed if a local image was found.
+- **missing**: Only pull the image when it does not exist in the local containers storage. Throw an error if no image is found and the pull fails.
+- **never**: Never pull the image but use the one from the local containers storage. Throw an error when no image is found.
+- **newer**: Pull if the image on the registry is newer than the one in the local containers storage. An image is considered to be newer when the digests are different. Comparing the time stamps is prone to errors. Pull errors are suppressed if a local image was found.
 
 **runtime**="llama.cpp"
 

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -759,6 +759,14 @@ def run_serve_perplexity_args(parser):
 def bench_run_serve_perplexity_args(parser):
     parser.add_argument("--authfile", help="path of the authentication file")
     parser.add_argument(
+        "--env",
+        dest="env",
+        action='append',
+        type=str,
+        default=CONFIG["env"],
+        help="environment variables to add to the running container",
+    )
+    parser.add_argument(
         "--device", dest="device", action='append', type=str, help="device to leak in to the running container"
     )
     parser.add_argument("-n", "--name", dest="name", help="name of container in which the Model will be run")

--- a/ramalama/config.py
+++ b/ramalama/config.py
@@ -68,17 +68,17 @@ def int_tuple_as_str(input: tuple) -> str:
 
 def load_config_defaults(config: Dict[str, Any]):
     """Set configuration defaults if these are not yet set."""
-    config['nocontainer'] = config.get('nocontainer', False)
     config['carimage'] = config.get('carimage', "registry.access.redhat.com/ubi9-micro:latest")
-    config['runtime'] = config.get('runtime', 'llama.cpp')
-    config['ngl'] = config.get('ngl', -1)
-    config['keep_groups'] = config.get('keep_groups', False)
     config['ctx_size'] = config.get('ctx_size', 2048)
-    config['pull'] = config.get('pull', "newer")
-    config['temp'] = config.get('temp', "0.8")
+    config['env'] = config.get('env', [])
     config['host'] = config.get('host', "0.0.0.0")
-    # print tuple as a range to avoid confusion
+    config['keep_groups'] = config.get('keep_groups', False)
+    config['ngl'] = config.get('ngl', -1)
+    config['nocontainer'] = config.get('nocontainer', False)
     config['port'] = config.get('port', int_tuple_as_str(DEFAULT_PORT_RANGE))
+    config['pull'] = config.get('pull', "newer")
+    config['runtime'] = config.get('runtime', 'llama.cpp')
+    config['temp'] = config.get('temp', "0.8")
     config['use_model_store'] = config.get('use_model_store', False)
 
 

--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -296,6 +296,12 @@ class Model(ModelBase):
 
         return conman_args
 
+    def add_env_option(self, conman_args, args):
+        for env in args.env:
+            conman_args += ["--env", env]
+
+        return conman_args
+
     def add_tty_option(self, conman_args):
         if sys.stdout.isatty() or sys.stdin.isatty():
             conman_args += ["-t"]
@@ -355,6 +361,7 @@ class Model(ModelBase):
         conman_args = self.handle_podman_specifics(conman_args, args)
         conman_args = self.handle_docker_pull(conman_args, args)
         conman_args = self.add_tty_option(conman_args)
+        conman_args = self.add_env_option(conman_args, args)
         conman_args = self.add_detach_option(conman_args, args)
         conman_args = self.add_port_option(conman_args, args)
         conman_args = self.add_device_options(conman_args, args)

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -22,6 +22,9 @@ EOF
 	is "$output" ".*-c 2048" "verify model name"
 	assert "$output" !~ ".*--seed" "assert seed does not show by default"
 
+	run_ramalama --dryrun run --env a=b --env test=success --name foobar ${model}
+	is "$output" "${verify_begin} foobar.*--env a=b --env test=success" "dryrun correct with --env"
+
 	run_ramalama --dryrun run --seed 9876 -c 4096 --net bridge --name foobar ${model}
 	is "$output" "${verify_begin} foobar.*--network bridge.*" "dryrun correct with --name"
 	is "$output" ".*${model}" "verify model name"

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -57,6 +57,7 @@ def test_load_config_from_env(env, config, expected):
             {
                 "nocontainer": False,
                 "carimage": "registry.access.redhat.com/ubi9-micro:latest",
+                "env": [],
                 "runtime": "llama.cpp",
                 "ngl": -1,
                 "keep_groups": False,
@@ -75,6 +76,7 @@ def test_load_config_from_env(env, config, expected):
             {
                 "nocontainer": True,
                 "carimage": "registry.access.redhat.com/ubi9-micro:latest",
+                "env": [],
                 "runtime": "llama.cpp",
                 "ngl": -1,
                 "keep_groups": False,


### PR DESCRIPTION
## Summary by Sourcery

Adds the ability to pass environment variables to ramalama commands when running in a container. This is achieved by adding an `--env` option to the command line interface and updating the container setup logic to include these environment variables.

New Features:
- Adds support for passing environment variables to ramalama commands via the `--env` option.

Tests:
- Adds a system test to verify the `--env` option is correctly passed to the container.