### PR TITLE
Bump all images to f42

### DIFF
--- a/container-images/asahi/Containerfile
+++ b/container-images/asahi/Containerfile
@@ -1,4 +1,4 @@
-FROM fedora:41
+FROM fedora:42
 
 ENV ASAHI_VISIBLE_DEVICES 1
 COPY --chmod=755 ../scripts /usr/bin

--- a/container-images/intel-gpu/Containerfile
+++ b/container-images/intel-gpu/Containerfile
@@ -1,10 +1,10 @@
-FROM quay.io/fedora/fedora:41 as builder
+FROM quay.io/fedora/fedora:42 as builder
 
 COPY intel-gpu/oneAPI.repo /etc/yum.repos.d/
 COPY --chmod=755 ../scripts /usr/bin
 RUN build_llama_and_whisper.sh "intel-gpu"
 
-FROM quay.io/fedora/fedora:41
+FROM quay.io/fedora/fedora:42
 
 COPY --from=builder /tmp/install/ /usr/
 COPY intel-gpu/oneAPI.repo /etc/yum.repos.d/


### PR DESCRIPTION
Some of the images were using f41 and others f42, moving them all to the same version. f42 is in beta now so good time to move.

## Summary by Sourcery

Chores:
- Standardize base image version to Fedora 42 for intel-gpu and asahi container images