### PR TITLE
Fix cann build

### DIFF
--- a/container-images/scripts/build_llama_and_whisper.sh
+++ b/container-images/scripts/build_llama_and_whisper.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -exu -o pipefail
 
 available() {
   command -v "$1" >/dev/null
@@ -272,7 +271,7 @@ main() {
   # shellcheck disable=SC1091
   source /etc/os-release
 
-  set -ex
+  set -ex -o pipefail
 
   local containerfile=${1-""}
   local install_prefix


### PR DESCRIPTION
set_env.sh uses unbound variables deliberately

## Summary by Sourcery

Chores:
- Modify bash script to add pipefail option to set command for more robust error handling