### PR TITLE
Allow building older versions of cuda

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,15 +86,15 @@ install: docs completions
 
 .PHONY: build
 build:
-	./container_build.sh build $(IMAGE)
+	./container_build.sh build $(IMAGE) -v "$(VERSION)"
 
 .PHONY: build-rm
 build-rm:
-	./container_build.sh -r build $(IMAGE)
+	./container_build.sh -r build $(IMAGE) -v "$(VERSION)"
 
 .PHONY: build_multi_arch
 build_multi_arch:
-	./container_build.sh multi-arch $(IMAGE)
+	./container_build.sh multi-arch $(IMAGE) -v "$(VERSION)"
 
 .PHONY: install-docs
 install-docs: docs

--- a/container-images/cuda/Containerfile
+++ b/container-images/cuda/Containerfile
@@ -1,11 +1,12 @@
+ARG VERSION=12.8.1
 # Base image with CUDA for compilation
-FROM docker.io/nvidia/cuda:12.8.1-devel-ubi9 AS builder
+FROM docker.io/nvidia/cuda:${VERSION}-devel-ubi9 AS builder
 
 COPY --chmod=755 ../scripts /usr/bin
 RUN build_llama_and_whisper.sh "cuda"
 
 # Final runtime image
-FROM docker.io/nvidia/cuda:12.8.1-runtime-ubi9
+FROM docker.io/nvidia/cuda:${VERSION}-runtime-ubi9
 
 # Copy the entire installation directory from the builder
 COPY --from=builder /tmp/install /usr


### PR DESCRIPTION
## Summary by Sourcery

Modify the container build script and Makefile to support building CUDA container images with configurable CUDA versions

New Features:
- Add support for specifying custom CUDA versions during container image build process

Enhancements:
- Extend build scripts to dynamically tag images with version information
- Introduce a new command-line option to specify CUDA version

Chores:
- Update Containerfile to use a build argument for CUDA version
- Modify container build and Makefile scripts to pass version parameter