### PR TITLE
Turn on client/server implementation of run

### DIFF
--- a/libexec/ramalama/ramalama-client-core
+++ b/libexec/ramalama/ramalama-client-core
@@ -72,7 +72,9 @@ def req(conversation_history, url, color):
             response = urllib.request.urlopen(request)
             break
         except Exception:
-            print(f"\r{c}", end="", flush=True)
+            if sys.stdout.isatty():
+                print(f"\r{c}", end="", flush=True)
+
             time.sleep(i)
             i *= 2
 

--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -12,6 +12,7 @@ import shutil
 import string
 import subprocess
 import sys
+import sysconfig
 import time
 import urllib.error
 from typing import List
@@ -514,10 +515,11 @@ def tagged_image(image):
     return f"{image}:{minor_release()}"
 
 
-def get_cmd_with_wrapper(cmd_args):
-    for dir in ["", "/opt/homebrew/", "/usr/local/", "/usr/"]:
-        if os.path.exists(f"{dir}libexec/ramalama/{cmd_args[0]}"):
-            return f"{dir}libexec/ramalama/{cmd_args[0]}"
+def get_cmd_with_wrapper(cmd_arg):
+    data_path = sysconfig.get_path("data")
+    for dir in ["", f"{data_path}/", "/opt/homebrew/", "/usr/local/", "/usr/"]:
+        if os.path.exists(f"{dir}libexec/ramalama/{cmd_arg}"):
+            return f"{dir}libexec/ramalama/{cmd_arg}"
 
     return ""
 
@@ -575,7 +577,7 @@ def select_cuda_image(config):
 
 
 def accel_image(config, args):
-    if args and len(args.image.split(":")) > 1:
+    if args and args.image and len(args.image.split(":")) > 1:
         return args.image
 
     if hasattr(args, 'image_override'):


### PR DESCRIPTION
Now that we've had one release with the wrapper scripts included in the container images it should be safe to turn this on everywhere.

## Summary by Sourcery

Enable the client/server implementation of run by removing conditional wrapper script usage

Enhancements:
- Simplify the model execution logic by removing conditional checks for wrapper script usage

Chores:
- Remove the `USE_RAMALAMA_WRAPPER` flag and its associated conditional logic