### PR TITLE
Enable llama.cpp rpc feature in containers

### DIFF
--- a/container-images/scripts/build_llama_and_whisper.sh
+++ b/container-images/scripts/build_llama_and_whisper.sh
@@ -248,11 +248,14 @@ clone_and_build_whisper_cpp() {
 
 clone_and_build_llama_cpp() {
   local llama_cpp_sha="daa422881a0ec7944771bcc8ff8de34d11f5bd3b"
+  local install_prefix
+  install_prefix=$(set_install_prefix)
   git clone https://github.com/ggml-org/llama.cpp
   cd llama.cpp
   git submodule update --init --recursive
   git reset --hard "$llama_cpp_sha"
   cmake_steps "${common_flags[@]}"
+  install -m 755 build/bin/rpc-server "$install_prefix"/bin/rpc-server
   cd ..
   rm -rf llama.cpp
 }
@@ -287,7 +290,7 @@ main() {
 
   setup_build_env
   clone_and_build_whisper_cpp
-  common_flags+=("-DLLAMA_CURL=ON")
+  common_flags+=("-DLLAMA_CURL=ON" "-DGGML_RPC=ON")
   case "$containerfile" in
     ramalama)
       if [ "$uname_m" = "x86_64" ] || [ "$uname_m" = "aarch64" ]; then


### PR DESCRIPTION
Enable both server and client support for rpc.
The feature currently PoC in llama.cpp, but can work in practice. Required for distributed inference.

## Summary by Sourcery

Enable RPC support for llama.cpp in container build scripts

New Features:
- Add RPC server binary installation for llama.cpp in container build process

Build:
- Modify build flags to enable GGML RPC feature during llama.cpp compilation
- Update build script to install RPC server binary