### PR TITLE
Workaround for CUDA image not pointing to libcuda.so.1 in ld.so.conf

### DIFF
--- a/container-images/cuda/Containerfile
+++ b/container-images/cuda/Containerfile
@@ -12,6 +12,9 @@ FROM docker.io/nvidia/cuda:${VERSION}-runtime-ubi9
 COPY --from=builder /tmp/install /usr
 COPY --chmod=755 ../scripts /usr/bin
 
+# Workaround for CUDA libraries not in the ld path in base container
+RUN echo "/usr/local/cuda-12.8/compat" > /etc/ld.so.conf.d/99_cuda_compat.conf && ldconfig
+
 RUN dnf install -y python3
 
 ENTRYPOINT []


### PR DESCRIPTION
libcuda.so.1 is located at /usr/local/cuda-12.8/compat and that path is not in any /etc/ld.so.conf.d/* files.

The workaround is to simply add the path and run ldconfig to make it available.

## Summary by Sourcery

Build:
- Add the CUDA compatibility library path to the linker configuration (`ld.so.conf.d`) and update the cache (`ldconfig`) within the Containerfile.