### PR TITLE
Add url support to rag to pull content to the host

### DIFF
--- a/bin/ramalama
+++ b/bin/ramalama
@@ -5,6 +5,7 @@ import glob
 import os
 import subprocess
 import sys
+import urllib
 
 
 def add_pipx_venvs_bin_to_path():
@@ -71,6 +72,8 @@ def main(args):
     # Process CLI
     try:
         args.func(args)
+    except urllib.error.HTTPError as e:
+        eprint(f"pulling {e.geturl()} failed: {e} ", errno.EINVAL)
     except ramalama.HelpException:
         parser.print_help()
     except AttributeError as e:

--- a/docs/ramalama-rag.1.md
+++ b/docs/ramalama-rag.1.md
@@ -14,8 +14,12 @@ down and launch a container to process the data.
 NOTE: this command does not work without a container engine.
 
 positional arguments:
-  path        Files/Directory containing PDF, DOCX, PPTX, XLSX, HTML, AsciiDoc & Markdown formatted files to be processed. Can be specified multiple times.
-  image       OCI Image name to contain processed rag data
+
+  *PATH*    Files/Directory containing PDF, DOCX, PPTX, XLSX, HTML,
+	    AsciiDoc & Markdown formatted files to be processed.
+	    Can be specified multiple times.
+
+  *IMAGE*   OCI Image name to contain processed rag data
 
 ## OPTIONS
 
@@ -28,10 +32,11 @@ sets the configuration for network namespaces when handling RUN instructions
 ## EXAMPLES
 
 ```
-$ ramalama rag https://arxiv.org/pdf/2408.09869 /tmp/pdf quay.io/rhatdan/myrag
-Fetching 9 files: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 9/9 [00:00<00:00, 68509.50it/s]
-Neither CUDA nor MPS are available - defaulting to CPU. Note: This module is much faster with a GPU.
-2024-12-04 13:49:07.372 (  70.927s) [        75AB6740]    doc_normalisation.h:448   WARN| found new `other` type: checkbox-unselected
+./bin/ramalama rag ./README.md https://github.com/containers/podman/blob/main/README.md quay.io/rhatdan/myrag
+100% |███████████████████████████████████████████████████████|  114.00 KB/    0.00 B 922.89 KB/s   59m 59s
+Building quay.io/ramalama/myrag...
+adding vectordb...
+c857ebc65c641084b34e39b740fdb6a2d9d2d97be320e6aa9439ed0ab8780fe0
 ```
 
 ## SEE ALSO

--- a/ramalama/oci.py
+++ b/ramalama/oci.py
@@ -200,7 +200,7 @@ LABEL {ociimage_car}
                     self.conman,
                     "build",
                     "--no-cache",
-                    f"--network={args.network}",
+                    "--network=none",
                     "-q",
                     "-f",
                     containerfile.name,

--- a/test/system/070-rag.bats
+++ b/test/system/070-rag.bats
@@ -1,0 +1,17 @@
+#!/usr/bin/env bats
+
+load helpers
+
+# bats test_tags=distro-integration
+@test "ramalama rag" {
+    skip_if_nocontainer
+    run_ramalama 22 rag bogus quay.io/ramalama/myrag:1.2
+    is "$output" "Error: bogus does not exist" "Expected failure"
+
+    run_ramalama rag README.md https://github.com/containers/ramalama/blob/main/README.md https://github.com/containers/podman/blob/main/README.md quay.io/ramalama/myrag:1.2
+    run_ramalama info
+    engine=$(echo "$output" | jq --raw-output '.Engine.Name')
+    run ${engine} rmi quay.io/ramalama/myrag:1.2
+}
+
+# vim: filetype=sh


### PR DESCRIPTION
Users should be able to list URLs and pull them to the host to be processed by doc2rag command.

## Summary by Sourcery

Add support for processing URLs as document sources in the RAG command

New Features:
- Enable downloading and processing documents from URLs during the RAG generation process

Enhancements:
- Improve document source handling to support both local files and remote URLs
- Add robust error handling for URL downloads

Tests:
- Add system test to verify URL support in RAG command, including error cases and multiple document sources