### PR TITLE
Use RamaLama instead of Ramalama for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ curl -fsSL https://raw.githubusercontent.com/containers/ramalama/s/install.sh | 
 
 __Note:__ On systems with NVIDIA GPUs, see **[ramalama-cuda(7)](docs/ramalama-cuda.7.md)** to correctly configure the host system.
 
-__Note:__ The following Intel GPUs are auto-detected by Ramalama:
+__Note:__ The following Intel GPUs are auto-detected by RamaLama:
 
 | GPU ID | Description |
 | ------ | ----------- |

--- a/docs/ramalama-cann.7.md
+++ b/docs/ramalama-cann.7.md
@@ -64,7 +64,7 @@ CONTAINER ID   IMAGE                                                         COM
 80fc31c131b0   quay.io/ramalama/cann:latest                                  "/bin/bash -c 'expor…"   About an hour ago   Up About an hour                                                  ame
 ```
 
-Other using guides see Ramalama ([README.md](https://github.com/containers/ramalama/blob/main/README.md))
+Other using guides see RamaLama ([README.md](https://github.com/containers/ramalama/blob/main/README.md))
 
 ## HISTORY
 Mar 2025, Originally compiled

--- a/install.sh
+++ b/install.sh
@@ -1948,7 +1948,7 @@ print_banner() {
 print_success_info() {
   echo
   echo "====================== Installation Completed ======================"
-  echo "Success! Ramalama has been installed successfully."
+  echo "Success! RamaLama has been installed successfully."
   echo "For further details, check the documentation at:"
   echo "https://github.com/containers/ramalama/tree/main/docs"
   echo "Or use the '--help' flag to learn more about usage."


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Update project name capitalization across documentation and scripts for consistency.