### PR TITLE
docs: fix python version guidance in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ This section describes how to make a contribution to RamaLama.
 
 ### Prepare your environment
 
-The minimum version of Python required to use RamaLama is PYTHON 3.12
+The minimum version of Python required to use RamaLama is PYTHON 3.8
 
 ### Fork and clone RamaLama
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ This section describes how to make a contribution to RamaLama.
 
 ### Prepare your environment
 
-The minimum version of Python required to use RamaLama is PYTHON 3.8
+The minimum version of Python required to use RamaLama is Python 3.8
 
 ### Fork and clone RamaLama
 


### PR DESCRIPTION
ramalama can run as low as Python 3.8

## Summary by Sourcery

Documentation:
- Corrected the minimum Python version from 3.12 to 3.8 in the CONTRIBUTING.md file