### PR TITLE
Add ability to pull via hf://user/repo:tag syntax

### DIFF
--- a/ramalama/huggingface.py
+++ b/ramalama/huggingface.py
@@ -8,6 +8,7 @@ import urllib.request
 from ramalama.common import available, download_file, exec_cmd, generate_sha256, perror, run_cmd, verify_checksum
 from ramalama.model import Model
 from ramalama.model_store import SnapshotFile, SnapshotFileType
+from ramalama.ollama import ollama_repo_pull
 
 missing_huggingface = """
 Optional: Huggingface models require the huggingface-cli module.
@@ -192,11 +193,8 @@ class Huggingface(Model):
                 repo_name = self.directory + "/" + model_name
                 registry_head = f"{Huggingface.REGISTRY_URL}{repo_name}"
 
-                # XXX: refactor
-                from ramalama.ollama import init_pull
-
                 show_progress = not args.quiet
-                return init_pull(
+                return ollama_repo_pull(
                     os.path.join(args.store, "repos", "huggingface"),
                     Huggingface.ACCEPT,
                     registry_head,

--- a/ramalama/huggingface.py
+++ b/ramalama/huggingface.py
@@ -144,13 +144,6 @@ def handle_repo_info(repo_name, repo_info, runtime):
             f"- https://huggingface.co/models?other=base_model:quantized:{repo_name} \n"
             "- https://huggingface.co/spaces/ggml-org/gguf-my-repo"
         )
-    if "gguf" in repo_info:
-        print("There are GGUF files to choose from in this repo, use one of the following commands to run one:\n")
-    for sibling in repo_info.get("siblings", []):
-        if sibling["rfilename"].endswith('.gguf'):
-            file = sibling["rfilename"]
-            print(f"- ramalama run hf://{repo_name}/{file}")
-    print("\n")
 
 
 class Huggingface(Model):
@@ -203,7 +196,7 @@ class Huggingface(Model):
                 from ramalama.ollama import init_pull
 
                 show_progress = not args.quiet
-                init_pull(
+                return init_pull(
                     os.path.join(args.store, "repos", "huggingface"),
                     Huggingface.ACCEPT,
                     registry_head,
@@ -214,14 +207,6 @@ class Huggingface(Model):
                     self.model,
                     show_progress,
                 )
-
-                # if we got here, we are successful, and the handle_repo_info stuff isn't relevant?
-                return
-
-                # old stuff
-                # XXX: make sure this is called with non-gguf
-                repo_info = get_repo_info(repo_name)
-                handle_repo_info(repo_name, repo_info, args.runtime)
 
             return self.url_pull(args, model_path, directory_path)
         except (urllib.error.HTTPError, urllib.error.URLError, KeyError) as e:

--- a/ramalama/huggingface.py
+++ b/ramalama/huggingface.py
@@ -209,7 +209,11 @@ class Huggingface(Model):
             return self.url_pull(args, model_path, directory_path)
         except (urllib.error.HTTPError, urllib.error.URLError, KeyError) as e:
 
-            if isinstance(e, urllib.error.HTTPError) and e.reason == "Bad Request" and b"tag is not a valid" in e.fp.read():
+            if (
+                isinstance(e, urllib.error.HTTPError)
+                and e.reason == "Bad Request"
+                and b"tag is not a valid" in e.fp.read()
+            ):
                 # This tag does not exist
                 raise KeyError(f"{self.model} was not found in the HuggingFace registry")
 

--- a/ramalama/ollama.py
+++ b/ramalama/ollama.py
@@ -51,7 +51,7 @@ def pull_blob(repos, layer_digest, accept, registry_head, models, model_name, mo
     run_cmd(["ln", "-sf", relative_target_path, model_path])
 
 
-def init_pull(repos, accept, registry_head, model_name, model_tag, models, model_path, model, show_progress):
+def ollama_repo_pull(repos, accept, registry_head, model_name, model_tag, models, model_path, model, show_progress):
     manifest_data = fetch_manifest_data(registry_head, model_tag, accept)
     pull_config_blob(repos, accept, registry_head, manifest_data, show_progress)
     for layer in manifest_data["layers"]:
@@ -250,7 +250,7 @@ class Ollama(Model):
         accept = "Accept: application/vnd.docker.distribution.manifest.v2+json"
         registry_head = f"{registry}/v2/{model_name}"
         try:
-            return init_pull(
+            return ollama_repo_pull(
                 repos, accept, registry_head, model_name, model_tag, models, model_path, self.model, show_progress
             )
         except urllib.error.HTTPError as e:


### PR DESCRIPTION
Closes #1057

## Summary by Sourcery

Enhance Hugging Face model pulling capabilities by adding support for user/repo:tag syntax and improving the model retrieval process

New Features:
- Add support for pulling Hugging Face models using the hf://user/repo:tag syntax
- Implement a more robust model retrieval mechanism with fallback options

Enhancements:
- Refactor the Hugging Face model pulling logic to handle different retrieval scenarios
- Improve error handling for model pulls

Chores:
- Rename ollama's init_pull function to ollama_repo_pull for better clarity