### PR TITLE
Fix bug in login_cli and update huggingface or hf registry behavior

### DIFF
--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -254,7 +254,7 @@ def normalize_registry(registry):
     if not registry or registry == "" or registry.startswith("oci://"):
         return "oci://"
 
-    if registry in ["ollama", "hf" "huggingface"]:
+    if registry in ["ollama", "hf", "huggingface"]:
         return registry
 
     return "oci://" + registry


### PR DESCRIPTION
I was investigating the https://github.com/containers/ramalama/issues/643, and tried to write some unit tests for the ramalama/cli.py, then I was so confused that the test always failed no matter when I used "huggingface" or "hf". Finally, I found there is a tiny bug here, let me first fix it before moving on:

Before the change:
```
if registry in ["ollama", "hf" "huggingface"]:
        return registry
```

After the change:
```
if registry in ["ollama", "hf", "huggingface"]:
        return registry
```

## Summary by Sourcery

Bug Fixes:
- Corrected the syntax in the `normalize_registry` function by adding a missing comma in the registry list, which was causing incorrect registry validation