### PR TITLE
Quick fix to installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -233,7 +233,7 @@ install_ramalama_libexecs() {
   local job_count=0
   local job_queue=()
   for i in "${python_files[@]}"; do
-    download_install "libexec" "libexec/ramalama" "ramalama-$i-core" &
+    download_install "libexec/ramalama" "libexec/ramalama" "ramalama-$i-core" &
     job_queue+=($!)
     ((++job_count))
 


### PR DESCRIPTION
Directory was not right

## Summary by Sourcery

Bug Fixes:
- Corrected the source directory path when downloading ramalama libexec files to ensure proper installation