### PR TITLE
Catch errors early about no support for --nocontainer

### DIFF
--- a/docs/ramalama-convert.1.md
+++ b/docs/ramalama-convert.1.md
@@ -9,7 +9,9 @@ ramalama\-convert - convert AI Models from local storage to OCI Image
 ## DESCRIPTION
 Convert specified AI Model to an OCI Formatted AI Model
 
-The model can be from RamaLama model storage in Huggingface, Ollama, or local model stored on disk. Converting from an OCI model is not supported.
+The model can be from RamaLama model storage in Huggingface, Ollama, or a local model stored on disk. Converting from an OCI model is not supported.
+
+Note: The convert command must be run with containers. Use of the --nocontainer option is not allowed.
 
 ## OPTIONS
 

--- a/docs/ramalama-serve.1.md
+++ b/docs/ramalama-serve.1.md
@@ -130,6 +130,8 @@ not have more privileges than the user that launched them.
 #### **--rag**=
 Specify path to Retrieval-Augmented Generation (RAG) database or an OCI Image containing a RAG database
 
+Note: RAG support requires AI Models be run within containers, --nocontainer not supported. Docker does not support image mounting, meaning Podman support required.
+
 #### **--runtime-args**="*args*"
 Add *args* to the runtime (llama.cpp or vllm) invocation.
 
@@ -327,7 +329,7 @@ WantedBy=multi-user.target default.target
 See **[ramalama-cuda(7)](ramalama.7.md)** for setting up the host Linux system for CUDA support.
 
 ## SEE ALSO
-**[ramalama(1)](ramalama.1.md)**, **[ramalama-stop(1)](ramalama-stop.1.md)**, **quadlet(1)**, **systemctl(1)**, **podman-ps(1)**, **[ramalama-cuda(7)](ramalama-cuda.7.md)**
+**[ramalama(1)](ramalama.1.md)**, **[ramalama-stop(1)](ramalama-stop.1.md)**, **quadlet(1)**, **systemctl(1)**, **podman(1)**, **podman-ps(1)**, **[ramalama-cuda(7)](ramalama-cuda.7.md)**
 
 ## HISTORY
 Aug 2024, Originally compiled by Dan Walsh <dwalsh@redhat.com>

--- a/docs/ramalama.1.md
+++ b/docs/ramalama.1.md
@@ -127,8 +127,10 @@ pass --group-add keep-groups to podman (default: False)
 Needed to access the gpu on some systems, but has an impact on security, use with caution.
 
 #### **--nocontainer**
-do not run RamaLama in the default container (default: False)
+Do not run RamaLama in the default container (default: False)
 The default can be overridden in the ramalama.conf file.
+
+Note: OCI images cannot be used with the --nocontainer option. This option disables the following features: GPU acceleration, containerized environment isolation, and dynamic resource allocation. For a complete list of affected features, please see the RamaLama documentation at [link-to-feature-list].
 
 #### **--quiet**
 Decrease output verbosity.

--- a/test/system/040-serve.bats
+++ b/test/system/040-serve.bats
@@ -187,6 +187,7 @@ verify_begin=".*run --rm -i --label ai.ramalama --name"
 @test "ramalama serve --generate=quadlet and --generate=kube with OCI" {
     skip_if_darwin
     skip_if_docker
+    skip_if_nocontainer
     local registry=localhost:${PODMAN_LOGIN_REGISTRY_PORT}
     local authfile=$RAMALAMA_TMPDIR/authfile.json
 
@@ -206,10 +207,8 @@ verify_begin=".*run --rm -i --label ai.ramalama --name"
 	run_ramalama push $modeltype --authfile=$authfile --tls-verify=false tiny oci://${ociimage}
 	run_ramalama serve --authfile=$authfile --tls-verify=false --name=${name} --port 1234 --generate=quadlet oci://${ociimage}
 	is "$output" ".*Generating quadlet file: ${name}.container" "generate .container file"
-	if is_container; then
-	   is "$output" ".*Generating quadlet file: ${name}.volume" "generate .volume file"
-	   is "$output" ".*Generating quadlet file: ${name}.image" "generate .image file"
-	fi
+	is "$output" ".*Generating quadlet file: ${name}.volume" "generate .volume file"
+	is "$output" ".*Generating quadlet file: ${name}.image" "generate .image file"
 
 	run cat $name.container
 	is "$output" ".*PublishPort=1234" "PublishPort should match"

--- a/test/system/050-pull.bats
+++ b/test/system/050-pull.bats
@@ -108,6 +108,13 @@ load setup_suite
 
 # bats test_tags=distro-integration
 @test "ramalama pull oci" {
+    if is_container; then
+        run_ramalama pull oci://quay.io/ramalama/smollm:135m
+    else
+        run_ramalama 22 pull oci://quay.io/ramalama/smollm:135m
+	is "$output" "Error: OCI containers cannot be used with the --nocontainer option."
+    fi
+
     skip "Waiting for podman artiface support" 
     run_ramalama pull oci://quay.io/mmortari/gguf-py-example:v1
     run_ramalama list
@@ -156,6 +163,7 @@ load setup_suite
 @test "ramalama use registry" {
     skip_if_darwin
     skip_if_docker
+    skip_if_nocontainer
     local registry=localhost:${PODMAN_LOGIN_REGISTRY_PORT}
     local authfile=$RAMALAMA_TMPDIR/authfile.json
 

--- a/test/system/055-convert.bats
+++ b/test/system/055-convert.bats
@@ -4,17 +4,21 @@ load helpers
 
 # bats test_tags=distro-integration
 @test "ramalama convert basic" {
-    skip_if_darwin
-    run_ramalama 2 convert
-    is "$output" ".*ramalama convert: error: the following arguments are required: SOURCE, TARGET"
-    run_ramalama 2 convert tiny
-    is "$output" ".*ramalama convert: error: the following arguments are required: TARGET"
-    run_ramalama 1 convert bogus foobar
-    is "$output" "Error: bogus was not found in the Ollama registry"
+    if is_container; then
+	run_ramalama 2 convert
+	is "$output" ".*ramalama convert: error: the following arguments are required: SOURCE, TARGET"
+	run_ramalama 2 convert tiny
+	is "$output" ".*ramalama convert: error: the following arguments are required: TARGET"
+	run_ramalama 1 convert bogus foobar
+	is "$output" "Error: bogus was not found in the Ollama registry"
+   else
+	run_ramalama 22 convert tiny quay.io/ramalama/foobar
+	is "$output" "Error: convert command cannot be run with the --nocontainer option."
+   fi
 }
 
 @test "ramalama convert file to image" {
-    skip_if_darwin
+    skip_if_nocontainer
     echo "hello" > $RAMALAMA_TMPDIR/aimodel
     run_ramalama convert $RAMALAMA_TMPDIR/aimodel foobar
     run_ramalama list
@@ -25,7 +29,7 @@ load helpers
     run_ramalama convert $RAMALAMA_TMPDIR/aimodel oci://foobar
     run_ramalama list
     is "$output" ".*foobar:latest"
-    run_ramalama 22 convert oci://foobar oci://newimage 
+    run_ramalama 22 convert oci://foobar oci://newimage
     is "$output" "Error: converting from an OCI based image oci://foobar is not supported"
 
     run_ramalama rm foobar
@@ -39,7 +43,7 @@ load helpers
 }
 
 @test "ramalama convert tiny to image" {
-    skip_if_darwin
+    skip_if_nocontainer
     skip_if_docker
     run_ramalama pull tiny
     run_ramalama convert tiny oci://quay.io/ramalama/tiny

--- a/test/unit/test_model.py
+++ b/test/unit/test_model.py
@@ -6,6 +6,14 @@ import pytest
 from ramalama.model import compute_serving_port
 from ramalama.model_factory import ModelFactory
 
+
+class ARGS:
+    store = "/tmp/store"
+    use_model_store = False
+    engine = ""
+    container = True
+
+
 hf_granite_blob = "https://huggingface.co/ibm-granite/granite-3b-code-base-2k-GGUF/blob"
 
 
@@ -52,7 +60,8 @@ hf_granite_blob = "https://huggingface.co/ibm-granite/granite-3b-code-base-2k-GG
     ],
 )
 def test_extract_model_identifiers(model_input: str, expected_name: str, expected_tag: str, expected_orga: str):
-    name, tag, orga = ModelFactory(model_input, "/tmp/store", False).create().extract_model_identifiers()
+    args = ARGS()
+    name, tag, orga = ModelFactory(model_input, args).create().extract_model_identifiers()
     assert name == expected_name
     assert tag == expected_tag
     assert orga == expected_orga

--- a/test/unit/test_model_factory.py
+++ b/test/unit/test_model_factory.py
@@ -18,6 +18,17 @@ class Input:
     Engine: str
 
 
+class ARGS:
+    store = "/tmp/store"
+    use_model_store = False
+    engine = ""
+    container = True
+
+    def __init__(self, store=False, engine=""):
+        self.use_model_store = store
+        self.engine = engine
+
+
 hf_granite_blob = "https://huggingface.co/ibm-granite/granite-3b-code-base-2k-GGUF/blob"
 
 
@@ -59,11 +70,13 @@ hf_granite_blob = "https://huggingface.co/ibm-granite/granite-3b-code-base-2k-GG
     ],
 )
 def test_model_factory_create(input: Input, expected: type[Union[Huggingface, Ollama, URL, OCI]], error):
+    args = ARGS(input.UseModelStore, input.Engine)
+
     if error is not None:
         with pytest.raises(error):
-            ModelFactory(input.Model, "/tmp/store", input.UseModelStore, input.Transport, input.Engine).create()
+            ModelFactory(input.Model, args, input.Transport).create()
     else:
-        model = ModelFactory(input.Model, "/tmp/store", input.UseModelStore, input.Transport, input.Engine).create()
+        model = ModelFactory(input.Model, args, input.Transport).create()
         assert isinstance(model, expected)
 
 
@@ -84,14 +97,14 @@ def test_model_factory_create(input: Input, expected: type[Union[Huggingface, Ol
     ],
 )
 def test_validate_oci_model_input(input: Input, error):
+    args = ARGS(input.UseModelStore, input.Engine)
+
     if error is not None:
         with pytest.raises(error):
-            ModelFactory(input.Model, "/tmp/store", input.Transport, input.Engine).validate_oci_model_input()
+            ModelFactory(input.Model, args, input.Transport).validate_oci_model_input()
         return
 
-    ModelFactory(
-        input.Model, "/tmp/store", input.UseModelStore, input.Transport, input.Engine
-    ).validate_oci_model_input()
+    ModelFactory(input.Model, args, input.Transport).validate_oci_model_input()
 
 
 @pytest.mark.parametrize(
@@ -140,7 +153,6 @@ def test_validate_oci_model_input(input: Input, error):
     ],
 )
 def test_prune_model_input(input: Input, expected: str):
-    pruned_model_input = ModelFactory(
-        input.Model, "/tmp/store", input.UseModelStore, input.Transport, input.Engine
-    ).prune_model_input()
+    args = ARGS(input.UseModelStore, input.Engine)
+    pruned_model_input = ModelFactory(input.Model, args, input.Transport).prune_model_input()
     assert pruned_model_input == expected


### PR DESCRIPTION
## Summary by Sourcery

Add support for catching errors early when using the --nocontainer option with commands that require container support

New Features:
- Add validation to prevent using OCI-based operations with --nocontainer flag

Enhancements:
- Improve error handling for commands that require container support
- Update ModelFactory to check container support before operations

Documentation:
- Update documentation to clarify limitations of --nocontainer option
- Add notes about container requirements for specific commands

Tests:
- Modify system tests to check --nocontainer behavior for convert and pull commands