### PR TITLE
Fix link to ramalama-cuda

### DIFF
--- a/docs/ramalama-serve.1.md
+++ b/docs/ramalama-serve.1.md
@@ -329,7 +329,7 @@ WantedBy=multi-user.target default.target
 
 ## NVIDIA CUDA Support
 
-See **[ramalama-cuda(7)](ramalama.7.md)** for setting up the host Linux system for CUDA support.
+See **[ramalama-cuda(7)](ramalama-cuda.7.md)** for setting up the host Linux system for CUDA support.
 
 ## SEE ALSO
 **[ramalama(1)](ramalama.1.md)**, **[ramalama-stop(1)](ramalama-stop.1.md)**, **quadlet(1)**, **systemctl(1)**, **podman(1)**, **podman-ps(1)**, **[ramalama-cuda(7)](ramalama-cuda.7.md)**


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Corrected the markdown link to the ramalama-cuda(7) documentation from 'ramalama.7.md' to 'ramalama-cuda.7.md'