### PR TITLE
Default whisper-server.sh, llama-server.sh to /mnt/models/model.file

### DIFF
--- a/container-images/asahi/Containerfile
+++ b/container-images/asahi/Containerfile
@@ -4,4 +4,3 @@ ENV ASAHI_VISIBLE_DEVICES 1
 COPY ../scripts /scripts
 RUN chmod +x /scripts/*.sh && \
     /scripts/build_llama_and_whisper.sh "asahi"
-

--- a/container-images/cann/Containerfile
+++ b/container-images/cann/Containerfile
@@ -10,7 +10,6 @@ RUN chmod +x /scripts/*.sh && \
 FROM quay.io/ascend/${ASCEND_VERSION}
 # Copy the entire installation directory from the builder
 COPY --from=builder /tmp/install /usr
-ENV MODEL_PATH=/mnt/models/model.file
 COPY --chmod=755 ../scripts /usr/bin
 ENTRYPOINT [ \
     "/bin/bash", \

--- a/container-images/cuda/Containerfile
+++ b/container-images/cuda/Containerfile
@@ -14,6 +14,4 @@ RUN dnf install -y python3 && \
 # Copy the entire installation directory from the builder
 COPY --from=builder /tmp/install /usr
 
-ENV MODEL_PATH=/mnt/models/model.file
-
 COPY --chmod=755 ../scripts /usr/bin

--- a/container-images/ramalama/Containerfile
+++ b/container-images/ramalama/Containerfile
@@ -1,7 +1,5 @@
 FROM registry.access.redhat.com/ubi9/ubi:9.5-1741850090
 
-ENV MODEL_PATH=/mnt/models/model.file
-
 COPY --chmod=755 ../scripts /usr/bin
 
 RUN /usr/bin/build_llama_and_whisper.sh "ramalama"

--- a/container-images/scripts/llama-server.sh
+++ b/container-images/scripts/llama-server.sh
@@ -9,15 +9,13 @@ if [ -n "${MODEL_CHAT_FORMAT}" ]; then
 fi
 
 if [ -n "${MODEL_PATH}" ]; then
-    eval llama-server \
-        --model "${MODEL_PATH}" \
-        --host "${HOST:=0.0.0.0}" \
-        --port "${PORT:=8001}" \
-        --gpu_layers "${GPU_LAYERS:=0}" \
-	"${CHAT_FORMAT}"
-    exit 0
+    MODEL_PATH="/mnt/models/model.file"
 fi
-
-echo "Please set a MODEL_PATH"
-exit 1
+eval llama-server \
+     --model "${MODEL_PATH}" \
+     --host "${HOST:=0.0.0.0}" \
+     --port "${PORT:=8001}" \
+     --gpu_layers "${GPU_LAYERS:=0}" \
+     "${CHAT_FORMAT}"
+exit 0
 

--- a/container-images/scripts/whisper-server.sh
+++ b/container-images/scripts/whisper-server.sh
@@ -1,14 +1,13 @@
 #!/bin/bash
 
 if [ -n "${MODEL_PATH}" ]; then
-    whisper-server \
-	-tr \
-	--model "${MODEL_PATH}" \
-	--convert \
-	--host "${HOST:=0.0.0.0}" \
-	--port "${PORT:=8001}"
-    exit 0
+    MODEL_PATH="/mnt/models/model.file"
 fi
 
-echo "Please set a MODEL_PATH"
-exit 1
+whisper-server \
+    -tr \
+    --model "${MODEL_PATH}" \
+    --convert \
+    --host "${HOST:=0.0.0.0}" \
+    --port "${PORT:=8001}"
+exit 0

--- a/container-images/vulkan/Containerfile
+++ b/container-images/vulkan/Containerfile
@@ -1,7 +1,5 @@
 FROM registry.access.redhat.com/ubi9/ubi:9.5-1741850090
 
-ENV MODEL_PATH=/mnt/models/model.file
-
 COPY --chmod=755 ../scripts /usr/bin
 
 RUN /usr/bin/build_llama_and_whisper.sh "vulkan"


### PR DESCRIPTION
Fixes: https://github.com/containers/ramalama/issues/980

## Summary by Sourcery

Bug Fixes:
- Fixes the issue where the MODEL_PATH was not being correctly set, causing the scripts to fail.