### PR TITLE
Give "image" config option precedence over hardware-based defaults

### DIFF
--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -507,6 +507,9 @@ def accel_image(config, args):
     if image:
         return tagged_image(image)
 
+    if config.is_set('image'):
+        return tagged_image(config['image'])
+
     conman = config['engine']
     images = config['images']
     set_accel_env_vars()

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -57,7 +57,10 @@ def test_load_config_from_env(env, config, expected):
             {
                 "nocontainer": False,
                 "carimage": "registry.access.redhat.com/ubi9-micro:latest",
+                "container": True,
+                "engine": "podman",
                 "env": [],
+                "image": "quay.io/ramalama/ramalama",
                 "images": {
                     "ASAHI_VISIBLE_DEVICES": "quay.io/ramalama/asahi",
                     "ASCEND_VISIBLE_DEVICES": "quay.io/ramalama/cann",
@@ -73,6 +76,8 @@ def test_load_config_from_env(env, config, expected):
                 "pull": "newer",
                 "temp": "0.8",
                 "host": "0.0.0.0",
+                "store": "~/.local/share/ramalama",
+                "transport": "ollama",
                 "use_model_store": False,
                 "port": int_tuple_as_str(DEFAULT_PORT_RANGE),
             },
@@ -87,7 +92,10 @@ def test_load_config_from_env(env, config, expected):
             {
                 "nocontainer": True,
                 "carimage": "registry.access.redhat.com/ubi9-micro:latest",
+                "container": True,
+                "engine": "podman",
                 "env": [],
+                "image": "quay.io/ramalama/ramalama",
                 "images": {
                     "HIP_VISIBLE_DEVICES": "quay.io/repo/rocm",
                 },
@@ -97,6 +105,8 @@ def test_load_config_from_env(env, config, expected):
                 "keep_groups": False,
                 "ctx_size": 2048,
                 "pull": "newer",
+                "store": "~/.local/share/ramalama",
+                "transport": "ollama",
                 "temp": "0.8",
                 "host": "0.0.0.0",
                 "use_model_store": False,
@@ -107,4 +117,6 @@ def test_load_config_from_env(env, config, expected):
 )
 def test_load_config_defaults(config, expected):
     load_config_defaults(config)
-    assert json.dumps(config, sort_keys=True) == json.dumps(expected, sort_keys=True)
+    # get_store() resolves tildes
+    config["store"] = "~/.local/share/ramalama"
+    assert json.dumps(dict(config), sort_keys=True) == json.dumps(expected, sort_keys=True)


### PR DESCRIPTION
Currently, the config options are stored in a single dict, regardless of where they are originated, e.g., environment variables, files, or the preset default. This prevents overriding certain options, such as "image", with a config file.

This groups config options by origins in `collections.ChainMap`.

## Summary by Sourcery

Improve configuration handling by introducing a hierarchical config system using ChainMap to give precedence to environment variables and config file settings over default values

New Features:
- Introduce a new Config class that groups configuration options by their origin (environment, file, and default)

Bug Fixes:
- Resolve issue with config options not being overridable by environment variables or config files
- Add ability to explicitly check if a configuration option has been set by a higher-priority source

Enhancements:
- Refactor configuration loading to use ChainMap for more flexible config precedence
- Modify config loading to allow easier overriding of default settings