### PR TITLE
fix: CHAT_FORMAT variable should be expanded

### DIFF
--- a/container-images/scripts/llama-server.sh
+++ b/container-images/scripts/llama-server.sh
@@ -9,7 +9,7 @@ if [ -n "${MODEL_CHAT_FORMAT}" ]; then
 fi
 
 if [ -n "${MODEL_PATH}" ]; then
-    llama-server \
+    eval llama-server \
         --model "${MODEL_PATH}" \
         --host "${HOST:=0.0.0.0}" \
         --port "${PORT:=8001}" \


### PR DESCRIPTION
fixes https://github.com/containers/ramalama/issues/925

## Summary by Sourcery

Bug Fixes:
- Fixes an issue where the CHAT_FORMAT variable was not being expanded, leading to incorrect behavior of the llama-server script.