### PR TITLE
Fix failover to OCI image on push

### DIFF
--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -689,9 +689,11 @@ def push_cli(args):
                 raise e
         try:
             # attempt to push as a container image
-            m = ModelFactory(tgt, args, engine=CONFIG['engine']).create_oci()
+            m = ModelFactory(tgt, args).create_oci()
             m.push(source, args)
-        except Exception:
+        except Exception as e1:
+            if args.debug:
+                print(e1)
             raise e
 
 

--- a/test/system/050-pull.bats
+++ b/test/system/050-pull.bats
@@ -181,12 +181,13 @@ load setup_suite
 	oci://$registry
     run_ramalama pull tiny
     run_ramalama push --authfile=$authfile --tls-verify=false tiny oci://$registry/tiny
+    run_ramalama push --authfile=$authfile --tls-verify=false tiny $registry/tiny
     run_ramalama push --authfile=$authfile --tls-verify=false --type car tiny oci://$registry/tiny-car
 
     tmpfile=${RAMALAMA_TMPDIR}/mymodel
     random=$(random_string 30)
     echo $random > $tmpfile
-    run_ramalama push --authfile=$authfile --tls-verify=false --type raw $tmpfile oci://$registry/mymodel
+    run_ramalama push --authfile=$authfile --tls-verify=false --type raw $tmpfile $registry/mymodel
 
 
     run_ramalama list


### PR DESCRIPTION
## Summary by Sourcery

Improve OCI image push functionality by adding more flexible push options and better error handling

Bug Fixes:
- Fix OCI image push by removing hardcoded engine parameter and adding more push destination flexibility
- Enhance error handling during push operations by optionally printing debug information

Tests:
- Update system tests to include additional push scenarios with different registry and image type configurations