### PR TITLE
Add partial files to be listed for ramalama list command

### DIFF
--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -12,7 +12,6 @@ import subprocess
 import sys
 import time
 import urllib.error
-import urllib.request
 from typing import List
 
 import ramalama.console as console

--- a/ramalama/http_client.py
+++ b/ramalama/http_client.py
@@ -3,7 +3,6 @@
 import os
 import shutil
 import time
-import urllib.error
 import urllib.request
 
 from ramalama.file import File

--- a/ramalama/model_store.py
+++ b/ramalama/model_store.py
@@ -479,7 +479,7 @@ class ModelStore:
     def _remove_blob_file(self, snapshot_file_path: str):
         blob_path = Path(snapshot_file_path).resolve()
         try:
-            if os.path.exists(blob_path) and self.base_path in blob_path.parents:
+            if os.path.exists(blob_path) and Path(self.base_path) in blob_path.parents:
                 os.remove(blob_path)
                 LOGGER.debug(f"Removed blob for '{snapshot_file_path}'")
         except Exception as ex:

--- a/ramalama/model_store.py
+++ b/ramalama/model_store.py
@@ -190,12 +190,22 @@ class GlobalModelStore:
                     model_path = root.replace(self.path, "").replace(os.sep, "", 1)
                     model_name = f"{model_path}:{ref_file_name}"
 
-                    models[model_name] = []
+                    collected_files = []
                     for snapshot_file in ref_file.filenames:
                         snapshot_file_path = os.path.join(root, DIRECTORY_NAME_SNAPSHOTS, ref_file.hash, snapshot_file)
+                        if not os.path.exists(snapshot_file_path):
+                            blobs_partial_file_path = os.path.join(
+                                root, DIRECTORY_NAME_BLOBS, ref_file.hash + ".partial"
+                            )
+                            if not os.path.exists(blobs_partial_file_path):
+                                continue
+                            snapshot_file_path = blobs_partial_file_path
+                            model_name = f"{model_path}:{ref_file_name} (partial)"
+
                         last_modified = os.path.getmtime(snapshot_file_path)
                         file_size = os.path.getsize(snapshot_file_path)
-                        models[model_name].append(ModelFile(snapshot_file, last_modified, file_size))
+                        collected_files.append(ModelFile(snapshot_file, last_modified, file_size))
+                    models[model_name] = collected_files
 
         oci_models = ramalama.oci.list_models(
             dotdict(


### PR DESCRIPTION
Fixes: https://github.com/containers/ramalama/issues/1104
    
The model store iterates through all files in the ref files for the list command. If a pull has been cancelled, then these point to non-existent files even though there are might be already partial files. To avoid this error, the model store list will check for the files to exist and check for partial files.

<details>
<summary>ramalama pull, cancel and list</summary>

```bash
$ ramalama --use-model-store pull smollm:360m
21% |██████████████████████████████                     |   47.96 MB/ 218.50

$ ramalama --use-model-store list
ollama/smollm:360m (partial) 4 seconds ago 145.43 MB

# continuing download
$ ramalama --use-model-store pull smollm:360m
ollama/smollm:360m      2 seconds ago 218.51 MB
```

</details>


## Summary by Sourcery

Improve model listing to handle partially downloaded files and enhance error handling for non-existent snapshot files

Bug Fixes:
- Fix listing of models when some snapshot files are missing by checking for partial files and handling incomplete downloads

Enhancements:
- Add support for displaying partially downloaded model files in the list command
- Improve robustness of file path checking by using Path for base path comparison