### PR TITLE
Describe what this test does

### DIFF
--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -116,6 +116,7 @@ EOF
 }
 
 @test "ramalama run --keepalive" {
+    # timeout within 1 second and generate a 124 error code.
     run_ramalama 124 --debug run --keepalive 1s tiny
 }
 


### PR DESCRIPTION
It failed for me once

## Summary by Sourcery

Tests:
- Added a test case for ramalama run command with a 1-second timeout to verify keepalive behavior