### PR TITLE
Don't use relative paths for destination

### DIFF
--- a/ramalama/rag.py
+++ b/ramalama/rag.py
@@ -66,8 +66,7 @@ COPY {src} /vector.db
         for path in args.PATH:
             if os.path.exists(path):
                 fpath = os.path.realpath(path)
-                rpath = os.path.relpath(path)
-                exec_args += ["-v", f"{fpath}:/docs/{rpath}:ro,z"]
+                exec_args += ["-v", f"{fpath}:/docs/{fpath}:ro,z"]
         tmpdir = "."
         if not os.access(tmpdir, os.W_OK):
             tmpdir = "/tmp"


### PR DESCRIPTION
This can cause the file to not be installed in a subdir of the destination (/docs) within the container.

## Summary by Sourcery

Bug Fixes:
- Fixes an issue where files were not being installed in the correct subdirectory within the container due to the use of relative paths.