### PR TITLE
More fixes to build scripts

### DIFF
--- a/container-images/rocm-fedora/Containerfile
+++ b/container-images/rocm-fedora/Containerfile
@@ -1,7 +1,7 @@
 FROM registry.fedoraproject.org/fedora:42
 
-COPY --chmod=755 ../scripts /scripts
-RUN /scripts/build_llama_and_whisper.sh "rocm" && \
+COPY --chmod=755 ../scripts /usr/bin/
+RUN /usr/bin/build_llama_and_whisper.sh "rocm" && \
     rag_framework load
 
 ENV WHISPER_CPP_SHA=${WHISPER_CPP_SHA}


### PR DESCRIPTION
Adding back rag_framework load

## Summary by Sourcery

Fix the build script by adding back the rag_framework load command and moving the scripts to /usr/bin.

Build:
- Add back rag_framework load command to the build script.
- Move scripts to /usr/bin.