### PR TITLE
Don't leak intermediate OCI image when converting model to OCI

### DIFF
--- a/ramalama/oci.py
+++ b/ramalama/oci.py
@@ -194,18 +194,21 @@ LABEL {ociimage_car}
                 c.write(model_car)
             else:
                 c.write(model_raw)
+        build_cmd = [
+            self.conman,
+            "build",
+            "--no-cache",
+            "--network=none",
+            "-q",
+            "-f",
+            containerfile.name,
+        ]
+        if os.path.basename(self.conman) == "podman":
+            build_cmd += ["--layers=false"]
+        build_cmd += [contextdir]
         imageid = (
             run_cmd(
-                [
-                    self.conman,
-                    "build",
-                    "--no-cache",
-                    "--network=none",
-                    "-q",
-                    "-f",
-                    containerfile.name,
-                    contextdir,
-                ],
+                build_cmd,
                 debug=args.debug,
             )
             .stdout.decode("utf-8")


### PR DESCRIPTION
Fixes: https://github.com/containers/ramalama/issues/904

We are currently leaking a <none><none> image every time we convert an image with ramalama convert.

There will still be a <none><none> image but this is assocated with the Manifest list created for the OCI image.

## Summary by Sourcery

Improve OCI image conversion by optimizing container build process to reduce intermediate image leakage

Bug Fixes:
- Prevent leaking of unnecessary <none><none> images during model conversion process

Enhancements:
- Modify container build command to minimize intermediate image creation
- Add Podman-specific build flag to reduce layer generation