### PR TITLE
Fixup use of /.venv

### DIFF
--- a/container-images/llama-stack/Containerfile
+++ b/container-images/llama-stack/Containerfile
@@ -9,9 +9,9 @@ RUN dnf -y update && \
     dnf -y install uv cmake gcc gcc-c++ python3-devel pkg-config sentencepiece-devel && \
     dnf -y clean all
 
-RUN uv pip install --system ramalama-stack
-
-RUN uv run llama stack run ~/.llama/distributions/ramalama/ramalama-run.yaml --image-type venv --image-name /venv
+RUN uv venv  && \
+    uv pip install ramalama-stack && \
+    uv run llama stack run  --image-type venv --image-name /.venv ~/.llama/distributions/ramalama/ramalama-run.yaml
 
 COPY --chmod=755 llama-stack/entrypoint.sh /usr/bin/entrypoint.sh
 

--- a/container-images/llama-stack/entrypoint.sh
+++ b/container-images/llama-stack/entrypoint.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 
 # shellcheck source=/dev/null
-source /venv/bin/activate
+source /.venv/bin/activate
 
 if [ $# -eq 0 ]; then
     exec bash


### PR DESCRIPTION
## Summary by Sourcery

Update the Containerfile and entrypoint script to use /.venv instead of /venv for the Python virtual environment

Enhancements:
- Modify virtual environment creation and activation to use a consistent /.venv path

Chores:
- Simplify the ramalama-stack installation process in the container