### PR TITLE
Use --quiet for ramalama version

### DIFF
--- a/docs/ramalama-version.1.md
+++ b/docs/ramalama-version.1.md
@@ -14,6 +14,15 @@ Print version of RamaLama
 #### **--help**, **-h**
 Print usage message
 
+## EXAMPLES
+
+```
+$ ramalama version
+ramalama version 1.2.3
+$ ramalama -q version
+1.2.3
+>
+```
 ## SEE ALSO
 **[ramalama(1)](ramalama.1.md)**
 

--- a/ramalama/version.py
+++ b/ramalama/version.py
@@ -14,4 +14,7 @@ def version():
 
 
 def print_version(args):
-    print("ramalama version %s" % version())
+    if args.quiet:
+        print(version())
+    else:
+        print("ramalama version %s" % version())

--- a/test/system/060-info.bats
+++ b/test/system/060-info.bats
@@ -15,6 +15,9 @@ load helpers
     run_ramalama version
     is "$output" "ramalama version $version"
 
+    run_ramalama -q version
+    is "$output" "$version"
+
     run_ramalama info
 
     # FIXME Engine  (podman|docker|'')


### PR DESCRIPTION
Makes figuring out what the version of ramalama is easier.

Fixes: https://github.com/containers/ramalama/issues/1258

## Summary by Sourcery

Add a quiet mode to the ramalama version command to simplify version output

New Features:
- Introduce a quiet flag (-q) to the version command that outputs only the version number without the 'ramalama version' prefix

Documentation:
- Update man page documentation to include an example of using the quiet flag for version output

Tests:
- Add a system test to verify the new quiet mode functionality for the version command