### PR TITLE
common: adjust nvidia-smi for check cuda version

### DIFF
--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -531,7 +531,7 @@ def check_cuda_version():
     """
     try:
         # Run nvidia-smi --version to get version info
-        command = ['nvidia-smi', '--version']
+        command = ['nvidia-smi']
         output = run_cmd(command).stdout.decode("utf-8").strip()
 
         # Look for CUDA Version in the output


### PR DESCRIPTION
Be compatible with both versions of nvidia-smi
with version flag or not.