### PR TITLE
fix intel-gpu container build

### DIFF
--- a/container-images/intel-gpu/Containerfile
+++ b/container-images/intel-gpu/Containerfile
@@ -18,7 +18,7 @@ RUN dnf install -y procps-ng python3 python3-pip python3-devel intel-level-zero 
 RUN useradd llama-user -u 10000 -d /home/llama-user -s /bin/bash && \
 groupmod -a -U llama-user render && \
 groupmod -a -U llama-user video && \
-chown llama-user:llama-user -R /home/llama-user && \
+chown llama-user:llama-user -R /home/llama-user
 
 USER 10000
 


### PR DESCRIPTION
49656ee3e9b32751d3cf3126fe3048eb6cee58d2 removed one line but did not removed the line join, leading to build failures.

## Summary by Sourcery

Bug Fixes:
- Resolved a build failure caused by an incomplete line join in the Containerfile for the intel-gpu image