### PR TITLE
Enable --jinja for all llama-server instances

### DIFF
--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -605,6 +605,7 @@ class Model(ModelBase):
                 f"{args.context}",
                 "--temp",
                 f"{args.temp}",
+                "--jinja",
             ] + args.runtime_args
             if chat_template_path != "":
                 exec_args.extend(["--chat-template-file", chat_template_path])


### PR DESCRIPTION
--jinja has been around a few months now, enable it everywhere.

## Summary by Sourcery

Enhancements:
- Unconditionally add the --jinja flag to the execution arguments for llama-server instances