### PR TITLE
Fix get/set selbool references.

### DIFF
--- a/docs/ramalama-cuda.7.md
+++ b/docs/ramalama-cuda.7.md
@@ -114,13 +114,13 @@ Follow the installation instructions provided in the [NVIDIA Container Toolkit i
    To check the status of the boolean, run the following:
 
    ```bash
-   getseboolean container_use_devices
+   getsebool container_use_devices
    ```
 
    If the result of the command shows that the boolean is `off`, run the following to turn the boolean on:
 
    ```bash
-   sudo setseboolean -P container_use_devices
+   sudo setsebool -P container_use_devices 1
    ```
 
 ## Troubleshooting


### PR DESCRIPTION
Documentation:
* As installed in current versions of Fedora, these commands are not 'boolean', but 'bool'.
* The set command will give an error message when the value of the boolean is not set.