### PR TITLE
docs: fix documentation README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,12 +1,3 @@
-# RamaLama Documentation
-
-The online man pages and other documents regarding RamaLama can be found at
-[Read The Docs](https://ramalama.readthedocs.io).  The man pages
-can be found under the [Commands](https://ramalama.readthedocs.io/en/latest/Commands.html)
-link on that page.
-
-# Build the Docs
-
 ## Directory Structure
 
 |                                      | Directory                   |
@@ -15,30 +6,6 @@ link on that page.
 | target for output                    | docs/*.[15]                 |
 | man pages                            | docs/*.[15]                 |
 
-## Manpage Syntax
+## Build the Docs
 
-The syntax for the formatting of all man pages can be found [here](MANPAGE_SYNTAX.md).
-
-## Local Testing
-
-To build standard man pages, run `make docs`. Results will be in `docs`.
-
-To build HTMLized man pages: Assuming that you have the
-[dependencies](https://ramalama.io/getting-started/installation#build-and-run-dependencies)
-installed, then also install (showing Fedora in the example):
-
-```
-$ sudo dnf install python3-sphinx python3-recommonmark
-$ pip install sphinx-markdown-tables myst_parser
-```
-(The above dependencies are current as of 2022-09-15. If you experience problems,
-please see [requirements.txt](requirements.txt) in this directory, it will almost
-certainly be more up-to-date than this README.)
-
-After that completes, cd to the `docs` directory in your RamaLama sandbox and then do `make html`.
-
-You can then preview the html files in `docs/build/html` with:
-```
-python -m http.server 8000 --directory build/html
-```
-...and point your web browser at `http://localhost:8000/`
+To build standard man pages, run `make install-tools` followed by `make docs`. Results will be in `docs`.


### PR DESCRIPTION
docs README had lots of broken links and phantom make targets

this commit removes a lot of the content and fixes some other workflow guidance

## Summary by Sourcery

Simplify and clean up the documentation README by removing outdated content and updating build instructions

Documentation:
- Removed outdated links and unnecessary documentation details from the README
- Updated documentation build instructions to use a simplified workflow