### PR TITLE
Update ramalama-serve.1.md

### DIFF
--- a/docs/ramalama-serve.1.md
+++ b/docs/ramalama-serve.1.md
@@ -30,7 +30,7 @@ URL support means if a model is on a web site or even on your local system, you 
 ## REST API ENDPOINTS
 Under the hood, `ramalama-serve` uses the `LLaMA.cpp` HTTP server by default.
 
-For REST API endpoint documentation, see: [https://github.com/ggml-org/llama.cpp/blob/master/examples/server/README.md#api-endpoints](https://github.com/ggml-org/llama.cpp/blob/master/examples/server/README.md#api-endpoints)
+For REST API endpoint documentation, see: [https://github.com/ggml-org/llama.cpp/blob/master/tools/server/README.md#api-endpoints](https://github.com/ggml-org/llama.cpp/blob/master/tools/server/README.md#api-endpoints)
 
 ## OPTIONS
 


### PR DESCRIPTION
according to  Commit 1d36b36, the files path was changed

https://github.com/ggml-org/llama.cpp/commit/1d36b3670b285e69e58b9d687c770a2a0a192194

## Summary by Sourcery

Documentation:
- Updated the REST API endpoint documentation link to point to the correct location in the repository