### PR TITLE
Add ramalama-ci image

### DIFF
--- a/container-images/ramalama-ci/Containerfile
+++ b/container-images/ramalama-ci/Containerfile
@@ -1,0 +1,8 @@
+FROM registry.fedoraproject.org/fedora:42
+
+COPY --chmod=755 ../scripts/build-ci.sh /usr/bin
+
+RUN build-ci.sh
+
+ENTRYPOINT [ "ramalama" ]
+

--- a/container-images/scripts/build-ci.sh
+++ b/container-images/scripts/build-ci.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+available() {
+  command -v "$1" >/dev/null
+}
+
+dnf_remove() {
+  dnf remove -y \
+      python3-devel \
+      python3-pip \
+      git 
+  dnf -y clean all
+}
+
+dnf_install() {
+  local rpm_list=("podman-remote" "python3" "python3-pip" \
+		  "python3-argcomplete" "python3-devel" "git" \
+		  "vim" "procps-ng" \
+                  )
+  dnf install -y "${rpm_list[@]}"
+  dnf -y clean all
+}
+
+clone_and_build_ramalama() {
+  # link podman-remote to podman for use by RamaLama
+  ln -sf /usr/bin/podman-remote /usr/bin/podman
+  git clone https://github.com/containers/ramalama
+  cd ramalama
+  git submodule update --init --recursive
+  python3 -m pip install .
+  cd ..
+  rm -rf ramalama
+}
+
+main() {
+  # shellcheck disable=SC1091
+  source /etc/os-release
+
+  set -ex
+  dnf_install
+  clone_and_build_ramalama
+  dnf_remove
+  rm -rf /var/cache/*dnf* /opt/rocm-*/lib/*/library/*gfx9*
+}
+
+main "$@"

--- a/container_build.sh
+++ b/container_build.sh
@@ -85,7 +85,7 @@ build() {
   local target=${1}
   cd "container-images/"
   local conman_build=("${conman[@]}")
-  local conman_show_size=("${conman[@]}" "images" "--filter" "reference='$REGISTRY_PATH/${target}'")
+  local conman_show_size=("${conman[@]}" "images" "--filter" "reference=$REGISTRY_PATH/${target}")
   if [ "$dryrun" == "-d" ]; then
       add_build_platform
       echo "${conman_build[@]}"
@@ -98,10 +98,13 @@ build() {
       add_build_platform
       echo "${conman_build[@]}"
       "${conman_build[@]}"
+      echo "${conman_show_size[@]}"
       "${conman_show_size[@]}"
-      add_entrypoints "${conman[@]}" "${REGISTRY_PATH}"/"${target}"
-      add_rag "${conman[@]}" "${target}"
-      rm_container_image
+      if [ "$target" != "ramalama-ci" ]; then
+	  add_entrypoints "${conman[@]}" "${REGISTRY_PATH}"/"${target}"
+	  add_rag "${conman[@]}" "${target}"
+	  rm_container_image
+      fi
       ;;
     push)
       "${conman[@]}" push "$REGISTRY_PATH/${target}"


### PR DESCRIPTION
This image will just run ramalama inside of a container and requires the user to leak the podman-socket into the container.

It will use Podman-remote for all of its actions.

Requested by the Podman Desktop team.

Fixes: https://github.com/containers/ramalama/issues/837

## Summary by Sourcery

Add a CI container image for RamaLama that uses Podman-remote for container operations

New Features:
- Create a specialized CI container image for RamaLama that can be used by the Podman Desktop team

Build:
- Modify container build script to handle the new ramalama-ci image differently
- Add a build script for the CI container that installs Podman-remote and RamaLama

Chores:
- Update container build process to skip certain steps for the ramalama-ci image