### PR TITLE
Added --chat-template-file support to ramalama serve

### DIFF
--- a/ramalama/kube.py
+++ b/ramalama/kube.py
@@ -5,7 +5,7 @@ from ramalama.version import version
 
 
 class Kube:
-    def __init__(self, model, image, args, exec_args):
+    def __init__(self, model, chat_template, image, args, exec_args):
         self.ai_image = model
         if hasattr(args, "MODEL"):
             self.ai_image = args.MODEL
@@ -19,6 +19,7 @@ class Kube:
         self.args = args
         self.exec_args = exec_args
         self.image = image
+        self.chat_template = chat_template
 
     def gen_volumes(self):
         mounts = f"""\
@@ -34,6 +35,9 @@ class Kube:
             volumes += self.gen_path_volume()
         else:
             volumes += self.gen_oci_volume()
+
+        if os.path.exists(self.chat_template):
+            volumes += self.gen_chat_template_volume()
 
         m, v = self.gen_devices()
         mounts += m
@@ -66,6 +70,12 @@ class Kube:
           reference: {self.ai_image}
           pullPolicy: IfNotPresent
         name: model"""
+
+    def gen_chat_template_volume(self):
+        return f"""
+      - hostPath:
+          path: {self.chat_template}
+        name: chat_template"""
 
     def _gen_ports(self):
         if not hasattr(self.args, "port"):


### PR DESCRIPTION
Relates to: https://github.com/containers/ramalama/issues/947

If a chat template file can be extracted from the gguf model or if specified by the model repo, it will now be used in the ramalama serve command and mounted into the container. It has been included in the generation of the quadlet and kube files as well.

## Summary by Sourcery

Adds support for specifying a chat template file to the ramalama serve command. This allows the server to use a specific chat template for generating responses. The chat template file can be extracted from the GGUF model or specified by the model repository. The changes include modifications to the quadlet and kube file generation to include the chat template file.

Enhancements:
- Adds support for specifying a chat template file to the ramalama serve command.
- Modifies the quadlet and kube file generation to include the chat template file.