### PR TITLE
Scripts currently used for releasing images

### DIFF
--- a/scripts/release-image.sh
+++ b/scripts/release-image.sh
@@ -1,0 +1,45 @@
+#!/bin/bash -ex
+
+if [ -z "$1" ]; then
+    echo "Usage: $0 IMAGE" >&2
+    exit 1
+fi
+
+# Prior to running this script, I run
+#    make build IMAGE=$IMAGE
+#         Where image is one of: ramalama, asahi, cann and cuda on both X86 and ARM platforms.
+#    Then on ARM Platform I first run release-image.sh $IMAGE to push the image
+#    to the ARMREPO
+# Once that is complete I run this script for each one of the $IMAGEs
+# This script assumes that ARM images have been pushed to ARMREPO from
+# MACS
+
+release-rhatdan() {
+    podman push quay.io/ramalama/"$1" quay.io/rhatdan/"$1"
+    podman push quay.io/ramalama/"$1"-whisper-server quay.io/rhatdan/"$1"-whisper-server
+    podman push quay.io/ramalama/"$1"-llama-server quay.io/rhatdan/"$1"-llama-server
+}
+
+release-ramalama() {
+    podman push quay.io/ramalama/"$1" quay.io/ramalama/"$1":0.7.3
+    podman push quay.io/ramalama/"$1" quay.io/ramalama/"$1":0.7
+    podman push quay.io/ramalama/"$1"
+}
+release() {
+    release-ramalama "$1"
+    release-ramalama "$1"-whisper-server
+    release-ramalama "$1"-llama-server
+    release-ramalama "$1"-rag
+}
+
+podman run quay.io/ramalama/"$1" ls -l /usr/bin/llama-server
+podman run quay.io/ramalama/"$1" ls -l /usr/bin/llama-run
+podman run quay.io/ramalama/"$1" ls -l /usr/bin/whisper-server
+podman run quay.io/ramalama/"$1"-rag rag_framework load
+
+uname_m=$(uname -m)
+if [ "${uname_m}" == "x86_64" ]; then
+    release "$1"
+else
+    release-rhatdan "$1"
+fi

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/bash -ex
+
+if [ -z "$1" ]; then
+    echo "Usage: $0 IMAGE" >&2
+    exit 1
+fi
+
+# Prior to running this script, I run
+#    make build IMAGE=$IMAGE
+#         Where image is one of: ramalama, asahi, cann and cuda on both X86 and ARM platforms.
+#    Then on ARM Platform I first run release-image.sh $IMAGE to push the image
+#    to the ARMREPO
+# Once that is complete I run this script for each one of the $IMAGEs
+
+# This script assumes that ARM images have been pushed to ARMREPO from
+# MACS
+export ARMREPO="quay.io/rhatdan"
+export REPO="quay.io/ramalama"
+
+release() {
+    DEST=${REPO}/"$1"
+    podman manifest rm "$1" 2>/dev/null|| true
+    podman manifest create "$1"
+    id=$(podman image inspect "${DEST}" --format '{{ .Id }}')
+    podman manifest add "$1" "$id"
+    id=$(podman pull -q --arch arm64 ${ARMREPO}/"$1")
+    podman manifest add "$1" "$id"
+    podman manifest inspect "$1"
+    podman manifest push --all "$1" "${DEST}":0.7.3
+    podman manifest push --all "$1" "${DEST}":0.7
+    podman manifest push --all "$1" "${DEST}"
+    podman manifest rm "$1"
+}
+
+podman run "${REPO}"/"$1" ls -l /usr/bin/llama-server
+podman run "${REPO}"/"$1" ls -l /usr/bin/llama-run
+podman run "${REPO}"/"$1" ls -l /usr/bin/whisper-server
+podman run "${REPO}"/"$1"-rag rag_framework load
+
+release "$1"
+release "$1"-whisper-server
+release "$1"-llama-server
+release "$1"-rag


### PR DESCRIPTION
These are the scripts I am using to push images and build multi-arch images to the quay.io repositories.

## Summary by Sourcery

Add scripts for releasing multi-architecture container images to different repositories

New Features:
- Create release scripts for pushing container images to multiple repositories with support for x86_64 and ARM64 architectures

Deployment:
- Add scripts to create and push multi-architecture container image manifests
- Implement repository-specific release workflows for different image variants

Chores:
- Implement release automation for container images with versioned tagging