### PR TITLE
Add the ability to identify a wider set of Intel GPUs that have enough Execution Units to produce decent results

### DIFF
--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -401,11 +401,11 @@ def check_rocm_amd():
 def check_intel():
     igpu_num = 0
     intel_gpus = (
-                 b"0xe20b",
-                 b"0xe20c",
-                 b"0x7d51",
-                 b"0x7dd5",
-                 b"0x7d55",
+        b"0xe20b",
+        b"0xe20c",
+        b"0x7d51",
+        b"0x7dd5",
+        b"0x7d55",
     )
     # Check to see if any of the device ids in intel_gpus are in the device id of the i915 driver
     for fp in sorted(glob.glob('/sys/bus/pci/drivers/i915/*/device')):

--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -400,11 +400,22 @@ def check_rocm_amd():
 
 def check_intel():
     igpu_num = 0
+    intel_gpus = (
+                 b"0xe20b",
+                 b"0xe20c",
+                 b"0x7d51",
+                 b"0x7dd5",
+                 b"0x7d55",
+    )
+    # Check to see if any of the device ids in intel_gpus are in the device id of the i915 driver
     for fp in sorted(glob.glob('/sys/bus/pci/drivers/i915/*/device')):
         with open(fp, 'rb') as file:
             content = file.read()
-            if b"0x7d55" in content:
-                igpu_num += 1
+            for gpu_id in intel_gpus:
+                if gpu_id in content:
+                    igpu_num += 1
+            # if b"0x7d55" in content:
+            #     igpu_num += 1
     if igpu_num:
         os.environ["INTEL_VISIBLE_DEVICES"] = str(igpu_num)
         return "intel"


### PR DESCRIPTION
Added the following Intel GPUs to the identification logic in common.py -

| GPU ID | Description |
| --- | --- |
|`0xe20b`| Intel® Arc™ B580 Graphics |
|`0xe20c`| Intel® Arc™ B570 Graphics |
|`0x7d51`| Intel® Graphics - Arrow Lake-H |
|`0x7dd5`| Intel® Graphics - Meteor Lake  |
|`0x7d55`| Intel® Arc™ Graphics - Meteor Lake |

## Summary by Sourcery

Enhancements:
- Expands the list of recognized Intel GPUs to include Arc B580, Arc B570, Arrow Lake-H, Meteor Lake, and Arc Graphics (Meteor Lake).