### PR TITLE
Use current ramalama directory rather them main from repo

### DIFF
--- a/container-images/scripts/build-cli.sh
+++ b/container-images/scripts/build-cli.sh
@@ -21,15 +21,10 @@ dnf_install() {
   dnf -y clean all
 }
 
-clone_and_build_ramalama() {
+install_ramalama() {
   # link podman-remote to podman for use by RamaLama
   ln -sf /usr/bin/podman-remote /usr/bin/podman
-  git clone https://github.com/containers/ramalama
-  cd ramalama
-  git submodule update --init --recursive
-  python3 -m pip install .
-  cd ..
-  rm -rf ramalama
+  python3 -m pip install /run/ramalama --prefix=/usr
 }
 
 main() {
@@ -38,7 +33,7 @@ main() {
 
   set -ex
   dnf_install
-  clone_and_build_ramalama
+  install_ramalama
   dnf_remove
   rm -rf /var/cache/*dnf* /opt/rocm-*/lib/*/library/*gfx9*
 }

--- a/container-images/scripts/build_llama_and_whisper.sh
+++ b/container-images/scripts/build_llama_and_whisper.sh
@@ -252,13 +252,10 @@ clone_and_build_llama_cpp() {
   rm -rf llama.cpp
 }
 
-clone_and_build_ramalama() {
-  git clone https://github.com/containers/ramalama
-  cd ramalama
-  git submodule update --init --recursive
-  python3 -m pip install . --prefix="$1"
-  cd ..
-  rm -rf ramalama
+install_ramalama() {
+  # link podman-remote to podman for use by RamaLama
+  ln -sf /usr/bin/podman-remote /usr/bin/podman
+  python3 -m pip install /run/ramalama --prefix="$1"
 }
 
 main() {
@@ -277,7 +274,7 @@ main() {
   common_flags+=("-DGGML_CCACHE=OFF" "-DCMAKE_INSTALL_PREFIX=${install_prefix}")
   available dnf && dnf_install
   if [ -n "$containerfile" ]; then
-    clone_and_build_ramalama "${install_prefix}"
+    install_ramalama "${install_prefix}"
   fi
 
   setup_build_env

--- a/container_build.sh
+++ b/container_build.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+RAMALAMA_DIR=${PWD}
+
 available() {
   command -v "$1" >/dev/null
 }
@@ -27,6 +29,8 @@ add_build_platform() {
   fi
 
   conman_build+=("--platform" "$platform")
+  conman_build+=("--volume=${RAMALAMA_DIR}:/run/ramalama")
+  conman_build+=("--security-opt=label=disable")
   if [ -n "$version" ]; then
       conman_build+=("--build-arg" "VERSION=$version")
       conman_build+=("-t" "$REGISTRY_PATH/${target}-${version}")


### PR DESCRIPTION
This allows users to experiment with content and get it into container image.

Fixes: https://github.com/containers/ramalama/issues/1274

## Summary by Sourcery

Modify the container image build process to install ramalama from the local source directory instead of cloning the remote repository. Increment the project version to 0.8.0.

Build:
- Install ramalama from a mounted local directory during container image builds instead of cloning the repository.
- Mount the local ramalama source directory into the build container environment.
- Update the RPM spec file version to 0.8.0.
- Disable SELinux labeling for the mounted volume in container builds.

Deployment:
- Update release scripts to tag images and manifests with the new version 0.8.0.

Chores:
- Increment project version from 0.7.5 to 0.8.0.