### PR TITLE
Do not list OCI containers when running with nocontainer

### DIFF
--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -469,7 +469,8 @@ def _list_models(args):
             # Store data for later use
             models.append({"name": name, "modified": modified, "size": size})
 
-    models.extend(ramalama.oci.list_models(args))
+    if args.container:
+        models.extend(ramalama.oci.list_models(args))
 
     os.chdir(mycwd)
     return models

--- a/test/system/050-pull.bats
+++ b/test/system/050-pull.bats
@@ -109,7 +109,13 @@ load setup_suite
 # bats test_tags=distro-integration
 @test "ramalama pull oci" {
     if is_container; then
-        run_ramalama pull oci://quay.io/ramalama/smollm:135m
+        model=oci://quay.io/ramalama/smollm:135m
+        run_ramalama pull ${model}
+        run_ramalama list
+        is "$output" ".*${model}.*" "image was actually pulled locally"
+        run_ramalama --nocontainer list
+        assert "$output" !~ ".*${model}" "model is not in list"
+        run_ramalama rm ${model}
     else
         run_ramalama 22 pull oci://quay.io/ramalama/smollm:135m
 	is "$output" "Error: OCI containers cannot be used with the --nocontainer option."


### PR DESCRIPTION
## Summary by Sourcery

Modify model listing behavior to exclude OCI containers when running with the --nocontainer option

Bug Fixes:
- Prevent OCI container models from being listed when --nocontainer flag is used

Tests:
- Add a test case to verify that OCI container models are not listed when using --nocontainer