### PR TITLE
Generate quadlets with rag databases

### DIFF
--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -25,6 +25,9 @@ MNT_DIR = "/mnt/models"
 MNT_FILE = f"{MNT_DIR}/model.file"
 MNT_CHAT_TEMPLATE_FILE = f"{MNT_DIR}/chat_template.file"
 
+RAG_DIR = "/rag"
+RAG_CONTENT = f"{MNT_DIR}/vector.db"
+
 HTTP_NOT_FOUND = 404
 HTTP_RANGE_NOT_SATISFIABLE = 416  # "Range Not Satisfiable" error (file already downloaded)
 

--- a/ramalama/quadlet.py
+++ b/ramalama/quadlet.py
@@ -1,6 +1,6 @@
 import os
 
-from ramalama.common import MNT_CHAT_TEMPLATE_FILE, MNT_DIR, MNT_FILE, get_accel_env_vars
+from ramalama.common import MNT_CHAT_TEMPLATE_FILE, MNT_DIR, MNT_FILE, RAG_DIR, get_accel_env_vars
 
 
 class Quadlet:
@@ -19,6 +19,11 @@ class Quadlet:
         self.exec_args = exec_args
         self.image = image
         self.chat_template = chat_template
+        self.rag = ""
+        self.rag_name = ""
+        if args.rag:
+            self.rag = args.rag.removeprefix("oci://")
+            self.rag_name = os.path.basename(self.rag) + "-rag"
 
     def kube(self):
         outfile = self.name + ".kube"
@@ -40,22 +45,15 @@ WantedBy=multi-user.target default.target
             )
 
     def generate(self):
-        port_string = ""
-        if hasattr(self.args, "port"):
-            port_string = f"PublishPort={self.args.port}"
-
-        name_string = ""
-        if hasattr(self.args, "name") and self.args.name:
-            name_string = f"ContainerName={self.args.name}"
-
-        env_var_string = ""
-        for k, v in get_accel_env_vars().items():
-            env_var_string += f"Environment={k}={v}\n"
+        chat_template_volume = self._gen_chat_template_volume()
+        env_var_string = self._gen_env()
+        model_volume = self._gen_model_volume()
+        name_string = self._gen_name()
+        port_string = self._gen_port()
+        rag_volume = self._gen_rag_volume()
 
         outfile = self.name + ".container"
         print(f"Generating quadlet file: {outfile}")
-        model_volume = self.gen_model_volume()
-        chat_template_volume = self.gen_chat_template_volume()
         with open(outfile, 'w') as c:
             c.write(
                 f"""\
@@ -65,13 +63,14 @@ After=local-fs.target
 
 [Container]
 AddDevice=-/dev/dri
-AddDevice=-/dev/kfd
-Exec={" ".join(self.exec_args)}
-Image={self.image}
+AddDevice=-/dev/kfd\
 {env_var_string}
-{model_volume}
-{chat_template_volume}
-{name_string}
+Exec={" ".join(self.exec_args)}
+Image={self.image}\
+{model_volume}\
+{rag_volume}\
+{chat_template_volume}\
+{name_string}\
 {port_string}
 
 [Install]
@@ -80,18 +79,42 @@ WantedBy=multi-user.target default.target
 """
             )
 
-    def gen_chat_template_volume(self):
+    def _gen_chat_template_volume(self):
         if os.path.exists(self.chat_template):
-            return f"Mount=type=bind,src={self.chat_template},target={MNT_CHAT_TEMPLATE_FILE},ro,Z"
+            return f"\nMount=type=bind,src={self.chat_template},target={MNT_CHAT_TEMPLATE_FILE},ro,Z"
         return ""
 
-    def gen_model_volume(self):
+    def _gen_env(self):
+        env_var_string = ""
+        for k, v in get_accel_env_vars().items():
+            env_var_string += f"\nEnvironment={k}={v}"
+        for e in self.args.env:
+            env_var_string += f"\nEnvironment={e}"
+        return env_var_string
+
+    def _gen_image(self, name, image):
+        outfile = name + ".image"
+        print(f"Generating quadlet file: {outfile} ")
+        with open(outfile, 'w') as c:
+            c.write(
+                f"""\
+[Image]
+Image={image}
+"""
+            )
+
+    def _gen_name(self):
+        name_string = ""
+        if hasattr(self.args, "name") and self.args.name:
+            name_string = f"ContainerName={self.args.name}"
+        return name_string
+
+    def _gen_model_volume(self):
         if os.path.exists(self.model):
-            return f"Mount=type=bind,src={self.model},target={MNT_FILE},ro,Z"
+            return f"\nMount=type=bind,src={self.model},target={MNT_FILE},ro,Z"
 
         outfile = self.name + ".volume"
 
-        self.gen_image()
         print(f"Generating quadlet file: {outfile} ")
         with open(outfile, 'w') as c:
             c.write(
@@ -101,15 +124,30 @@ Driver=image
 Image={self.name}.image
 """
             )
-            return f"Mount=type=image,source={self.ai_image},destination={MNT_DIR},subpath=/models,readwrite=false"
+        self._gen_image(self.name, self.ai_image)
+        return f"\nMount=type=image,source={self.ai_image},destination={MNT_DIR},subpath=/models,readwrite=false"
 
-    def gen_image(self):
-        outfile = self.name + ".image"
+    def _gen_port(self):
+        port_string = ""
+        if hasattr(self.args, "port"):
+            port_string = f"\nPublishPort={self.args.port}"
+        return port_string
+
+    def _gen_rag_volume(self):
+        rag_volume = ""
+        if not hasattr(self.args, "rag") or not self.rag:
+            return rag_volume
+
+        outfile = self.rag_name + ".volume"
+
         print(f"Generating quadlet file: {outfile} ")
         with open(outfile, 'w') as c:
             c.write(
                 f"""\
-[Image]
-Image={self.ai_image}
+[Volume]
+Driver=image
+Image={self.rag_name}.image
 """
             )
+        self._gen_image(self.rag_name, self.rag)
+        return f"\nMount=type=image,source={self.rag},destination={RAG_DIR},readwrite=false"


### PR DESCRIPTION
## Summary by Sourcery

Adds support for specifying a Retrieval-Augmented Generation (RAG) database when generating quadlets. This allows the quadlet to access and use the specified RAG database for enhanced functionality.

New Features:
- Adds support for specifying a RAG database when generating quadlets.
- Introduces a new `rag` argument to specify the RAG database OCI image.
- Generates a volume for the RAG database and mounts it to `/rag` inside the container.