### PR TITLE
Point vllm ramalama at rhel registry

### DIFF
--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -491,10 +491,7 @@ def accel_image(config, args):
         gpu_type, _ = next(iter(env_vars.items()))
 
     if args.runtime == "vllm":
-        if "HIP_VISIBLE_DEVICES" in os.environ:
-            return "docker.io/rocm/vllm-dev:main"
-
-        return "docker.io/vllm/vllm-openai"
+        return "registry.redhat.io/rhelai1/ramalama-vllm"
 
     split = version().split(".")
     vers = ".".join(split[:2])


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Replace the default VLLM Docker image sources with a Red Hat-specific registry image