### PR TITLE
feat: add ramalama stack subcommand

### DIFF
--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -23,6 +23,7 @@ from ramalama.model import MODEL_TYPES
 from ramalama.model_factory import ModelFactory
 from ramalama.model_store import GlobalModelStore
 from ramalama.shortnames import Shortnames
+from ramalama.stack_factory import StackFactory
 from ramalama.version import print_version, version
 
 shortnames = Shortnames()
@@ -208,6 +209,7 @@ def configure_subcommands(parser):
     rm_parser(subparsers)
     run_parser(subparsers)
     serve_parser(subparsers)
+    stack_parser(subparsers)
     stop_parser(subparsers)
     version_parser(subparsers)
 
@@ -1038,6 +1040,10 @@ def New(model, args, transport=CONFIG["transport"]):
     return ModelFactory(model, args, transport=transport).create()
 
 
+def NewStack(distro, args, transport=CONFIG["transport"]):
+    return StackFactory(distro, args, transport=transport).create()
+
+
 def client_cli(args):
     """Handle client command execution"""
     client_args = ["ramalama-client-core", "-c", "2048", "--temp", "0.8", args.HOST] + args.ARGS
@@ -1070,3 +1076,14 @@ def inspect_cli(args):
     args.pull = "never"
     model = New(args.MODEL, args)
     model.inspect(args)
+
+
+def stack_parser(subparsers):
+    parser = subparsers.add_parser("stack", help="run a Llama Stack distribution")
+    parser.add_argument("DISTRO")  # positional argument
+    parser.set_defaults(func=stack_cli)
+
+
+def stack_cli(args):
+    stack = NewStack(args.DISTRO, args)
+    stack.run(args)

--- a/ramalama/stack.py
+++ b/ramalama/stack.py
@@ -1,0 +1,286 @@
+import glob
+import os
+import sys
+
+import ramalama
+from ramalama.common import check_nvidia, exec_cmd, genname, get_accel_env_vars
+
+USE_RAMALAMA_WRAPPER = False
+
+file_not_found = """\
+RamaLama requires the "%(cmd)s" command to be installed on the host when running with --nocontainer.
+RamaLama is designed to run AI Models inside of containers, where "%(cmd)s" is already installed.
+Either install a package containing the "%(cmd)s" command or run the workload inside of a container.
+%(error)s"""
+
+
+class StackBase:
+
+    def __not_implemented_error(self, param):
+        return NotImplementedError(f"ramalama {param} for '{type(self).__name__}' not implemented")
+
+    def pull(self, args):
+        raise self.__not_implemented_error("pull")
+
+    def run(self, args):
+        raise self.__not_implemented_error("serve")
+
+
+class Stack(StackBase):
+    """Stack super class"""
+
+    distro = ""
+    type = "Distro"
+
+    def __init__(self, distro):
+        self.distro = distro
+
+        split = self.distro.rsplit("/", 1)
+        self.directory = split[0] if len(split) > 1 else ""
+        self.filename = split[1] if len(split) > 1 else split[0]
+
+        self._distro_name: str
+        self._distro_tag: str
+        self._distro_organization: str
+        self._distro_type: str
+        self._distro_name, self._distro_tag, self._distro_organization = self.extract_distro_identifiers()
+        self._distro_type = type(self).__name__.lower()
+
+    def extract_distro_identifiers(self):
+        distro_name = self.distro
+        distro_tag = "latest"
+        distro_organization = ""
+
+        # extract distro tag from name if exists
+        if ":" in distro_name:
+            distro_name, distro_tag = distro_name.split(":", 1)
+
+        # extract distro organization from name if exists and update name
+        split = distro_name.rsplit("/", 1)
+        distro_organization = split[0].removeprefix("/") if len(split) > 1 else ""
+        distro_name = split[1] if len(split) > 1 else split[0]
+
+        return distro_name, distro_tag, distro_organization
+
+    @property
+    def name(self) -> str:
+        return self._distro_name
+
+    @property
+    def tag(self) -> str:
+        return self._distro_tag
+
+    @property
+    def organization(self) -> str:
+        return self._distro_organization
+
+    @property
+    def distro_type(self) -> str:
+        return self._distro_type
+
+    def get_container_name(self, args):
+        if hasattr(args, "name") and args.name:
+            return args.name
+
+        return genname()
+
+    def get_base_conman_args(self, args, name):
+        return [
+            args.engine,
+            "run",
+            "--rm",
+            "-i",
+            "--label",
+            "ai.ramalama",
+            "--name",
+            name,
+            "--env=HOME=/tmp",
+            "--init",
+        ]
+
+    def add_privileged_options(self, conman_args, args):
+        if args.privileged:
+            conman_args += ["--privileged"]
+        else:
+            conman_args += [
+                "--security-opt=label=disable",
+                "--cap-drop=all",
+                "--security-opt=no-new-privileges",
+            ]
+
+        return conman_args
+
+    def add_container_labels(self, conman_args, args):
+        if hasattr(args, "MODEL"):
+            conman_args += ["--label", f"ai.ramalama.model={args.MODEL}"]
+
+        if hasattr(args, "engine"):
+            conman_args += ["--label", f"ai.ramalama.engine={args.engine}"]
+
+        if hasattr(args, "runtime"):
+            conman_args += ["--label", f"ai.ramalama.runtime={args.runtime}"]
+
+        if hasattr(args, "port"):
+            conman_args += ["--label", f"ai.ramalama.port={args.port}"]
+
+        if hasattr(args, "subcommand"):
+            conman_args += ["--label", f"ai.ramalama.command={args.subcommand}"]
+
+        return conman_args
+
+    def handle_podman_specifics(self, conman_args, args):
+        if os.path.basename(args.engine) == "podman" and args.podman_keep_groups:
+            conman_args += ["--group-add", "keep-groups"]
+
+        return conman_args
+
+    def add_env_option(self, conman_args, args):
+        for env in args.env:
+            conman_args += ["--env", env]
+
+        return conman_args
+
+    def add_tty_option(self, conman_args):
+        if sys.stdout.isatty() or sys.stdin.isatty():
+            conman_args += ["-t"]
+
+        return conman_args
+
+    def add_detach_option(self, conman_args, args):
+        if hasattr(args, "detach") and args.detach is True:
+            conman_args += ["-d"]
+
+        return conman_args
+
+    def add_port_option(self, conman_args, args):
+        if hasattr(args, "port"):
+            conman_args += ["-p", f"{args.port}:{args.port}"]
+
+        return conman_args
+
+    def add_device_options(self, conman_args, args):
+        if args.device:
+            for device_arg in args.device:
+                conman_args += ["--device", device_arg]
+
+        if ramalama.common.podman_machine_accel:
+            conman_args += ["--device", "/dev/dri"]
+
+        for path in ["/dev/dri", "/dev/kfd", "/dev/accel", "/dev/davinci*", "/dev/devmm_svm", "/dev/hisi_hdc"]:
+            for dev in glob.glob(path):
+                conman_args += ["--device", dev]
+
+        for k, v in get_accel_env_vars().items():
+            # Special case for Cuda
+            if k == "CUDA_VISIBLE_DEVICES":
+                if os.path.basename(args.engine) == "docker":
+                    conman_args += ["--gpus", "all"]
+                else:
+                    # newer Podman versions support --gpus=all, but < 5.0 do not
+                    conman_args += ["--device", "nvidia.com/gpu=all"]
+
+            conman_args += ["-e", f"{k}={v}"]
+
+        return conman_args
+
+    def add_network_option(self, conman_args, args):
+        if args.network:
+            conman_args += ["--network", args.network]
+
+        return conman_args
+
+    def add_oci_runtime(self, conman_args, args):
+        if args.oci_runtime:
+            conman_args += ["--runtime", args.oci_runtime]
+        elif check_nvidia() == "cuda":
+            if os.path.basename(args.engine) == "docker":
+                conman_args += ["--runtime", "nvidia"]
+            else:
+                conman_args += ["--runtime", "/usr/bin/nvidia-container-runtime"]
+
+        return conman_args
+
+    def exists(self, args):
+        distro_path = self.distro_path(args)
+        if not os.path.exists(distro_path):
+            return None
+
+        return distro_path
+
+    def get_distro_path(self, args):
+        distro_path = self.exists(args)
+        if distro_path:
+            return distro_path
+
+        if args.dryrun:
+            return "/path/to/distro"
+
+        distro_path = self.pull(args)
+
+        return distro_path
+
+    def get_distro_registry(self, args):
+        distro_path = self.get_distro_path(args)
+        if not distro_path or args.dryrun:
+            return ""
+
+        parts = distro_path.replace(args.store, "").split(os.sep)
+        if len(parts) < 3:
+            return ""
+        return parts[2]
+
+    def validate_args(self, args):
+        if args.container:
+            return
+        if args.privileged:
+            raise KeyError(
+                "--nocontainer and --privileged options conflict. The --privileged option requires a container."
+            )
+        if hasattr(args, "name") and args.name:
+            if hasattr(args, "generate"):
+                # Do not fail on serve if user specified --generate
+                if args.generate:
+                    return
+            raise KeyError("--nocontainer and --name options conflict. The --name option requires a container.")
+
+    def build_exec_args_run(self, args, distro_path):
+        exec_args = []
+        if USE_RAMALAMA_WRAPPER:
+            exec_args += ["ramalama-serve-core"]
+
+        exec_args += [
+            f"CONTAINER_BINARY={args.engine}" "llama",
+            "stack",
+            "run",
+            distro_path,
+            "--image-type",
+            "container",
+        ] + args.runtime_args
+
+        return exec_args
+
+    def execute_command(self, distro_path, exec_args, args):
+        try:
+            if args.dryrun:
+                dry_run(exec_args)
+                return
+            exec_cmd(exec_args, debug=args.debug)
+        except FileNotFoundError as e:
+            raise NotImplementedError(file_not_found % {"cmd": exec_args[0], "error": str(e).strip("'")})
+
+    def run(self, args):
+        self.validate_args(args)
+        distro_path = self.get_distro_path(args)
+        exec_args = self.build_exec_args_run(args, distro_path)
+        self.execute_command(distro_path, exec_args, args)
+
+
+def dry_run(args):
+    for arg in args:
+        if not arg:
+            continue
+        if " " in arg:
+            print('"%s"' % arg, end=" ")
+        else:
+            print("%s" % arg, end=" ")
+    print()

--- a/ramalama/stack_factory.py
+++ b/ramalama/stack_factory.py
@@ -1,0 +1,28 @@
+import argparse
+from typing import Callable
+
+from ramalama.stack import Stack
+
+
+class StackFactory:
+
+    def __init__(
+        self,
+        distro: str,
+        args: argparse,
+        transport: str = "ollama",
+        ignore_stderr: bool = False,
+    ):
+        self.distro = distro
+        self.store_path = args.store
+        self.use_model_store = args.use_model_store
+        self.transport = transport
+        self.engine = args.engine
+        self.ignore_stderr = ignore_stderr
+        self.container = args.container
+
+        self.create: Callable[[], Stack]
+
+    def create(self) -> Stack:
+        stack = Stack(self.distro)
+        return stack


### PR DESCRIPTION
## Summary by Sourcery

Add a new 'stack' subcommand to the RamaLama CLI for running Llama Stack distributions

New Features:
- Introduce a new 'stack' subcommand to run Llama Stack distributions
- Create StackFactory and Stack classes to manage stack-related operations

Enhancements:
- Extend CLI infrastructure to support stack-related commands
- Add flexible configuration options for running stacks