### PR TITLE
Exit ramalama if user types exit

### DIFF
--- a/libexec/ramalama/ramalama-client-core
+++ b/libexec/ramalama/ramalama-client-core
@@ -96,7 +96,7 @@ class RamaLamaShell(cmd.Cmd):
         return True
 
     def default(self, user_content):
-        if user_content == "/bye":
+        if user_content in ["/bye", "exit"]:
             return True
 
         self.conversation_history.append({"role": "user", "content": user_content})


### PR DESCRIPTION
To behave like bash or python3

## Summary by Sourcery

Enhancements:
- Allow the `ramalama` client to terminate when the user inputs "exit".