### PR TITLE
More fixes to get release out

### DIFF
--- a/container-images/intel-gpu/Containerfile
+++ b/container-images/intel-gpu/Containerfile
@@ -1,10 +1,10 @@
-FROM quay.io/fedora/fedora:42 as builder
+FROM quay.io/fedora/fedora:41 as builder
 
 COPY intel-gpu/oneAPI.repo /etc/yum.repos.d/
 COPY --chmod=755 ../scripts /usr/bin
 RUN build_llama_and_whisper.sh "intel-gpu"
 
-FROM quay.io/fedora/fedora:42
+FROM quay.io/fedora/fedora:41
 
 COPY --from=builder /tmp/install/ /usr/
 COPY intel-gpu/oneAPI.repo /etc/yum.repos.d/

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -34,7 +34,7 @@ release() {
 
 case ${1} in
     ramalama-cli)
-	podman run --pull=never --rm "${REPO}/$1" /usr/bin/ramalama version
+	podman run --pull=never --rm "${REPO}/$1" version
 	release "$1"
 	;;
     llama-stack)


### PR DESCRIPTION
intel-gpu will not currently build on Fedora 42, there are issues in the glibc library. Should try again when Fedora 42 is released in May.

Verification of the ramalama-cli command, was broken, since ramalama is the entrypoint.

## Summary by Sourcery

Modify container image base and fix release script for ramalama-cli

Bug Fixes:
- Fix ramalama-cli version command verification by removing explicit binary path

Chores:
- Change base container image from Fedora 42 to Fedora 41 due to build compatibility issues