### PR TITLE
Switch all f41 container to f42

### DIFF
--- a/container-images/llama-stack/Containerfile
+++ b/container-images/llama-stack/Containerfile
@@ -1,7 +1,7 @@
-FROM registry.fedoraproject.org/fedora:41
+FROM registry.fedoraproject.org/fedora:42
 
 RUN dnf -y update && \
-    dnf -y install uv cmake gcc gcc-c++ python3-devel pkg-config && \
+    dnf -y install uv cmake gcc gcc-c++ python3-devel pkg-config sentencepiece-devel && \
     uv run --with llama-stack llama stack build --template ollama --image-type venv --image-name /venv && \
     dnf -y clean all
 


### PR DESCRIPTION
Actually only 1 container left on f41,
making all to use f42.

## Summary by Sourcery

Update base container image from Fedora 41 to Fedora 42

Enhancements:
- Add sentencepiece-devel package to the container build

Chores:
- Migrate the llama-stack container to use the latest Fedora base image