### PR TITLE
Setup /venv for running llama-stack

### DIFF
--- a/container-images/llama-stack/Containerfile
+++ b/container-images/llama-stack/Containerfile
@@ -1,6 +1,11 @@
-FROM registry.fedoraproject.org/fedora:42
+FROM registry.fedoraproject.org/fedora:41
 
-RUN dnf -y install pip && \
-    pip install -U llama-stack --prefix=/usr
+RUN dnf -y update && \
+    dnf -y install uv cmake gcc gcc-c++ python3-devel pkg-config && \
+    uv run --with llama-stack llama stack build --template ollama --image-type venv --image-name /venv && \
+    dnf -y clean all
 
+COPY --chmod=755 entrypoint.sh /usr/bin/entrypoint.sh
+
+ENTRYPOINT [ "/usr/bin/entrypoint.sh" ]
 

--- a/install.sh
+++ b/install.sh
@@ -1318,7 +1318,7 @@ shotgun_install_dir_to_path() {
             fi
         done
 
-        # Fall through to previous "create + write to first file in list" behavior
+        # Fall through to previous "create + write to first file in list" behaviour
 	    if [ "$_found" = false ]; then
             add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" "$_rcfiles" "$_shell"
         fi


### PR DESCRIPTION
## Summary by Sourcery

Set up a virtual environment for llama-stack using uv and create a containerized build process

New Features:
- Create a virtual environment for llama-stack using uv build tool

Build:
- Update Fedora base image from version 42 to 41
- Install additional build dependencies like cmake, gcc, and python development tools
- Use uv to build llama-stack in a virtual environment

Chores:
- Add an entrypoint script to the container
- Clean up dnf cache after installation