### PR TITLE
Add support for /dev/accel being leaked into containers

### DIFF
--- a/docs/ramalama-serve.1.md
+++ b/docs/ramalama-serve.1.md
@@ -180,6 +180,7 @@ Description=RamaLama $HOME/.local/share/ramalama/models/huggingface/instructlab/
 After=local-fs.target
 
 [Container]
+AddDevice=-/dev/accel
 AddDevice=-/dev/dri
 AddDevice=-/dev/kfd
 Exec=llama-server --port 1234 -m $HOME/.local/share/ramalama/models/huggingface/instructlab/granite-7b-lab-GGUF/granite-7b-lab-Q4_K_M.gguf
@@ -231,6 +232,7 @@ Description=RamaLama /run/model/model.file AI Model Service
 After=local-fs.target
 
 [Container]
+AddDevice=-/dev/accel
 AddDevice=-/dev/dri
 AddDevice=-/dev/kfd
 Exec=vllm serve --port 8080 /run/model/model.file

--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -1,3 +1,4 @@
+import glob
 import os
 import platform
 import random
@@ -288,11 +289,12 @@ class Model(ModelBase):
             for device_arg in args.device:
                 conman_args += ["--device", device_arg]
 
-        if ramalama.common.podman_machine_accel or os.path.exists("/dev/dri"):
+        if ramalama.common.podman_machine_accel:
             conman_args += ["--device", "/dev/dri"]
 
-        if os.path.exists("/dev/kfd"):
-            conman_args += ["--device", "/dev/kfd"]
+        for path in ["/dev/dri", "/dev/kfd", "/dev/accel", "/dev/davinci*", "/dev/devmm_svm", "/dev/hisi_hdc"]:
+            for dev in glob.glob(path):
+                conman_args += ["--device", dev]
 
         for k, v in get_accel_env_vars().items():
             # Special case for Cuda

--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -287,23 +287,23 @@ class Model(ModelBase):
         if args.device:
             for device_arg in args.device:
                 conman_args += ["--device", device_arg]
-        else:
-            if ramalama.common.podman_machine_accel or os.path.exists("/dev/dri"):
-                conman_args += ["--device", "/dev/dri"]
 
-            if os.path.exists("/dev/kfd"):
-                conman_args += ["--device", "/dev/kfd"]
+        if ramalama.common.podman_machine_accel or os.path.exists("/dev/dri"):
+            conman_args += ["--device", "/dev/dri"]
 
-            for k, v in get_accel_env_vars().items():
-                # Special case for Cuda
-                if k == "CUDA_VISIBLE_DEVICES":
-                    if os.path.basename(args.engine) == "docker":
-                        conman_args += ["--gpus", "all"]
-                    else:
-                        # newer Podman versions support --gpus=all, but < 5.0 do not
-                        conman_args += ["--device", "nvidia.com/gpu=all"]
+        if os.path.exists("/dev/kfd"):
+            conman_args += ["--device", "/dev/kfd"]
 
-                conman_args += ["-e", f"{k}={v}"]
+        for k, v in get_accel_env_vars().items():
+            # Special case for Cuda
+            if k == "CUDA_VISIBLE_DEVICES":
+                if os.path.basename(args.engine) == "docker":
+                    conman_args += ["--gpus", "all"]
+                else:
+                    # newer Podman versions support --gpus=all, but < 5.0 do not
+                    conman_args += ["--device", "nvidia.com/gpu=all"]
+
+            conman_args += ["-e", f"{k}={v}"]
 
         return conman_args
 

--- a/ramalama/quadlet.py
+++ b/ramalama/quadlet.py
@@ -62,6 +62,7 @@ Description=RamaLama {self.model} AI Model Service
 After=local-fs.target
 
 [Container]
+AddDevice=-/dev/accel
 AddDevice=-/dev/dri
 AddDevice=-/dev/kfd\
 {env_var_string}


### PR DESCRIPTION
## Summary by Sourcery

Add support for exposing /dev/accel device to containers across different configuration methods

New Features:
- Add support for automatically passing /dev/accel device to containers when it exists on the host system

Enhancements:
- Refactor device addition logic to consistently handle different acceleration devices
- Simplify device configuration by removing nested conditionals

Documentation:
- Update documentation examples to include /dev/accel in container device configurations