### PR TITLE
llama-stack relative COPY

### DIFF
--- a/container-images/llama-stack/Containerfile
+++ b/container-images/llama-stack/Containerfile
@@ -5,7 +5,7 @@ RUN dnf -y update && \
     uv run --with llama-stack llama stack build --template ollama --image-type venv --image-name /venv && \
     dnf -y clean all
 
-COPY --chmod=755 entrypoint.sh /usr/bin/entrypoint.sh
+COPY --chmod=755 llama-stack/entrypoint.sh /usr/bin/entrypoint.sh
 
 ENTRYPOINT [ "/usr/bin/entrypoint.sh" ]
 


### PR DESCRIPTION
cdb6df687724808c82da23af5a36e1b1b4529abb recently added the entrypoint.sh however the Containerfile does not have relative path to container-images/ as for example
intel-gpu has.
container_build.sh uses container-images as working directory.

## Summary by Sourcery

Chores:
- Modify the COPY command in the Containerfile to use a relative path from the container-images directory