### PR TITLE
Link ramalama-nvidia.1 to ramalama-cuda.1

### DIFF
--- a/docs/links/ramalama-nvidia.1
+++ b/docs/links/ramalama-nvidia.1
@@ -1,0 +1,1 @@
+.so man1/ramalama-cuda.1


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Add a symbolic link from ramalama-nvidia.1 to ramalama-cuda.1 manual page to provide consistent documentation access