### PR TITLE
Remove Ollama from macOS build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,10 +171,6 @@ jobs:
            brew install go bats bash jq llama.cpp shellcheck
            make install-requirements
 
-      - name: install ollama
-        shell: bash
-        run: ./.github/scripts/install-ollama.sh
-
       - name: Run a one-line script
         shell: bash
         run: |


### PR DESCRIPTION
We still will test this stuff on Linux.

## Summary by Sourcery

CI:
- Removes the installation of Ollama on macOS.