### PR TITLE
Fixed mac gpu not being enabled from stale global var check

### DIFF
--- a/ramalama/engine.py
+++ b/ramalama/engine.py
@@ -4,7 +4,9 @@ import os
 import subprocess
 import sys
 
-from ramalama.common import check_nvidia, exec_cmd, get_accel_env_vars, perror, podman_machine_accel, run_cmd
+# Live reference for checking global vars
+import ramalama.common
+from ramalama.common import check_nvidia, exec_cmd, get_accel_env_vars, perror, run_cmd
 from ramalama.console import EMOJI
 
 
@@ -118,7 +120,7 @@ class Engine:
             for device_arg in self.args.device:
                 self.exec_args += ["--device", device_arg]
 
-        if podman_machine_accel:
+        if ramalama.common.podman_machine_accel:
             self.exec_args += ["--device", "/dev/dri"]
 
         for path in ["/dev/dri", "/dev/kfd", "/dev/accel", "/dev/davinci*", "/dev/devmm_svm", "/dev/hisi_hdc"]:


### PR DESCRIPTION
I noticed that playing around with mac and podman desktop machine with libkrun enabled --device wasn't properly being put into the podman command. Turns out it was just a invalid global var reference

## Summary by Sourcery

Bug Fixes:
- Corrected the global variable reference for podman machine acceleration to properly enable GPU devices