### PR TITLE
Report on the use of cached models

### DIFF
--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -1064,5 +1064,6 @@ def inspect_parser(subparsers):
 
 
 def inspect_cli(args):
+    args.pull = "never"
     model = New(args.MODEL, args)
     model.inspect(args)

--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -397,6 +397,9 @@ class Model(ModelBase):
         if args.dryrun:
             return "/path/to/model"
 
+        if args.pull == "never":
+            raise ValueError(f"{args.MODEL} does not exists")
+
         model_path = self.pull(args)
 
         return model_path

--- a/test/system/050-pull.bats
+++ b/test/system/050-pull.bats
@@ -25,7 +25,7 @@ load setup_suite
     run_ramalama rm ollama://smollm:135m ollama://smollm:360m
 
     random_image_name=i_$(safename)
-    run_ramalama 1 pull ${random_image_name}
+    run_ramalama 1 -q pull ${random_image_name}
     is "$output" "Error: Manifest for ${random_image_name}:latest was not found in the Ollama registry"
 }
 
@@ -54,7 +54,7 @@ load setup_suite
     ollama rm smollm:135m smollm:360m
 
     random_image_name=i_$(safename)
-    run_ramalama 1 pull ${random_image_name}
+    run_ramalama 1 -q pull ${random_image_name}
     is "$output" "Error: Manifest for ${random_image_name}:latest was not found in the Ollama registry"
 
     pkill ollama

--- a/test/system/100-inspect.bats
+++ b/test/system/100-inspect.bats
@@ -6,6 +6,11 @@ load setup_suite
 
 # bats test_tags=distro-integration
 @test "ramalama inspect GGUF model" {
+    MODEL=c_$(safename)
+    run_ramalama 22 inspect ${MODEL}
+    is "$output" "Error: ${MODEL} does not exists" "error on missing models"
+    
+    run_ramalama pull tiny
     run_ramalama inspect tiny
 
     is "${lines[0]}" "tinyllama" "model name"


### PR DESCRIPTION
## Summary by Sourcery

Add user feedback messages during model pulling for Ollama and Hugging Face integrations.

Enhancements:
- Print a message indicating when a cached model (Ollama or Hugging Face) is being used.
- Print messages indicating when a model (Ollama or Hugging Face) is being downloaded.