### PR TITLE
Fix: huggingface logout doesn't use token

### DIFF
--- a/docs/ramalama-logout.1.md
+++ b/docs/ramalama-logout.1.md
@@ -34,7 +34,7 @@ $ ramalama logout ollama
 
 Logout from huggingface
 ```
-$ ramalama logout --token=XYZ huggingface
+$ ramalama logout huggingface
 ```
 ## SEE ALSO
 **[ramalama(1)](ramalama.1.md)**


### PR DESCRIPTION
I got errors when following https://github.com/containers/ramalama/blob/main/docs/ramalama-logout.1.md to log out Huggingface, I think the token is not needed. Even when we try "huggingface-cli logout", token is not a necessary parameter.

**Using ramalama log in and log out huggingface WITH token:**
```
$ ramalama login --token=hf_token huggingface
The token has not been saved to the git credentials helper. Pass `add_to_git_credential=True` in this function directly or `--add-to-git-credential` if using via `huggingface-cli` if you want to set the git credential as well.
Token is valid (permission: write).
Your token has been saved to ...
Login successful
$ ramalama logout --token=hf_token huggingface
usage: huggingface-cli <command> [<args>]
huggingface-cli: error: unrecognized arguments: --token hf_token
```

**Using ramalama log out huggingface WITHOUT token:**
```
$ ramalama logout  huggingface
Successfully logged out.
```

**Here is the behavior of huggingface-cli**
```
$ huggingface-cli login --token=hf_token
The token has not been saved to the git credentials helper. Pass `add_to_git_credential=True` in this function directly or `--add-to-git-credential` if using via `huggingface-cli` if you want to set the git credential as well.
Token is valid (permission: write).
Your token has been saved to ...
Login successful
$ huggingface-cli logout --token=hf_token
usage: huggingface-cli <command> [<args>]
huggingface-cli: error: unrecognized arguments: --token=hf_token
$ huggingface-cli logout 
Successfully logged out.
```

## Summary by Sourcery

Remove token parameter from huggingface logout documentation

Bug Fixes:
- Fix documentation example to show logout without token parameter

Documentation:
- Update documentation to reflect that the token is not required when logging out of Huggingface