### PR TITLE
Complete move from fedora-rocm to rocm

### DIFF
--- a/.github/workflows/ci-images.yml
+++ b/.github/workflows/ci-images.yml
@@ -9,7 +9,7 @@ on:
       - "**/container-images/**"
       - ".github/workflows/ci-images.yml"
     paths-ignore:
-      - "**/container-images/rocm-fedora"
+      - "**/container-images/rocm"
   push:
     branches:
       - main
@@ -17,7 +17,7 @@ on:
       - "**/container-images/**"
       - ".github/workflows/ci-images.yml"
     paths-ignore:
-      - "**/container-images/rocm-fedora"
+      - "**/container-images/rocm"
 
 jobs:
   build:

--- a/ramalama/config.py
+++ b/ramalama/config.py
@@ -87,7 +87,7 @@ def load_config_defaults(config: Dict[str, Any]):
             "ASAHI_VISIBLE_DEVICES": "quay.io/ramalama/asahi",
             "ASCEND_VISIBLE_DEVICES": "quay.io/ramalama/cann",
             "CUDA_VISIBLE_DEVICES": "quay.io/ramalama/cuda",
-            "HIP_VISIBLE_DEVICES": "quay.io/ramalama/rocm-fedora",
+            "HIP_VISIBLE_DEVICES": "quay.io/ramalama/rocm",
             "INTEL_VISIBLE_DEVICES": "quay.io/ramalama/intel-gpu",
         },
     )

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -62,7 +62,7 @@ def test_load_config_from_env(env, config, expected):
                     "ASAHI_VISIBLE_DEVICES": "quay.io/ramalama/asahi",
                     "ASCEND_VISIBLE_DEVICES": "quay.io/ramalama/cann",
                     "CUDA_VISIBLE_DEVICES": "quay.io/ramalama/cuda",
-                    "HIP_VISIBLE_DEVICES": "quay.io/ramalama/rocm-fedora",
+                    "HIP_VISIBLE_DEVICES": "quay.io/ramalama/rocm",
                     "INTEL_VISIBLE_DEVICES": "quay.io/ramalama/intel-gpu",
                 },
                 "runtime": "llama.cpp",


### PR DESCRIPTION
## Summary by Sourcery

Update references from 'rocm-fedora' to 'rocm' across project configuration and workflows

CI:
- Update GitHub Actions workflow paths to ignore the new 'rocm' container image directory

Chores:
- Migrate container image and configuration references from 'rocm-fedora' to 'rocm'