### PR TITLE
Revert "Replace project.license with an SPDX license expression."

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ maintainers = [
 ]
 description = "RamaLama is a command line tool for working with AI LLM models."
 readme = "README.md"
-license = "MIT"
+license = {file = "LICENSE"}
 keywords = ["ramalama", "llama", "AI"]
 
 [project.urls]


### PR DESCRIPTION
Reverts containers/ramalama#1271

## Summary by Sourcery

Build:
- Restore the `project.license` field in `pyproject.toml` to refer to the LICENSE file.