### PR TITLE
Removed unused cli_args param from GGUF parse function

### DIFF
--- a/ramalama/gguf_parser.py
+++ b/ramalama/gguf_parser.py
@@ -160,7 +160,7 @@ class GGUFInfoParser:
             return value
         raise ParseError(f"Unknown type '{value_type}'")
 
-    def parse(model_name: str, model_registry: str, model_path: str, cli_args) -> GGUFModelInfo:
+    def parse(model_name: str, model_registry: str, model_path: str) -> GGUFModelInfo:
         # By default, models are little-endian encoded
         is_little_endian = True
 

--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -720,7 +720,7 @@ class Model(ModelBase):
         model_registry = self.get_model_registry(args)
 
         if GGUFInfoParser.is_model_gguf(model_path):
-            gguf_info: GGUFModelInfo = GGUFInfoParser.parse(model_name, model_registry, model_path, args)
+            gguf_info: GGUFModelInfo = GGUFInfoParser.parse(model_name, model_registry, model_path)
             print(gguf_info.serialize(json=args.json, all=args.all))
             return
 


### PR DESCRIPTION
Fixes: https://github.com/containers/ramalama/issues/1103

Removed unused cli_args param from GGUFInfoParser.parse function which caused also the call in the model store to fail since it wasn't passed in.

/cc @edmcman 