### PR TITLE
Add docling support version 2

### DIFF
--- a/container-images/scripts/build_rag.sh
+++ b/container-images/scripts/build_rag.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -exu -o pipefail
+
+export PYTHON_VERSION="python3 -m"
+pyversion=$(python3 --version)
+
+version_greater() {
+        string="$1
+$2"
+    [ "$string" != "$(sort --version-sort <<< "$string")" ]
+}
+
+packages=""
+if [ "$1" = "cuda" ]; then
+    packages="libcudnn9-devel-cuda-12 libcusparselt0 cuda-cupti-12\*"
+fi
+
+if version_greater "$pyversion" 3.11; then
+    eval dnf install -y python3-pip "${packages}"
+else
+    eval dnf install -y python3.11 python3.11-pip "${packages}"
+    export PYTHON_VERSION="/usr/bin/python3.11 -m"
+    ln -sf /usr/bin/python3.11 /usr/bin/python3
+fi
+${PYTHON_VERSION} pip install wheel qdrant_client fastembed docling docling-core --extra-index-url https://download.pytorch.org/whl/"$1"
+
+dnf -y clean all
+rm -rf /var/cache/*dnf* /opt/rocm-*/lib/*/library/*gfx9* /root/.cache \
+   /root/buildinfo
+ldconfig

--- a/container-images/scripts/doc2rag
+++ b/container-images/scripts/doc2rag
@@ -1,0 +1,104 @@
+#!/usr/bin/python3
+
+import argparse
+import hashlib
+import os
+import sys
+import uuid
+
+import qdrant_client
+from docling.chunking import HybridChunker
+from docling.document_converter import DocumentConverter
+
+SPARSE_MODEL = "prithivida/Splade_PP_en_v1"
+COLLECTION_NAME = "rag"
+
+
+# Global Vars
+EMBED_MODEL = "sentence-transformers/all-MiniLM-L6-v2"
+
+
+class Converter:
+    """A Class designed to handle all document conversions using Docling"""
+
+    def __init__(self, output, targets):
+        self.doc_converter = DocumentConverter()
+        self.targets = []
+        for target in targets:
+            self.add(target)
+        self.output = output
+        self.client = qdrant_client.QdrantClient(path=output)
+        self.client.set_model(EMBED_MODEL)
+        self.client.set_sparse_model(SPARSE_MODEL)
+
+    def add(self, file_path):
+        if os.path.isdir(file_path):
+            self.walk(file_path)  # Walk directory and process all files
+        else:
+            self.targets.append(file_path)  # Process the single file
+
+    def convert(self):
+        result = self.doc_converter.convert_all(self.targets)
+
+        documents, metadata, ids = [], [], []
+        chunker = HybridChunker(tokenizer=EMBED_MODEL, max_tokens=500, overlap=100)
+        for file in result:
+            chunk_iter = chunker.chunk(dl_doc=file.document)
+            for i, chunk in enumerate(chunk_iter):
+                doc_text = chunker.serialize(chunk=chunk)
+                # Extract the text and metadata from the chunk
+                doc_meta = chunk.meta.export_json_dict()
+
+                # Append to respective lists
+                documents.append(doc_text)
+                metadata.append(doc_meta)
+
+                # Generate unique ID for the chunk
+                doc_id = self.generate_hash(doc_text)
+                ids.append(doc_id)
+        return self.client.add(COLLECTION_NAME, documents=documents, metadata=metadata, ids=ids)
+
+    def walk(self, path):
+        for root, dirs, files in os.walk(path, topdown=True):
+            if len(files) == 0:
+                continue
+            for f in files:
+                file = os.path.join(root, f)
+                if os.path.isfile(file):
+                    self.targets.append(file)
+
+    def generate_hash(self, document: str) -> str:
+        """Generate a unique hash for a document."""
+        sha256_hash = hashlib.sha256(document.encode('utf-8')).hexdigest()
+
+        # Use the first 32 characters of the hash to create a UUID
+        return str(uuid.UUID(sha256_hash[:32]))
+
+
+parser = argparse.ArgumentParser(
+    prog="docling",
+    description="process source files into RAG vector database",
+)
+
+parser.add_argument("target")  # positional argument
+parser.add_argument("source", nargs='+')
+
+
+def perror(*args, **kwargs):
+    print(*args, file=sys.stderr, **kwargs)
+
+
+def eprint(e, exit_code):
+    perror("Error: " + str(e).strip("'\""))
+    sys.exit(exit_code)
+
+
+try:
+    args = parser.parse_args()
+    converter = Converter(args.target, args.source)
+    converter.convert()
+
+except FileNotFoundError as e:
+    eprint(e, 1)
+except KeyboardInterrupt:
+    pass

--- a/docs/ramalama-run.1.md
+++ b/docs/ramalama-run.1.md
@@ -100,6 +100,9 @@ Pull image policy. The default is **missing**.
 - **never**: Never pull the image but use the one from the local containers storage. Throw an error when no image is found.
 - **newer**: Pull if the image on the registry is newer than the one in the local containers storage. An image is considered to be newer when the digests are different. Comparing the time stamps is prone to errors. Pull errors are suppressed if a local image was found.
 
+#### **--rag**=
+Specify path to Retrieval-Augmented Generation (RAG) database or an OCI Image containing a RAG database
+
 #### **--runtime-args**="*args*"
 Add *args* to the runtime (llama.cpp or vllm) invocation.
 

--- a/docs/ramalama-serve.1.md
+++ b/docs/ramalama-serve.1.md
@@ -127,6 +127,9 @@ not have more privileges than the user that launched them.
 - **never**: Never pull the image but use the one from the local containers storage. Throw an error when no image is found.
 - **newer**: Pull if the image on the registry is newer than the one in the local containers storage. An image is considered to be newer when the digests are different. Comparing the time stamps is prone to errors. Pull errors are suppressed if a local image was found.
 
+#### **--rag**=
+Specify path to Retrieval-Augmented Generation (RAG) database or an OCI Image containing a RAG database
+
 #### **--runtime-args**="*args*"
 Add *args* to the runtime (llama.cpp or vllm) invocation.
 

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -882,7 +882,7 @@ def rag_parser(subparsers):
         "rag",
         help="generate and convert retrieval augmented generation (RAG) data from provided documents into an OCI Image",
     )
-    add_network_argument(parser)
+    add_network_argument(parser, dflt=None)
     parser.add_argument(
         "PATH",
         nargs="*",

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -760,6 +760,7 @@ def run_parser(subparsers):
     run_serve_perplexity_args(parser)
     add_network_argument(parser)
     parser.add_argument("--keepalive", type=str, help="duration to keep a model loaded (e.g. 5m)")
+    parser.add_argument("--rag", help="RAG vector database or OCI Image to be served with the model")
     parser.add_argument("MODEL")  # positional argument
     parser.add_argument(
         "ARGS", nargs="*", help="overrides the default prompt, and the output is returned without entering the chatbot"
@@ -800,13 +801,25 @@ def serve_parser(subparsers):
         help="generate specified configuration format for running the AI Model as a service",
     )
     parser.add_argument("-p", "--port", default=CONFIG['port'], help="port for AI Model server to listen on")
+    parser.add_argument("--rag", help="RAG vector database or OCI Image to be served with the model")
     parser.add_argument("MODEL")  # positional argument
     parser.set_defaults(func=serve_cli)
+
+
+def _get_rag(args):
+    if os.path.exists(args.rag):
+        return
+    model = New(args.rag, args=args, transport="oci")
+    if not model.exists(args):
+        model.pull(args)
 
 
 def serve_cli(args):
     if not args.container:
         args.detach = False
+
+    if args.rag:
+        _get_rag(args)
 
     try:
         model = New(args.MODEL, args)
@@ -949,8 +962,8 @@ def rm_cli(args):
     _rm_model(models, args)
 
 
-def New(model, args):
-    return ModelFactory(model, args.store, args.use_model_store, CONFIG["transport"], args.engine).create()
+def New(model, args, transport=CONFIG["transport"]):
+    return ModelFactory(model, args.store, args.use_model_store, transport, args.engine).create()
 
 
 def perplexity_parser(subparsers):

--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -6,10 +6,10 @@ import sys
 
 import ramalama
 from ramalama.common import (
-    DEFAULT_IMAGE,
     MNT_CHAT_TEMPLATE_FILE,
     MNT_DIR,
     MNT_FILE,
+    accel_image,
     check_nvidia,
     exec_cmd,
     genname,
@@ -179,40 +179,6 @@ class Model(ModelBase):
             if not args.ignore:
                 raise KeyError(f"removing {self.model}: {e}")
         self.garbage_collection(args)
-
-    def attempt_to_use_versioned(self, conman, image, vers, args):
-        try:
-            if run_cmd([conman, "inspect", f"{image}:{vers}"], ignore_all=True, debug=args.debug):
-                return True
-
-            return run_cmd([conman, "pull", f"{image}:{vers}"], debug=args.debug)
-
-        except Exception:
-            return False
-
-    def _image(self, args):
-        if args.image != DEFAULT_IMAGE:
-            return args.image
-
-        env_vars = get_accel_env_vars()
-
-        if not env_vars:
-            gpu_type = None
-        else:
-            gpu_type, _ = next(iter(env_vars.items()))
-
-        if args.runtime == "vllm":
-            return "docker.io/vllm/vllm-openai"
-
-        split = version().split(".")
-        vers = ".".join(split[:2])
-        conman = CONFIG['engine']
-        images = CONFIG['images']
-        image = images.get(gpu_type, args.image)
-        if self.attempt_to_use_versioned(conman, image, vers, args):
-            return f"{image}:{vers}"
-
-        return f"{image}:latest"
 
     def get_container_name(self, args):
         if hasattr(args, "name") and args.name:
@@ -426,7 +392,7 @@ class Model(ModelBase):
                 conman_args += [f"--mount=type=bind,src={chat_template_path},destination={MNT_CHAT_TEMPLATE_FILE},ro"]
 
         # Make sure Image precedes cmd_args.
-        conman_args += [self._image(args)] + cmd_args
+        conman_args += [accel_image(CONFIG, args)] + cmd_args
 
         if args.dryrun:
             dry_run(conman_args)
@@ -638,7 +604,7 @@ class Model(ModelBase):
         return exec_args
 
     def generate_container_config(self, model_path, chat_template_path, args, exec_args):
-        self.image = self._image(args)
+        self.image = accel_image(CONFIG, args)
         if args.generate == "quadlet":
             self.quadlet(model_path, chat_template_path, args, exec_args)
         elif args.generate == "kube":

--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -321,6 +321,18 @@ class Model(ModelBase):
 
         return conman_args
 
+    def add_rag(self, exec_args, args):
+        if not hasattr(args, "rag") or not args.rag:
+            return exec_args
+
+        if os.path.exists(args.rag):
+            rag = os.path.realpath(args.rag)
+            exec_args.append(f"--mount=type=bind,source={rag},destination=/rag/vector.db")
+        else:
+            exec_args.append(f"--mount=type=image,source={args.rag},destination=/rag")
+
+        return exec_args
+
     def setup_container(self, args):
         if not args.engine:
             return []
@@ -339,6 +351,7 @@ class Model(ModelBase):
         conman_args = self.add_port_option(conman_args, args)
         conman_args = self.add_device_options(conman_args, args)
         conman_args = self.add_network_option(conman_args, args)
+        conman_args = self.add_rag(conman_args, args)
 
         return conman_args
 
@@ -649,6 +662,7 @@ class Model(ModelBase):
                 )
 
         exec_args = self.build_exec_args_serve(args, exec_model_path, chat_template_path)
+
         exec_args = self.handle_runtime(args, exec_args, exec_model_path)
         if self.generate_container_config(model_path, chat_template_path, args, exec_args):
             return


### PR DESCRIPTION
Remove pragmatic, and move to using local implementation until llama-stack version is ready.

 python3 container-images/scripts/doc2rag.py --help
usage: docling [-h] target source [source ...]

process source files into RAG vector database

positional arguments:
  target
  source

options:
  -h, --help  show this help message and exit

## Summary by Sourcery

Enhancements:
- Replaces the pragmatic tool with a local doc2rag implementation.