### PR TITLE
Only use nvidia-container-runtime if it is installed

### DIFF
--- a/container-images/intel-gpu/Containerfile
+++ b/container-images/intel-gpu/Containerfile
@@ -19,7 +19,6 @@ RUN useradd llama-user -u 10000 -d /home/llama-user -s /bin/bash && \
 groupmod -a -U llama-user render && \
 groupmod -a -U llama-user video && \
 chown llama-user:llama-user -R /home/llama-user && \
-python3 -m pip install openvino
 
 USER 10000
 

--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -315,10 +315,12 @@ class Model(ModelBase):
     def add_oci_runtime(self, conman_args, args):
         if args.oci_runtime:
             conman_args += ["--runtime", args.oci_runtime]
-        elif check_nvidia() == "cuda":
+            return conman_args
+        if check_nvidia() == "cuda":
             if os.path.basename(args.engine) == "docker":
                 conman_args += ["--runtime", "nvidia"]
-            else:
+                return conman_args
+            if os.access("/usr/bin/nvidia-container-runtime", os.X_OK):
                 conman_args += ["--runtime", "/usr/bin/nvidia-container-runtime"]
 
         return conman_args


### PR DESCRIPTION
Also we no longer need to ship openvino with intel containerfile

## Summary by Sourcery

Improve NVIDIA runtime detection and simplify container image configuration

Enhancements:
- Modify NVIDIA runtime detection to only use nvidia-container-runtime when it is explicitly installed and executable

Chores:
- Remove OpenVINO installation from Intel GPU container image