### PR TITLE
Default use_model_store=false for release. Will revert for next

### DIFF
--- a/ramalama/config.py
+++ b/ramalama/config.py
@@ -101,7 +101,7 @@ def load_config_defaults(config: Dict[str, Any]):
     config.setdefault('store', get_store())
     config.setdefault('temp', "0.8")
     config.setdefault('transport', "ollama")
-    config.setdefault('use_model_store', True)
+    config.setdefault('use_model_store', False)
 
 
 class Config(ChainMap):

--- a/ramalama/engine.py
+++ b/ramalama/engine.py
@@ -23,8 +23,9 @@ class Engine:
             "run",
             "--rm",
         ]
-        self.use_docker = os.path.basename(args.engine) == "docker"
-        self.use_podman = os.path.basename(args.engine) == "podman"
+        engine = os.path.basename(args.engine)
+        self.use_docker = engine == "docker"
+        self.use_podman = engine == "podman"
         self.args = args
         self.add_container_labels()
         self.add_device_options()


### PR DESCRIPTION
Also add micro improvement on speed.

## Summary by Sourcery

Change the default configuration for model store usage to be disabled by default for release

Enhancements:
- Simplified engine initialization by extracting engine name extraction into a separate variable

Chores:
- Set default 'use_model_store' configuration to False