### PR TITLE
Turn on verbose logging in llama-server if --debug is on

### DIFF
--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -596,6 +596,10 @@ class Model(ModelBase):
             ] + args.runtime_args
             if chat_template_path != "":
                 exec_args.extend(["--chat-template-file", chat_template_path])
+
+            if args.debug:
+                exec_args.extend(["-v"])
+
         if args.seed:
             exec_args += ["--seed", args.seed]
 


### PR DESCRIPTION
Can see more verbose request/response info, etc.

## Summary by Sourcery

Enhancements:
- Enable verbose logging in llama-server when the --debug flag is used.