### PR TITLE
Use -rag images when using --rag commands

### DIFF
--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -249,6 +249,10 @@ class Model(ModelBase):
         return conman_args
 
     def handle_oci_pull(self, conman_args, args):
+        # force accel_image to use -rag version. Drop TAG if it exists
+        # so that accel_image will add -rag to the image specification.
+        if hasattr(args, "rag") and args.rag:
+            args.image = args.image.split(":")[0]
         self.image = accel_image(CONFIG, args)
         if not args.dryrun and os.path.basename(args.engine) == "docker" and args.pull == "newer":
             try:
@@ -423,6 +427,10 @@ class Model(ModelBase):
                 chat_template_path = self.store.get_snapshot_file_path(ref_file.hash, ref_file.chat_template_name)
                 conman_args += [f"--mount=type=bind,src={chat_template_path},destination={MNT_CHAT_TEMPLATE_FILE},ro"]
 
+        # force accel_image to use -rag version. Drop TAG if it exists
+        # so that accel_image will add -rag to the image specification.
+        if hasattr(args, "rag") and args.rag:
+            args.image = args.image.split(":")[0]
         # Make sure Image precedes cmd_args.
         conman_args += [accel_image(CONFIG, args)] + cmd_args
 

--- a/ramalama/rag.py
+++ b/ramalama/rag.py
@@ -86,7 +86,6 @@ COPY {src} /vector.db
         if not os.access(tmpdir, os.W_OK):
             tmpdir = "/tmp"
 
-        args.image = accel_image(CONFIG, args)
         docsdb = tempfile.TemporaryDirectory(dir=tmpdir, prefix='RamaLama_docs_')
         docsdb_used = False
         exec_args = [args.engine, "run", "--rm"]

--- a/test/system/070-rag.bats
+++ b/test/system/070-rag.bats
@@ -9,6 +9,10 @@ load helpers
     is "$output" "Error: bogus does not exist" "Expected failure"
 
     run_ramalama rag README.md https://github.com/containers/ramalama/blob/main/README.md https://github.com/containers/podman/blob/main/README.md quay.io/ramalama/myrag:1.2
+
+    run_ramalama --dryrun run --rag quay.io/ramalama/myrag:1.2 ollama://smollm:135m
+    is "$output" ".*quay.io/ramalama/.*-rag.*" "Expected to use -rag image"
+
     run_ramalama info
     engine=$(echo "$output" | jq --raw-output '.Engine.Name')
     run ${engine} rmi quay.io/ramalama/myrag:1.2


### PR DESCRIPTION
Fixes: https://github.com/containers/ramalama/issues/1143

## Summary by Sourcery

Modify image handling for RAG commands to automatically use -rag image variants when the --rag flag is specified

Bug Fixes:
- Ensure that RAG commands automatically use the correct -rag image variant by stripping existing tags and letting the image selection mechanism add the -rag suffix

Tests:
- Add a test case to verify that --rag commands use the correct -rag image variant