### PR TITLE
Use this container if we detect ROCm accelerator

### DIFF
--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -486,6 +486,9 @@ def accel_image(config, args):
         gpu_type, _ = next(iter(env_vars.items()))
 
     if args.runtime == "vllm":
+        if "HIP_VISIBLE_DEVICES" in os.environ:
+            return "docker.io/rocm/vllm-dev:main"
+
         return "docker.io/vllm/vllm-openai"
 
     split = version().split(".")


### PR DESCRIPTION
Should help get ROCm + vLLM working

## Summary by Sourcery

Use the ROCm vLLM container image when a ROCm accelerator is detected.