### PR TITLE
Asashi build is failing because of no python3-devel package

### DIFF
--- a/container-images/scripts/build_llama_and_whisper.sh
+++ b/container-images/scripts/build_llama_and_whisper.sh
@@ -14,9 +14,16 @@ dnf_install_intel_gpu() {
   . /opt/intel/oneapi/setvars.sh
 }
 
+dnf_remove() {
+  dnf remove -y \
+      python3-devel \
+      libcurl-devel
+  dnf -y clean all
+}
+
 dnf_install() {
   local rpm_list=("podman-remote" "python3" "python3-pip" "python3-argcomplete" \
-                  "python3-dnf-plugin-versionlock" "gcc-c++" "cmake" "vim" \
+                  "python3-dnf-plugin-versionlock" "python3-devel" "gcc-c++" "cmake" "vim" \
                   "procps-ng" "git" "dnf-plugins-core" "libcurl-devel" "gawk")
   local vulkan_rpms=("vulkan-headers" "vulkan-loader-devel" "vulkan-tools" \
                      "spirv-tools" "glslc" "glslang")
@@ -225,6 +232,7 @@ main() {
   esac
 
   clone_and_build_llama_cpp
+  available dnf && dnf_remove
   rm -rf /var/cache/*dnf* /opt/rocm-*/lib/*/library/*gfx9*
   ldconfig # needed for libraries
 }

--- a/docs/ramalama-serve.1.md
+++ b/docs/ramalama-serve.1.md
@@ -140,12 +140,12 @@ llama.cpp explains this as:
 
         Usage: Lower numbers are good for virtual assistants where we need deterministic responses. Higher numbers are good for roleplay or creative tasks like editing stories
 
-#### **--tls-verify**=*true*
-require HTTPS and verify certificates when contacting OCI registries
-
 #### **--threads**, **-t**
 maximum number of cpu threads to use for inferencing
 The default -1, uses the default of the underlying implementation
+
+#### **--tls-verify**=*true*
+require HTTPS and verify certificates when contacting OCI registries
 
 ## EXAMPLES
 ### Run two AI Models at the same time. Notice both are running within Podman Containers.


### PR DESCRIPTION
Also remove devel packages when completing install.

## Summary by Sourcery

Fixes the Asashi build by including the python3-devel package in the dnf install list. Also removes devel packages after the installation is complete to reduce the image size.

Bug Fixes:
- Fixes the Asashi build by including the python3-devel package in the dnf install list. 

Chores:
- Removes devel packages after the installation is complete to reduce the image size.