### PR TITLE
rocm-ubi repo path fix

### DIFF
--- a/container-images/rocm-ubi/Containerfile
+++ b/container-images/rocm-ubi/Containerfile
@@ -1,7 +1,7 @@
 FROM registry.access.redhat.com/ubi9/ubi:9.5-1744101466
 
-COPY rocm/amdgpu.repo /etc/yum.repos.d/
-COPY rocm/rocm.repo /etc/yum.repos.d/
+COPY rocm-ubi/amdgpu.repo /etc/yum.repos.d/
+COPY rocm-ubi/rocm.repo /etc/yum.repos.d/
 COPY --chmod=755 ../scripts /usr/bin
 
 ARG AMDGPU_TARGETS=


### PR DESCRIPTION
rocm-ubi pointed to a wrong path for the repo files, this change fixing it.

## Summary by Sourcery

Bug Fixes:
- Correct the file paths for the repository files in the rocm-ubi container image to point to the correct directory.