### PR TITLE
Add Linux x86-64 support for Ascend NPU accelerator in llama.cpp backend

### DIFF
--- a/container-images/scripts/build_llama_and_whisper.sh
+++ b/container-images/scripts/build_llama_and_whisper.sh
@@ -87,12 +87,12 @@ setup_build_env() {
     if [ -f "${cann_in_sys_path}/set_env.sh" ]; then
         # shellcheck disable=SC1091
         source ${cann_in_sys_path}/set_env.sh;
-        export LD_LIBRARY_PATH=${cann_in_sys_path}/latest/lib64:${cann_in_sys_path}/latest/aarch64-linux/devlib:${LD_LIBRARY_PATH};
+        export LD_LIBRARY_PATH=${cann_in_sys_path}/latest/lib64:${cann_in_sys_path}/latest/${uname_m}-linux/devlib:${LD_LIBRARY_PATH};
         export LIBRARY_PATH=${cann_in_sys_path}/latest/lib64:${LIBRARY_PATH};
     elif [ -f "${cann_in_user_path}/set_env.sh" ]; then
         # shellcheck disable=SC1091
         source "$HOME/Ascend/ascend-toolkit/set_env.sh";
-        export LD_LIBRARY_PATH=${cann_in_user_path}/latest/lib64:${cann_in_user_path}/latest/aarch64-linux/devlib:${LD_LIBRARY_PATH};
+        export LD_LIBRARY_PATH=${cann_in_user_path}/latest/lib64:${cann_in_user_path}/latest/${uname_m}-linux/devlib:${LD_LIBRARY_PATH};
         export LIBRARY_PATH=${cann_in_user_path}/latest/lib64:${LIBRARY_PATH};
     else
         echo "No Ascend Toolkit found";

--- a/docs/ramalama-cann.7.md
+++ b/docs/ramalama-cann.7.md
@@ -5,6 +5,7 @@
 This guide walks through the steps required to set up RamaLama with Ascend NPU support.
  - [Background](#background)
  - [Hardware](#hardware)
+ - [Model](#model)
  - [Docker](#docker)
  - [HISTORY](#todo)
 
@@ -20,6 +21,7 @@ This guide walks through the steps required to set up RamaLama with Ascend NPU s
 
 **Verified devices**
 
+Table Supported Hardware List:
 | Ascend NPU                     | Status  |
 | -----------------------------  | ------- |
 | Atlas A2 Training series       | Support |
@@ -28,7 +30,10 @@ This guide walks through the steps required to set up RamaLama with Ascend NPU s
 *Notes:*
 
 - If you have trouble with Ascend NPU device, please create an issue with **[CANN]** prefix/tag.
-- If you run successfully with your Ascend NPU device, please help update the upper table.
+- If you are running successfully with an Ascend NPU device, please help update the "Supported Hardware List" table above.
+
+## Model
+Currently, Ascend NPU acceleration is only supported when the llama.cpp backend is selected. For supported models, please refer to the page [llama.cpp/backend/CANN.md](https://github.com/ggml-org/llama.cpp/blob/master/docs/backend/CANN.md).
 
 ## Docker
 ### Install the Ascend driver


### PR DESCRIPTION
Code:
Currently the Ascend NPU accelerator in the llama.cpp backend only supports linux aarch64. Adjust the Ascend driver library path linked when compiling llama.cpp/CANN to support the use of Ascend NPU in Linux x86-64.

Documentation:
Add llm model support information for Ascend NPU.

## Summary by Sourcery

Add Linux x86-64 support for Ascend NPU accelerator in llama.cpp backend by adjusting the Ascend driver library path linked when compiling llama.cpp/CANN. Update documentation with llm model support information for Ascend NPU.

Build:
- Adjust the Ascend driver library path linked when compiling llama.cpp/CANN to support the use of Ascend NPU in Linux x86-64 platform.

Documentation:
- Add llm model support information for Ascend NPU.