### PR TITLE
Add --webui flag to optionally disable web UI for ramalama serve

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,13 @@ $ ramalama stop mylama
 
 ### UI support
 
-To use a UI, run a `ramalama serve` command, then connect via your browser at:
+By default, the `ramalama serve` command runs with a web UI enabled. To disable the web UI, use the `--webui off` flag:
+
+```
+$ ramalama serve --webui off llama3
+```
+
+When the web UI is enabled, you can connect via your browser at:
 
 127.0.0.1:< port >
 

--- a/docs/ramalama-serve.1.md
+++ b/docs/ramalama-serve.1.md
@@ -155,6 +155,9 @@ The default is to use half the cores available on this system for the number of 
 #### **--tls-verify**=*true*
 require HTTPS and verify certificates when contacting OCI registries
 
+#### **--webui**=*on* | *off*
+Enable or disable the web UI for the served model (enabled by default). When set to "on" (the default), the web interface is properly initialized. When set to "off", the `--no-webui` option is passed to the llama-server command to disable the web interface.
+
 ## EXAMPLES
 ### Run two AI Models at the same time. Notice both are running within Podman Containers.
 ```

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -821,6 +821,13 @@ def serve_parser(subparsers):
         help="IP address to listen",
     )
     parser.add_argument(
+        "--webui",
+        dest="webui",
+        choices=["on", "off"],
+        default="on",
+        help="enable or disable the web UI (default: on)",
+    )
+    parser.add_argument(
         "--generate",
         choices=["quadlet", "kube", "quadlet/kube"],
         help="generate specified configuration format for running the AI Model as a service",

--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -612,6 +612,9 @@ class Model(ModelBase):
             if args.debug:
                 exec_args.extend(["-v"])
 
+            if hasattr(args, "webui") and args.webui == "off":
+                exec_args.extend(["--no-webui"])
+
         if args.seed:
             exec_args += ["--seed", args.seed]
 

--- a/test/system/040-serve.bats
+++ b/test/system/040-serve.bats
@@ -14,6 +14,10 @@ verify_begin=".*run --rm -i --label ai.ramalama --name"
         assert "$output" =~ "serving on port .*"
         is "$output" "${verify_begin} ramalama_.*" "dryrun correct"
         is "$output" ".*${model}" "verify model name"
+        assert "$output" !~ ".*--no-webui"
+
+        run_ramalama --dryrun serve --webui off ${model}
+        assert "$output" =~ ".*--no-webui"
 
         run_ramalama --dryrun serve --name foobar ${model}
         is "$output" "${verify_begin} foobar .*" "dryrun correct with --name"


### PR DESCRIPTION
Fixes #694

## Summary by Sourcery

Modify the default behavior of the web UI for the ramalama serve command by disabling it by default and adding an optional flag to enable it

New Features:
- Add a new `--web` flag to optionally enable the web UI for the ramalama serve command

Enhancements:
- Change the default configuration to disable the web UI when serving a model

Documentation:
- Update README.md and man page documentation to reflect the new web UI flag and default behavior
- Clarify that the web UI is now disabled by default and can be enabled with `--web`

Tests:
- Update system tests to verify the new default behavior and `--web` flag functionality