### PR TITLE
Add openvino to all images

### DIFF
--- a/container-images/scripts/build_llama_and_whisper.sh
+++ b/container-images/scripts/build_llama_and_whisper.sh
@@ -113,7 +113,7 @@ dnf_install_ffmpeg() {
 dnf_install() {
   local rpm_list=("podman-remote" "python3" "python3-pip" "python3-argcomplete" \
                   "python3-dnf-plugin-versionlock" "python3-devel" "gcc-c++" "cmake" "vim" \
-                  "procps-ng" "git" "dnf-plugins-core" "libcurl-devel" "gawk")
+                  "procps-ng" "git" "dnf-plugins-core" "libcurl-devel" "gawk" "python3-openvino")
   local vulkan_rpms=("vulkan-headers" "vulkan-loader-devel" "vulkan-tools" \
                      "spirv-tools" "glslc" "glslang")
   if [ "${containerfile}" = "ramalama" ] || [[ "${containerfile}" =~ rocm* ]] || \


### PR DESCRIPTION
Podman desktop has asked us to add openvino support to our containers, this is first step, next we need to pull non-gguf images and start actually allowing users to specify openvino as a service.

## Summary by Sourcery

Add OpenVINO support to container images by installing the Python OpenVINO package

New Features:
- Add support for OpenVINO by including python3-openvino package in the default installation

Chores:
- Updated build script to include OpenVINO package for Podman desktop integration