### PR TITLE
Default the number of threads to (nproc)/(2)

### DIFF
--- a/docs/ramalama-bench.1.md
+++ b/docs/ramalama-bench.1.md
@@ -105,8 +105,8 @@ llama.cpp explains this as:
         Usage: Lower numbers are good for virtual assistants where we need deterministic responses. Higher numbers are good for roleplay or creative tasks like editing stories
 
 #### **--threads**, **-t**
-maximum number of cpu threads to use for inferencing
-The default -1, uses the default of the underlying implementation
+Maximum number of cpu threads to use.
+The default is to use half the cores available on this system for the number of threads.
 
 #### **--tls-verify**=*true*
 require HTTPS and verify certificates when contacting OCI registries

--- a/docs/ramalama-perplexity.1.md
+++ b/docs/ramalama-perplexity.1.md
@@ -113,8 +113,8 @@ llama.cpp explains this as:
         Usage: Lower numbers are good for virtual assistants where we need deterministic responses. Higher numbers are good for roleplay or creative tasks like editing stories
 
 #### **--threads**, **-t**
-maximum number of cpu threads to use for inferencing
-The default -1, uses the default of the underlying implementation
+Maximum number of cpu threads to use.
+The default is to use half the cores available on this system for the number of threads.
 
 #### **--tls-verify**=*true*
 require HTTPS and verify certificates when contacting OCI registries

--- a/docs/ramalama-run.1.md
+++ b/docs/ramalama-run.1.md
@@ -120,8 +120,8 @@ llama.cpp explains this as:
     Usage: Lower numbers are good for virtual assistants where we need deterministic responses. Higher numbers are good for roleplay or creative tasks like editing stories
 
 #### **--threads**, **-t**
-maximum number of cpu threads to use for inferencing
-The default -1, uses the default of the underlying implementation
+Maximum number of cpu threads to use.
+The default is to use half the cores available on this system for the number of threads.
 
 #### **--tls-verify**=*true*
 require HTTPS and verify certificates when contacting OCI registries

--- a/docs/ramalama-serve.1.md
+++ b/docs/ramalama-serve.1.md
@@ -147,8 +147,8 @@ llama.cpp explains this as:
         Usage: Lower numbers are good for virtual assistants where we need deterministic responses. Higher numbers are good for roleplay or creative tasks like editing stories
 
 #### **--threads**, **-t**
-maximum number of cpu threads to use for inferencing
-The default -1, uses the default of the underlying implementation
+Maximum number of cpu threads to use.
+The default is to use half the cores available on this system for the number of threads.
 
 #### **--tls-verify**=*true*
 require HTTPS and verify certificates when contacting OCI registries


### PR DESCRIPTION
The llama.cpp default for threads is hardcoded to 4. This changes that harcoding so instead we use the (number of cpu cores)/(2).

## Summary by Sourcery

Enhancements:
- Updates the default number of threads to be the number of CPU cores divided by 2.