### PR TITLE
Never use entrypoint

### DIFF
--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -198,6 +198,7 @@ class Model(ModelBase):
             name,
             "--env=HOME=/tmp",
             "--init",
+            "--entrypoint=[]",
         ]
 
     def add_privileged_options(self, conman_args, args):


### PR DESCRIPTION
    Turn off all use of entrypoints when running and serving containers.
    
    Entrypoints have the chance of screwing up the way containers run, and
    if a user provides their own image with an entrypoint this could become
    tough to diagnose errors.
