### PR TITLE
Allow jinja argument

### DIFF
--- a/libexec/ramalama/ramalama-client-core
+++ b/libexec/ramalama/ramalama-client-core
@@ -130,6 +130,7 @@ def main(args):
         default=2048,
         help="size of the prompt context (0 = loaded from model)",
     )
+    parser.add_argument("--jinja", action="store_true", help="enable jinja")
     parser.add_argument("--kill-server", dest="pid2kill", type=int, help="server process to kill on termination of client")
     parser.add_argument("--temp", default=0.8, help="temperature of the response from the AI model")
     parser.add_argument(

--- a/libexec/ramalama/ramalama-run-core
+++ b/libexec/ramalama/ramalama-run-core
@@ -23,6 +23,7 @@ def main(args):
         default=2048,
         help="size of the prompt context (0 = loaded from model)",
     )
+    parser.add_argument("--jinja", action="store_true", help="enable jinja")
     parser.add_argument("--temp", default=0.8, help="temperature of the response from the AI model")
     parser.add_argument(
         "--ngl",


### PR DESCRIPTION
It's on everywhere anyway, this just ensures these wrapper scripts don't crash if jinja gets passed.

## Summary by Sourcery

Enhancements:
- Add support for Jinja argument to prevent script crashes