### PR TITLE
Packit: use latest version for rpm

### DIFF
--- a/.packit-copr-rpm.sh
+++ b/.packit-copr-rpm.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# This script handles any custom processing of the spec file using the `fix-spec-file`
+# action in .packit.yaml. These steps only work on copr builds, not on official
+# Fedora builds.
+
+set -exo pipefail
+
+# Get Version from HEAD
+VERSION=$(awk -F'[""]' '/version=/ {print $(NF-1)}' setup.py)
+
+SPEC_FILE=rpm/python-ramalama.spec
+
+# RPM Spec modifications
+
+# Use the Version from HEAD in rpm spec
+sed -i "s/^Version:.*/Version: $VERSION/" "$SPEC_FILE"
+
+# Use Packit's supplied variable in the Release field in rpm spec.
+sed -i "s/^Release:.*/Release: 1000.$PACKIT_RPMSPEC_RELEASE%{?dist}/" "$SPEC_FILE"

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -16,6 +16,9 @@ packages:
 srpm_build_deps:
   - make
 
+actions:
+  fix-spec-file: "bash .packit-copr-rpm.sh"
+
 jobs:
   # Copr builds for Fedora
   - job: copr_build


### PR DESCRIPTION
Packit by default uses `git describe` for rpm version in copr builds. This can often lag behind the latest release thus making it impossible to update default distro builds with copr builds.
    
Ref: https://copr.fedorainfracloud.org/coprs/rhcontainerbot/podman-next/package/python-ramalama/ . The latest build in there still shows version: `0.7.3` when v0.7.4 is the latest upstream release.
    
This commit adds a packit action to modify the spec file which fetches version info from setup.py.
    
The rpm release info is also modified such that it will update over the latest distro package in almost all circumstances, assuming no distro package will have a release 1001+.



## Summary by Sourcery

Add a custom script for handling RPM spec file modifications in Packit builds

Build:
- Create a bash script to dynamically modify RPM spec file version based on the project's version

Chores:
- Add a script for custom RPM spec file processing specific to Copr builds

## Summary by Sourcery

Modify Packit configuration to dynamically update RPM spec file version for Copr builds using a custom bash script

New Features:
- Implement a mechanism to ensure Copr builds use the latest project version by modifying the spec file dynamically

Build:
- Add a bash script (.packit-copr-rpm.sh) to dynamically modify the RPM spec file version by extracting the version from setup.py

Chores:
- Configure Packit to use a custom script for spec file modifications during Copr builds