### PR TITLE
Switch all Ramalama to RamaLama

### DIFF
--- a/.codespelldict
+++ b/.codespelldict
@@ -2,6 +2,7 @@ hugginface->huggingface
 ramalamay->ramalama
 ramamlama->ramalama
 olama->ollama
+lama.cpp->llama.cpp
 alterting->altering
 annotationg->annotating
 assemlbe->assemble

--- a/.codespellrc
+++ b/.codespellrc
@@ -2,7 +2,7 @@
 [codespell]
 
 # Comma-separated list of files to skip.
-skip = ./logos,./vendor,./.git #,bin,vendor,.git,go.sum,changelog.txt,.cirrus.yml,"RELEASE_NOTES.md,*.xz,*.gz,*.tar,*.tgz,bin2img,*ico,*.png,*.1,*.5,*.7,copyimg,*.orig,apidoc.go"
+skip = build,ramalama.egg-info,logos,.git #,bin,vendor,.git,go.sum,changelog.txt,.cirrus.yml,"RELEASE_NOTES.md,*.xz,*.gz,*.tar,*.tgz,bin2img,*ico,*.png,*.1,*.5,*.7,copyimg,*.orig,apidoc.go"
 
 # Comma separated list of words to be ignored. Words must be lowercased.
 ignore-words-list = clos,creat,ro,hastable,shouldnot,mountns,passt,assertin

--- a/.github/workflows/install_ramalama.yml
+++ b/.github/workflows/install_ramalama.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           ramalama ls | grep NAME
       
-      - name: Ramalama info
+      - name: RamaLama info
         run: |
           ramalama info
 

--- a/README.md
+++ b/README.md
@@ -9,39 +9,24 @@
 ## Description
 RamaLama strives to make working with AI simple, straightforward, and familiar by using OCI containers.
 
-Ramalama is an open-source tool that simplifies the local use and serving of AI models for inference from any source through the familiar approach of containers. Using a container engine like Podman, engineers can use container-centric development patterns and benefits to extend to AI use cases.
+RamaLama is an open-source tool that simplifies the local use and serving of AI models for inference from any source through the familiar approach of containers. Using a container engine like Podman, engineers can use container-centric development patterns and benefits to extend to AI use cases.
 
-<<<<<<< HEAD
-Ramalama eliminates the need to configure the host system by instead pulling a container image specific to the GPUs discovered on the host system, and allowing you to work with various models and platforms.
+RamaLama eliminates the need to configure the host system by instead pulling a container image specific to the GPUs discovered on the host system, and allowing you to work with various models and platforms.
 
 - Eliminates the complexity for users to configure the host system for AI.
 - Detects and pulls an [accelerated container image](#accelerated-images) specific to the GPUs on the host system, handling dependencies and hardware optimization.
-- Ramalama supports multiple [AI model registries](#transports), including OCI Container Registries.
+- RamaLama supports multiple [AI model registries](#transports), including OCI Container Registries.
 - Models are treated similarly to how Podman and Docker treat container images.
 - Use common [container commands](#commands) to work with AI models.
 - Run AI models [securely](#security) in rootless containers, isolating the model from the underlying host.
-=======
-Ramalama eliminates the need to configure the host sytem by instead pulling a container image specific to the GPUs discovered on the host system, and allowing you to work with various models and platforms. 
-
-- Eliminates the complexity for users to configure the host system for AI.
-- Detects and pulls an accelerated container image specific to the GPUs on the host system, handling dependencies and hardware optimization.
-- Ramalama supports multiple AI model registries, including OCI Container Registries.
-- Models are treated similarly to how Podman and Docker treat container images.
-- Use common container commands to work with AI models.
-- Run AI models securely in rootless containers, isolating the model from the underlying host.
->>>>>>> c3012a2 (# This is a combination of 2 commits.)
-- Keep data secure by defaulting to no network access and removing all temporary data on application exits. 
+- Keep data secure by defaulting to no network access and removing all temporary data on application exits.
 - Interact with models via REST API or as a chatbot.
 <br>
 
 ## Accelerated images
 
 | Accelerator             | Image                      |
-<<<<<<< HEAD
 | :-----------------------| :------------------------- |
-=======
-| :-----------------------| :------------------------ |
->>>>>>> c3012a2 (# This is a combination of 2 commits.)
 |  CPU, Apple             | quay.io/ramalama/ramalama  |
 |  HIP_VISIBLE_DEVICES    | quay.io/ramalama/rocm      |
 |  CUDA_VISIBLE_DEVICES   | quay.io/ramalama/cuda      |
@@ -54,10 +39,10 @@ On first run, RamaLama inspects your system for GPU support, falling back to CPU
 
 <details>
 <summary>
-How does Ramalama select the right image?
+How does RamaLama select the right image?
 </summary>
 <br>
-	
+
 After initialization, RamaLama runs AI Models within a container based on the OCI image. RamaLama pulls container images specific to the GPUs discovered on your system. These images are tied to the minor version of RamaLama.
 - For example, RamaLama version 1.2.3 on an NVIDIA system pulls quay.io/ramalama/cuda:1.2. To override the default image, use the `--image` option.
 
@@ -82,7 +67,7 @@ RamaLama then pulls AI Models from model registries, starting a chatbot or REST 
 On systems with NVIDIA GPUs, see [ramalama-cuda](docs/ramalama-cuda.7.md) documentation for the correct host system configuration.
 
 ### Intel GPUs
-The following Intel GPUs are auto-detected by Ramalama:
+The following Intel GPUs are auto-detected by RamaLama:
 
 | GPU ID  | Description                        |
 | :------ | :--------------------------------- |
@@ -116,14 +101,14 @@ curl -fsSL https://raw.githubusercontent.com/containers/ramalama/s/install.sh | 
 ```
 
 #### Default Container Engine
-When both Podman and Docker are installed, RamaLama defaults to Podman. The `RAMALAMA_CONTAINER_ENGINE=docker` environment variable can override this behavior. When neither are installed, RamaLama will attempt to run the model with software on the local system.
+When both Podman and Docker are installed, RamaLama defaults to Podman. The `RAMALAMA_CONTAINER_ENGINE=docker` environment variable can override this behaviour. When neither are installed, RamaLama will attempt to run the model with software on the local system.
 <br>
 <br>
 
 ## Security
 
 ### Test and run your models more securely
-Because RamaLama defaults to running AI models inside rootless containers using Podman or Docker, these containers isolate the AI models from information on the underlying host.  With RamaLama containers, the AI model is mounted as a volume into the container in read-only mode. 
+Because RamaLama defaults to running AI models inside rootless containers using Podman or Docker, these containers isolate the AI models from information on the underlying host.  With RamaLama containers, the AI model is mounted as a volume into the container in read-only mode.
 
 This results in the process running the model (llama.cpp or vLLM) being isolated from the host. Additionally, since `ramalama run` uses the `--network=none` option, the container cannot reach the network and leak any information out of the system. Finally, containers are run with the `--rm` option, which means any content written during container execution is deleted when the application exits.
 
@@ -138,7 +123,7 @@ This results in the process running the model (llama.cpp or vLLM) being isolated
 
 
 ## Transports
-RamaLama supports multiple AI model registries types called transports. 
+RamaLama supports multiple AI model registries types called transports.
 
 ### Supported transports
 
@@ -157,7 +142,7 @@ RamaLama uses the Ollama registry transport by default
 How to change transports.
 </summary>
 <br>
-	
+
 Use the RAMALAMA_TRANSPORTS environment variable to modify the default. `export RAMALAMA_TRANSPORT=huggingface` Changes RamaLama to use huggingface transport.
 
 Individual model transports can be modified when specifying a model via the `huggingface://`, `oci://`, or `ollama://` prefix.
@@ -176,10 +161,10 @@ To make it easier for users, RamaLama uses shortname files, which contain alias 
 More information on shortnames.
 </summary>
 <br>
-	
+
 RamaLama reads shortnames.conf files if they exist. These files contain a list of name-value pairs that specify the model. The following table specifies the order in which RamaLama reads the files. Any duplicate names that exist override previously defined shortnames.
 <br>
-	
+
 | Shortnames type | Path                                     |
 | :-------------- | :--------------------------------------- |
 | Distribution    | /usr/share/ramalama/shortnames.conf      |
@@ -211,47 +196,47 @@ $ cat /usr/share/ramalama/shortnames.conf
 	<summary>
 		Benchmark specified AI Model
 	</summary>
- 	<br>
-	
+	<br>
+
 	```
 	$ ramalama bench granite-moe3
 	```
 </details>
 
 ### [`ramalama-containers`](https://github.com/containers/ramalama/blob/main/docs/ramalama-containers.1.md)
-#### List all Ramalama containers.
+#### List all RamaLama containers.
 - <details>
 	<summary>
 		List all containers running AI Models
 	</summary>
- 	<br>
-	
+	<br>
+
 	```
 	$ ramalama containers
 	```
- 	Returns for example:
-  	```
+	Returns for example:
+	```
 	CONTAINER ID  IMAGE                             COMMAND               CREATED        STATUS                    PORTS                   NAMES
 	85ad75ecf866  quay.io/ramalama/ramalama:latest  /usr/bin/ramalama...  5 hours ago    Up 5 hours                0.0.0.0:8080->8080/tcp  ramalama_s3Oh6oDfOP
 	85ad75ecf866  quay.io/ramalama/ramalama:latest  /usr/bin/ramalama...  4 minutes ago  Exited (0) 4 minutes ago                          granite-server
-   	```
+	```
 </details>
 
 - <details>
 	<summary>
 		List all containers in a particular format
 	</summary>
- 	<br>
-	
+	<br>
+
 	```
 	$ ramalama ps --noheading --format "{{ .Names }}"
 	```
 	Returns for example:
 
-  	```
+	```
 	ramalama_s3Oh6oDfOP
 	granite-server
-  	```
+	```
 </details>
 
 ### [`ramalama-convert`](https://github.com/containers/ramalama/blob/main/docs/ramalama-convert.1.md)
@@ -260,13 +245,13 @@ $ cat /usr/share/ramalama/shortnames.conf
 	<summary>
 		Generate an oci model out of an Ollama model.
 	</summary>
- 	<br>
-	
+	<br>
+
 	```
 	$ ramalama convert ollama://tinyllama:latest oci://quay.io/rhatdan/tiny:latest
 	```
- 	Returns for example:
-  	```
+	Returns for example:
+	```
 	Building quay.io/rhatdan/tiny:latest...
 	STEP 1/2: FROM scratch
 	STEP 2/2: COPY sha256:2af3b81862c6be03c769683af18efdadb2c33f60ff32ab6f83e42c043d6c7816 /model
@@ -280,24 +265,23 @@ $ cat /usr/share/ramalama/shortnames.conf
 
 - <details>
 	<summary>
-<<<<<<< HEAD
 		Generate and run an OCI model with a quantized GGUF converted from Safetensors.
 	</summary>
- 	<br>
+	<br>
 
 	Generate OCI model
 	```
 	$ ramalama --image quay.io/ramalama/ramalama-rag convert --gguf Q4_K_M hf://ibm-granite/granite-3.2-2b-instruct oci://quay.io/kugupta/granite-3.2-q4-k-m:latest
 	```
 
-  	Returns for example:
-  	```
+	Returns for example:
+	```
 	Converting /Users/kugupta/.local/share/ramalama/models/huggingface/ibm-granite/granite-3.2-2b-instruct to quay.io/kugupta/granite-3.2-q4-k-m:latest...
 	Building quay.io/kugupta/granite-3.2-q4-k-m:latest...
 	```
 
 	Run the generated model
-   	```
+	```
 	$ ramalama run oci://quay.io/kugupta/granite-3.2-q4-k-m:latest
 	```
 </details>
@@ -308,69 +292,69 @@ $ cat /usr/share/ramalama/shortnames.conf
 	<summary>
 		Info with no container engine.
 	</summary>
- 	<br>
-	
+	<br>
+
 	```
 	$ ramalama info
 	```
- 	Returns for example:
-  	```
+	Returns for example:
+	```
 	{
 	    "Accelerator": "cuda",
 	    "Engine": {
-	        "Name": ""
+		"Name": ""
 	    },
 	    "Image": "quay.io/ramalama/cuda:0.7",
 	    "Runtime": "llama.cpp",
 	    "Shortnames": {
-	        "Names": {
-	            "cerebrum": "huggingface://froggeric/Cerebrum-1.0-7b-GGUF/Cerebrum-1.0-7b-Q4_KS.gguf",
-	            "deepseek": "ollama://deepseek-r1",
-	            "dragon": "huggingface://llmware/dragon-mistral-7b-v0/dragon-mistral-7b-q4_k_m.gguf",
-	            "gemma3": "hf://bartowski/google_gemma-3-4b-it-GGUF/google_gemma-3-4b-it-IQ2_M.gguf",
-	            "gemma3:12b": "hf://bartowski/google_gemma-3-12b-it-GGUF/google_gemma-3-12b-it-IQ2_M.gguf",
-	            "gemma3:1b": "hf://bartowski/google_gemma-3-1b-it-GGUF/google_gemma-3-1b-it-IQ2_M.gguf",
-	            "gemma3:27b": "hf://bartowski/google_gemma-3-27b-it-GGUF/google_gemma-3-27b-it-IQ2_M.gguf",
-	            "gemma3:4b": "hf://bartowski/google_gemma-3-4b-it-GGUF/google_gemma-3-4b-it-IQ2_M.gguf",
-	            "granite": "ollama://granite3.1-dense",
-	            "granite-code": "hf://ibm-granite/granite-3b-code-base-2k-GGUF/granite-3b-code-base.Q4_K_M.gguf",
-	            "granite-code:20b": "hf://ibm-granite/granite-20b-code-base-8k-GGUF/granite-20b-code-base.Q4_K_M.gguf",
-	            "granite-code:34b": "hf://ibm-granite/granite-34b-code-base-8k-GGUF/granite-34b-code-base.Q4_K_M.gguf",
-	            "granite-code:3b": "hf://ibm-granite/granite-3b-code-base-2k-GGUF/granite-3b-code-base.Q4_K_M.gguf",
-	            "granite-code:8b": "hf://ibm-granite/granite-8b-code-base-4k-GGUF/granite-8b-code-base.Q4_K_M.gguf",
-	            "granite-lab-7b": "huggingface://instructlab/granite-7b-lab-GGUF/granite-7b-lab-Q4_K_M.gguf",
-	            "granite-lab-8b": "huggingface://ibm-granite/granite-8b-code-base-GGUF/granite-8b-code-base.Q4_K_M.gguf",
-	            "granite-lab:7b": "huggingface://instructlab/granite-7b-lab-GGUF/granite-7b-lab-Q4_K_M.gguf",
-	            "granite:2b": "ollama://granite3.1-dense:2b",
-	            "granite:7b": "huggingface://instructlab/granite-7b-lab-GGUF/granite-7b-lab-Q4_K_M.gguf",
-	            "granite:8b": "ollama://granite3.1-dense:8b",
-	            "hermes": "huggingface://NousResearch/Hermes-2-Pro-Mistral-7B-GGUF/Hermes-2-Pro-Mistral-7B.Q4_K_M.gguf",
-	            "ibm/granite": "ollama://granite3.1-dense:8b",
-	            "ibm/granite:2b": "ollama://granite3.1-dense:2b",
-	            "ibm/granite:7b": "huggingface://instructlab/granite-7b-lab-GGUF/granite-7b-lab-Q4_K_M.gguf",
-	            "ibm/granite:8b": "ollama://granite3.1-dense:8b",
-	            "merlinite": "huggingface://instructlab/merlinite-7b-lab-GGUF/merlinite-7b-lab-Q4_K_M.gguf",
-	            "merlinite-lab-7b": "huggingface://instructlab/merlinite-7b-lab-GGUF/merlinite-7b-lab-Q4_K_M.gguf",
-	            "merlinite-lab:7b": "huggingface://instructlab/merlinite-7b-lab-GGUF/merlinite-7b-lab-Q4_K_M.gguf",
-	            "merlinite:7b": "huggingface://instructlab/merlinite-7b-lab-GGUF/merlinite-7b-lab-Q4_K_M.gguf",
-	            "mistral": "huggingface://TheBloke/Mistral-7B-Instruct-v0.2-GGUF/mistral-7b-instruct-v0.2.Q4_K_M.gguf",
-	            "mistral:7b": "huggingface://TheBloke/Mistral-7B-Instruct-v0.2-GGUF/mistral-7b-instruct-v0.2.Q4_K_M.gguf",
-	            "mistral:7b-v1": "huggingface://TheBloke/Mistral-7B-Instruct-v0.1-GGUF/mistral-7b-instruct-v0.1.Q5_K_M.gguf",
-	            "mistral:7b-v2": "huggingface://TheBloke/Mistral-7B-Instruct-v0.2-GGUF/mistral-7b-instruct-v0.2.Q4_K_M.gguf",
-	            "mistral:7b-v3": "huggingface://MaziyarPanahi/Mistral-7B-Instruct-v0.3-GGUF/Mistral-7B-Instruct-v0.3.Q4_K_M.gguf",
-	            "mistral_code_16k": "huggingface://TheBloke/Mistral-7B-Code-16K-qlora-GGUF/mistral-7b-code-16k-qlora.Q4_K_M.gguf",
-	            "mistral_codealpaca": "huggingface://TheBloke/Mistral-7B-codealpaca-lora-GGUF/mistral-7b-codealpaca-lora.Q4_K_M.gguf",
-	            "mixtao": "huggingface://MaziyarPanahi/MixTAO-7Bx2-MoE-Instruct-v7.0-GGUF/MixTAO-7Bx2-MoE-Instruct-v7.0.Q4_K_M.gguf",
-	            "openchat": "huggingface://TheBloke/openchat-3.5-0106-GGUF/openchat-3.5-0106.Q4_K_M.gguf",
-	            "openorca": "huggingface://TheBloke/Mistral-7B-OpenOrca-GGUF/mistral-7b-openorca.Q4_K_M.gguf",
-	            "phi2": "huggingface://MaziyarPanahi/phi-2-GGUF/phi-2.Q4_K_M.gguf",
-	            "smollm:135m": "ollama://smollm:135m",
-	            "tiny": "ollama://tinyllama"
-	        },
-	        "Files": [
-	            "/usr/share/ramalama/shortnames.conf",
-	            "/home/dwalsh/.config/ramalama/shortnames.conf",
-	        ]
+		"Names": {
+		    "cerebrum": "huggingface://froggeric/Cerebrum-1.0-7b-GGUF/Cerebrum-1.0-7b-Q4_KS.gguf",
+		    "deepseek": "ollama://deepseek-r1",
+		    "dragon": "huggingface://llmware/dragon-mistral-7b-v0/dragon-mistral-7b-q4_k_m.gguf",
+		    "gemma3": "hf://bartowski/google_gemma-3-4b-it-GGUF/google_gemma-3-4b-it-IQ2_M.gguf",
+		    "gemma3:12b": "hf://bartowski/google_gemma-3-12b-it-GGUF/google_gemma-3-12b-it-IQ2_M.gguf",
+		    "gemma3:1b": "hf://bartowski/google_gemma-3-1b-it-GGUF/google_gemma-3-1b-it-IQ2_M.gguf",
+		    "gemma3:27b": "hf://bartowski/google_gemma-3-27b-it-GGUF/google_gemma-3-27b-it-IQ2_M.gguf",
+		    "gemma3:4b": "hf://bartowski/google_gemma-3-4b-it-GGUF/google_gemma-3-4b-it-IQ2_M.gguf",
+		    "granite": "ollama://granite3.1-dense",
+		    "granite-code": "hf://ibm-granite/granite-3b-code-base-2k-GGUF/granite-3b-code-base.Q4_K_M.gguf",
+		    "granite-code:20b": "hf://ibm-granite/granite-20b-code-base-8k-GGUF/granite-20b-code-base.Q4_K_M.gguf",
+		    "granite-code:34b": "hf://ibm-granite/granite-34b-code-base-8k-GGUF/granite-34b-code-base.Q4_K_M.gguf",
+		    "granite-code:3b": "hf://ibm-granite/granite-3b-code-base-2k-GGUF/granite-3b-code-base.Q4_K_M.gguf",
+		    "granite-code:8b": "hf://ibm-granite/granite-8b-code-base-4k-GGUF/granite-8b-code-base.Q4_K_M.gguf",
+		    "granite-lab-7b": "huggingface://instructlab/granite-7b-lab-GGUF/granite-7b-lab-Q4_K_M.gguf",
+		    "granite-lab-8b": "huggingface://ibm-granite/granite-8b-code-base-GGUF/granite-8b-code-base.Q4_K_M.gguf",
+		    "granite-lab:7b": "huggingface://instructlab/granite-7b-lab-GGUF/granite-7b-lab-Q4_K_M.gguf",
+		    "granite:2b": "ollama://granite3.1-dense:2b",
+		    "granite:7b": "huggingface://instructlab/granite-7b-lab-GGUF/granite-7b-lab-Q4_K_M.gguf",
+		    "granite:8b": "ollama://granite3.1-dense:8b",
+		    "hermes": "huggingface://NousResearch/Hermes-2-Pro-Mistral-7B-GGUF/Hermes-2-Pro-Mistral-7B.Q4_K_M.gguf",
+		    "ibm/granite": "ollama://granite3.1-dense:8b",
+		    "ibm/granite:2b": "ollama://granite3.1-dense:2b",
+		    "ibm/granite:7b": "huggingface://instructlab/granite-7b-lab-GGUF/granite-7b-lab-Q4_K_M.gguf",
+		    "ibm/granite:8b": "ollama://granite3.1-dense:8b",
+		    "merlinite": "huggingface://instructlab/merlinite-7b-lab-GGUF/merlinite-7b-lab-Q4_K_M.gguf",
+		    "merlinite-lab-7b": "huggingface://instructlab/merlinite-7b-lab-GGUF/merlinite-7b-lab-Q4_K_M.gguf",
+		    "merlinite-lab:7b": "huggingface://instructlab/merlinite-7b-lab-GGUF/merlinite-7b-lab-Q4_K_M.gguf",
+		    "merlinite:7b": "huggingface://instructlab/merlinite-7b-lab-GGUF/merlinite-7b-lab-Q4_K_M.gguf",
+		    "mistral": "huggingface://TheBloke/Mistral-7B-Instruct-v0.2-GGUF/mistral-7b-instruct-v0.2.Q4_K_M.gguf",
+		    "mistral:7b": "huggingface://TheBloke/Mistral-7B-Instruct-v0.2-GGUF/mistral-7b-instruct-v0.2.Q4_K_M.gguf",
+		    "mistral:7b-v1": "huggingface://TheBloke/Mistral-7B-Instruct-v0.1-GGUF/mistral-7b-instruct-v0.1.Q5_K_M.gguf",
+		    "mistral:7b-v2": "huggingface://TheBloke/Mistral-7B-Instruct-v0.2-GGUF/mistral-7b-instruct-v0.2.Q4_K_M.gguf",
+		    "mistral:7b-v3": "huggingface://MaziyarPanahi/Mistral-7B-Instruct-v0.3-GGUF/Mistral-7B-Instruct-v0.3.Q4_K_M.gguf",
+		    "mistral_code_16k": "huggingface://TheBloke/Mistral-7B-Code-16K-qlora-GGUF/mistral-7b-code-16k-qlora.Q4_K_M.gguf",
+		    "mistral_codealpaca": "huggingface://TheBloke/Mistral-7B-codealpaca-lora-GGUF/mistral-7b-codealpaca-lora.Q4_K_M.gguf",
+		    "mixtao": "huggingface://MaziyarPanahi/MixTAO-7Bx2-MoE-Instruct-v7.0-GGUF/MixTAO-7Bx2-MoE-Instruct-v7.0.Q4_K_M.gguf",
+		    "openchat": "huggingface://TheBloke/openchat-3.5-0106-GGUF/openchat-3.5-0106.Q4_K_M.gguf",
+		    "openorca": "huggingface://TheBloke/Mistral-7B-OpenOrca-GGUF/mistral-7b-openorca.Q4_K_M.gguf",
+		    "phi2": "huggingface://MaziyarPanahi/phi-2-GGUF/phi-2.Q4_K_M.gguf",
+		    "smollm:135m": "ollama://smollm:135m",
+		    "tiny": "ollama://tinyllama"
+		},
+		"Files": [
+		    "/usr/share/ramalama/shortnames.conf",
+		    "/home/dwalsh/.config/ramalama/shortnames.conf",
+		]
 	    },
 	    "Store": "/home/dwalsh/.local/share/ramalama",
 	    "UseContainer": true,
@@ -379,345 +363,249 @@ $ cat /usr/share/ramalama/shortnames.conf
 	```
 </details>
 
-=======
-		Generate and run an oci model with a quantized GGUF converted from Safetensors.
-	</summary>
- 	<br>
-	
-	```
-	$ ramalama --image quay.io/ramalama/ramalama-rag convert --gguf Q4_K_M hf://ibm-granite/granite-3.2-2b-instruct oci://quay.io/kugupta/granite-3.2-q4-k-m:latest
-	```
- 	Returns for example:
-  	```
-	Converting /Users/kugupta/.local/share/ramalama/models/huggingface/ibm-granite/granite-3.2-2b-instruct to quay.io/kugupta/granite-3.2-q4-k-m:latest...
-	Building quay.io/kugupta/granite-3.2-q4-k-m:latest...
-	```
-   	```
-    	$ ramalama run oci://quay.io/kugupta/granite-3.2-q4-k-m:latest
-    	```
-</details>
-
-### [`ramalama-info`](https://github.com/containers/ramalama/blob/main/docs/ramalama-info.1.md)
-#### Display RamaLama configuration information.
-- <details>
-	<summary>
-		Info with no container engine.
-	</summary>
- 	<br>
-	
-	```
-	$ ramalama info
-	```
- 	Returns for example:
-  	```
-	{
-	    "Accelerator": "cuda",
-	    "Engine": {
-	        "Name": ""
-	    },
-	    "Image": "quay.io/ramalama/cuda:0.7",
-	    "Runtime": "llama.cpp",
-	    "Shortnames": {
-	        "Names": {
-	            "cerebrum": "huggingface://froggeric/Cerebrum-1.0-7b-GGUF/Cerebrum-1.0-7b-Q4_KS.gguf",
-	            "deepseek": "ollama://deepseek-r1",
-	            "dragon": "huggingface://llmware/dragon-mistral-7b-v0/dragon-mistral-7b-q4_k_m.gguf",
-	            "gemma3": "hf://bartowski/google_gemma-3-4b-it-GGUF/google_gemma-3-4b-it-IQ2_M.gguf",
-	            "gemma3:12b": "hf://bartowski/google_gemma-3-12b-it-GGUF/google_gemma-3-12b-it-IQ2_M.gguf",
-	            "gemma3:1b": "hf://bartowski/google_gemma-3-1b-it-GGUF/google_gemma-3-1b-it-IQ2_M.gguf",
-	            "gemma3:27b": "hf://bartowski/google_gemma-3-27b-it-GGUF/google_gemma-3-27b-it-IQ2_M.gguf",
-	            "gemma3:4b": "hf://bartowski/google_gemma-3-4b-it-GGUF/google_gemma-3-4b-it-IQ2_M.gguf",
-	            "granite": "ollama://granite3.1-dense",
-	            "granite-code": "hf://ibm-granite/granite-3b-code-base-2k-GGUF/granite-3b-code-base.Q4_K_M.gguf",
-	            "granite-code:20b": "hf://ibm-granite/granite-20b-code-base-8k-GGUF/granite-20b-code-base.Q4_K_M.gguf",
-	            "granite-code:34b": "hf://ibm-granite/granite-34b-code-base-8k-GGUF/granite-34b-code-base.Q4_K_M.gguf",
-	            "granite-code:3b": "hf://ibm-granite/granite-3b-code-base-2k-GGUF/granite-3b-code-base.Q4_K_M.gguf",
-	            "granite-code:8b": "hf://ibm-granite/granite-8b-code-base-4k-GGUF/granite-8b-code-base.Q4_K_M.gguf",
-	            "granite-lab-7b": "huggingface://instructlab/granite-7b-lab-GGUF/granite-7b-lab-Q4_K_M.gguf",
-	            "granite-lab-8b": "huggingface://ibm-granite/granite-8b-code-base-GGUF/granite-8b-code-base.Q4_K_M.gguf",
-	            "granite-lab:7b": "huggingface://instructlab/granite-7b-lab-GGUF/granite-7b-lab-Q4_K_M.gguf",
-	            "granite:2b": "ollama://granite3.1-dense:2b",
-	            "granite:7b": "huggingface://instructlab/granite-7b-lab-GGUF/granite-7b-lab-Q4_K_M.gguf",
-	            "granite:8b": "ollama://granite3.1-dense:8b",
-	            "hermes": "huggingface://NousResearch/Hermes-2-Pro-Mistral-7B-GGUF/Hermes-2-Pro-Mistral-7B.Q4_K_M.gguf",
-	            "ibm/granite": "ollama://granite3.1-dense:8b",
-	            "ibm/granite:2b": "ollama://granite3.1-dense:2b",
-	            "ibm/granite:7b": "huggingface://instructlab/granite-7b-lab-GGUF/granite-7b-lab-Q4_K_M.gguf",
-	            "ibm/granite:8b": "ollama://granite3.1-dense:8b",
-	            "merlinite": "huggingface://instructlab/merlinite-7b-lab-GGUF/merlinite-7b-lab-Q4_K_M.gguf",
-	            "merlinite-lab-7b": "huggingface://instructlab/merlinite-7b-lab-GGUF/merlinite-7b-lab-Q4_K_M.gguf",
-	            "merlinite-lab:7b": "huggingface://instructlab/merlinite-7b-lab-GGUF/merlinite-7b-lab-Q4_K_M.gguf",
-	            "merlinite:7b": "huggingface://instructlab/merlinite-7b-lab-GGUF/merlinite-7b-lab-Q4_K_M.gguf",
-	            "mistral": "huggingface://TheBloke/Mistral-7B-Instruct-v0.2-GGUF/mistral-7b-instruct-v0.2.Q4_K_M.gguf",
-	            "mistral:7b": "huggingface://TheBloke/Mistral-7B-Instruct-v0.2-GGUF/mistral-7b-instruct-v0.2.Q4_K_M.gguf",
-	            "mistral:7b-v1": "huggingface://TheBloke/Mistral-7B-Instruct-v0.1-GGUF/mistral-7b-instruct-v0.1.Q5_K_M.gguf",
-	            "mistral:7b-v2": "huggingface://TheBloke/Mistral-7B-Instruct-v0.2-GGUF/mistral-7b-instruct-v0.2.Q4_K_M.gguf",
-	            "mistral:7b-v3": "huggingface://MaziyarPanahi/Mistral-7B-Instruct-v0.3-GGUF/Mistral-7B-Instruct-v0.3.Q4_K_M.gguf",
-	            "mistral_code_16k": "huggingface://TheBloke/Mistral-7B-Code-16K-qlora-GGUF/mistral-7b-code-16k-qlora.Q4_K_M.gguf",
-	            "mistral_codealpaca": "huggingface://TheBloke/Mistral-7B-codealpaca-lora-GGUF/mistral-7b-codealpaca-lora.Q4_K_M.gguf",
-	            "mixtao": "huggingface://MaziyarPanahi/MixTAO-7Bx2-MoE-Instruct-v7.0-GGUF/MixTAO-7Bx2-MoE-Instruct-v7.0.Q4_K_M.gguf",
-	            "openchat": "huggingface://TheBloke/openchat-3.5-0106-GGUF/openchat-3.5-0106.Q4_K_M.gguf",
-	            "openorca": "huggingface://TheBloke/Mistral-7B-OpenOrca-GGUF/mistral-7b-openorca.Q4_K_M.gguf",
-	            "phi2": "huggingface://MaziyarPanahi/phi-2-GGUF/phi-2.Q4_K_M.gguf",
-	            "smollm:135m": "ollama://smollm:135m",
-	            "tiny": "ollama://tinyllama"
-	        },
-	        "Files": [
-	            "/usr/share/ramalama/shortnames.conf",
-	            "/home/dwalsh/.config/ramalama/shortnames.conf",
-	        ]
-	    },
-	    "Store": "/home/dwalsh/.local/share/ramalama",
-	    "UseContainer": true,
-	    "Version": "0.7.5"
-	}
-	```
-</details>
-
->>>>>>> c3012a2 (# This is a combination of 2 commits.)
 - <details>
 	<summary>
 		Info with Podman engine.
 	</summary>
- 	<br>
-	
+	<br>
+
 	```
 	$ ramalama info
 	```
- 	Returns for example:
-  	```
+	Returns for example:
+	```
 	{
 	    "Accelerator": "cuda",
 	    "Engine": {
-	        "Info": {
-	            "host": {
-	                "arch": "amd64",
-	                "buildahVersion": "1.39.4",
-	                "cgroupControllers": [
-	                    "cpu",
-	                    "io",
-	                    "memory",
-	                    "pids"
-	                ],
-	                "cgroupManager": "systemd",
-	                "cgroupVersion": "v2",
-	                "conmon": {
-	                    "package": "conmon-2.1.13-1.fc42.x86_64",
-	                    "path": "/usr/bin/conmon",
-	                    "version": "conmon version 2.1.13, commit: "
-	                },
-	                "cpuUtilization": {
-	                    "idlePercent": 97.36,
-	                    "systemPercent": 0.64,
-	                    "userPercent": 2
-	                },
-	                "cpus": 32,
-	                "databaseBackend": "sqlite",
-	                "distribution": {
-	                    "distribution": "fedora",
-	                    "variant": "workstation",
-	                    "version": "42"
-	                },
-	                "eventLogger": "journald",
-	                "freeLocks": 2043,
-	                "hostname": "danslaptop",
-	                "idMappings": {
-	                    "gidmap": [
-	                        {
-	                            "container_id": 0,
-	                            "host_id": 3267,
-	                            "size": 1
-	                        },
-	                        {
-	                            "container_id": 1,
-	                            "host_id": 524288,
-	                            "size": 65536
-	                        }
-	                    ],
-	                    "uidmap": [
-	                        {
-	                            "container_id": 0,
-	                            "host_id": 3267,
-	                            "size": 1
-	                        },
-	                        {
-	                            "container_id": 1,
-	                            "host_id": 524288,
-	                            "size": 65536
-	                        }
-	                    ]
-	                },
-	                "kernel": "6.14.2-300.fc42.x86_64",
-	                "linkmode": "dynamic",
-	                "logDriver": "journald",
-	                "memFree": 65281908736,
-	                "memTotal": 134690979840,
-	                "networkBackend": "netavark",
-	                "networkBackendInfo": {
-	                    "backend": "netavark",
-	                    "dns": {
-	                        "package": "aardvark-dns-1.14.0-1.fc42.x86_64",
-	                        "path": "/usr/libexec/podman/aardvark-dns",
-	                        "version": "aardvark-dns 1.14.0"
-	                    },
-	                    "package": "netavark-1.14.1-1.fc42.x86_64",
-	                    "path": "/usr/libexec/podman/netavark",
-	                    "version": "netavark 1.14.1"
-	                },
-	                "ociRuntime": {
-	                    "name": "crun",
-	                    "package": "crun-1.21-1.fc42.x86_64",
-	                    "path": "/usr/bin/crun",
-	                    "version": "crun version 1.21\ncommit: 10269840aa07fb7e6b7e1acff6198692d8ff5c88\nrundir: /run/user/3267/crun\nspec: 1.0.0\n+SYSTEMD +SELINUX +APPARMOR +CAP +SECCOMP +EBPF +CRIU +LIBKRUN +WASM:wasmedge +YAJL"
-	                },
-	                "os": "linux",
-	                "pasta": {
-	                    "executable": "/bin/pasta",
-	                    "package": "passt-0^20250415.g2340bbf-1.fc42.x86_64",
-	                    "version": ""
-	                },
-	                "remoteSocket": {
-	                    "exists": true,
-	                    "path": "/run/user/3267/podman/podman.sock"
-	                },
-	                "rootlessNetworkCmd": "pasta",
-	                "security": {
-	                    "apparmorEnabled": false,
-	                    "capabilities": "CAP_CHOWN,CAP_DAC_OVERRIDE,CAP_FOWNER,CAP_FSETID,CAP_KILL,CAP_NET_BIND_SERVICE,CAP_SETFCAP,CAP_SETGID,CAP_SETPCAP,CAP_SETUID,CAP_SYS_CHROOT",
-	                    "rootless": true,
-	                    "seccompEnabled": true,
-	                    "seccompProfilePath": "/usr/share/containers/seccomp.json",
-	                    "selinuxEnabled": true
-	                },
-	                "serviceIsRemote": false,
-	                "slirp4netns": {
-	                    "executable": "/bin/slirp4netns",
-	                    "package": "slirp4netns-1.3.1-2.fc42.x86_64",
-	                    "version": "slirp4netns version 1.3.1\ncommit: e5e368c4f5db6ae75c2fce786e31eef9da6bf236\nlibslirp: 4.8.0\nSLIRP_CONFIG_VERSION_MAX: 5\nlibseccomp: 2.5.5"
-	                },
-	                "swapFree": 8589930496,
-	                "swapTotal": 8589930496,
-	                "uptime": "116h 35m 40.00s (Approximately 4.83 days)",
-	                "variant": ""
-	            },
-	            "plugins": {
-	                "authorization": null,
-	                "log": [
-	                    "k8s-file",
-	                    "none",
-	                    "passthrough",
-	                    "journald"
-	                ],
-	                "network": [
-	                    "bridge",
-	                    "macvlan",
-	                    "ipvlan"
-	                ],
-	                "volume": [
-	                    "local"
-	                ]
-	            },
-	            "registries": {
-	                "search": [
-	                    "registry.fedoraproject.org",
-	                    "registry.access.redhat.com",
-	                    "docker.io"
-	                ]
-	            },
-	            "store": {
-	                "configFile": "/home/dwalsh/.config/containers/storage.conf",
-	                "containerStore": {
-	                    "number": 5,
-	                    "paused": 0,
-	                    "running": 0,
-	                    "stopped": 5
-	                },
-	                "graphDriverName": "overlay",
-	                "graphOptions": {},
-	                "graphRoot": "/home/dwalsh/.local/share/containers/storage",
-	                "graphRootAllocated": 2046687182848,
-	                "graphRootUsed": 399990419456,
-	                "graphStatus": {
-	                    "Backing Filesystem": "btrfs",
-	                    "Native Overlay Diff": "true",
-	                    "Supports d_type": "true",
-	                    "Supports shifting": "false",
-	                    "Supports volatile": "true",
-	                    "Using metacopy": "false"
-	                },
-	                "imageCopyTmpDir": "/var/tmp",
-	                "imageStore": {
-	                    "number": 297
-	                },
-	                "runRoot": "/run/user/3267/containers",
-	                "transientStore": false,
-	                "volumePath": "/home/dwalsh/.local/share/containers/storage/volumes"
-	            },
-	            "version": {
-	                "APIVersion": "5.4.2",
-	                "BuildOrigin": "Fedora Project",
-	                "Built": 1743552000,
-	                "BuiltTime": "Tue Apr  1 19:00:00 2025",
-	                "GitCommit": "be85287fcf4590961614ee37be65eeb315e5d9ff",
-	                "GoVersion": "go1.24.1",
-	                "Os": "linux",
-	                "OsArch": "linux/amd64",
-	                "Version": "5.4.2"
-	            }
-	        },
-	        "Name": "podman"
+		"Info": {
+		    "host": {
+			"arch": "amd64",
+			"buildahVersion": "1.39.4",
+			"cgroupControllers": [
+			    "cpu",
+			    "io",
+			    "memory",
+			    "pids"
+			],
+			"cgroupManager": "systemd",
+			"cgroupVersion": "v2",
+			"conmon": {
+			    "package": "conmon-2.1.13-1.fc42.x86_64",
+			    "path": "/usr/bin/conmon",
+			    "version": "conmon version 2.1.13, commit: "
+			},
+			"cpuUtilization": {
+			    "idlePercent": 97.36,
+			    "systemPercent": 0.64,
+			    "userPercent": 2
+			},
+			"cpus": 32,
+			"databaseBackend": "sqlite",
+			"distribution": {
+			    "distribution": "fedora",
+			    "variant": "workstation",
+			    "version": "42"
+			},
+			"eventLogger": "journald",
+			"freeLocks": 2043,
+			"hostname": "danslaptop",
+			"idMappings": {
+			    "gidmap": [
+				{
+				    "container_id": 0,
+				    "host_id": 3267,
+				    "size": 1
+				},
+				{
+				    "container_id": 1,
+				    "host_id": 524288,
+				    "size": 65536
+				}
+			    ],
+			    "uidmap": [
+				{
+				    "container_id": 0,
+				    "host_id": 3267,
+				    "size": 1
+				},
+				{
+				    "container_id": 1,
+				    "host_id": 524288,
+				    "size": 65536
+				}
+			    ]
+			},
+			"kernel": "6.14.2-300.fc42.x86_64",
+			"linkmode": "dynamic",
+			"logDriver": "journald",
+			"memFree": 65281908736,
+			"memTotal": 134690979840,
+			"networkBackend": "netavark",
+			"networkBackendInfo": {
+			    "backend": "netavark",
+			    "dns": {
+				"package": "aardvark-dns-1.14.0-1.fc42.x86_64",
+				"path": "/usr/libexec/podman/aardvark-dns",
+				"version": "aardvark-dns 1.14.0"
+			    },
+			    "package": "netavark-1.14.1-1.fc42.x86_64",
+			    "path": "/usr/libexec/podman/netavark",
+			    "version": "netavark 1.14.1"
+			},
+			"ociRuntime": {
+			    "name": "crun",
+			    "package": "crun-1.21-1.fc42.x86_64",
+			    "path": "/usr/bin/crun",
+			    "version": "crun version 1.21\ncommit: 10269840aa07fb7e6b7e1acff6198692d8ff5c88\nrundir: /run/user/3267/crun\nspec: 1.0.0\n+SYSTEMD +SELINUX +APPARMOR +CAP +SECCOMP +EBPF +CRIU +LIBKRUN +WASM:wasmedge +YAJL"
+			},
+			"os": "linux",
+			"pasta": {
+			    "executable": "/bin/pasta",
+			    "package": "passt-0^20250415.g2340bbf-1.fc42.x86_64",
+			    "version": ""
+			},
+			"remoteSocket": {
+			    "exists": true,
+			    "path": "/run/user/3267/podman/podman.sock"
+			},
+			"rootlessNetworkCmd": "pasta",
+			"security": {
+			    "apparmorEnabled": false,
+			    "capabilities": "CAP_CHOWN,CAP_DAC_OVERRIDE,CAP_FOWNER,CAP_FSETID,CAP_KILL,CAP_NET_BIND_SERVICE,CAP_SETFCAP,CAP_SETGID,CAP_SETPCAP,CAP_SETUID,CAP_SYS_CHROOT",
+			    "rootless": true,
+			    "seccompEnabled": true,
+			    "seccompProfilePath": "/usr/share/containers/seccomp.json",
+			    "selinuxEnabled": true
+			},
+			"serviceIsRemote": false,
+			"slirp4netns": {
+			    "executable": "/bin/slirp4netns",
+			    "package": "slirp4netns-1.3.1-2.fc42.x86_64",
+			    "version": "slirp4netns version 1.3.1\ncommit: e5e368c4f5db6ae75c2fce786e31eef9da6bf236\nlibslirp: 4.8.0\nSLIRP_CONFIG_VERSION_MAX: 5\nlibseccomp: 2.5.5"
+			},
+			"swapFree": 8589930496,
+			"swapTotal": 8589930496,
+			"uptime": "116h 35m 40.00s (Approximately 4.83 days)",
+			"variant": ""
+		    },
+		    "plugins": {
+			"authorization": null,
+			"log": [
+			    "k8s-file",
+			    "none",
+			    "passthrough",
+			    "journald"
+			],
+			"network": [
+			    "bridge",
+			    "macvlan",
+			    "ipvlan"
+			],
+			"volume": [
+			    "local"
+			]
+		    },
+		    "registries": {
+			"search": [
+			    "registry.fedoraproject.org",
+			    "registry.access.redhat.com",
+			    "docker.io"
+			]
+		    },
+		    "store": {
+			"configFile": "/home/dwalsh/.config/containers/storage.conf",
+			"containerStore": {
+			    "number": 5,
+			    "paused": 0,
+			    "running": 0,
+			    "stopped": 5
+			},
+			"graphDriverName": "overlay",
+			"graphOptions": {},
+			"graphRoot": "/home/dwalsh/.local/share/containers/storage",
+			"graphRootAllocated": 2046687182848,
+			"graphRootUsed": 399990419456,
+			"graphStatus": {
+			    "Backing Filesystem": "btrfs",
+			    "Native Overlay Diff": "true",
+			    "Supports d_type": "true",
+			    "Supports shifting": "false",
+			    "Supports volatile": "true",
+			    "Using metacopy": "false"
+			},
+			"imageCopyTmpDir": "/var/tmp",
+			"imageStore": {
+			    "number": 297
+			},
+			"runRoot": "/run/user/3267/containers",
+			"transientStore": false,
+			"volumePath": "/home/dwalsh/.local/share/containers/storage/volumes"
+		    },
+		    "version": {
+			"APIVersion": "5.4.2",
+			"BuildOrigin": "Fedora Project",
+			"Built": 1743552000,
+			"BuiltTime": "Tue Apr  1 19:00:00 2025",
+			"GitCommit": "be85287fcf4590961614ee37be65eeb315e5d9ff",
+			"GoVersion": "go1.24.1",
+			"Os": "linux",
+			"OsArch": "linux/amd64",
+			"Version": "5.4.2"
+		    }
+		},
+		"Name": "podman"
 	    },
 	    "Image": "quay.io/ramalama/cuda:0.7",
 	    "Runtime": "llama.cpp",
 	    "Shortnames": {
-	        "Names": {
-	            "cerebrum": "huggingface://froggeric/Cerebrum-1.0-7b-GGUF/Cerebrum-1.0-7b-Q4_KS.gguf",
-	            "deepseek": "ollama://deepseek-r1",
-	            "dragon": "huggingface://llmware/dragon-mistral-7b-v0/dragon-mistral-7b-q4_k_m.gguf",
-	            "gemma3": "hf://bartowski/google_gemma-3-4b-it-GGUF/google_gemma-3-4b-it-IQ2_M.gguf",
-	            "gemma3:12b": "hf://bartowski/google_gemma-3-12b-it-GGUF/google_gemma-3-12b-it-IQ2_M.gguf",
-	            "gemma3:1b": "hf://bartowski/google_gemma-3-1b-it-GGUF/google_gemma-3-1b-it-IQ2_M.gguf",
-	            "gemma3:27b": "hf://bartowski/google_gemma-3-27b-it-GGUF/google_gemma-3-27b-it-IQ2_M.gguf",
-	            "gemma3:4b": "hf://bartowski/google_gemma-3-4b-it-GGUF/google_gemma-3-4b-it-IQ2_M.gguf",
-	            "granite": "ollama://granite3.1-dense",
-	            "granite-code": "hf://ibm-granite/granite-3b-code-base-2k-GGUF/granite-3b-code-base.Q4_K_M.gguf",
-	            "granite-code:20b": "hf://ibm-granite/granite-20b-code-base-8k-GGUF/granite-20b-code-base.Q4_K_M.gguf",
-	            "granite-code:34b": "hf://ibm-granite/granite-34b-code-base-8k-GGUF/granite-34b-code-base.Q4_K_M.gguf",
-	            "granite-code:3b": "hf://ibm-granite/granite-3b-code-base-2k-GGUF/granite-3b-code-base.Q4_K_M.gguf",
-	            "granite-code:8b": "hf://ibm-granite/granite-8b-code-base-4k-GGUF/granite-8b-code-base.Q4_K_M.gguf",
-	            "granite-lab-7b": "huggingface://instructlab/granite-7b-lab-GGUF/granite-7b-lab-Q4_K_M.gguf",
-	            "granite-lab-8b": "huggingface://ibm-granite/granite-8b-code-base-GGUF/granite-8b-code-base.Q4_K_M.gguf",
-	            "granite-lab:7b": "huggingface://instructlab/granite-7b-lab-GGUF/granite-7b-lab-Q4_K_M.gguf",
-	            "granite:2b": "ollama://granite3.1-dense:2b",
-	            "granite:7b": "huggingface://instructlab/granite-7b-lab-GGUF/granite-7b-lab-Q4_K_M.gguf",
-	            "granite:8b": "ollama://granite3.1-dense:8b",
-	            "hermes": "huggingface://NousResearch/Hermes-2-Pro-Mistral-7B-GGUF/Hermes-2-Pro-Mistral-7B.Q4_K_M.gguf",
-	            "ibm/granite": "ollama://granite3.1-dense:8b",
-	            "ibm/granite:2b": "ollama://granite3.1-dense:2b",
-	            "ibm/granite:7b": "huggingface://instructlab/granite-7b-lab-GGUF/granite-7b-lab-Q4_K_M.gguf",
-	            "ibm/granite:8b": "ollama://granite3.1-dense:8b",
-	            "merlinite": "huggingface://instructlab/merlinite-7b-lab-GGUF/merlinite-7b-lab-Q4_K_M.gguf",
-	            "merlinite-lab-7b": "huggingface://instructlab/merlinite-7b-lab-GGUF/merlinite-7b-lab-Q4_K_M.gguf",
-	            "merlinite-lab:7b": "huggingface://instructlab/merlinite-7b-lab-GGUF/merlinite-7b-lab-Q4_K_M.gguf",
-	            "merlinite:7b": "huggingface://instructlab/merlinite-7b-lab-GGUF/merlinite-7b-lab-Q4_K_M.gguf",
-	            "mistral": "huggingface://TheBloke/Mistral-7B-Instruct-v0.2-GGUF/mistral-7b-instruct-v0.2.Q4_K_M.gguf",
-	            "mistral:7b": "huggingface://TheBloke/Mistral-7B-Instruct-v0.2-GGUF/mistral-7b-instruct-v0.2.Q4_K_M.gguf",
-	            "mistral:7b-v1": "huggingface://TheBloke/Mistral-7B-Instruct-v0.1-GGUF/mistral-7b-instruct-v0.1.Q5_K_M.gguf",
-	            "mistral:7b-v2": "huggingface://TheBloke/Mistral-7B-Instruct-v0.2-GGUF/mistral-7b-instruct-v0.2.Q4_K_M.gguf",
-	            "mistral:7b-v3": "huggingface://MaziyarPanahi/Mistral-7B-Instruct-v0.3-GGUF/Mistral-7B-Instruct-v0.3.Q4_K_M.gguf",
-	            "mistral_code_16k": "huggingface://TheBloke/Mistral-7B-Code-16K-qlora-GGUF/mistral-7b-code-16k-qlora.Q4_K_M.gguf",
-	            "mistral_codealpaca": "huggingface://TheBloke/Mistral-7B-codealpaca-lora-GGUF/mistral-7b-codealpaca-lora.Q4_K_M.gguf",
-	            "mixtao": "huggingface://MaziyarPanahi/MixTAO-7Bx2-MoE-Instruct-v7.0-GGUF/MixTAO-7Bx2-MoE-Instruct-v7.0.Q4_K_M.gguf",
-	            "openchat": "huggingface://TheBloke/openchat-3.5-0106-GGUF/openchat-3.5-0106.Q4_K_M.gguf",
-	            "openorca": "huggingface://TheBloke/Mistral-7B-OpenOrca-GGUF/mistral-7b-openorca.Q4_K_M.gguf",
-	            "phi2": "huggingface://MaziyarPanahi/phi-2-GGUF/phi-2.Q4_K_M.gguf",
-	            "smollm:135m": "ollama://smollm:135m",
-	            "tiny": "ollama://tinyllama"
-	        },
-	        "Files": [
-	            "/usr/share/ramalama/shortnames.conf",
-	            "/home/dwalsh/.config/ramalama/shortnames.conf",
-	        ]
+		"Names": {
+		    "cerebrum": "huggingface://froggeric/Cerebrum-1.0-7b-GGUF/Cerebrum-1.0-7b-Q4_KS.gguf",
+		    "deepseek": "ollama://deepseek-r1",
+		    "dragon": "huggingface://llmware/dragon-mistral-7b-v0/dragon-mistral-7b-q4_k_m.gguf",
+		    "gemma3": "hf://bartowski/google_gemma-3-4b-it-GGUF/google_gemma-3-4b-it-IQ2_M.gguf",
+		    "gemma3:12b": "hf://bartowski/google_gemma-3-12b-it-GGUF/google_gemma-3-12b-it-IQ2_M.gguf",
+		    "gemma3:1b": "hf://bartowski/google_gemma-3-1b-it-GGUF/google_gemma-3-1b-it-IQ2_M.gguf",
+		    "gemma3:27b": "hf://bartowski/google_gemma-3-27b-it-GGUF/google_gemma-3-27b-it-IQ2_M.gguf",
+		    "gemma3:4b": "hf://bartowski/google_gemma-3-4b-it-GGUF/google_gemma-3-4b-it-IQ2_M.gguf",
+		    "granite": "ollama://granite3.1-dense",
+		    "granite-code": "hf://ibm-granite/granite-3b-code-base-2k-GGUF/granite-3b-code-base.Q4_K_M.gguf",
+		    "granite-code:20b": "hf://ibm-granite/granite-20b-code-base-8k-GGUF/granite-20b-code-base.Q4_K_M.gguf",
+		    "granite-code:34b": "hf://ibm-granite/granite-34b-code-base-8k-GGUF/granite-34b-code-base.Q4_K_M.gguf",
+		    "granite-code:3b": "hf://ibm-granite/granite-3b-code-base-2k-GGUF/granite-3b-code-base.Q4_K_M.gguf",
+		    "granite-code:8b": "hf://ibm-granite/granite-8b-code-base-4k-GGUF/granite-8b-code-base.Q4_K_M.gguf",
+		    "granite-lab-7b": "huggingface://instructlab/granite-7b-lab-GGUF/granite-7b-lab-Q4_K_M.gguf",
+		    "granite-lab-8b": "huggingface://ibm-granite/granite-8b-code-base-GGUF/granite-8b-code-base.Q4_K_M.gguf",
+		    "granite-lab:7b": "huggingface://instructlab/granite-7b-lab-GGUF/granite-7b-lab-Q4_K_M.gguf",
+		    "granite:2b": "ollama://granite3.1-dense:2b",
+		    "granite:7b": "huggingface://instructlab/granite-7b-lab-GGUF/granite-7b-lab-Q4_K_M.gguf",
+		    "granite:8b": "ollama://granite3.1-dense:8b",
+		    "hermes": "huggingface://NousResearch/Hermes-2-Pro-Mistral-7B-GGUF/Hermes-2-Pro-Mistral-7B.Q4_K_M.gguf",
+		    "ibm/granite": "ollama://granite3.1-dense:8b",
+		    "ibm/granite:2b": "ollama://granite3.1-dense:2b",
+		    "ibm/granite:7b": "huggingface://instructlab/granite-7b-lab-GGUF/granite-7b-lab-Q4_K_M.gguf",
+		    "ibm/granite:8b": "ollama://granite3.1-dense:8b",
+		    "merlinite": "huggingface://instructlab/merlinite-7b-lab-GGUF/merlinite-7b-lab-Q4_K_M.gguf",
+		    "merlinite-lab-7b": "huggingface://instructlab/merlinite-7b-lab-GGUF/merlinite-7b-lab-Q4_K_M.gguf",
+		    "merlinite-lab:7b": "huggingface://instructlab/merlinite-7b-lab-GGUF/merlinite-7b-lab-Q4_K_M.gguf",
+		    "merlinite:7b": "huggingface://instructlab/merlinite-7b-lab-GGUF/merlinite-7b-lab-Q4_K_M.gguf",
+		    "mistral": "huggingface://TheBloke/Mistral-7B-Instruct-v0.2-GGUF/mistral-7b-instruct-v0.2.Q4_K_M.gguf",
+		    "mistral:7b": "huggingface://TheBloke/Mistral-7B-Instruct-v0.2-GGUF/mistral-7b-instruct-v0.2.Q4_K_M.gguf",
+		    "mistral:7b-v1": "huggingface://TheBloke/Mistral-7B-Instruct-v0.1-GGUF/mistral-7b-instruct-v0.1.Q5_K_M.gguf",
+		    "mistral:7b-v2": "huggingface://TheBloke/Mistral-7B-Instruct-v0.2-GGUF/mistral-7b-instruct-v0.2.Q4_K_M.gguf",
+		    "mistral:7b-v3": "huggingface://MaziyarPanahi/Mistral-7B-Instruct-v0.3-GGUF/Mistral-7B-Instruct-v0.3.Q4_K_M.gguf",
+		    "mistral_code_16k": "huggingface://TheBloke/Mistral-7B-Code-16K-qlora-GGUF/mistral-7b-code-16k-qlora.Q4_K_M.gguf",
+		    "mistral_codealpaca": "huggingface://TheBloke/Mistral-7B-codealpaca-lora-GGUF/mistral-7b-codealpaca-lora.Q4_K_M.gguf",
+		    "mixtao": "huggingface://MaziyarPanahi/MixTAO-7Bx2-MoE-Instruct-v7.0-GGUF/MixTAO-7Bx2-MoE-Instruct-v7.0.Q4_K_M.gguf",
+		    "openchat": "huggingface://TheBloke/openchat-3.5-0106-GGUF/openchat-3.5-0106.Q4_K_M.gguf",
+		    "openorca": "huggingface://TheBloke/Mistral-7B-OpenOrca-GGUF/mistral-7b-openorca.Q4_K_M.gguf",
+		    "phi2": "huggingface://MaziyarPanahi/phi-2-GGUF/phi-2.Q4_K_M.gguf",
+		    "smollm:135m": "ollama://smollm:135m",
+		    "tiny": "ollama://tinyllama"
+		},
+		"Files": [
+		    "/usr/share/ramalama/shortnames.conf",
+		    "/home/dwalsh/.config/ramalama/shortnames.conf",
+		]
 	    },
 	    "Store": "/home/dwalsh/.local/share/ramalama",
 	    "UseContainer": true,
@@ -730,13 +618,13 @@ $ cat /usr/share/ramalama/shortnames.conf
 	<summary>
 		Using jq to print specific `ramalama info` content.
 	</summary>
- 	<br>
-	
+	<br>
+
 	```
 	$ ramalama info |  jq .Shortnames.Names.mixtao
 	```
- 	Returns for example:
-  	```
+	Returns for example:
+	```
    "huggingface://MaziyarPanahi/MixTAO-7Bx2-MoE-Instruct-v7.0-GGUF/MixTAO-7Bx2-MoE-Instruct-v7.0.Q4_K_M.gguf"
 	```
 </details>
@@ -747,13 +635,13 @@ $ cat /usr/share/ramalama/shortnames.conf
 	<summary>
 		Inspect the smollm:135m model for basic information.
 	</summary>
- 	<br>
-	
-  	```
+	<br>
+
+	```
 	$ ramalama inspect smollm:135m
-   	```
-   	Returns for example:
-  	```
+	```
+	Returns for example:
+	```
 	smollm:135m
 	   Path: /var/lib/ramalama/models/ollama/smollm:135m
 	   Registry: ollama
@@ -769,13 +657,13 @@ $ cat /usr/share/ramalama/shortnames.conf
 	<summary>
 		Inspect the smollm:135m model for all information in json format.
 	</summary>
- 	<br>
-	
-  	```
+	<br>
+
+	```
 	$ ramalama inspect smollm:135m --all --json
-   	```
-   	Returns for example:
-  	```
+	```
+	Returns for example:
+	```
 	{
 	    "Name": "smollm:135m",
 	    "Path": "/home/mengel/.local/share/ramalama/models/ollama/smollm:135m",
@@ -784,42 +672,42 @@ $ cat /usr/share/ramalama/shortnames.conf
 	    "Version": 3,
 	    "LittleEndian": true,
 	    "Metadata": {
-	        "general.architecture": "llama",
-	        "general.base_model.0.name": "SmolLM 135M",
-	        "general.base_model.0.organization": "HuggingFaceTB",
-	        "general.base_model.0.repo_url": "https://huggingface.co/HuggingFaceTB/SmolLM-135M",
-	        ...
+		"general.architecture": "llama",
+		"general.base_model.0.name": "SmolLM 135M",
+		"general.base_model.0.organization": "HuggingFaceTB",
+		"general.base_model.0.repo_url": "https://huggingface.co/HuggingFaceTB/SmolLM-135M",
+		...
 	    },
 	    "Tensors": [
-	        {
-	            "dimensions": [
-	                576,
-	                49152
-	            ],
-	            "n_dimensions": 2,
-	            "name": "token_embd.weight",
-	            "offset": 0,
-	            "type": 8
-	        },
-	        ...
+		{
+		    "dimensions": [
+			576,
+			49152
+		    ],
+		    "n_dimensions": 2,
+		    "name": "token_embd.weight",
+		    "offset": 0,
+		    "type": 8
+		},
+		...
 	    ]
 	}
 	```
 </details>
 
-### [`ramalama-list`](https://github.com/containers/ramalama/blob/main/docs/ramalama-list.1.md) 
+### [`ramalama-list`](https://github.com/containers/ramalama/blob/main/docs/ramalama-list.1.md)
 #### List all downloaded AI Models.
 - <details>
 	<summary>
 		You can `list` all models pulled into local storage.
 	</summary>
- 	<br>
-	
-  	```
+	<br>
+
+	```
 	$ ramalama list
-   	```
-   	Returns for example:
-  	```
+	```
+	Returns for example:
+	```
 	NAME                                                                    MODIFIED      SIZE
 	ollama://smollm:135m                                                    16 hours ago  5.5M
 	huggingface://afrideva/Tiny-Vicuna-1B-GGUF/tiny-vicuna-1b.q2_k.gguf     14 hours ago  460M
@@ -840,8 +728,8 @@ $ cat /usr/share/ramalama/shortnames.conf
 		Log in to quay.io/username oci registry
 	</summary>
 	<br>
-	
- 	```
+
+	```
 	$ export RAMALAMA_TRANSPORT=quay.io/username
 	$ ramalama login -u username
 	```
@@ -851,8 +739,8 @@ $ cat /usr/share/ramalama/shortnames.conf
 	<summary>
 		Log in to ollama registry
 	</summary>
- 	<br>
-	
+	<br>
+
 	```
 	$ export RAMALAMA_TRANSPORT=ollama
 	$ ramalama login
@@ -863,14 +751,14 @@ $ cat /usr/share/ramalama/shortnames.conf
 	<summary>
 		Log in to huggingface registry
 	</summary>
- 	<br>
-	
+	<br>
+
 	```
 	$ export RAMALAMA_TRANSPORT=huggingface
 	$ ramalama login --token=XYZ
 	```
 
-	Logging in to Hugging Face requires the `huggingface-cli tool`. For installation and usage instructions, see the documentation of the [Hugging Face command line interface](https://huggingface.co/docs/huggingface_hub/en/guides/cli). 
+	Logging in to Hugging Face requires the `huggingface-cli tool`. For installation and usage instructions, see the documentation of the [Hugging Face command line interface](https://huggingface.co/docs/huggingface_hub/en/guides/cli).
 </details>
 
 ### [`ramalama-logout`](https://github.com/containers/ramalama/blob/main/docs/ramalama-logout.1.md)
@@ -879,8 +767,8 @@ $ cat /usr/share/ramalama/shortnames.conf
 	<summary>
 		Log out from quay.io/username oci repository
 	</summary>
- 	<br>
-	
+	<br>
+
 	```
 	$ ramalama logout quay.io/username
 	```
@@ -890,8 +778,8 @@ $ cat /usr/share/ramalama/shortnames.conf
 	<summary>
 		Log out from ollama repository
 	</summary>
- 	<br>
-	
+	<br>
+
 	```
 	$ ramalama logout ollama
 	```
@@ -901,8 +789,8 @@ $ cat /usr/share/ramalama/shortnames.conf
 	<summary>
 		Log out from huggingface
 	</summary>
- 	<br>
-	
+	<br>
+
 	```
 	$ ramalama logout huggingface
 	```
@@ -928,9 +816,9 @@ $ cat /usr/share/ramalama/shortnames.conf
 	<summary>
 		Pull a model
 	</summary>
- 	<br>
+	<br>
 
-  	You can `pull` a model using the `pull` command. By default, it pulls from the Ollama registry.
+	You can `pull` a model using the `pull` command. By default, it pulls from the Ollama registry.
 	```
 	$ ramalama pull granite3-moe
 	```
@@ -961,7 +849,7 @@ $ cat /usr/share/ramalama/shortnames.conf
 	<summary>
 		Generate RAG data from provided documents and convert into an OCI Image.
 	</summary>
- 	<br>
+	<br>
 
 	This command uses a specific container image containing the docling tool to convert the specified content into a RAG vector database. If the image does not exists locally RamaLama will pull the image down and launch a container to process the data.
 
@@ -971,7 +859,7 @@ $ cat /usr/share/ramalama/shortnames.conf
 
 	IMAGE OCI Image name to contain processed rag data
 
-  	```
+	```
 	./bin/ramalama rag ./README.md https://github.com/containers/podman/blob/main/README.md quay.io/rhatdan/myrag
 	100% |███████████████████████████████████████████████████████|  114.00 KB/    0.00 B 922.89 KB/s   59m 59s
 	Building quay.io/ramalama/myrag...
@@ -986,9 +874,9 @@ $ cat /usr/share/ramalama/shortnames.conf
 	<summary>
 		Specify one or more AI Models to be removed from local storage.
 	</summary>
- 	<br>
-	
-  	```
+	<br>
+
+	```
 	$ ramalama rm ollama://tinyllama
 	```
 </details>
@@ -997,9 +885,9 @@ $ cat /usr/share/ramalama/shortnames.conf
 	<summary>
 		Remove all AI Models from local storage.
 	</summary>
- 	<br>
-	
-  	```
+	<br>
+
+	```
 	$ ramalama rm --all
 	```
 </details>
@@ -1012,12 +900,12 @@ $ cat /usr/share/ramalama/shortnames.conf
 		Run a chatbot on a model using the run command. By default, it pulls from the Ollama registry.
 	</summary>
 	<br>
-	
+
 	Note: RamaLama will inspect your machine for native GPU support and then will use a container engine like Podman to pull an OCI container image with the appropriate code and libraries to run the AI Model. This can take a long time to setup, but only on the first run.
 
 	```
 	$ ramalama run instructlab/merlinite-7b-lab
- 	```
+	```
 </details>
 
 - <details>
@@ -1025,14 +913,14 @@ $ cat /usr/share/ramalama/shortnames.conf
 		After the initial container image has been downloaded, you can interact with different models using the container image.
 	</summary>
 	<br>
-	
+
 	```
 	$ ramalama run granite3-moe
- 	```
- 	Returns for example:
- 	```
+	```
+	Returns for example:
+	```
 	> Write a hello world application in python
-	
+
 	print("Hello World")
 	```
 </details>
@@ -1042,7 +930,7 @@ $ cat /usr/share/ramalama/shortnames.conf
 		In a different terminal window see the running podman container.
 	</summary>
 	<br>
- 
+
 	```
 	$ podman ps
 	CONTAINER ID  IMAGE                             COMMAND               CREATED        STATUS        PORTS       NAMES
@@ -1057,11 +945,11 @@ $ cat /usr/share/ramalama/shortnames.conf
 		Serve a model and connect via a browser.
 	</summary>
 	<br>
-	
+
 	```
- 	$ ramalama serve llama3
- 	```
- 	When the web UI is enabled, you can connect via your browser at: 127.0.0.1:< port >
+	$ ramalama serve llama3
+	```
+	When the web UI is enabled, you can connect via your browser at: 127.0.0.1:< port >
 	The default serving port will be 8080 if available, otherwise a free random port in the range 8081-8090. If you wish, you can specify a port to use with --port/-p.
 </details>
 
@@ -1069,15 +957,15 @@ $ cat /usr/share/ramalama/shortnames.conf
 	<summary>
 		Run two AI Models at the same time. Notice both are running within Podman Containers.
 	</summary>
- 	<br>
-	
-  	```
+	<br>
+
+	```
 	$ ramalama serve -d -p 8080 --name mymodel ollama://smollm:135m
 	09b0e0d26ed28a8418fb5cd0da641376a08c435063317e89cf8f5336baf35cfa
-	
+
 	$ ramalama serve -d -n example --port 8081 oci://quay.io/mmortari/gguf-py-example/v1/example.gguf
 	3f64927f11a5da5ded7048b226fbe1362ee399021f5e8058c73949a677b6ac9c
-	
+
 	$ podman ps
 	CONTAINER ID  IMAGE                             COMMAND               CREATED         STATUS         PORTS                   NAMES
 	09b0e0d26ed2  quay.io/ramalama/ramalama:latest  /usr/bin/ramalama...  32 seconds ago  Up 32 seconds  0.0.0.0:8081->8081/tcp  ramalama_sTLNkijNNP
@@ -1090,10 +978,10 @@ $ cat /usr/share/ramalama/shortnames.conf
 		To disable the web UI, use the `--webui` off flag.
 	</summary>
 	<br>
-	
+
 	```
 	$ ramalama serve --webui off llama3
-	```	
+	```
 </details>
 
 
@@ -1104,39 +992,39 @@ $ cat /usr/share/ramalama/shortnames.conf
 	<summary>
 		Stop a running model if it is running in a container.
 	</summary>
- 	<br>
-	
-  	```
+	<br>
+
+	```
 	$ ramalama stop mymodel
-   	```
+	```
 </details>
 
 - <details>
 	<summary>
 		Stop all running models running in containers.
 	</summary>
- 	<br>
-	
-  	```
+	<br>
+
+	```
 	$ ramalama stop --all
-   	```
+	```
 </details>
 
-### [`ramalama-version`](https://github.com/containers/ramalama/blob/main/docs/ramalama-version.1.md) 
+### [`ramalama-version`](https://github.com/containers/ramalama/blob/main/docs/ramalama-version.1.md)
 #### Display version of the AI Model.
 - <details>
 	<summary>
-		Print the version of Ramalama.
+		Print the version of RamaLama.
 	</summary>
- 	<br>
-	
-  	```
+	<br>
+
+	```
 	$ ramalama version
 	```
-   	Returns for example:
-  	```
+	Returns for example:
+	```
 	ramalama version 1.2.3
-   	```
+	```
 </details>
 
 ### Appendix

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,5 @@
-# Ramalama Docs
-Ramalama uses man pages
+# RamaLama Docs
+RamaLama uses man pages
 
 ## Directory Structure
 | Description                          | Directory                   |

--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
 
       forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
 
-      mkRamalama = pkgs: with pkgs;
+      mkRamaLama = pkgs: with pkgs;
         callPackage
           (
             { ramalamaOverrides ? { }
@@ -37,7 +37,7 @@
       ramalama = forAllSystems (system:
         let
           pkgs = nixpkgs.legacyPackages.${system};
-          package = mkRamalama pkgs;
+          package = mkRamaLama pkgs;
         in {
           inherit package;
           app = {


### PR DESCRIPTION
Fix Ramalama names that have snuck into the repo.
Cleanup whitespace in README.md doc.

## Summary by Sourcery

Replace all occurrences of 'Ramalama' with 'RamaLama' throughout the project documentation and code

Documentation:
- Updated README.md and documentation to consistently use 'RamaLama' spelling

Chores:
- Corrected project name spelling across multiple files