### PR TITLE
[CANN]Fix the bug that openEuler repo does not have ffmpeg-free package, instand of using ffmpeg for openEuler

### DIFF
--- a/container-images/scripts/build_llama_and_whisper.sh
+++ b/container-images/scripts/build_llama_and_whisper.sh
@@ -92,6 +92,8 @@ dnf_install_epel() {
   crb enable # this is in epel-release, can only install epel-release via url
 }
 
+# There is no ffmpeg-free package in the openEuler repository. openEuler can use ffmpeg,
+# which also has the same GPL/LGPL license as ffmpeg-free.
 dnf_install_ffmpeg() {
   if [ "${ID}" = "rhel" ]; then
     dnf_install_epel
@@ -100,7 +102,11 @@ dnf_install_ffmpeg() {
     add_stream_repo "CRB"
   fi
 
-  dnf install -y ffmpeg-free
+  if [[ "${ID}" == "openEuler" ]]; then
+    dnf install -y ffmpeg
+  else
+    dnf install -y ffmpeg-free
+  fi
   rm_non_ubi_repos
 }
 


### PR DESCRIPTION
[CANN]Fix the bug that openEuler repo does not have ffmpeg-free package. Instand of using ffmpeg for openEuler, which also has LGPL license. 

Signed-off-by: leo-pony <nengjunma@outlook.com>

## Summary by Sourcery

Bug Fixes:
- Fixes an issue where the ffmpeg-free package is unavailable in the openEuler repository.