### PR TITLE
No longer install podman remote and openvino in general images

### DIFF
--- a/container-images/intel-gpu/Containerfile
+++ b/container-images/intel-gpu/Containerfile
@@ -19,7 +19,7 @@ RUN useradd llama-user -u 10000 -d /home/llama-user -s /bin/bash && \
 groupmod -a -U llama-user render && \
 groupmod -a -U llama-user video && \
 chown llama-user:llama-user -R /home/llama-user && \
-/usr/bin/build_rag.sh rag
+python3 -m pip install openvino
 
 USER 10000
 

--- a/container-images/scripts/build_llama_and_whisper.sh
+++ b/container-images/scripts/build_llama_and_whisper.sh
@@ -17,7 +17,13 @@ dnf_install_intel_gpu() {
 dnf_remove() {
   dnf remove -y \
       python3-devel \
-      libcurl-devel
+      libcurl-devel \
+      git \
+      gcc \
+      gcc-c++ \
+      make \
+      cmake \
+      findutils
   dnf -y clean all
 }
 
@@ -119,7 +125,7 @@ dnf_install_ffmpeg() {
 }
 
 dnf_install() {
-  local rpm_list=("podman-remote" "python3" "python3-pip" \
+  local rpm_list=("python3" "python3-pip" \
                   "python3-argcomplete" "python3-dnf-plugin-versionlock" \
                   "python3-devel" "gcc-c++" "cmake" "vim" "procps-ng" "git" \
                   "dnf-plugins-core" "libcurl-devel" "gawk")
@@ -258,18 +264,12 @@ clone_and_build_llama_cpp() {
 }
 
 clone_and_build_ramalama() {
-  # link podman-remote to podman for use by RamaLama
-  ln -sf /usr/bin/podman-remote /usr/bin/podman
   git clone https://github.com/containers/ramalama
   cd ramalama
   git submodule update --init --recursive
   python3 -m pip install . --prefix="$1"
   cd ..
   rm -rf ramalama
-}
-
-pip_install() {
-  python3 -m pip install openvino  --prefix="$1"
 }
 
 main() {
@@ -287,9 +287,8 @@ main() {
   configure_common_flags
   common_flags+=("-DGGML_CCACHE=OFF" "-DCMAKE_INSTALL_PREFIX=${install_prefix}")
   available dnf && dnf_install
-  if [ -n "$containerfile" ]; then 
+  if [ -n "$containerfile" ]; then
     clone_and_build_ramalama "${install_prefix}"
-    pip_install "${install_prefix}"
   fi
 
   setup_build_env


### PR DESCRIPTION
Remove other packages that are not necessary when running the
containers.

Remove leftover build_rag load command and move openvino to only the
intel container.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

## Summary by Sourcery

Streamline container image build script by removing unnecessary packages and build steps

Bug Fixes:
- Clean up unnecessary package installations to reduce image size and complexity

Enhancements:
- Simplify the build script by removing unused components like podman-remote and RamaLama

Chores:
- Remove unnecessary build dependencies and packages from the container image build process