### PR TITLE
github: add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,74 @@
+name: Bug Report
+description: File a bug report
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: >
+        #### Before submitting a bug, please make sure the issue hasn't been already addressed by searching through [the
+        existing and past issues](https://github.com/containers/ramalama/issues).
+  - type: textarea
+    id: description
+    attributes:
+      label: Issue Description
+      description: Please explain your issue
+      value: "Describe your issue"
+    validations:
+      required: true
+  - type: textarea
+    id: reproducer
+    attributes:
+      label: Steps to reproduce the issue
+      description: Please explain the steps to reproduce the issue
+      value: "Steps to reproduce the issue\n1.\n2.\n3.\n"
+    validations:
+      required: true
+  - type: textarea
+    id: received_results
+    attributes:
+      label: Describe the results you received
+      description: Please explain the results you are noticing
+      value: "Describe the results you received"
+    validations:
+      required: true
+  - type: textarea
+    id: expected_results
+    attributes:
+      label: Describe the results you expected
+      description: Please explain the results you are expecting
+      value: "Describe the results you expected"
+    validations:
+      required: true
+  - type: textarea
+    id: ramalama_info
+    attributes:
+      label: ramalama info output
+      description: Please copy and paste ramalama info output.
+      value: If you are unable to run ramalama info for any reason, please provide the ramalama version, operating system and its version and the architecture you are running.
+      render: yaml
+    validations:
+      required: true
+  - type: dropdown
+    id: upstream_latest
+    attributes:
+      label: Upstream Latest Release
+      description: Have you tried running the [latest upstream release](https://github.com/containers/podman/releases/latest)
+      options:
+        - 'Yes'
+        - 'No'
+    validations:
+      required: true
+  - type: textarea
+    id: additional_environment
+    attributes:
+      label: Additional environment details
+      description: Please describe any additional environment details like (AWS, VirtualBox,...)
+      value: "Additional environment details"
+  - type: textarea
+    id: additional_info
+    attributes:
+      label: Additional information
+      description: Please explain the additional information you deem important
+      value: "Additional information like issue happens only occasionally or issue happens with a particular architecture or on a particular setting"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,40 @@
+name: Feature Request
+description: Suggest an idea for this project
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this feature request!
+  - type: textarea
+    id: feature_description
+    attributes:
+      label: Feature request description
+      description: Please explain your feature request and if it is related to a problem
+      value: "A clear and concise description of what the feature request is about."
+    validations:
+      required: true
+  - type: textarea
+    id: potential_solution
+    attributes:
+      label: Suggest potential solution
+      description: Please explain if you can suggest any potential solution
+      value: "A clear and concise description of what you want to happen."
+    validations:
+      required: false
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Have you considered any alternatives?
+      description: Please explain what alternatives you have tried.
+      value: "A clear and concise description of any alternative solutions or features you've considered."
+    validations:
+      required: false
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Additional context
+      description: Please add any context to this feature request
+      value: "Add any other context or screenshots about the feature request here."
+    validations:
+      required: false


### PR DESCRIPTION
the CONTRIBUTING.md doc refers to several issue templates being present in the projec but currently none exist

this commit adds templates in based on the podman project

## Summary by Sourcery

Add GitHub issue templates for bug reports and feature requests to improve issue tracking and user guidance

New Features:
- Introduce a comprehensive bug report template with detailed environment and reproduction steps
- Add a feature request template to capture user suggestions and context

Documentation:
- Create GitHub issue templates to provide structured guidance for users submitting bugs and feature requests