### PR TITLE
Default to --pull=newer for ramalama rag command.

### DIFF
--- a/docs/ramalama-rag.1.md
+++ b/docs/ramalama-rag.1.md
@@ -29,6 +29,14 @@ Print usage message
 #### **--network**=*none*
 sets the configuration for network namespaces when handling RUN instructions
 
+#### **--pull**=*policy*
+Pull image policy. The default is **missing**.
+
+- **always**: Always pull the image and throw an error if the pull fails.
+- **missing**: Only pull the image when it does not exist in the local containers storage. Throw an error if no image is found and the pull fails.
+- **never**: Never pull the image but use the one from the local containers storage. Throw an error when no image is found.
+- **newer**: Pull if the image on the registry is newer than the one in the local containers storage. An image is considered to be newer when the digests are different. Comparing the time stamps is prone to errors. Pull errors are suppressed if a local image was found.
+
 ## EXAMPLES
 
 ```

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -947,6 +947,14 @@ def rag_parser(subparsers):
     )
     add_network_argument(parser, dflt=None)
     parser.add_argument(
+        "--pull",
+        dest="pull",
+        type=str,
+        default=CONFIG['pull'],
+        choices=["always", "missing", "never", "newer"],
+        help='pull image policy',
+    )
+    parser.add_argument(
         "PATH",
         nargs="*",
         help="""\

--- a/ramalama/rag.py
+++ b/ramalama/rag.py
@@ -88,7 +88,13 @@ COPY {src} /vector.db
 
         docsdb = tempfile.TemporaryDirectory(dir=tmpdir, prefix='RamaLama_docs_')
         docsdb_used = False
-        exec_args = [args.engine, "run", "--rm"]
+        exec_args = [
+            args.engine,
+            "run",
+            "--rm",
+            "--pull",
+            args.pull,
+        ]
         if args.network:
             exec_args += ["--network", args.network]
 

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -36,14 +36,14 @@ EOF
 	is "$output" ".*--temp 0.8" "verify temp is set"
 	is "$output" ".*--seed 9876" "verify seed is set"
 	if not_docker; then
-	   is "$output" ".*--pull=newer" "verify pull is newer"
+	   is "$output" ".*--pull newer" "verify pull is newer"
 	fi
 
 	run_ramalama -q --dryrun run --pull=never -c 4096 --name foobar ${MODEL}
-	is "$output" ".*--pull=never" "verify pull is never"
+	is "$output" ".*--pull never" "verify pull is never"
 
 	RAMALAMA_CONFIG=${conf} run_ramalama -q --dryrun run ${MODEL}
-	is "$output" ".*--pull=missing" "verify pull is missing"
+	is "$output" ".*--pull missing" "verify pull is missing"
 
 	run_ramalama 2 -q --dryrun run --pull=bogus ${MODEL}
 	is "$output" ".*error: argument --pull: invalid choice: 'bogus'" "verify pull can not be bogus"

--- a/test/system/040-serve.bats
+++ b/test/system/040-serve.bats
@@ -38,13 +38,13 @@ verify_begin=".*run --rm -i --label ai.ramalama --name"
         run_ramalama -q --dryrun serve --seed 1234 ${model}
         is "$output" ".*--seed 1234" "verify seed is set"
         if not_docker; then
-            is "$output" ".*--pull=newer" "verify pull is newer"
+            is "$output" ".*--pull newer" "verify pull is newer"
         fi
         assert "$output" =~ ".*--cap-drop=all" "verify --cap-add is present"
         assert "$output" =~ ".*no-new-privileges" "verify --no-new-privs is not present"
 
-        run_ramalama -q --dryrun serve --pull=never ${model}
-        is "$output" ".*--pull=never" "verify pull is never"
+        run_ramalama -q --dryrun serve --pull never ${model}
+        is "$output" ".*--pull never" "verify pull is never"
 
         run_ramalama 2 -q --dryrun serve --pull=bogus ${model}
         is "$output" ".*error: argument --pull: invalid choice: 'bogus'" "verify pull can not be bogus"

--- a/test/system/070-rag.bats
+++ b/test/system/070-rag.bats
@@ -12,6 +12,7 @@ load helpers
 
     run_ramalama --dryrun run --rag quay.io/ramalama/myrag:1.2 ollama://smollm:135m
     is "$output" ".*quay.io/ramalama/.*-rag.*" "Expected to use -rag image"
+    is "$output" ".*--pull newer.*" "Expected to use --pull newer"
 
     run_ramalama info
     engine=$(echo "$output" | jq --raw-output '.Engine.Name')

--- a/test/system/070-rag.bats
+++ b/test/system/070-rag.bats
@@ -12,7 +12,9 @@ load helpers
 
     run_ramalama --dryrun run --rag quay.io/ramalama/myrag:1.2 ollama://smollm:135m
     is "$output" ".*quay.io/ramalama/.*-rag.*" "Expected to use -rag image"
-    is "$output" ".*--pull newer.*" "Expected to use --pull newer"
+    if not_docker; then
+       is "$output" ".*--pull newer.*" "Expected to use --pull newer"
+    fi
 
     run_ramalama info
     engine=$(echo "$output" | jq --raw-output '.Engine.Name')


### PR DESCRIPTION
Fixes: https://github.com/containers/ramalama/issues/1192

## Summary by Sourcery

Set the default pull policy to 'newer' for the ramalama rag command

New Features:
- Add support for configurable pull policy with multiple options (always, missing, never, newer)

Bug Fixes:
- Fix issue with image pulling behavior by introducing a more flexible pull policy

Enhancements:
- Modify CLI to add --pull argument with a default value from configuration
- Update rag command to pass pull policy to container engine

Documentation:
- Update man page documentation to explain the new --pull argument and its policy options