### PR TITLE
Make compatible with the macOS system python3

### DIFF
--- a/ramalama/model_store.py
+++ b/ramalama/model_store.py
@@ -107,7 +107,8 @@ class GlobalModelStore:
                 ref_dir = os.path.join(root, DIRECTORY_NAME_REFS)
                 for ref_file_name in os.listdir(ref_dir):
                     ref_file: RefFile = RefFile.from_path(os.path.join(ref_dir, ref_file_name))
-                    model_name = f"{root.replace(self.path, "").replace(os.sep, "", 1)}:{ref_file_name}"
+                    model_path = root.replace(self.path, "").replace(os.sep, "", 1)
+                    model_name = f"{model_path}:{ref_file_name}"
 
                     models[model_name] = []
                     for snapshot_file in ref_file.filenames:

--- a/ramalama/ollama.py
+++ b/ramalama/ollama.py
@@ -107,7 +107,9 @@ class OllamaRepository:
         except urllib.error.HTTPError as e:
             if "Not Found" in e.reason:
                 raise KeyError(f"Manifest for {self.name}:{tag} was not found in the Ollama registry")
-            raise KeyError(f"failed to fetch manifest: {str(e).strip("'")}")
+
+            err = str(e).strip("'")
+            raise KeyError(f"failed to fetch manifest: {err}")
 
     def get_file_list(self, tag, cached_files, is_model_in_ollama_cache, manifest=None) -> list[SnapshotFile]:
         if manifest is None:
@@ -282,7 +284,9 @@ class Ollama(Model):
         except urllib.error.HTTPError as e:
             if "Not Found" in e.reason:
                 raise KeyError(f"{name}:{tag} was not found in the Ollama registry")
-            raise KeyError(f"failed to fetch snapshot files: {str(e).strip("'")}")
+
+            err = str(e).strip("'")
+            raise KeyError(f"failed to fetch snapshot files: {err}")
 
         # If a model has been downloaded via ollama cli, only create symlink in the snapshots directory
         if is_model_in_ollama_cache:


### PR DESCRIPTION
populate variables first. Reproducible on systems with brew macOS also by switching shebang to #!/usr/bin/python3

## Summary by Sourcery

Improve error message handling and model name construction.

Bug Fixes:
- Fixes an issue where error messages were not properly formatted when fetching manifest or snapshot files.
- Fixes an issue where model names were not properly constructed when listing models in the model store.