### PR TITLE
Fix ENTRYPOINTS of whisper-server and llama-server

### DIFF
--- a/container_build.sh
+++ b/container_build.sh
@@ -41,10 +41,13 @@ add_entrypoint() {
     containerfile=$(mktemp)
     cat > "${containerfile}" <<EOF
 FROM $2
-ENTRYPOINT [ "/usr/bin/$3.sh" ]
+ENTRYPOINT [ "/usr/bin/$3" ]
 EOF
     echo "$1 build --no-cache -t $2-$3 -f ${containerfile} ."
     eval "$1 build --no-cache -t $2-$3 -f ${containerfile} ."
+    # verify entrypoints created correctly by running help on them.
+    echo "$1 run --rm $2-$3 -h"
+    eval "$1 run --rm $2-$3 -h"
     rm "${containerfile}"
 }
 


### PR DESCRIPTION
Fixes:https://github.com/containers/ramalama/issues/964

## Summary by Sourcery

Bug Fixes:
- Fixes an issue where the wrong executable was being called due to an incorrect entrypoint in the container build.