### PR TITLE
Fixes port error when executing container with --rag flag

### DIFF
--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -269,7 +269,11 @@ class Model(ModelBase):
     def add_env_option(self, conman_args, args):
         for env in args.env:
             conman_args += ["--env", env]
-
+        
+        # Add port as environment variable if it exists
+        if hasattr(args, "port"):
+            conman_args += ["--env", f"PORT={args.port}"]
+        
         return conman_args
 
     def add_tty_option(self, conman_args):
@@ -700,7 +704,7 @@ class Model(ModelBase):
             exec_args = [
                 "bash",
                 "-c",
-                f"nohup {' '.join(exec_args)} &> /tmp/llama-server.log & rag_framework run /rag/vector.db",
+                f"nohup {' '.join(exec_args)} &> /tmp/llama-server.log & rag_framework run /rag/vector.db --port {args.port}",
             ]
 
         self.execute_command(model_path, exec_args, args)


### PR DESCRIPTION
Addresses issue #1162 

When ramalama run --rag is executed and port 8080 is already in use, the CLI correctly chooses an available alternative (e.g., 8084). However, the rag_framework script invoked inside the container still assumes port 8080, leading to a Connection refused error at runtime.

## Summary by Sourcery

Fix port configuration for RAG framework when running in a container with a dynamically assigned port

Bug Fixes:
- Resolve connection refused error by passing the dynamically selected port to the rag_framework script inside the container

Enhancements:
- Add support for dynamically passing the container's port as an environment variable
- Modify serve command to pass the correct port to rag_framework