### PR TITLE
Give --image option higher precedence over config variables

### DIFF
--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -112,7 +112,6 @@ Needed to access gpu on some systems, but has security implications.""",
     )
     parser.add_argument(
         "--image",
-        default=CONFIG["image"],
         help="OCI container image to run with the specified AI model",
     )
     parser.add_argument(

--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -483,9 +483,6 @@ def rm_until_substring(input, substring):
 
 
 def accel_image(config, args):
-    if args.image != DEFAULT_IMAGE:
-        return args.image
-
     env_vars = get_accel_env_vars()
 
     if not env_vars:
@@ -500,7 +497,19 @@ def accel_image(config, args):
     vers = ".".join(split[:2])
     conman = config['engine']
     images = config['images']
-    image = images.get(gpu_type, args.image)
+    # Determine the image in this order: the --image command-line
+    # option, the "images" option in the config file, and the default
+    # (either set through the RAMALAMA_IMAGE envvar or "image" config
+    # option).
+    #
+    # Note that, while the first two expect an image name without a
+    # tag, the last one includes it and thus do not further modify it.
+    if args.image:
+        image = args.image
+    else:
+        image = images.get(gpu_type)
+        if not image:
+            return config['image']
     if hasattr(args, "rag") and args.rag:
         image += "-rag"
     if args.container and attempt_to_use_versioned(conman, image, vers, args.quiet, args.debug):


### PR DESCRIPTION
While the manual page mentions that the --image option can be used to override the default image, the option only has effect when the value is not equal to the hard-coded default ("quay.io/ramalama/ramalama"), meaning that it is not possible to easily enforce CPU-only acceleration when a GPU is detected:
```console
  $ ramalama --image quay.io/ramalama/ramalama run deepseek
  Attempting to pull quay.io/ramalama/rocm:0.7...
```
This patch removes the check and slightly changes the logic to determine the image: first try the --image option, then the "images" configuration, and finally the "image" configuration and the RAMALAMA_IMAGE envvar.

## Summary by Sourcery

Modify the image selection logic to give the --image command-line option higher precedence when determining the container image to use

New Features:
- Implement a more flexible image selection hierarchy: command-line option, config 'images', then default image

Bug Fixes:
- Fix issue where --image option was not always effective in overriding the default image

Enhancements:
- Improve image selection logic to prioritize command-line image option over configuration variables