### PR TITLE
Add shortnames for mistral-small3.1 model

### DIFF
--- a/shortnames/shortnames.conf
+++ b/shortnames/shortnames.conf
@@ -32,6 +32,8 @@
   "mistral:7b-v3" = "huggingface://MaziyarPanahi/Mistral-7B-Instruct-v0.3-GGUF/Mistral-7B-Instruct-v0.3.Q4_K_M.gguf"
   "mistral:7b-v2" = "huggingface://TheBloke/Mistral-7B-Instruct-v0.2-GGUF/mistral-7b-instruct-v0.2.Q4_K_M.gguf"
   "mistral:7b-v1" = "huggingface://TheBloke/Mistral-7B-Instruct-v0.1-GGUF/mistral-7b-instruct-v0.1.Q5_K_M.gguf"
+  "mistral-small3.1" = "hf://bartowski/mistralai_Mistral-Small-3.1-24B-Instruct-2503-GGUF/mistralai_Mistral-Small-3.1-24B-Instruct-2503-IQ2_M.gguf"
+  "mistral-small3.1:24b" = "hf://bartowski/mistralai_Mistral-Small-3.1-24B-Instruct-2503-GGUF/mistralai_Mistral-Small-3.1-24B-Instruct-2503-IQ2_M.gguf"
   "hermes" = "huggingface://NousResearch/Hermes-2-Pro-Mistral-7B-GGUF/Hermes-2-Pro-Mistral-7B.Q4_K_M.gguf"
   "mistral_codealpaca" = "huggingface://TheBloke/Mistral-7B-codealpaca-lora-GGUF/mistral-7b-codealpaca-lora.Q4_K_M.gguf"
   "mistral_code_16k" = "huggingface://TheBloke/Mistral-7B-Code-16K-qlora-GGUF/mistral-7b-code-16k-qlora.Q4_K_M.gguf"


### PR DESCRIPTION
Another Ollama model that's only compatible with Ollama's forking of llama.cpp

## Summary by Sourcery

Add shortnames for the Mistral Small 3.1 24B model to the shortnames configuration

New Features:
- Added shortname 'mistral-small3.1' for Mistral Small 3.1 24B Instruct model
- Added alternative shortname 'mistral-small3.1:24b' for the same model