### PR TITLE
Minor bugfix remove self. from self.prompt

### DIFF
--- a/container-images/scripts/rag_framework
+++ b/container-images/scripts/rag_framework
@@ -34,7 +34,7 @@ class QueryRequest(BaseModel):
     max_tokens: int = 150  # Default to 150 tokens
 
 class Rag(cmd.Cmd):
-    self.prompt = "> "
+    prompt = "> "
 
     def __init__(self, vector_path):
         # Setup vector database


### PR DESCRIPTION
Not needed in non-constructor scope

## Summary by Sourcery

Removes unnecessary 'self.' prefix from a variable within a non-constructor scope.