### PR TITLE
More fixes to build scripts

### DIFF
--- a/container-images/asahi/Containerfile
+++ b/container-images/asahi/Containerfile
@@ -1,6 +1,6 @@
 FROM fedora:41
 
 ENV ASAHI_VISIBLE_DEVICES 1
-COPY ../scripts /scripts
-RUN chmod +x /scripts/*.sh && \
-    /scripts/build_llama_and_whisper.sh "asahi"
+COPY --chmod=755 ../scripts /usr/bin
+RUN /usr/bin/build_llama_and_whisper.sh "asahi" && \
+    rag_framework load

--- a/container-images/cann/Containerfile
+++ b/container-images/cann/Containerfile
@@ -3,14 +3,14 @@ ARG ASCEND_VERSION=cann:8.0.0-910b-openeuler22.03-py3.10
 
 FROM quay.io/ascend/${ASCEND_VERSION} AS builder
 ARG GOLANG_VERSION
-COPY ../scripts /scripts
-RUN chmod +x /scripts/*.sh && \
-    sh -x /scripts/build_llama_and_whisper.sh "cann"
+COPY --chmod=755 ../scripts /scripts
+RUN sh -x /scripts/build_llama_and_whisper.sh "cann"
 
 FROM quay.io/ascend/${ASCEND_VERSION}
 # Copy the entire installation directory from the builder
 COPY --from=builder /tmp/install /usr
 COPY --chmod=755 ../scripts /usr/bin
+RUN rag_framework load
 ENTRYPOINT [ \
     "/bin/bash", \
     "-c", \

--- a/container-images/cuda/Containerfile
+++ b/container-images/cuda/Containerfile
@@ -1,17 +1,16 @@
 # Base image with CUDA for compilation
 FROM docker.io/nvidia/cuda:12.8.1-devel-ubi9 AS builder
 
-COPY ../scripts /scripts
-RUN chmod +x /scripts/*.sh && \
-    /scripts/build_llama_and_whisper.sh "cuda"
+COPY --chmod=755 ../scripts /scripts
+RUN /scripts/build_llama_and_whisper.sh "cuda"
 
 # Final runtime image
 FROM docker.io/nvidia/cuda:12.8.1-runtime-ubi9
 
-RUN dnf install -y python3 && \
-    dnf clean all && rm -rf /var/cache/*dnf*
-
 # Copy the entire installation directory from the builder
 COPY --from=builder /tmp/install /usr
-
 COPY --chmod=755 ../scripts /usr/bin
+
+RUN dnf install -y python3 && \
+    rag_framework load && \
+    dnf clean all && rm -rf /var/cache/*dnf*

--- a/container-images/intel-gpu/Containerfile
+++ b/container-images/intel-gpu/Containerfile
@@ -1,10 +1,9 @@
 FROM quay.io/fedora/fedora:41 as builder
 
 COPY intel-gpu/oneAPI.repo /etc/yum.repos.d/
-COPY scripts/build_llama_and_whisper.sh /
+COPY --chmod=755 scripts/build_llama_and_whisper.sh /
 
-RUN chmod +x /build_llama_and_whisper.sh ; \
-    /build_llama_and_whisper.sh "intel-gpu"
+RUN /build_llama_and_whisper.sh "intel-gpu"
 
 FROM quay.io/fedora/fedora:41
 
@@ -19,6 +18,7 @@ RUN dnf install -y procps-ng python3 python3-pip python3-devel intel-level-zero 
 RUN useradd llama-user -u 10000 -d /home/llama-user -s /bin/bash; \
 groupmod -a -U llama-user render; \
 groupmod -a -U llama-user video; \
+rag_framework load; \
 echo ". /opt/intel/oneapi/setvars.sh" >> "/home/llama-user/.zshrc"; \
 echo ". /opt/intel/oneapi/setvars.sh" >> "/home/llama-user/.bashrc"; \
 chown llama-user:llama-user -R /home/llama-user

--- a/container-images/ramalama/Containerfile
+++ b/container-images/ramalama/Containerfile
@@ -2,4 +2,5 @@ FROM registry.access.redhat.com/ubi9/ubi:9.5-1741850090
 
 COPY --chmod=755 ../scripts /usr/bin
 
-RUN /usr/bin/build_llama_and_whisper.sh "ramalama"
+RUN /usr/bin/build_llama_and_whisper.sh "ramalama" && \
+    rag_framework load

--- a/container-images/rocm-fedora/Containerfile
+++ b/container-images/rocm-fedora/Containerfile
@@ -1,8 +1,8 @@
 FROM registry.fedoraproject.org/fedora:42
 
-COPY ../scripts /scripts
-RUN chmod +x /scripts/*.sh && \
-    /scripts/build_llama_and_whisper.sh "rocm" 
+COPY --chmod=755 ../scripts /scripts
+RUN /scripts/build_llama_and_whisper.sh "rocm" && \
+    rag_framework load
 
 ENV WHISPER_CPP_SHA=${WHISPER_CPP_SHA}
 ENV LLAMA_CPP_SHA=${LLAMA_CPP_SHA}

--- a/container-images/rocm/Containerfile
+++ b/container-images/rocm/Containerfile
@@ -2,9 +2,9 @@ FROM registry.access.redhat.com/ubi9/ubi:9.5-1741850090
 
 COPY rocm/amdgpu.repo /etc/yum.repos.d/
 COPY rocm/rocm.repo /etc/yum.repos.d/
-COPY scripts /scripts
+COPY --chmod=755 scripts /scripts
 
 ARG AMDGPU_TARGETS=
 ENV AMDGPU_TARGETS=${AMDGPU_TARGETS}
-RUN chmod +x /scripts/*.sh && \
-    /scripts/build_llama_and_whisper.sh "rocm"
+RUN /scripts/build_llama_and_whisper.sh "rocm" && \
+    rag_framework load

--- a/container-images/vulkan/Containerfile
+++ b/container-images/vulkan/Containerfile
@@ -2,5 +2,6 @@ FROM registry.access.redhat.com/ubi9/ubi:9.5-1741850090
 
 COPY --chmod=755 ../scripts /usr/bin
 
-RUN /usr/bin/build_llama_and_whisper.sh "vulkan"
+RUN /usr/bin/build_llama_and_whisper.sh "vulkan"  && \
+    rag_framework load
 


### PR DESCRIPTION
Adding back rag_framework load

## Summary by Sourcery

Adds the rag_framework load command to several containerfiles to ensure the framework is loaded during the build process.

Chores:
- Adds the rag_framework load command to several containerfiles.
- Changes the COPY command to include --chmod=755 to ensure the scripts are executable.