### PR TITLE
TMT: run tests with GPUs

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -26,8 +26,7 @@ jobs:
     packages: [ramalama-fedora]
     enable_net: true
     targets: &fedora_copr_targets
-      - fedora-development
-      - fedora-latest-stable
+      - fedora-all
     osh_diff_scan_after_copr_build: false
 
   # Copr builds for CentOS Stream
@@ -52,12 +51,27 @@ jobs:
     trigger: pull_request
     packages: [ramalama-fedora]
     targets: *fedora_copr_targets
+    tmt_plan: "/plans/rpm"
+    identifier: "rpm-fedora"
+
+  - job: tests
+    trigger: pull_request
+    skip_build: true
+    packages: [ramalama-fedora]
+    targets:
+      # FIXME: Validate test breaks on Fedora 41
+      - fedora-development
+      - fedora-latest-stable
+    tmt_plan: "/plans/no-rpm"
+    identifier: "no-rpm-fedora"
 
   # Tests for CentOS Stream
   - job: tests
     trigger: pull_request
     packages: [ramalama-centos]
     targets: *centos_copr_targets
+    tmt_plan: "/plans/rpm"
+    identifier: "rpm-centos"
 
   - job: propose_downstream
     trigger: release

--- a/container_build.sh
+++ b/container_build.sh
@@ -221,7 +221,7 @@ process_all_targets() {
 
   # build ramalama container image first, as other images inherit from it
   build "ramalama" "$command"
-  for i in container-images/*; do
+  for i in ./container-images/*; do
     i=$(basename "$i")
     # skip these directories
     if [[ "$i" =~ ^(scripts|ramalama)$ ]]; then

--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -1,6 +1,0 @@
-summary: Check installed rpm metadata
-discover:
-    how: shell
-execute:
-    how: tmt
-    script: rpm -qi python3-ramalama

--- a/plans/no-rpm.fmf
+++ b/plans/no-rpm.fmf
@@ -1,0 +1,36 @@
+discover:
+    how: fmf
+
+execute:
+    how: tmt
+
+prepare:
+    how: feature
+    epel: enabled
+
+provision:
+    how: artemis
+    hardware:
+        gpu:
+            device-name: GK210 (Tesla K80)
+            vendor-name: NVIDIA
+        disk:
+            - size: ">= 512 GiB"
+        memory: ">= 16 GB"
+
+/gpu_info:
+    summary: Display GPU info
+    discover+:
+        test: /test/tmt/no-rpm/gpu_info
+
+/validate:
+    discover+:
+        test: /test/tmt/no-rpm/validate
+
+/unit:
+    discover+:
+        test: /test/tmt/no-rpm/unit
+
+/bats-nocontainer:
+    discover+:
+        test: /test/tmt/no-rpm/bats-nocontainer

--- a/plans/rpm.fmf
+++ b/plans/rpm.fmf
@@ -1,0 +1,8 @@
+discover:
+    how: shell
+    tests:
+        - name: /info
+          test: rpm -qi python3-ramalama
+
+execute:
+    how: tmt

--- a/test/system/015-help.bats
+++ b/test/system/015-help.bats
@@ -171,7 +171,11 @@ EOF
 @test "ramalama verify default store" {
     store=e_$(safename)
     run_ramalama --help
-    is "$output" ".*default: ${HOME}/.local/share/ramalama"  "Verify default store"
+    if is_rootless; then
+        is "$output" ".*default: ${HOME}/.local/share/ramalama"  "Verify default store"
+    else
+        is "$output" ".*default: /var/lib/ramalama"  "Verify default store"
+    fi
 
     conf=$RAMALAMA_TMPDIR/ramalama.conf
     cat >$conf <<EOF

--- a/test/tmt/bats-tests.sh
+++ b/test/tmt/bats-tests.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+# FIXME: enable bats-docker tests in TMT. Currently, they are not being run in
+# CI jobs, but can be triggered manually using this script.
+if [[ $# -eq 0 || $1 != "docker" && $1 != "nocontainer" ]]; then
+    echo "Error: provide only one argument: 'docker'  or 'nocontainer'"
+    exit 1
+fi
+
+set -x
+TMT_TREE=${TMT_TREE:-$(git rev-parse --show-toplevel)}
+pushd "$TMT_TREE"
+
+if [[ $1 == "docker" ]]; then
+    ./container_build.sh build ramalama
+elif [[ $1 == "nocontainer" ]]; then
+    ./container-images/scripts/build_llama_and_whisper.sh
+fi
+./.github/scripts/install-ollama.sh
+
+set +e
+tty
+set -e
+
+make bats-"$1"
+popd

--- a/test/tmt/no-rpm.fmf
+++ b/test/tmt/no-rpm.fmf
@@ -1,0 +1,42 @@
+enabled: true
+adjust:
+    # FIXME: these tests should ideally run on all envs including dist-git and
+    # bodhi, but we can leave that for later.
+    enabled: false
+    when: initiator != packit
+
+require:
+    - bats
+    - black
+    - codespell
+    - flake8
+    - isort
+    - jq
+    - make
+    - perl-Clone
+    - perl-FindBin
+    - pipx
+    - podman-docker
+    - pytest
+    - python3-argcomplete
+    - python3-huggingface-hub
+    - shellcheck
+
+/gpu_info:
+    summary: Display GPU info
+    test: lshw -C display
+    require:
+        - lshw
+
+/validate:
+    summary: Run validate test
+    test: make -C $TMT_TREE validate
+
+/unit:
+    summary: Run unit tests
+    test: make -C $TMT_TREE unit-tests
+
+/bats-nocontainer:
+    summary: Run system tests on host
+    test: bash ./bats-tests.sh nocontainer
+    duration: 30m

--- a/test/unit/test_common.py
+++ b/test/unit/test_common.py
@@ -103,7 +103,13 @@ DEFAULT_IMAGES = {
         ("HIP_VISIBLE_DEVICES", None, f"{DEFAULT_IMAGE}:latest", f"{DEFAULT_IMAGE}:latest"),
     ],
 )
-def test_accel_image(accel_env: str, env_override, config_override: str, expected_result: str):
+@patch("ramalama.common.attempt_to_use_versioned")
+def test_accel_image(mock_attempt_versioned, accel_env: str, env_override, config_override: str, expected_result: str):
+    # We force the check for a versioned image to fail. This allows the test
+    # to correctly verify the fallback logic to ':latest', making the test
+    # independent of the actual images present on the host machine.
+    mock_attempt_versioned.return_value = False
+
     with tempfile.NamedTemporaryFile('w', delete_on_close=False) as f:
         cmdline = []
         cmdline.extend(["run", "granite"])
@@ -114,7 +120,7 @@ def test_accel_image(accel_env: str, env_override, config_override: str, expecte
                 f"""\
 [ramalama]
 image = "{config_override}"
-            """
+                """
             )
             f.flush()
             env["RAMALAMA_CONFIG"] = f.name


### PR DESCRIPTION
This commit adds TMT test jobs triggered via Packit that fetches an instance with NVIDIA GPU, specified in `plans/no-rpm.fmf`, and can be verified in the gpu_info test result.
    
In addition, system tests (nocontainer), validate, and unit tests are also triggered via TMT.
    
Fixes: #1054
    
TODO:
1. Enable bats-docker tests
2. Resolve f41 validate test failures


## Summary by Sourcery

Tests:
- Update test metadata configuration to enable GPU-based test execution

## Summary by Sourcery

Enable GPU-accelerated and comprehensive TMT-based test workflows via Packit and new FMF plans, updating configuration and test scripts to support the enhanced testing pipeline.

New Features:
- Add TMT-driven GPU tests via Packit using new `/plans/rpm` and `/plans/no-rpm` FMF plans for Fedora and CentOS
- Provide a `bats-tests.sh` script to manually run docker or nocontainer bats tests under TMT

Enhancements:
- Consolidate Fedora Copr build targets into `fedora-all` in `.packit.yaml`
- Standardize container build path resolution in `container_build.sh`

CI:
- Configure Packit jobs to trigger TMT plans for system, validate, and unit tests

Tests:
- Mock versioned image lookup in `test_accel_image` for stable unit testing
- Update system help test to handle both rootless and root default store paths
- Add FMF plan files to register TMT-based system and unit test runs