### PR TITLE
fix: add 'pipx' install to 'make install-requirements'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ help:
 
 .PHONY: install-requirements
 install-requirements:
+	pip install -U pipx
 	pipx install \
 			argcomplete~=3.0 \
 			black~=25.0 \


### PR DESCRIPTION
'make install-requirements' currently assumes 'pipx' is installed in your env, but this may not be the case

add an explict install/upgrade command via pip

## Summary by Sourcery

Bug Fixes:
- Add an explicit pip installation step for 'pipx' to prevent potential installation failures when 'pipx' is not already present in the environment