### PR TITLE
Removing git breaks rocm images

### DIFF
--- a/container-images/scripts/build_llama_and_whisper.sh
+++ b/container-images/scripts/build_llama_and_whisper.sh
@@ -18,7 +18,6 @@ dnf_remove() {
   dnf remove -y \
       python3-devel \
       libcurl-devel \
-      git \
       gcc \
       gcc-c++ \
       make \


### PR DESCRIPTION
Rocm requres a couple of -devel packages which require git.

Removing git removed these packages.

## Summary by Sourcery

Bug Fixes:
- Prevent breaking rocm images by ensuring git package is not removed, as it is required for -devel package dependencies