### PR TITLE
Add "ramalama open-webui"

### DIFF
--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -163,6 +163,7 @@ def configure_subcommands(parser):
     list_parser(subparsers)
     login_parser(subparsers)
     logout_parser(subparsers)
+    open_webui_parser(subparsers)
     perplexity_parser(subparsers)
     pull_parser(subparsers)
     push_parser(subparsers)
@@ -897,6 +898,13 @@ def version_parser(subparsers):
     parser.add_argument("--container", default=False, action="store_false", help=argparse.SUPPRESS)
     parser.set_defaults(func=print_version)
 
+
+def open_webui_parser(subparsers):
+    parser = subparsers.add_parser(
+        "open-webui",
+        help="run open-webui",
+    )
+    parser.add_argument("MODEL")
 
 def rag_parser(subparsers):
     parser = subparsers.add_parser(


### PR DESCRIPTION
ramalama open-webui granite3-moe for an example will just spin up a whole inferencing evironment, including inferencing server and webui server.

## Summary by Sourcery

New Features:
- Introduce a new CLI command 'open-webui' to spin up an inferencing environment, including an inferencing server and a web UI server.