### PR TITLE
Print error when converting from an OCI Image

### DIFF
--- a/docs/ramalama-convert.1.md
+++ b/docs/ramalama-convert.1.md
@@ -9,7 +9,7 @@ ramalama\-convert - convert AI Models from local storage to OCI Image
 ## DESCRIPTION
 Convert specified AI Model to an OCI Formatted AI Model
 
-The model can be from RamaLama model storage in Huggingface, Ollama, or local model stored on disk.
+The model can be from RamaLama model storage in Huggingface, Ollama, or local model stored on disk. Converting from an OCI model is not supported.
 
 ## OPTIONS
 

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -711,11 +711,10 @@ def _get_source(args):
         src = args.SOURCE
     smodel = New(src, args)
     if smodel.type == "OCI":
-        return src
-    else:
-        if not smodel.exists(args):
-            return smodel.pull(args)
-        return smodel.model_path(args)
+        raise ValueError("converting from an OCI based image %s is not supported" % src)
+    if not smodel.exists(args):
+        return smodel.pull(args)
+    return smodel.model_path(args)
 
 
 def push_cli(args):

--- a/test/system/055-convert.bats
+++ b/test/system/055-convert.bats
@@ -25,6 +25,9 @@ load helpers
     run_ramalama convert $RAMALAMA_TMPDIR/aimodel oci://foobar
     run_ramalama list
     is "$output" ".*foobar:latest"
+    run_ramalama 22 convert oci://foobar oci://newimage 
+    is "$output" "Error: converting from an OCI based image oci://foobar is not supported"
+
     run_ramalama rm foobar
     run_ramalama list
     assert "$output" !~ ".*foobar" "image was removed"


### PR DESCRIPTION
Fixes: https://github.com/containers/ramalama/issues/929

## Summary by Sourcery

Tests:
- Add a test case to verify that converting from an OCI image is not allowed and that the correct error message is displayed to the user.