### PR TITLE
Always use --jinja with run too

### DIFF
--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -551,7 +551,7 @@ class Model(ModelBase):
             os.environ["LLAMA_PROMPT_PREFIX"] = "🦙 > "
 
         exec_args = ["ramalama-run-core"] if USE_RAMALAMA_WRAPPER else ["llama-run"]
-        exec_args += ["-c", f"{args.context}", "--temp", f"{args.temp}"]
+        exec_args += ["--jinja", "-c", f"{args.context}", "--temp", f"{args.temp}"]
         exec_args += args.runtime_args
 
         if args.seed:

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -108,7 +108,7 @@ EOF
 }
 
 @test "ramalama run smollm with prompt" {
-    run_ramalama run ${MODEL} "What is the first line of the declaration of independence?"
+    run_ramalama run --temp 0 ${MODEL} "What is the first line of the declaration of independence?"
 }
 
 @test "ramalama run --keepalive" {


### PR DESCRIPTION
`ramalama serve` already using --jinja by default, `ramalama run` should do it too.

fixes: #1212

## Summary by Sourcery

Bug Fixes:
- Ensure consistent Jinja template handling between ramalama serve and ramalama run commands