### PR TITLE
Fix the error: ramalama login can NOT get the value of RAMALAMA_TRANSPORT

### DIFF
--- a/docs/ramalama-login.1.md
+++ b/docs/ramalama-login.1.md
@@ -9,6 +9,8 @@ ramalama\-login - login to remote registry
 ## DESCRIPTION
 login to remote model registry
 
+By default, RamaLama uses the Ollama registry transport. You can override this default by configuring the `ramalama.conf` file or setting the `RAMALAMA_TRANSPORTS` environment variable. Ensure a registry transport is set before attempting to log in.
+
 ## OPTIONS
 Options are specific to registry types.
 
@@ -37,17 +39,20 @@ username for registry
 
 Login to quay.io/username oci registry
 ```
-$ ramalama login -u username quay.io/username
+$ export RAMALAMA_TRANSPORT=quay.io/username
+$ ramalama login -u username
 ```
 
 Login to ollama registry
 ```
-$ ramalama login ollama
+$ export RAMALAMA_TRANSPORT=ollama
+$ ramalama login
 ```
 
 Login to huggingface registry
 ```
-$ ramalama login --token=XYZ huggingface
+$ export RAMALAMA_TRANSPORT=huggingface
+$ ramalama login --token=XYZ
 ```
 Logging in to Hugging Face requires the `huggingface-cli` tool. For installation and usage instructions, see the documentation of the Hugging Face command line interface: [*https://huggingface.co/docs/huggingface_hub/en/guides/cli*](https://huggingface.co/docs/huggingface_hub/en/guides/cli).
 

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -250,6 +250,9 @@ def login_parser(subparsers):
 
 
 def normalize_registry(registry):
+    # Determine the registry to use. Check the value of `RAMALAMA_TRANSPORT` env var if no `registry` argument is set.
+    registry = registry or os.getenv("RAMALAMA_TRANSPORT") or CONFIG['transport']
+
     if not registry or registry == "" or registry.startswith("oci://"):
         return "oci://"
 


### PR DESCRIPTION
**Problem before the modification:**

```
$ export RAMALAMA_TRANSPORT=huggingface
$ ramalama login --token=hf_mytoken 
Authenticating with existing credentials for registry.fedoraproject.org
Existing credentials are valid. Already logged in to registry.fedoraproject.org
```

The value of the env var RAMALAMA_TRANSPORT was not recognized and handled in the code.

**Test after the modification**
test 1:
```
$ export RAMALAMA_TRANSPORT=huggingface
$ ramalama login --token=hf_mytoken 
The token has not been saved to the git credentials helper. Pass `add_to_git_credential=True` in this function directly or `--add-to-git-credential` if using via `huggingface-cli` if you want to set the git credential as well.
Token is valid (permission: write).
Your token has been saved to ~/.cache/huggingface/token
Login successful
$ ramalama logout
Successfully logged out.
```

test 2:
```
$ export RAMALAMA_TRANSPORT=huggingface
$ ramalama login --token=hf_mytoken huggingface
The token has not been saved to the git credentials helper. Pass `add_to_git_credential=True` in this function directly or `--add-to-git-credential` if using via `huggingface-cli` if you want to set the git credential as well.
Token is valid (permission: write).
Your token has been saved to ~/.cache/huggingface/token
Login successful
$ ramalama logout huggingface
Successfully logged out.
```

## Summary by Sourcery

Bug Fixes:
- The `login` command now correctly uses the `RAMALAMA_TRANSPORT` environment variable to determine the registry if no explicit registry argument is provided.