### PR TITLE
Fix doc2rag warning

### DIFF
--- a/container-images/scripts/doc2rag
+++ b/container-images/scripts/doc2rag
@@ -43,7 +43,7 @@ class Converter:
             chunk_iter = chunker.chunk(dl_doc=file.document)
             for chunk in chunk_iter:
                 # Extract the enriched text from the chunk
-                doc_text = chunker.serialize(chunk=chunk)
+                doc_text = chunker.contextualize(chunk=chunk)
                 # Append to respective lists
                 documents.append(doc_text)
                 # Generate unique ID for the chunk


### PR DESCRIPTION
/usr/bin/doc2rag:46: DeprecationWarning: Use contextualize() instead.
  doc_text = chunker.serialize(chunk=chunk)

## Summary by Sourcery

Bug Fixes:
- Resolve deprecation warning in doc2rag script by updating the method call to use the recommended contextualize() instead of serialize()