### PR TITLE
Make --no-cache optional for make build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,8 @@ help:
 	@echo "  - make build IMAGE=ramalama"
 	@echo "  - make multi-arch"
 	@echo "  - make multi-arch IMAGE=ramalama"
+	@echo "  Build using build cache, for development only"
+	@echo "  - make build IMAGE=ramalama CACHE=-C"
 	@echo
 	@echo "Build docs"
 	@echo
@@ -86,15 +88,15 @@ install: docs completions
 
 .PHONY: build
 build:
-	./container_build.sh build $(IMAGE) -v "$(VERSION)"
+	./container_build.sh ${CACHE} build $(IMAGE) -v "$(VERSION)"
 
 .PHONY: build-rm
 build-rm:
-	./container_build.sh -r build $(IMAGE) -v "$(VERSION)"
+	./container_build.sh ${CACHE} -r build $(IMAGE) -v "$(VERSION)"
 
 .PHONY: build_multi_arch
 build_multi_arch:
-	./container_build.sh multi-arch $(IMAGE) -v "$(VERSION)"
+	./container_build.sh ${CACHE} multi-arch $(IMAGE) -v "$(VERSION)"
 
 .PHONY: install-docs
 install-docs: docs

--- a/container_build.sh
+++ b/container_build.sh
@@ -22,11 +22,11 @@ select_container_manager() {
 
 add_build_platform() {
   conman_build+=("build")
-
   # This build saves space
-  if ! $rm_after_build; then
-    conman_build+=("--no-cache")
+  if [ -n "${nocache}" ]; then
+      conman_build+=("${nocache}")
   fi
+
 
   conman_build+=("--platform" "$platform")
   conman_build+=("--volume=${RAMALAMA_DIR}:/run/ramalama")
@@ -57,8 +57,8 @@ add_entrypoint() {
 FROM $2
 ENTRYPOINT [ "/usr/bin/$3.sh" ]
 EOF
-echo "$1 build --no-cache -t $tag -f ${containerfile} ."
-eval "$1 build --no-cache -t $tag -f ${containerfile} ."
+echo "$1 build ${nocache} -t $tag -f ${containerfile} ."
+eval "$1 build ${nocache} -t $tag -f ${containerfile} ."
 rm "${containerfile}"
 }
 
@@ -89,8 +89,8 @@ USER root
 RUN /usr/bin/build_rag.sh ${GPU}
 ENTRYPOINT []
 EOF
-    echo "$1 build --no-cache -t ${REGISTRY_PATH}/$tag-rag -f ${containerfile} ."
-    eval "$1 build --no-cache -t ${REGISTRY_PATH}/$tag-rag -f ${containerfile} ."
+    echo "$1 build ${nocache} -t ${REGISTRY_PATH}/$tag-rag -f ${containerfile} ."
+    eval "$1 build ${nocache} -t ${REGISTRY_PATH}/$tag-rag -f ${containerfile} ."
     rm "${containerfile}"
 }
 
@@ -173,12 +173,17 @@ parse_arguments() {
         ci="true"
         shift
         ;;
+      -C)
+        nocache=""
+        shift
+        ;;
       -d)
         dryrun="$1"
         shift
         ;;
       -r)
         rm_after_build="true"
+        nocache=""
         shift
         ;;
       -v)
@@ -259,6 +264,7 @@ main() {
   local rm_after_build="false"
   local ci="false"
   local version=""
+  local nocache="--no-cache"
   parse_arguments "$@"
   if [ -z "$command" ]; then
     echo "Error: command is required (build or push)"


### PR DESCRIPTION
## Summary by Sourcery

Allow enabling the build cache for container builds.

Build:
- Add a `-C` flag to `container_build.sh` to optionally enable the build cache.
- Update Makefile targets (`build`, `build-rm`, `build_multi_arch`) to accept a `CACHE` variable for controlling build caching.
- Enable the build cache automatically when the `-r` (remove after build) flag is used in `container_build.sh`.
- Default container builds to use `--no-cache` unless explicitly overridden.

Documentation:
- Document the new `CACHE=-C` option in the Makefile help output.