### PR TITLE
Initial draft model support

### DIFF
--- a/docs/ramalama-serve.1.md
+++ b/docs/ramalama-serve.1.md
@@ -79,6 +79,15 @@ show this help message and exit
 #### **--host**="0.0.0.0"
 IP address for llama.cpp to listen on.
 
+#### **--model-draft**
+The model to be used for speculative decoding, typically significantly smaller than
+the main model with the same vocabulary. It proposes next tokens the main model verify
+the proposal cheaply in case it is good the generation will be faster.
+Server logs contains statistics about it's usefulness.
+Use --runtime-arg to pass the other draft model related parameters.
+Make sure you set the sampling parameters like top_k on the web UI correctly
+as well.
+
 #### **--name**, **-n**
 Name of the container to run the Model in.
 

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -868,6 +868,8 @@ def serve_parser(subparsers):
     parser.add_argument(
         "--rag", help="RAG vector database or OCI Image to be served with the model", completer=local_models
     )
+    parser.add_argument("--model-draft", help="Draft model", completer=local_models)
+
     parser.add_argument("MODEL", completer=local_models)  # positional argument
     parser.set_defaults(func=serve_cli)
 

--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -23,6 +23,7 @@ logging.basicConfig(level=logging.WARNING, format="%(asctime)s - %(levelname)s -
 
 MNT_DIR = "/mnt/models"
 MNT_FILE = f"{MNT_DIR}/model.file"
+MNT_FILE_DRAFT = f"{MNT_DIR}/draft_model.file"
 MNT_CHAT_TEMPLATE_FILE = f"{MNT_DIR}/chat_template.file"
 
 RAG_DIR = "/rag"


### PR DESCRIPTION
Allows to pass draft model to serve and fetching it when needed. 'run' does not supports passing draft_model.
You should also pass draft related args tuned to your combination and do not forget to set the sampling parameters like top_k on the UI.

## Summary by Sourcery

Add support for draft models in the model serving and loading process, enabling users to specify and use draft models with additional configuration options.

New Features:
- Introduce ability to pass and use draft models during model serving
- Add new CLI arguments for specifying draft models and GPU layer offloading for draft models

Enhancements:
- Extend model factory to support draft model initialization
- Modify GPU argument handling to accommodate draft model configurations

Chores:
- Update configuration defaults to include draft model-related settings