### PR TITLE
We should be pulling minor versions not latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,25 @@ On first run RamaLama inspects your system for GPU support, falling back to CPU 
 
 RamaLama uses container engines like Podman or Docker to pull the appropriate OCI image with all of the software necessary to run an AI Model for your systems setup.
 
-Running in containers eliminates the need for users to configure the host system for AI. After the initialization, RamaLama runs the AI Models within a container based on the OCI image.
+Running in containers eliminates the need for users to configure the
+host system for AI. After the initialization, RamaLama runs the AI
+Models within a container based on the OCI image. RamaLama pulls
+container image specific to the GPUs discovered on the host
+system. These images are tied to the minor version of RamaLama. For
+example RamaLama version 1.2.3 on an NVIDIA system pulls
+quay.io/ramalama/cuda:1.2. To override the default image use the
+`--image` option.
+
+Accelerated images:
+
+| Accelerator             | Image                      |
+| ------------------------| -------------------------- |
+|  CPU, Apple             | quay.io/ramalama/ramalama  |
+|  HIP_VISIBLE_DEVICES    | quay.io/ramalama/rocm      |
+|  CUDA_VISIBLE_DEVICES   | quay.io/ramalama/cuda      |
+|  ASAHI_VISIBLE_DEVICES  | quay.io/ramalama/asahi     |
+|  INTEL_VISIBLE_DEVICES  | quay.io/ramalama/intel-gpu |
+|  ASCEND_VISIBLE_DEVICES | quay.io/ramalama/cann      |
 
 RamaLama then pulls AI Models from model registries. Starting a chatbot or a rest API service from a simple single command. Models are treated similarly to how Podman and Docker treat container images.
 
@@ -100,7 +118,7 @@ pip install ramalama
 > If you are a macOS user, this is the preferred method.
 
 
-Install RamaLama by running this one-liner:
+Install RamaLama by running:
 
 ```
 curl -fsSL https://raw.githubusercontent.com/containers/ramalama/s/install.sh | bash
@@ -249,10 +267,10 @@ The default serving port will be 8080 if available, otherwise a free random port
 +-------+-------------------+
 	|
 	|
-        |           +------------------+           +------------------+
-        |           | Pull inferencing |           | Pull model layer |
-        +-----------| runtime (cuda)   |---------->| granite3-moe     |
-                    +------------------+           +------------------+
+	|           +------------------+           +------------------+
+	|           | Pull inferencing |           | Pull model layer |
+	+-----------| runtime (cuda)   |---------->| granite3-moe     |
+		    +------------------+           +------------------+
 						   | Repo options:    |
 						   +-+-------+------+-+
 						     |       |      |
@@ -273,7 +291,7 @@ The default serving port will be 8080 if available, otherwise a free random port
 
 ## In development
 
-Regard this alpha, everything is under development, so expect breaking changes, luckily it's easy to reset everything and re-install:
+Regarding this alpha, everything is under development, so expect breaking changes, luckily it's easy to reset everything and reinstall:
 
 ```
 rm -rf /var/lib/ramalama # only required if running as root user
@@ -286,11 +304,11 @@ and install again.
 
 This project wouldn't be possible without the help of other projects like:
 
-llama.cpp  
-whisper.cpp  
-vllm  
-podman   
-huggingface  
+llama.cpp
+whisper.cpp
+vllm
+podman
+huggingface
 
 so if you like this tool, give some of these repos a :star:, and hey, give us a :star: too while you are at it.
 

--- a/docs/ramalama.1.md
+++ b/docs/ramalama.1.md
@@ -15,7 +15,24 @@ On first run RamaLama inspects your system for GPU support, falling back to CPU 
 
 RamaLama uses container engines like Podman or Docker to pull the appropriate OCI image with all of the software necessary to run an AI Model for your systems setup.
 
-Running in containers eliminates the need for users to configure the host system for AI. After the initialization, RamaLama runs the AI Models within a container based on the OCI image.
+Running in containers eliminates the need for users to configure the host
+system for AI. After the initialization, RamaLama runs the AI Models within a
+container based on the OCI image. RamaLama pulls container image specific to
+the GPUs discovered on the host system. These images are tied to the minor
+version of RamaLama. For example RamaLama version 1.2.3 on an NVIDIA system
+pulls quay.io/ramalama/cuda:1.2. To override the default image use the
+`--image` option.
+
+Accelerated images:
+
+| Accelerator             | Image                      |
+| ------------------------| -------------------------- |
+|  CPU, Apple             | quay.io/ramalama/ramalama  |
+|  HIP_VISIBLE_DEVICES    | quay.io/ramalama/rocm      |
+|  CUDA_VISIBLE_DEVICES   | quay.io/ramalama/cuda      |
+|  ASAHI_VISIBLE_DEVICES  | quay.io/ramalama/asahi     |
+|  INTEL_VISIBLE_DEVICES  | quay.io/ramalama/intel-gpu |
+|  ASCEND_VISIBLE_DEVICES | quay.io/ramalama/cann      |
 
 RamaLama pulls AI Models from model registries. Starting a chatbot or a rest API service from a simple single command. Models are treated similarly to how Podman and Docker treat container images.
 
@@ -114,13 +131,15 @@ The default can be overridden in the ramalama.conf file or via the RAMALAMA_CONT
 show this help message and exit
 
 #### **--image**=IMAGE
-OCI container image to run with specified AI model. By default RamaLama uses
-`quay.io/ramalama/ramalama:latest`. The --image option allows users to override
-the default.
+OCI container image to run with specified AI model. RamaLama defaults to use
+images based on the accelerator it discovers. For example:
+`quay.io/ramalama/ramalama`. See the table below for all default images.
+The default image tag is based on the minor version of the RamaLama package.
+Version 1.2.3 of RamaLama pulls $IMAGE:1.2 from the quay.io/ramalama OCI repository. The --image option overrides this default.
 
 The default can be overridden in the ramalama.conf file or via the
-RAMALAMA_IMAGE environment variable. `export RAMALAMA_TRANSPORT=quay.io/ramalama/aiimage:latest` tells
-RamaLama to use the `quay.io/ramalama/aiimage:latest` image.
+RAMALAMA_IMAGE environment variable. `export RAMALAMA_IMAGE=quay.io/ramalama/aiimage:1.2` tells
+RamaLama to use the `quay.io/ramalama/aiimage:1.2` image.
 
 #### **--keep-groups**
 pass --group-add keep-groups to podman (default: False)

--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -509,10 +509,17 @@ def accel_image(config, args):
 
 def attempt_to_use_versioned(conman, image, vers, debug):
     try:
+        # check if versioned image exists locally
         if run_cmd([conman, "inspect", f"{image}:{vers}"], ignore_all=True, debug=debug):
             return True
 
-        return run_cmd([conman, "pull", f"{image}:{vers}"], debug=debug)
+    except Exception:
+        pass
+
+    try:
+        # attempt to pull the versioned image
+        run_cmd([conman, "pull", f"{image}:{vers}"], ignore_stderr=True, debug=debug)
+        return True
 
     except Exception:
         return False


### PR DESCRIPTION
This way users can stick with an older version of RamaLama and not get breakage from a major upgrade. Then when their RamaLama version gets updated, it will pull an updated image.

Also update the README.md and ramalama.1.md man page to show the accelerated images.

## Summary by Sourcery

Update RamaLama to pull container images based on minor version instead of always using 'latest', improving version stability and predictability for users.

New Features:
- Add support for pulling container images tied to the minor version of RamaLama
- Introduce a table of accelerated images in documentation

Enhancements:
- Modify image pulling mechanism to use minor version tag instead of 'latest'
- Update documentation to explain new image versioning approach

Documentation:
- Update README.md with detailed explanation of image versioning
- Update man page (ramalama.1.md) to reflect new image pulling behavior