### PR TITLE
Fix for using client/server version of "ramalama run"

### DIFF
--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -509,6 +509,9 @@ class Model(ModelBase):
         return model_path
 
     def get_model_path(self, args):
+        if os.path.exists(args.MODEL):
+            return args.MODEL
+
         model_path = self.exists(args)
         if model_path:
             return model_path


### PR DESCRIPTION
When using containers we need this check so the code doesn't start going into some pulling logic.

## Summary by Sourcery

Bug Fixes:
- Add a direct check for existing local model path before attempting to retrieve model through existing methods