### PR TITLE
fix llama.cpp CANN backend x86 build failing issue

### DIFF
--- a/container-images/scripts/build_llama_and_whisper.sh
+++ b/container-images/scripts/build_llama_and_whisper.sh
@@ -247,8 +247,7 @@ clone_and_build_whisper_cpp() {
 }
 
 clone_and_build_llama_cpp() {
-  local llama_cpp_sha="fe5b78c89670b2f37ecb216306bed3e677b49d9f"
-
+  local llama_cpp_sha="daa422881a0ec7944771bcc8ff8de34d11f5bd3b"
   git clone https://github.com/ggml-org/llama.cpp
   cd llama.cpp
   git submodule update --init --recursive


### PR DESCRIPTION
Fix llama.cpp CANN backend x86 build failing issue: update llama.cpp to the new commit that has fixed this build issue.
Detail information can see in llama.cpp issue [12945](https://github.com/ggml-org/llama.cpp/issues/12945#issuecomment-2802159371). Llama.cpp has create a PR [12950](https://github.com/ggml-org/llama.cpp/pull/12950) to add CANN x86 building in CI.

I have test on CANN(x86 and arm) and GPU A100, function is Ok.

Signed-off-by: leo-pony <nengjunma@outlook.com>

## Summary by Sourcery

Update llama.cpp to a new commit that resolves CANN backend x86 build issues

Bug Fixes:
- Fixed CANN backend x86 build failing issue by updating to a specific llama.cpp commit

Chores:
- Updated llama.cpp repository reference in build script