### PR TITLE
Move model and rag to use shared Engine implementation

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -5,7 +5,7 @@
 skip = ./logos,./vendor,./.git #,bin,vendor,.git,go.sum,changelog.txt,.cirrus.yml,"RELEASE_NOTES.md,*.xz,*.gz,*.tar,*.tgz,bin2img,*ico,*.png,*.1,*.5,*.7,copyimg,*.orig,apidoc.go"
 
 # Comma separated list of words to be ignored. Words must be lowercased.
-ignore-words-list = clos,creat,ro,hastable,shouldnot,mountns,passt
+ignore-words-list = clos,creat,ro,hastable,shouldnot,mountns,passt,assertin
 
 # Custom dictionary file that contains spelling corrections.
 # Run with option '--dictionary=-' to include also default dictionary.

--- a/ramalama/engine.py
+++ b/ramalama/engine.py
@@ -1,0 +1,272 @@
+import glob
+import json
+import os
+import subprocess
+import sys
+
+from ramalama.common import (
+    check_nvidia,
+    exec_cmd,
+    get_accel_env_vars,
+    perror,
+    podman_machine_accel,
+    run_cmd,
+)
+from ramalama.console import EMOJI
+
+
+class Engine:
+
+    def __init__(self, args):
+        self.exec_args = [
+            args.engine,
+            "run",
+            "--rm",
+        ]
+        self.use_docker = os.path.basename(args.engine) == "docker"
+        self.use_podman = os.path.basename(args.engine) == "podman"
+        self.args = args
+        self.add_container_labels()
+        self.add_device_options()
+        self.add_env_option()
+        self.add_network()
+        self.add_oci_runtime()
+        self.add_port_option()
+        self.add_privileged_options()
+        self.add_pull_newer()
+        self.add_rag()
+        self.add_subcommand_env()
+        self.add_tty_option()
+        self.handle_podman_specifics()
+        self.add_detach_option()
+        self.debug = args.debug
+
+    def add_label(self, label):
+        self.add(["--label", label])
+
+    def add_container_labels(self):
+        label_map = {
+            "MODEL": "ai.ramalama.model",
+            "engine": "ai.ramalama.engine",
+            "runtime": "ai.ramalama.runtime",
+            "port": "ai.ramalama.port",
+            "subcommand": "ai.ramalama.command",
+        }
+        for arg, label_prefix in label_map.items():
+            if hasattr(self.args, arg):
+                value = getattr(self.args, arg)
+                if value:
+                    self.add_label(f"{label_prefix}={value}")
+
+    def add_pull_newer(self):
+        if not self.args.dryrun and self.use_docker and self.args.pull == "newer":
+            try:
+                if not self.args.quiet:
+                    print(f"Checking for newer image {self.args.image}")
+                run_cmd([self.args.engine, "pull", "-q", self.args.image], ignore_all=True)
+            except Exception:  # Ignore errors, the run command will handle it.
+                pass
+        else:
+            self.exec_args += ["--pull", self.args.pull]
+
+    def add_network(self):
+        if hasattr(self.args, "network") and self.args.network:
+            self.exec_args += ["--network", self.args.network]
+
+    def add_oci_runtime(self):
+        if hasattr(self.args, "oci_runtime") and self.args.oci_runtime:
+            self.exec_args += ["--runtime", self.args.oci_runtime]
+            return
+        if check_nvidia() == "cuda":
+            if self.use_docker:
+                self.exec_args += ["--runtime", "nvidia"]
+            else:
+                self.exec_args += ["--runtime", "/usr/bin/nvidia-container-runtime"]
+
+    def add_privileged_options(self):
+        if hasattr(self.args, "privileged") and self.args.privileged:
+            self.exec_args += ["--privileged"]
+        else:
+            self.exec_args += [
+                "--security-opt=label=disable",
+            ]
+            if not hasattr(self.args, "nocapdrop"):
+                self.exec_args += [
+                    "--cap-drop=all",
+                    "--security-opt=no-new-privileges",
+                ]
+
+    def add_subcommand_env(self):
+        if EMOJI and hasattr(self.args, "subcommand") and self.args.subcommand == "run":
+            if os.path.basename(self.args.engine) == "podman":
+                self.exec_args += ["--env", "LLAMA_PROMPT_PREFIX=🦭 > "]
+            if self.use_docker:
+                self.exec_args += ["--env", "LLAMA_PROMPT_PREFIX=🐋 > "]
+
+    def add_env_option(self):
+        if hasattr(self.args, "env"):
+            for env in self.args.env:
+                self.exec_args += ["--env", env]
+
+    def add_tty_option(self):
+        if sys.stdout.isatty() or sys.stdin.isatty():
+            self.exec_args += ["-t"]
+
+    def add_detach_option(self):
+        if hasattr(self.args, "detach") and self.args.detach is True:
+            self.exec_args += ["-d"]
+
+    def add_port_option(self):
+        if hasattr(self.args, "port"):
+            self.exec_args += ["-p", f"{self.args.port}:{self.args.port}"]
+
+    def add_device_options(self):
+        if hasattr(self.args, "device") and self.args.device:
+            for device_arg in self.args.device:
+                self.exec_args += ["--device", device_arg]
+
+        if podman_machine_accel:
+            self.exec_args += ["--device", "/dev/dri"]
+
+        for path in ["/dev/dri", "/dev/kfd", "/dev/accel", "/dev/davinci*", "/dev/devmm_svm", "/dev/hisi_hdc"]:
+            for dev in glob.glob(path):
+                self.exec_args += ["--device", dev]
+
+        for k, v in get_accel_env_vars().items():
+            # Special case for Cuda
+            if k == "CUDA_VISIBLE_DEVICES":
+                if self.use_docker:
+                    self.exec_args += ["--gpus", "all"]
+                else:
+                    # newer Podman versions support --gpus=all, but < 5.0 do not
+                    self.exec_args += ["--device", "nvidia.com/gpu=all"]
+
+            self.exec_args += ["-e", f"{k}={v}"]
+
+    def add_rag(self):
+        if not hasattr(self.args, "rag") or not self.args.rag:
+            return
+
+        if os.path.exists(self.args.rag):
+            rag = os.path.realpath(self.args.rag)
+            # Added temp read write because vector database requires write access even if nothing is written
+            self.exec_args.append(f"--mount=type=bind,source={rag},destination=/rag/vector.db,rw=true")
+        else:
+            self.exec_args.append(f"--mount=type=image,source={self.args.rag},destination=/rag,rw=true")
+
+    def handle_podman_specifics(self):
+        if hasattr(self.args, "podman_keep_groups") and self.args.podman_keep_groups:
+            self.exec_args += ["--group-add", "keep-groups"]
+
+    def add(self, newargs):
+        self.exec_args += newargs
+
+    def dryrun(self):
+        dry_run(self.exec_args)
+
+    def run(self):
+        run_cmd(self.exec_args, debug=self.debug)
+
+    def exec(self):
+        exec_cmd(self.exec_args, debug=self.debug)
+
+
+def dry_run(args):
+    for arg in args:
+        if not arg:
+            continue
+        if " " in arg:
+            print('"%s"' % arg, end=" ")
+        else:
+            print("%s" % arg, end=" ")
+    print()
+
+
+def images(args):
+    conman = args.engine
+    if conman == "" or conman is None:
+        raise ValueError("no container manager (Podman, Docker) found")
+
+    conman_args = [conman, "images"]
+    if hasattr(args, "noheading") and args.noheading:
+        conman_args += ["--noheading"]
+
+    if hasattr(args, "notrunc") and args.notrunc:
+        conman_args += ["--no-trunc"]
+
+    if args.format:
+        conman_args += [f"--format={args.format}"]
+
+    try:
+        output = run_cmd(conman_args, debug=args.debug).stdout.decode("utf-8").strip()
+        if output == "":
+            return []
+        return output.split("\n")
+    except subprocess.CalledProcessError as e:
+        perror("ramalama list command requires a running container engine")
+        raise (e)
+
+
+def containers(args):
+    conman = args.engine
+    if conman == "" or conman is None:
+        raise ValueError("no container manager (Podman, Docker) found")
+
+    conman_args = [conman, "ps", "-a", "--filter", "label=ai.ramalama"]
+    if hasattr(args, "noheading") and args.noheading:
+        conman_args += ["--noheading"]
+
+    if hasattr(args, "notrunc") and args.notrunc:
+        conman_args += ["--no-trunc"]
+
+    if args.format:
+        conman_args += [f"--format={args.format}"]
+
+    try:
+        output = run_cmd(conman_args, debug=args.debug).stdout.decode("utf-8").strip()
+        if output == "":
+            return []
+        return output.split("\n")
+    except subprocess.CalledProcessError as e:
+        perror("ramalama list command requires a running container engine")
+        raise (e)
+
+
+def info(args):
+    conman = args.engine
+    if conman == "":
+        raise ValueError("no container manager (Podman, Docker) found")
+
+    conman_args = [conman, "info", "--format", "json"]
+    try:
+        output = run_cmd(conman_args, debug=args.debug).stdout.decode("utf-8").strip()
+        if output == "":
+            return []
+        return json.loads(output)
+    except FileNotFoundError as e:
+        return str(e)
+
+
+def stop_container(args, name):
+    if not name:
+        raise ValueError("must specify a container name")
+    conman = args.engine
+    if conman == "":
+        raise ValueError("no container manager (Podman, Docker) found")
+
+    conman_args = [conman, "stop", "-t=0"]
+    ignore_stderr = False
+    if args.ignore:
+        if conman == "podman":
+            conman_args += ["--ignore", str(args.ignore)]
+        else:
+            ignore_stderr = True
+
+    conman_args += [name]
+    try:
+        run_cmd(conman_args, ignore_stderr=ignore_stderr, debug=args.debug)
+    except subprocess.CalledProcessError:
+        if args.ignore and conman == "docker":
+            return
+        else:
+            raise

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -15,22 +15,23 @@ EOF
     if is_container; then
 	run_ramalama info
 	conman=$(jq .Engine.Name <<< $output | tr -d '"' )
-	verify_begin="${conman} run --rm -i --label ai.ramalama --name"
+	verify_begin="${conman} run --rm"
 
 	run_ramalama -q --dryrun run ${MODEL}
-	is "$output" "${verify_begin} ramalama_.*--network none.*" "dryrun correct"
+	is "$output" "${verify_begin}.*"
+	is "$output" ".*--network none.*" "dryrun correct"
 	is "$output" ".*${MODEL}" "verify model name"
 	is "$output" ".*-c 2048" "verify model name"
 	assert "$output" !~ ".*--seed" "assert seed does not show by default"
 
 	run_ramalama -q --dryrun run --env a=b --env test=success --name foobar ${MODEL}
-	is "$output" "${verify_begin} foobar.*--env a=b --env test=success" "dryrun correct with --env"
+	is "$output" ".*--env a=b --env test=success" "dryrun correct with --env"
 
 	run_ramalama -q --dryrun run --oci-runtime foobar ${MODEL}
-	is "$output" "${verify_begin} .*--runtime foobar" "dryrun correct with --oci-runtime"
+	is "$output" ".*--runtime foobar" "dryrun correct with --oci-runtime"
 
 	run_ramalama -q --dryrun run --seed 9876 -c 4096 --net bridge --name foobar ${MODEL}
-	is "$output" "${verify_begin} foobar.*--network bridge.*" "dryrun correct with --name"
+	is "$output" ".*--network bridge.*" "dryrun correct with --name"
 	is "$output" ".*${MODEL}" "verify model name"
 	is "$output" ".*-c 4096" "verify ctx-size is set"
 	is "$output" ".*--temp 0.8" "verify temp is set"
@@ -49,9 +50,9 @@ EOF
 	is "$output" ".*error: argument --pull: invalid choice: 'bogus'" "verify pull can not be bogus"
 
 	run_ramalama -q --dryrun run --name foobar ${MODEL}
-	is "$output" "${verify_begin} foobar .*" "dryrun correct with --name"
-	assert "$output" =~ ".*--cap-drop=all" "verify --cap-add is present"
-	assert "$output" =~ ".*no-new-privileges" "verify --no-new-privs is not present"
+	is "$output" ".*--name foobar" "dryrun correct with --name"
+	is "$output" ".*--cap-drop=all" "verify --cap-add is present"
+	is "$output" ".*no-new-privileges" "verify --no-new-privs is not present"
 
     run_ramalama -q --dryrun run --runtime-args="--foo -bar" ${MODEL}
     assert "$output" =~ ".*--foo" "--foo passed to runtime"
@@ -79,7 +80,7 @@ EOF
 
     else
 	run_ramalama -q --dryrun run -c 4096 ${MODEL}
-	is "$output" '.*run.*-c 4096 --temp 0.8.*/path/to/model.*' "dryrun correct"
+	is "$output" '.*run.*-c 4096 --temp 0.8.*' "dryrun correct"
 	is "$output" ".*-c 4096" "verify model name"
 
 	run_ramalama 1 run --ctx-size=4096 --name foobar ${MODEL}
@@ -112,7 +113,7 @@ EOF
 }
 
 @test "ramalama run --keepalive" {
-    run_ramalama 124 run --keepalive 1s tiny
+    run_ramalama 124 --debug run --keepalive 1s tiny
 }
 
 # vim: filetype=sh

--- a/test/system/040-serve.bats
+++ b/test/system/040-serve.bats
@@ -4,7 +4,7 @@ load helpers
 load helpers.registry
 load setup_suite
 
-verify_begin=".*run --rm -i --label ai.ramalama --name"
+verify_begin=".*run --rm"
 
 @test "ramalama --dryrun serve basic output" {
     model=m_$(safename)
@@ -12,7 +12,8 @@ verify_begin=".*run --rm -i --label ai.ramalama --name"
     if is_container; then
         run_ramalama -q --dryrun serve ${model}
         assert "$output" =~ "serving on port .*"
-        is "$output" "${verify_begin} ramalama_.*" "dryrun correct"
+        is "$output" "${verify_begin}.*" "dryrun correct"
+        is "$output" ".*--name ramalama_.*" "dryrun correct"
         is "$output" ".*${model}" "verify model name"
         is "$output" ".*--cache-reuse 256" "cache"
         assert "$output" !~ ".*--no-webui"
@@ -21,9 +22,9 @@ verify_begin=".*run --rm -i --label ai.ramalama --name"
         assert "$output" =~ ".*--no-webui"
 
         run_ramalama -q --dryrun serve --name foobar ${model}
-        is "$output" "${verify_begin} foobar .*" "dryrun correct with --name"
+        is "$output" ".*--name foobar .*" "dryrun correct with --name"
         assert "$output" !~ ".*--network" "--network is not part of the output"
-        assert "$output" =~ ".*--host 0.0.0.0" "verify host 0.0.0.0 is added when run within container"
+        is "$output" ".*--host 0.0.0.0" "verify host 0.0.0.0 is added when run within container"
         is "$output" ".*${model}" "verify model name"
         assert "$output" !~ ".*--seed" "assert seed does not show by default"
 
@@ -89,10 +90,12 @@ verify_begin=".*run --rm -i --label ai.ramalama --name"
     model=m_$(safename)
 
     run_ramalama -q --dryrun serve --detach ${model}
-    is "$output" "${verify_begin} ramalama_.*" "serve in detach mode"
+    is "$output" ".*-d .*" "dryrun correct"
+    is "$output" ".*--name ramalama_.*" "serve in detach mode"
 
     run_ramalama -q --dryrun serve -d ${model}
-    is "$output" "${verify_begin} ramalama_.*" "dryrun correct"
+    is "$output" ".*-d .*" "dryrun correct"
+    is "$output" ".*--name ramalama_.*" "dryrun correct"
 
     run_ramalama stop --all
 }

--- a/test/unit/test_engine.py
+++ b/test/unit/test_engine.py
@@ -1,0 +1,92 @@
+import unittest
+from argparse import Namespace
+from unittest.mock import patch
+
+from ramalama.engine import Engine, containers, dry_run, images, stop_container
+
+
+class TestEngine(unittest.TestCase):
+    def setUp(self):
+        self.base_args = Namespace(
+            engine="podman", debug=False, dryrun=False, pull="never", image="test-image:latest", quiet=True
+        )
+
+    def test_init_basic(self):
+        engine = Engine(self.base_args)
+        self.assertEqual(engine.use_podman, True)
+        self.assertEqual(engine.use_docker, False)
+        self.assertIn("--rm", engine.exec_args)
+
+    def test_add_container_labels(self):
+        args = Namespace(**vars(self.base_args), MODEL="test-model", port="8080", subcommand="run")
+        engine = Engine(args)
+        exec_args = engine.exec_args
+        self.assertIn("--label", exec_args)
+        self.assertIn("ai.ramalama.model=test-model", exec_args)
+        self.assertIn("ai.ramalama.port=8080", exec_args)
+        self.assertIn("ai.ramalama.command=run", exec_args)
+
+    @patch('ramalama.engine.check_nvidia')
+    def test_add_oci_runtime_nvidia(self, mock_check_nvidia):
+        mock_check_nvidia.return_value = "cuda"
+
+        # Test Podman
+        podman_engine = Engine(self.base_args)
+        self.assertIn("--runtime", podman_engine.exec_args)
+        self.assertIn("/usr/bin/nvidia-container-runtime", podman_engine.exec_args)
+
+        # Test Docker
+        args = self.base_args
+        args.engine = "docker"
+        docker_args = Namespace(**vars(args))
+        docker_engine = Engine(docker_args)
+        self.assertIn("--runtime", docker_engine.exec_args)
+        self.assertIn("nvidia", docker_engine.exec_args)
+
+    def test_add_privileged_options(self):
+        # Test non-privileged (default)
+        engine = Engine(self.base_args)
+        self.assertIn("--security-opt=label=disable", engine.exec_args)
+        self.assertIn("--cap-drop=all", engine.exec_args)
+
+        # Test privileged
+        privileged_args = Namespace(**vars(self.base_args), privileged=True)
+        privileged_engine = Engine(privileged_args)
+        self.assertIn("--privileged", privileged_engine.exec_args)
+
+    def test_add_port_option(self):
+        args = Namespace(**vars(self.base_args), port="8080")
+        engine = Engine(args)
+        self.assertIn("-p", engine.exec_args)
+        self.assertIn("8080:8080", engine.exec_args)
+
+    @patch('ramalama.engine.run_cmd')
+    def test_images(self, mock_run_cmd):
+        mock_run_cmd.return_value.stdout = b"image1\nimage2\n"
+        args = Namespace(engine="podman", debug=False, format="", noheading=False, notrunc=False)
+        result = images(args)
+        self.assertEqual(result, ["image1", "image2"])
+        mock_run_cmd.assert_called_once()
+
+    @patch('ramalama.engine.run_cmd')
+    def test_containers(self, mock_run_cmd):
+        mock_run_cmd.return_value.stdout = b"container1\ncontainer2\n"
+        args = Namespace(engine="podman", debug=False, format="", noheading=False, notrunc=False)
+        result = containers(args)
+        self.assertEqual(result, ["container1", "container2"])
+        mock_run_cmd.assert_called_once()
+
+    @patch('ramalama.engine.run_cmd')
+    def test_stop_container(self, mock_run_cmd):
+        args = Namespace(engine="podman", debug=False, ignore=False)
+        stop_container(args, "test-container")
+        mock_run_cmd.assert_called_with(["podman", "stop", "-t=0", "test-container"], ignore_stderr=False, debug=False)
+
+    def test_dry_run(self):
+        with patch('sys.stdout') as mock_stdout:
+            dry_run(["podman", "run", "--rm", "test-image"])
+            mock_stdout.write.assert_called()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Shrink the size of cly.py and model.py by moving all engine related functions into new engine.py python module.

## Summary by Sourcery

Refactor container engine interactions by introducing a new Engine class to centralize and simplify container management logic across the project

Enhancements:
- Create a new Engine class in engine.py to encapsulate container engine operations
- Reduce code duplication by centralizing container-related methods
- Simplify method calls for container management across model.py and rag.py

Chores:
- Remove redundant methods from model.py and rag.py
- Move container engine utility functions to a centralized location