### PR TITLE
Change CLI behaviour

### DIFF
--- a/libexec/ramalama/ramalama-client-core
+++ b/libexec/ramalama/ramalama-client-core
@@ -84,6 +84,7 @@ class RamaLamaShell(cmd.Cmd):
         super().__init__()
         self.conversation_history = []
         self.parsed_args = parsed_args
+        self.request_in_process = False
         if "LLAMA_PROMPT_PREFIX" in os.environ:
             self.prompt = os.environ["LLAMA_PROMPT_PREFIX"]
         else:
@@ -100,9 +101,21 @@ class RamaLamaShell(cmd.Cmd):
             return True
 
         self.conversation_history.append({"role": "user", "content": user_content})
+        self.request_in_process = True
         self.conversation_history.append(
             {"role": "assistant", "content": req(self.conversation_history, self.url, self.parsed_args.color)}
         )
+        self.request_in_process = False
+
+    def cmdloop(self, intro=None):
+        try:
+            super().cmdloop(intro)
+        except KeyboardInterrupt:
+            print("")
+            if not self.request_in_process:
+                print("Use Ctrl + d or /bye or exit to quit.")
+
+            self.cmdloop(intro)  # Restart the command loop
 
 def do_kills(parsed_args):
     if parsed_args.pid2kill:
@@ -144,11 +157,7 @@ def main(args):
         do_kills(parsed_args)
         return 0
 
-    try:
-        ramalama_shell.cmdloop()
-    except KeyboardInterrupt:
-        print("")
-
+    ramalama_shell.cmdloop()
     do_kills(parsed_args)
 
 

--- a/libexec/ramalama/ramalama-run-core
+++ b/libexec/ramalama/ramalama-run-core
@@ -9,12 +9,7 @@ import sys
 from argparse import Namespace
 
 
-def main(args):
-    sys.path.append('./')
-    from ramalama.cli import serve_cli
-    from ramalama.common import exec_cmd, run_cmd
-    from ramalama.model import get_available_port_if_any
-
+def initialize_parser():
     parser = argparse.ArgumentParser(description="Run ramalama run core")
     parser.add_argument(
         "-c",
@@ -46,27 +41,47 @@ def main(args):
     parser.add_argument(
         "ARGS", nargs="*", help="overrides the default prompt, and the output is returned without entering the chatbot"
     )
-    parsed_args = parser.parse_args()
 
+    return parser
+
+
+def initialize_args():
+    from ramalama.model import get_available_port_if_any
+
+    parser = initialize_parser()
+    parsed_args = parser.parse_args()
     port = get_available_port_if_any(False)
+
+    return parsed_args, port
+
+
+def main(args):
+    sys.path.append('./')
+    from ramalama.cli import serve_cli
+    from ramalama.common import exec_cmd
+
+    parsed_args, port = initialize_args()
+
     pid = os.fork()
     if pid == 0:
+        signal.pthread_sigmask(signal.SIG_BLOCK, {signal.SIGINT})
         with open(os.devnull, 'w') as devnull:
             os.dup2(devnull.fileno(), sys.stderr.fileno())
 
         args = Namespace(
-        container=False, dryrun=False, engine=None, podman_keep_groups=False,
-        image='quay.io/ramalama/ramalama', runtime='llama.cpp',
-        store=os.path.expanduser("~/.local/share/ramalama"), use_model_store=False,
-        quiet=False, debug=False, subcommand='serve', ngl=-1, threads=6,
-        temp=parsed_args.temp, authfile=None, env=[], device=None, name=None,
-        oci_runtime=None, privileged=False, pull='newer', seed=None,
-        tlsverify=True, context=parsed_args.context, runtime_args=[], network=None,
-        detach=False, host='127.0.0.1', webui='on', generate=None, port=str(port),
-        rag=None, MODEL=parsed_args.MODEL, func=lambda: None,
-        UNRESOLVED_MODEL=parsed_args.MODEL
+            container=False, dryrun=False, engine=None, podman_keep_groups=False,
+            image='quay.io/ramalama/ramalama', runtime='llama.cpp',
+            store=os.path.expanduser("~/.local/share/ramalama"), use_model_store=False,
+            quiet=False, debug=False, subcommand='serve', ngl=-1, threads=6,
+            temp=parsed_args.temp, authfile=None, env=[], device=None, name=None,
+            oci_runtime=None, privileged=False, pull='newer', seed=None,
+            tlsverify=True, context=parsed_args.context, runtime_args=[], network=None,
+            detach=False, host='127.0.0.1', webui='on', generate=None, port=str(port),
+            rag=None, MODEL=parsed_args.MODEL, func=lambda: None,
+            UNRESOLVED_MODEL=parsed_args.MODEL
         )
         serve_cli(args)
+
         return 0
 
     client_args = build_args(args, "ramalama-client-core")


### PR DESCRIPTION
Don't exit on Ctrl-C, cut response short or print an info message to the user telling them how they may exit.

## Summary by Sourcery

Enhancements:
- Handle Ctrl-C by truncating output and informing the user how to exit, instead of immediately terminating.