### PR TITLE
Make sure build_rag.sh is in intel-gpu container image

### DIFF
--- a/container-images/intel-gpu/Containerfile
+++ b/container-images/intel-gpu/Containerfile
@@ -8,6 +8,7 @@ FROM quay.io/fedora/fedora:41
 
 COPY --from=builder /tmp/install/ /usr/
 COPY intel-gpu/oneAPI.repo /etc/yum.repos.d/
+COPY --chmod=755 ../scripts /usr/bin
 
 RUN dnf install -y procps-ng python3 python3-pip python3-devel intel-level-zero oneapi-level-zero intel-compute-runtime libcurl lspci clinfo intel-oneapi-runtime-compilers intel-oneapi-mkl-core intel-oneapi-mkl-sycl-blas intel-oneapi-runtime-dnnl && \
     chown 0:0 /etc/passwd && \


### PR DESCRIPTION
Fixes: https://github.com/containers/ramalama/issues/1074

## Summary by Sourcery

Add build_rag.sh script to the intel-gpu container image

Bug Fixes:
- Ensure build_rag.sh and other scripts are available in the intel-gpu container image

Chores:
- Copy scripts directory to /usr/bin in the intel-gpu container image with executable permissions