### PR TITLE
Use client and server for "ramalama run"

### DIFF
--- a/bin/ramalama
+++ b/bin/ramalama
@@ -27,7 +27,7 @@ def add_site_packages_to_syspath(base_path):
     matched_paths = glob.glob(search_pattern)
     if matched_paths:
         for path in matched_paths:
-            sys.path.insert(0, path)
+            sys.path.append(path)
         return
 
     # Fallback to a more general pattern if the specific version doesn't match
@@ -35,19 +35,19 @@ def add_site_packages_to_syspath(base_path):
     matched_paths = glob.glob(search_pattern)
     if matched_paths:
         for path in matched_paths:
-            sys.path.insert(0, path)
+            sys.path.append(path)
 
 
 def main(args):
     sharedirs = ["/opt/homebrew/share/ramalama", "/usr/local/share/ramalama", "/usr/share/ramalama"]
     syspath = next((d for d in sharedirs if os.path.exists(d + "/ramalama/cli.py")), None)
     if syspath:
-        sys.path.insert(0, syspath)
+        sys.path.append(syspath)
 
     add_site_packages_to_syspath('~/.local/pipx/venvs/*')
     add_site_packages_to_syspath('/usr/local')
     add_pipx_venvs_bin_to_path()
-    sys.path.insert(0, './')
+    sys.path.append('./')
     try:
         import ramalama
     except Exception:

--- a/libexec/ramalama-run-core
+++ b/libexec/ramalama-run-core
@@ -1,11 +1,23 @@
 #!/usr/bin/env python3
 
+import os
 import sys
 
 
 def main(args):
-    return 0
+    sys.path.append('./')
+    os.environ["PATH"] += f"{os.pathsep}libexec"
+    from ramalama.common import exec_cmd
+
+    pid = os.fork()
+    if pid == 0:
+        cmd = ["ramalama-serve-core"]
+        exec_cmd(cmd, stderr2null=True)
+        return 0
+
+    cmd = ["ramalama-client-core"]
+    exec_cmd(cmd)
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main(sys.argv[1:])

--- a/libexec/ramalama-serve-core
+++ b/libexec/ramalama-serve-core
@@ -4,6 +4,23 @@ import sys
 
 
 def main(args):
+    sys.path.append('./')
+    from ramalama.common import exec_cmd
+
+    cmd = [
+        "llama-server",
+        "--port",
+        "8080",
+        "-m",
+        "/Users/ecurtin/.local/share/ramalama/models/ollama/deepseek-r1:1.5b",
+        "-c",
+        "2048",
+        "--temp",
+        "0.8",
+        "--host",
+        "0.0.0.0",
+    ]
+    exec_cmd(cmd)
     return 0
 
 

--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -118,9 +118,13 @@ def available(cmd):
     return shutil.which(cmd) is not None
 
 
-def exec_cmd(args, debug=False):
+def exec_cmd(args, debug=False, stderr2null=False):
     if debug:
         perror("exec_cmd: ", *args)
+
+    if stderr2null:
+        with open(os.devnull, 'w') as devnull:
+            os.dup2(devnull.fileno(), sys.stderr.fileno())
 
     try:
         return os.execvp(args[0], args)


### PR DESCRIPTION
To focus on vLLM server and llama-server being the endpoint

## Summary by Sourcery

Refactor ramalama to use a client-server architecture.

Chores:
- Remove the ramalama-run-core and ramalama-serve-core scripts.
- Update exec_cmd to allow redirecting stderr to /dev/null.