### PR TITLE
Revert VULKAN change until podman 5.5 is released

### DIFF
--- a/container-images/scripts/build_llama_and_whisper.sh
+++ b/container-images/scripts/build_llama_and_whisper.sh
@@ -220,12 +220,8 @@ configure_common_flags() {
     cuda)
       common_flags+=("-DGGML_CUDA=ON" "-DCMAKE_EXE_LINKER_FLAGS=-Wl,--allow-shlib-undefined")
       ;;
-    ramalama | asahi)
-      if [ "$uname_m" = "x86_64" ] || [ "$uname_m" = "aarch64" ]; then
-        common_flags+=("-DGGML_VULKAN=ON")
-      else
-        common_flags+=("-DGGML_BLAS=ON" "-DGGML_BLAS_VENDOR=OpenBLAS")
-      fi
+    vulkan | asahi)
+      common_flags+=("-DGGML_VULKAN=1")
       ;;
     intel-gpu)
       common_flags+=("-DGGML_SYCL=ON" "-DCMAKE_C_COMPILER=icx" "-DCMAKE_CXX_COMPILER=icpx")
@@ -294,6 +290,16 @@ main() {
   setup_build_env
   clone_and_build_whisper_cpp
   common_flags+=("-DLLAMA_CURL=ON")
+  case "$containerfile" in
+    ramalama)
+      if [ "$uname_m" = "x86_64" ] || [ "$uname_m" = "aarch64" ]; then
+        common_flags+=("-DGGML_KOMPUTE=ON" "-DKOMPUTE_OPT_DISABLE_VULKAN_VERSION_CHECK=ON")
+      else
+        common_flags+=("-DGGML_BLAS=ON" "-DGGML_BLAS_VENDOR=OpenBLAS")
+      fi
+      ;;
+  esac
+
   clone_and_build_llama_cpp
   available dnf && dnf_remove
   rm -rf /var/cache/*dnf* /opt/rocm-*/lib/*/library/*gfx9*


### PR DESCRIPTION
## Summary by Sourcery

Revert Vulkan-related configuration changes in the build script for container images, with a specific focus on handling Vulkan support conditionally

Enhancements:
- Modify build script to handle Vulkan configuration more flexibly for different architectures and container types

Chores:
- Update build configuration for ramalama container to conditionally enable Kompute or BLAS based on architecture