### PR TITLE
INFERENCE_MODEL should be set by the container engine

### DIFF
--- a/container-images/llama-stack/Containerfile
+++ b/container-images/llama-stack/Containerfile
@@ -12,8 +12,6 @@ RUN dnf -y update && \
 RUN uv venv && \
     uv pip install ramalama-stack
 
-ENV INFERENCE_MODEL=/mnt/model/model.file
-
 COPY --chmod=755 llama-stack/entrypoint.sh /usr/bin/entrypoint.sh
 
 ENTRYPOINT [ "/usr/bin/entrypoint.sh" ]


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Remove hardcoded model path environment variable