### PR TITLE
Replace project.license with an SPDX license expression.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ maintainers = [
 ]
 description = "RamaLama is a command line tool for working with AI LLM models."
 readme = "README.md"
-license = {file = "LICENSE"}
+license = "MIT"
 keywords = ["ramalama", "llama", "AI"]
 
 [project.urls]


### PR DESCRIPTION
`project.license` as a TOML table is deprecated. The new format for license is a valid SPDX license expression consisting of one or more license identifiers.

See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license.

## Summary by Sourcery

Update project license specification in pyproject.toml to use SPDX license expression

Enhancements:
- Replace deprecated TOML table license format with a standard SPDX license identifier

Documentation:
- Update license specification to follow current Python packaging guidelines