### PR TITLE
[NPU][Fix] only specify device num, but without ascend-docker-runtime installed, running ramalama/cann container image will failing

### DIFF
--- a/docs/ramalama-cann.7.md
+++ b/docs/ramalama-cann.7.md
@@ -42,6 +42,7 @@ This provides NPU acceleration using the AI cores of your Ascend NPU. And [CANN]
 For more information about Ascend NPU in [Ascend Community](https://www.hiascend.com/en/).
 
 Make sure to have the CANN toolkit installed. You can download it from here: [CANN Toolkit](https://www.hiascend.com/developer/download/community/result?module=cann)
+Make sure the Ascend Docker runtime is installed. You can download it from here: [Ascend-docker-runtime](https://www.hiascend.com/document/detail/en/mindx-dl/300/dluserguide/clusterscheduling/dlug_installation_02_000025.html)
 
 ### Build Images
 Go to `ramalama` directory and build using make.
@@ -52,7 +53,8 @@ make install
 
 You can test with:
 ```bash
-ramalama --image quay.io/ramalama/cann:latest serve -d -p 8080 --device=/dev/davinci0 -name ollama://smollm:135m
+export ASCEND_VISIBLE_DEVICES=0
+ramalama --image quay.io/ramalama/cann:latest serve -d -p 8080 -name ollama://smollm:135m
 ```
 
 In a window see the running podman container.

--- a/docs/ramalama.conf
+++ b/docs/ramalama.conf
@@ -51,7 +51,7 @@
 #CUDA_VISIBLE_DEVICES="quay.io/ramalama/cuda"
 #ASAHI_VISIBLE_DEVICES="quay.io/ramalama/asahi"
 #INTEL_VISIBLE_DEVICES="quay.io/ramalama/intel-gpu"
-#CANN_VISIBLE_DEVICES="quay.io/ramalama/cann"
+#ASCEND_VISIBLE_DEVICES="quay.io/ramalama/cann"
 
 # IP address for llama.cpp to listen on.
 #

--- a/docs/ramalama.conf.5.md
+++ b/docs/ramalama.conf.5.md
@@ -96,7 +96,7 @@ RAMALAMA_IMAGE environment variable overrides this field.
   CUDA_VISIBLE_DEVICES  = "quay.io/ramalama/cuda"
   ASAHI_VISIBLE_DEVICES = "quay.io/ramalama/asahi"
   INTEL_VISIBLE_DEVICES = "quay.io/ramalama/intel-gpu"
-  CANN_VISIBLE_DEVICES  = "quay.io/ramalama/cann"
+  ASCEND_VISIBLE_DEVICES  = "quay.io/ramalama/cann"
 
 Alternative images to use when RamaLama recognizes specific hardware
 

--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -370,9 +370,9 @@ def check_nvidia():
 
 def check_ascend():
     try:
-        command = ['npu-smi']
+        command = ['npu-smi', 'info']
         run_cmd(command).stdout.decode("utf-8")
-        os.environ["CANN_VISIBLE_DEVICES"] = "0"
+        os.environ["ASCEND_VISIBLE_DEVICES"] = "0"
         return "cann"
     except Exception:
         pass
@@ -440,7 +440,7 @@ def set_accel_env_vars():
 def get_accel_env_vars():
     gpu_vars = (
         "ASAHI_VISIBLE_DEVICES",
-        "CANN_VISIBLE_DEVICES",
+        "ASCEND_VISIBLE_DEVICES",
         "CUDA_VISIBLE_DEVICES",
         "CUDA_LAUNCH_BLOCKING",
         "HIP_VISIBLE_DEVICES",

--- a/ramalama/config.py
+++ b/ramalama/config.py
@@ -87,7 +87,7 @@ def load_config_defaults(config: Dict[str, Any]):
             "CUDA_VISIBLE_DEVICES": "quay.io/ramalama/cuda",
             "ASAHI_VISIBLE_DEVICES": "quay.io/ramalama/asahi",
             "INTEL_VISIBLE_DEVICES": "quay.io/ramalama/intel-gpu",
-            "CANN_VISIBLE_DEVICES": "quay.io/ramalama/cann",
+            "ASCEND_VISIBLE_DEVICES": "quay.io/ramalama/cann",
         },
     )
 

--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -325,9 +325,6 @@ class Model(ModelBase):
             if os.path.exists("/dev/kfd"):
                 conman_args += ["--device", "/dev/kfd"]
 
-            if os.path.exists("/dev/davinci0"):
-                conman_args += ["--device", "/dev/davinci0"]
-
             for k, v in get_accel_env_vars().items():
                 # Special case for Cuda
                 if k == "CUDA_VISIBLE_DEVICES":
@@ -387,7 +384,7 @@ class Model(ModelBase):
             or os.getenv("ASAHI_VISIBLE_DEVICES")
             or os.getenv("CUDA_VISIBLE_DEVICES")
             or os.getenv("INTEL_VISIBLE_DEVICES")
-            or os.getenv("CANN_VISIBLE_DEVICES")
+            or os.getenv("ASCEND_VISIBLE_DEVICES")
             or (
                 # linux and macOS report aarch64 (linux), arm64 (macOS)
                 ramalama.common.podman_machine_accel

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -63,7 +63,7 @@ def test_load_config_from_env(env, config, expected):
                     "CUDA_VISIBLE_DEVICES": "quay.io/ramalama/cuda",
                     "ASAHI_VISIBLE_DEVICES": "quay.io/ramalama/asahi",
                     "INTEL_VISIBLE_DEVICES": "quay.io/ramalama/intel-gpu",
-                    "CANN_VISIBLE_DEVICES": "quay.io/ramalama/cann",
+                    "ASCEND_VISIBLE_DEVICES": "quay.io/ramalama/cann",
                 },
                 "runtime": "llama.cpp",
                 "ngl": -1,


### PR DESCRIPTION
1. Keep the environment variable of visible Ascend device in ramalama consistent with ascend-docker-runtime. 
2. Temporarily remove the default value of using device 0 when no ascend device is specified. The reason is that currently, if you only specify device 0 without using ascend-docker-runtime, it cannot be offloaded to NPU normally.

Signed-off-by: leo-pony <nengjunma@outlook.com>

## Summary by Sourcery

This PR ensures that the environment variable for visible Ascend devices is consistent with ascend-docker-runtime and updates the documentation to include instructions for installing Ascend docker runtime.