### PR TITLE
There must be at least one CDI device present to use CUDA

### DIFF
--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -2,7 +2,7 @@
 
 load helpers
 
-MODEL=smollm:135m
+MODEL=smollm:1.7b
 
 @test "ramalama --dryrun run basic output" {
     image=m_$(safename)


### PR DESCRIPTION
Otherwise we get failures like:

Error: setting up CDI devices: unresolvable CDI devices nvidia.com/gpu=all

Co-authored-by: Brian <bmahabir@bu.edu>