### PR TITLE
Add --gguf option to convert Safetensors using llama.cpp scripts and functionality

### DIFF
--- a/container-images/scripts/build_rag.sh
+++ b/container-images/scripts/build_rag.sh
@@ -38,8 +38,13 @@ rag() {
     rag_framework load
 }
 
+to_gguf() {
+    ${PYTHON_VERSION} pip install "numpy~=1.26.4" "sentencepiece~=0.2.0" "transformers>=4.45.1,<5.0.0" git+https://github.com/ggml-org/llama.cpp#subdirectory=gguf-py "protobuf>=4.21.0,<5.0.0"
+}
+
 update_python
 
+to_gguf
 rag
 docling "${GPU}"
 

--- a/docs/ramalama-convert.1.md
+++ b/docs/ramalama-convert.1.md
@@ -15,6 +15,10 @@ Note: The convert command must be run with containers. Use of the --nocontainer 
 
 ## OPTIONS
 
+#### **--gguf**=*Q2_K* | *Q3_K_S* | *Q3_K_M* | *Q3_K_L* | *Q4_0* | *Q4_K_S* | *Q4_K_M* | *Q5_0* | *Q5_K_S* | *Q5_K_M* | *Q6_K* | *Q8_0* 
+
+Convert Safetensor models into a GGUF with the specified quantization format. To learn more about model quantization, read [this llama.cpp documentation](https://github.com/ggml-org/llama.cpp/blob/master/examples/quantize/README.md)
+
 #### **--help**, **-h**
 Print usage message
 
@@ -43,6 +47,14 @@ COMMIT quay.io/rhatdan/tiny:latest
 --> 69db4a10191c
 Successfully tagged quay.io/rhatdan/tiny:latest
 69db4a10191c976d2c3c24da972a2a909adec45135a69dbb9daeaaf2a3a36344
+```
+
+Generate and run an oci model with a quantized GGUF converted from Safetensors.
+```
+$ ramalama --image quay.io/ramalama/ramalama-rag convert --gguf Q4_K_M hf://ibm-granite/granite-3.2-2b-instruct oci://quay.io/kugupta/granite-3.2-q4-k-m:latest
+Converting /Users/kugupta/.local/share/ramalama/models/huggingface/ibm-granite/granite-3.2-2b-instruct to quay.io/kugupta/granite-3.2-q4-k-m:latest...
+Building quay.io/kugupta/granite-3.2-q4-k-m:latest...
+$ ramalama run oci://quay.io/kugupta/granite-3.2-q4-k-m:latest
 ```
 
 ## SEE ALSO

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -600,6 +600,24 @@ type of OCI Model Image to push.
 Model "car" includes base image with the model stored in a /models subdir.
 Model "raw" contains the model and a link file model.file to it stored at /.""",
     )
+    parser.add_argument(
+        "--gguf",
+        choices=[
+            "Q2_K",
+            "Q3_K_S",
+            "Q3_K_M",
+            "Q3_K_L",
+            "Q4_0",
+            "Q4_K_S",
+            "Q4_K_M",
+            "Q5_0",
+            "Q5_K_S",
+            "Q5_K_M",
+            "Q6_K",
+            "Q8_0",
+        ],
+        help="GGUF quantization format",
+    )
     add_network_argument(parser)
     parser.add_argument("SOURCE")  # positional argument
     parser.add_argument("TARGET")  # positional argument

--- a/test/system/055-convert.bats
+++ b/test/system/055-convert.bats
@@ -72,6 +72,27 @@ load helpers
     podman image prune --force
 }
 
+@test "ramalama convert tiny to GGUF image" {
+    skip_if_nocontainer
+    skip_if_docker
+    run_ramalama pull hf://TinyLlama/TinyLlama-1.1B-Chat-v1.0
+    run_ramalama --image quay.io/ramalama/ramalama-rag convert --gguf Q4_0 hf://TinyLlama/TinyLlama-1.1B-Chat-v1.0 oci://quay.io/ramalama/tiny-q4-0
+    run_ramalama list
+    is "$output" ".*ramalama/tiny-q4-0:latest"
+#    FIXME:  This test will work on all podman 5.3 and greater clients.
+#    right now Ubuntu test suite is stuck on podman 5.0.3 Ubuntu 24.10 support
+#    it bug github is stuck on 24.04.  Should change when 25.04 is released
+#    if is_container and not_docker; then
+#       cname=c_$(safename)
+#       run_podman version
+#       run_ramalama serve -n ${cname} -d quay.io/ramalama/tiny-q4-0
+#       run_ramalama stop ${cname}
+#    fi
+    run_ramalama rm quay.io/ramalama/tiny-q4-0
+    run_ramalama list
+    assert "$output" !~ ".*quay.io/ramalama/tiny-q4-0" "image was removed"
 
+    podman image prune --force
+}
 
 # vim: filetype=sh


### PR DESCRIPTION
This PR adds support for converting and quantizing models to the GGUF format during OCI image creation. Users who initially try to use the newest/latest models may not have pre-quantized GGUFs readily available, so this feature will let them create them using one command.

Fixes #1139 

- Introduce GGUF quantization option for model conversion in the CLI
- Add support for converting models to different GGUF quantization formats during OCI image build
- Update build process to handle GGUF model creation and linking with the same model.file to run the built OCI model
- Deduplicate modelcar and raw containerfiles
- Docs updated with example and an additional test for GGUF conversion

Some thoughts:
- Could be -q or --quantize instead
- Remote functionality is super interesting for the `convert_hf_to_gguf.py` script from a storage preservation perspective, but containers are currently built with no network so not sure how best to handle that
- Image builds go well except for Ashai, seems that it tries to build numpy and can't find a compiler? Would love help troubleshooting here
- Converted image builds go by silently, could cause some users to miss out on the notes and debugging info during the quantization process. 
    - Workaround could be to make it noisy for quantized only