### PR TITLE
Verify OCI image format in rag command

### DIFF
--- a/ramalama/rag.py
+++ b/ramalama/rag.py
@@ -13,6 +13,8 @@ class Rag:
     target = ""
 
     def __init__(self, target):
+        if not target.islower():
+            raise ValueError(f"invalid reference format: repository name '{target}' must be lowercase")
         self.target = target
         set_accel_env_vars()
 

--- a/test/system/070-rag.bats
+++ b/test/system/070-rag.bats
@@ -8,6 +8,9 @@ load helpers
     run_ramalama 22 -q rag bogus quay.io/ramalama/myrag:1.2
     is "$output" "Error: bogus does not exist" "Expected failure"
 
+    run_ramalama 22 -q rag README.md quay.io/ramalama/MYRAG:1.2
+    is "$output" "Error: invalid reference format: repository name 'quay.io/ramalama/MYRAG:1.2' must be lowercase"
+
     run_ramalama rag README.md https://github.com/containers/ramalama/blob/main/README.md https://github.com/containers/podman/blob/main/README.md quay.io/ramalama/myrag:1.2
 
     run_ramalama --dryrun run --rag quay.io/ramalama/myrag:1.2 ollama://smollm:135m


### PR DESCRIPTION
Fixes: https://github.com/containers/ramalama/issues/1244

## Summary by Sourcery

Add validation to ensure OCI image references are lowercase

Bug Fixes:
- Implement validation to prevent using uppercase characters in OCI image repository names

Tests:
- Add test case to verify lowercase validation for OCI image references