### PR TITLE
Add --runtime-arg option for run and serve

### DIFF
--- a/docs/ramalama-perplexity.1.md
+++ b/docs/ramalama-perplexity.1.md
@@ -96,6 +96,9 @@ not have more privileges than the user that launched them.
 - **never**: Never pull the image but use the one from the local containers storage. Throw an error when no image is found.
 - **newer**: Pull if the image on the registry is newer than the one in the local containers storage. An image is considered to be newer when the digests are different. Comparing the time stamps is prone to errors. Pull errors are suppressed if a local image was found.
 
+#### **--runtime-args**="*args*"
+Add *args* to the runtime (llama.cpp or vllm) invocation.
+
 #### **--seed**=
 Specify seed rather than using random seed model interaction
 

--- a/docs/ramalama-run.1.md
+++ b/docs/ramalama-run.1.md
@@ -100,6 +100,9 @@ Pull image policy. The default is **missing**.
 - **never**: Never pull the image but use the one from the local containers storage. Throw an error when no image is found.
 - **newer**: Pull if the image on the registry is newer than the one in the local containers storage. An image is considered to be newer when the digests are different. Comparing the time stamps is prone to errors. Pull errors are suppressed if a local image was found.
 
+#### **--runtime-args**="*args*"
+Add *args* to the runtime (llama.cpp or vllm) invocation.
+
 #### **--seed**=
 Specify seed rather than using random seed model interaction
 

--- a/docs/ramalama-serve.1.md
+++ b/docs/ramalama-serve.1.md
@@ -127,11 +127,14 @@ not have more privileges than the user that launched them.
 - **never**: Never pull the image but use the one from the local containers storage. Throw an error when no image is found.
 - **newer**: Pull if the image on the registry is newer than the one in the local containers storage. An image is considered to be newer when the digests are different. Comparing the time stamps is prone to errors. Pull errors are suppressed if a local image was found.
 
+#### **--runtime-args**="*args*"
+Add *args* to the runtime (llama.cpp or vllm) invocation.
+
 #### **--seed**=
 Specify seed rather than using random seed model interaction
 
 #### **--temp**="0.8"
-Temperature of the response from the AI Model
+Temperature of the response from the AI Model.
 llama.cpp explains this as:
 
     The lower the number is, the more deterministic the response.

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -2,6 +2,7 @@ import argparse
 import glob
 import json
 import os
+import shlex
 import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
@@ -186,6 +187,8 @@ def post_parse_setup(args):
         if resolved_model:
             args.UNRESOLVED_MODEL = args.MODEL
             args.MODEL = resolved_model
+    if hasattr(args, "runtime_args"):
+        args.runtime_args = shlex.split(args.runtime_args)
 
 
 def login_parser(subparsers):
@@ -689,6 +692,13 @@ def run_serve_perplexity_args(parser):
         dest="context",
         default=CONFIG['ctx_size'],
         help="size of the prompt context (0 = loaded from model)",
+    )
+    parser.add_argument(
+        "--runtime-args",
+        dest="runtime_args",
+        default="",
+        type=str,
+        help="arguments to add to runtime invocation",
     )
 
 

--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -540,6 +540,7 @@ class Model(ModelBase):
             os.environ["LLAMA_PROMPT_PREFIX"] = "🦙 > "
 
         exec_args = ["llama-run", "-c", f"{args.context}", "--temp", f"{args.temp}"]
+        exec_args += args.runtime_args
 
         if args.seed:
             exec_args += ["--seed", args.seed]
@@ -601,7 +602,7 @@ class Model(ModelBase):
                 args.port,
                 "--max-sequence-length",
                 f"{args.context}",
-            ]
+            ] + args.runtime_args
         else:
             exec_args = [
                 "llama-server",
@@ -613,7 +614,7 @@ class Model(ModelBase):
                 f"{args.context}",
                 "--temp",
                 f"{args.temp}",
-            ]
+            ] + args.runtime_args
             if chat_template_path != "":
                 exec_args.extend(["--chat-template-file", chat_template_path])
         if args.seed:

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -53,6 +53,16 @@ EOF
 	assert "$output" =~ ".*--cap-drop=all" "verify --cap-add is present"
 	assert "$output" =~ ".*no-new-privileges" "verify --no-new-privs is not present"
 
+    run_ramalama --dryrun run --runtime-args="--foo -bar" ${MODEL}
+    assert "$output" =~ ".*--foo" "--foo passed to runtime"
+    assert "$output" =~ ".*-bar" "-bar passed to runtime"
+
+    run_ramalama --dryrun run --runtime-args="--foo='a b c'" ${MODEL}
+    assert "$output" =~ ".*--foo=a b c" "argument passed to runtime with spaces"
+
+    run_ramalama 1 --dryrun run --runtime-args="--foo='a b c" ${MODEL}
+    assert "$output" =~ "No closing quotation" "error for improperly quoted runtime arguments"
+
 	if is_container; then
 	    run_ramalama --dryrun run --privileged ${MODEL}
 	    is "$output" ".*--privileged" "verify --privileged is set"


### PR DESCRIPTION
See #948 

Useful for passing `--jinja` to llama.cpp at the moment to enable tool calling.

## Summary by Sourcery

Adds the `--runtime-args` option to the `run` and `serve` commands, allowing users to pass arguments directly to the underlying runtime (llama.cpp or vllm).

New Features:
- Adds the `--runtime-args` option to the `run` and `serve` commands.

Tests:
- Adds tests to verify that `--runtime-args` are passed to the runtime.