### PR TITLE
FIX: Ollama install with brew for CI

### DIFF
--- a/.github/scripts/install-ollama.sh
+++ b/.github/scripts/install-ollama.sh
@@ -4,6 +4,7 @@ os_name=$(uname)
 
 if [[ "$os_name" == "Darwin" ]]; then
   brew install ollama
+  brew update
   brew services start ollama
 elif [[ "$os_name" == "Linux" ]]; then
   curl -L https://ollama.com/download/ollama-linux-amd64.tgz -o ollama-linux-amd64.tgz


### PR DESCRIPTION
Update brew before starting Ollama with MacOS during CI testing

## Summary by Sourcery

CI:
- Update brew before starting Ollama with MacOS during CI testing.