### PR TITLE
Fixes for llama-stack image to build and install

### DIFF
--- a/scripts/release-image.sh
+++ b/scripts/release-image.sh
@@ -57,7 +57,7 @@ case ${1} in
 	podman run --pull=never --rm "${REPO}/$1" ls -l bin/ovms
 	;;
     llama-stack)
-	podman run --pull=never --rm "${REPO}/$1" /usr/bin/llama -h
+	podman run --pull=never --rm "${REPO}/$1" llama -h
 	;;
     *)
 	podman run --pull=never --rm "${REPO}/$1" ls -l /usr/bin/llama-server

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -42,7 +42,7 @@ case ${1} in
 	release "$1"
 	;;
     llama-stack)
-	podman run --pull=never --rm "${REPO}/$1" /usr/bin/llama
+	podman run --pull=never --rm "${REPO}/$1" llama -h
 	release "$1"
 	;;
     *)


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix command invocation for llama binary in release and release-image scripts by removing the full path and using the direct command