### PR TITLE
Fix gen of name in quadlet to be on its own line.

### DIFF
--- a/ramalama/quadlet.py
+++ b/ramalama/quadlet.py
@@ -107,7 +107,7 @@ Image={image}
     def _gen_name(self):
         name_string = ""
         if hasattr(self.args, "name") and self.args.name:
-            name_string = f"ContainerName={self.args.name}"
+            name_string = f"\nContainerName={self.args.name}"
         return name_string
 
     def _gen_model_volume(self):


### PR DESCRIPTION
Fixes: https://github.com/containers/ramalama/issues/1078

## Summary by Sourcery

Bug Fixes:
- Adjust the ContainerName generation to start on a new line when a name is specified