### PR TITLE
Disable ARM neon for now in cuda builds

### DIFF
--- a/container-images/scripts/build_llama_and_whisper.sh
+++ b/container-images/scripts/build_llama_and_whisper.sh
@@ -218,7 +218,7 @@ configure_common_flags() {
       common_flags+=("-DGGML_HIP=ON" "-DAMDGPU_TARGETS=${AMDGPU_TARGETS:-gfx1010,gfx1012,gfx1030,gfx1032,gfx1100,gfx1101,gfx1102,gfx1103,gfx1151,gfx1200,gfx1201}")
       ;;
     cuda)
-      common_flags+=("-DGGML_CUDA=ON" "-DCMAKE_EXE_LINKER_FLAGS=-Wl,--allow-shlib-undefined")
+      common_flags+=("-DGGML_CUDA=ON" "-DCMAKE_EXE_LINKER_FLAGS=-Wl,--allow-shlib-undefined" "-DCMAKE_CUDA_FLAGS=\"-U__ARM_NEON -U__ARM_NEON__\"")
       ;;
     vulkan | asahi)
       common_flags+=("-DGGML_VULKAN=1")


### PR DESCRIPTION
Otherwize we get build errors

## Summary by Sourcery

Disable ARM NEON support for CUDA builds to resolve build errors

Bug Fixes:
- Prevent build errors in CUDA builds by explicitly disabling ARM NEON compilation flags

Build:
- Modified build script to add CUDA compilation flags that undefine ARM NEON macros