### PR TITLE
ux: add vllm runtime suggestion when downloading safetensors

### DIFF
--- a/ramalama/huggingface.py
+++ b/ramalama/huggingface.py
@@ -220,7 +220,7 @@ def handle_repo_info(repo_name, repo_info, runtime):
     if "safetensors" in repo_info and runtime == "llama.cpp":
         print(
             "\nllama.cpp does not support running safetensor models, "
-            "please use a/convert to the GGUF format using:\n"
+            "please switch your runtime to vLLM or use a/convert to the GGUF format using:\n"
             f"- https://huggingface.co/models?other=base_model:quantized:{repo_name} \n"
             "- https://huggingface.co/spaces/ggml-org/gguf-my-repo"
         )


### PR DESCRIPTION
currently when downloading safetensors and using llama.cpp ramalama suggests using a or converting to a GGUF format

this commit updates the text to inform users they can also switch to use the vLLM engine if they want to run safetensors

## Summary by Sourcery

Update the user guidance for safetensors model downloads to include vLLM runtime as an alternative to GGUF conversion

Bug Fixes:
- Improve user guidance when downloading safetensors models with llama.cpp runtime

Enhancements:
- Expand runtime recommendation for safetensors models to provide users with more flexibility in model execution