### PR TITLE
Remove files with colon in their name

### DIFF
--- a/test/unit/data/verify_checksum/sha256-62fbfd9ed093d6e5ac83190c86eec5369317919f4b149598d2dbb38900e9faef
+++ b/test/unit/data/verify_checksum/sha256-62fbfd9ed093d6e5ac83190c86eec5369317919f4b149598d2dbb38900e9faef
@@ -1,6 +1,0 @@
-{{ if .System }}<|im_start|>system
-{{ .System }}<|im_end|>
-{{ end }}{{ if .Prompt }}<|im_start|>user
-{{ .Prompt }}<|im_end|>
-{{ end }}<|im_start|>assistant
-{{ .Response }}<|im_end|>

--- a/test/unit/data/verify_checksum/sha256:123
+++ b/test/unit/data/verify_checksum/sha256:123
@@ -1,1 +1,0 @@
-RamaLama - make working with AI boring through the use of OCI containers.

--- a/test/unit/data/verify_checksum/sha256:16cd1aa2bd52b0e87ff143e8a8a7bb6fcb0163c624396ca58e7f75ec99ef081f
+++ b/test/unit/data/verify_checksum/sha256:16cd1aa2bd52b0e87ff143e8a8a7bb6fcb0163c624396ca58e7f75ec99ef081f
@@ -1,3 +1,0 @@
-{"model_format":"gguf","model_family":"llama","model_families":["llama"],"model_type":"361.82M","file_type":"Q4_0","architecture":"amd64","os":"linux","rootfs":{"type":"layers","diff_ids":["sha256:f7ae49f9d598730afa2de96fc7dade47f5850446bf813df2e9d739cc8a6c4f29","sha256:62fbfd9ed093d6e5ac83190c86eec5369317919f4b149598d2dbb38900e9faef","sha256:cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30","sha256:ca7a9654b5469dc2d638456f31a51a03367987c54135c089165752d9eeb08cd7"]}}
-
-I have been tampered with

--- a/test/unit/data/verify_checksum/sha256:62fbfd9ed093d6e5ac83190c86eec5369317919f4b149598d2dbb38900e9faef
+++ b/test/unit/data/verify_checksum/sha256:62fbfd9ed093d6e5ac83190c86eec5369317919f4b149598d2dbb38900e9faef
@@ -1,6 +1,0 @@
-{{ if .System }}<|im_start|>system
-{{ .System }}<|im_end|>
-{{ end }}{{ if .Prompt }}<|im_start|>user
-{{ .Prompt }}<|im_end|>
-{{ end }}<|im_start|>assistant
-{{ .Response }}<|im_end|>

--- a/test/unit/test_common.py
+++ b/test/unit/test_common.py
@@ -1,4 +1,6 @@
 import os
+import shutil
+from sys import platform
 from pathlib import Path
 
 import pytest
@@ -30,23 +32,49 @@ def test_rm_until_substring(input: str, rm_until: str, expected: str):
     assert actual == expected
 
 
+
+valid_input = """{{ if .System }}<|im_start|>system
+{{ .System }}<|im_end|>
+{{ end }}{{ if .Prompt }}<|im_start|>user
+{{ .Prompt }}<|im_end|>
+{{ end }}<|im_start|>assistant
+{{ .Response }}<|im_end|>
+"""
+
+tampered_input = """{"model_format":"gguf","model_family":"llama","model_families":["llama"],"model_type":"361.82M","file_type":"Q4_0","architecture":"amd64","os":"linux","rootfs":{"type":"layers","diff_ids":["sha256:f7ae49f9d598730afa2de96fc7dade47f5850446bf813df2e9d739cc8a6c4f29","sha256:62fbfd9ed093d6e5ac83190c86eec5369317919f4b149598d2dbb38900e9faef","sha256:cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30","sha256:ca7a9654b5469dc2d638456f31a51a03367987c54135c089165752d9eeb08cd7"]}}
+
+I have been tampered with
+
+"""
+
 @pytest.mark.parametrize(
-    "input_file,expected_error,expected_result",
+    "input_file_name,content,expected_error,expected_result",
     [
-        ("", ValueError, None),
-        ("invalidname", ValueError, None),
-        ("sha256:123", ValueError, None),
-        ("sha256:62fbfd9ed093d6e5ac83190c86eec5369317919f4b149598d2dbb38900e9faef", None, True),
-        ("sha256-62fbfd9ed093d6e5ac83190c86eec5369317919f4b149598d2dbb38900e9faef", None, True),
-        ("sha256:16cd1aa2bd52b0e87ff143e8a8a7bb6fcb0163c624396ca58e7f75ec99ef081f", None, False),
+        ("invalidname", "", ValueError, None),
+        ("sha256:123", "RamaLama - make working with AI boring through the use of OCI containers.", ValueError, None),
+        ("sha256:62fbfd9ed093d6e5ac83190c86eec5369317919f4b149598d2dbb38900e9faef", valid_input, None, True),
+        ("sha256-62fbfd9ed093d6e5ac83190c86eec5369317919f4b149598d2dbb38900e9faef", valid_input, None, True),
+        ("sha256:16cd1aa2bd52b0e87ff143e8a8a7bb6fcb0163c624396ca58e7f75ec99ef081f", tampered_input, None, False),
     ],
 )
-def test_verify_checksum(input_file: str, expected_error: Exception, expected_result: bool):
-    full_path = os.path.join(Path(__file__).parent, "data", "verify_checksum", input_file)
-
-    if expected_error is None:
-        assert verify_checksum(full_path) == expected_result
+def test_verify_checksum(input_file_name: str, content: str, expected_error: Exception, expected_result: bool):
+    # skip this test case on Windows since colon is not a valid file symbol
+    if ":" in input_file_name and platform == "win32":
         return
 
-    with pytest.raises(expected_error):
-        verify_checksum(full_path)
+    full_dir_path = os.path.join(Path(__file__).parent, "verify_checksum")
+    file_path = os.path.join(full_dir_path, input_file_name)
+
+    try:
+        os.makedirs(full_dir_path, exist_ok=True)
+        with open(file_path, "w") as f:
+            f.write(content)
+    
+        if expected_error is None:
+            assert verify_checksum(file_path) == expected_result
+            return
+
+        with pytest.raises(expected_error):
+            verify_checksum(file_path)
+    finally:
+        shutil.rmtree(full_dir_path)


### PR DESCRIPTION
The verify_checksum unit tests use files with a colon in their name. This causes issues for Windows machines since file names/paths can not contain this symbol. Therefore, these files have been removed and the tests create these on the fly and only when not run on Windows machines.

## Summary by Sourcery

Modify verify_checksum unit tests to create test files dynamically and avoid issues with file names containing colons on Windows

Bug Fixes:
- Resolve cross-platform compatibility issue with file naming in unit tests

Tests:
- Refactor verify_checksum test to dynamically create test files instead of using pre-existing files with colons in their names
- Add logic to skip tests with colon-containing file names on Windows platforms