### PR TITLE
whisper.cpp requires ffmpeg

### DIFF
--- a/container-images/scripts/build_llama_and_whisper.sh
+++ b/container-images/scripts/build_llama_and_whisper.sh
@@ -24,7 +24,7 @@ dnf_remove() {
 dnf_install() {
   local rpm_list=("podman-remote" "python3" "python3-pip" "python3-argcomplete" \
                   "python3-dnf-plugin-versionlock" "python3-devel" "gcc-c++" "cmake" "vim" \
-                  "procps-ng" "git" "dnf-plugins-core" "libcurl-devel" "gawk")
+                  "procps-ng" "git" "dnf-plugins-core" "libcurl-devel" "gawk" "ffmpeg-free")
   local vulkan_rpms=("vulkan-headers" "vulkan-loader-devel" "vulkan-tools" \
                      "spirv-tools" "glslc" "glslang")
   if [[ "${containerfile}" = "ramalama" ]] || [[ "${containerfile}" =~ rocm* ]] || \


### PR DESCRIPTION
Installing ffmpeg-free from Fedora/EPEL, ffmpeg-free includes only the FOSS/patent free bits of ffmpeg.

## Summary by Sourcery

Chores:
- Add ffmpeg-free to the build environment.