### PR TITLE
feat: add CTX_SIZE env config to container-images llama-server.sh

### DIFF
--- a/container-images/scripts/llama-server.sh
+++ b/container-images/scripts/llama-server.sh
@@ -16,12 +16,15 @@ fi
 if [ -z "${MODEL_PATH}" ]; then
     MODEL_PATH="/mnt/models/model.file"
 fi
+if [ -n "${CTX_SIZE}" ]; then
+    CTX_SIZE_FLAG="--ctx_size ${CTX_SIZE}"
+fi
 eval llama-server \
      --model "${MODEL_PATH}" \
      --host "${HOST:=0.0.0.0}" \
      --port "${PORT:=8001}" \
      --gpu_layers "${GPU_LAYERS:=0}" \
-     --ctx_size "${CTX_SIZE:=2048}" \
+     "${CTX_SIZE_FLAG:=""}" \
      "${CHAT_FORMAT}"
 exit 0
 

--- a/container-images/scripts/llama-server.sh
+++ b/container-images/scripts/llama-server.sh
@@ -21,6 +21,7 @@ eval llama-server \
      --host "${HOST:=0.0.0.0}" \
      --port "${PORT:=8001}" \
      --gpu_layers "${GPU_LAYERS:=0}" \
+     --ctx_size "${CTX_SIZE:=2048}" \
      "${CHAT_FORMAT}"
 exit 0
 


### PR DESCRIPTION
Relates to https://github.com/containers/podman-desktop-extension-ai-lab/issues/2630

Allow overriding the [context size](https://github.com/containers/ramalama/blob/v0.7.4/docs/ramalama-serve.1.md#--ctx-size--c) when running ramalama from a container.

2048 tokens is a small context window when running the inference server with MCP tools or even for longer chat completion conversations. Being able to provide a context window larger than 2048 is critical for those use cases.

/cc @jeffmaury

## Summary by Sourcery

Add support for configuring the context size via an environment variable in the llama-server container startup script

New Features:
- Allow customization of the context window size for the ramalama inference server through the CTX_SIZE environment variable

Enhancements:
- Extend the llama-server.sh script to support dynamic context size configuration