### PR TITLE
Add gemma3 shortnames

### DIFF
--- a/shortnames/shortnames.conf
+++ b/shortnames/shortnames.conf
@@ -1,5 +1,10 @@
 [shortnames]
   "deepseek" = "ollama://deepseek-r1"
+  "gemma3" = "hf://bartowski/google_gemma-3-4b-it-GGUF/google_gemma-3-4b-it-IQ2_M.gguf"
+  "gemma3:1b" = "hf://bartowski/google_gemma-3-1b-it-GGUF/google_gemma-3-1b-it-IQ2_M.gguf"
+  "gemma3:4b" = "hf://bartowski/google_gemma-3-4b-it-GGUF/google_gemma-3-4b-it-IQ2_M.gguf"
+  "gemma3:12b" = "hf://bartowski/google_gemma-3-12b-it-GGUF/google_gemma-3-12b-it-IQ2_M.gguf"
+  "gemma3:27b" = "hf://bartowski/google_gemma-3-27b-it-GGUF/google_gemma-3-27b-it-IQ2_M.gguf"
   "granite" = "ollama://granite3.1-dense"
   "granite-lab-8b" = "huggingface://ibm-granite/granite-8b-code-base-GGUF/granite-8b-code-base.Q4_K_M.gguf"
   "granite:2b" = "ollama://granite3.1-dense:2b"


### PR DESCRIPTION
Otherwise we will pull the incompatible gguf's from Ollama registry.

## Summary by Sourcery

Chores:
- Update `shortnames.conf` with new entries for Gemma 3 model variants.