### PR TITLE
fix: ignore <none>:<none> images

### DIFF
--- a/ramalama/oci.py
+++ b/ramalama/oci.py
@@ -101,6 +101,9 @@ def list_models(args):
         return []
 
     models = json.loads("[" + output[:-1] + "]")
+    # exclude dangling images having no tag (i.e. <none>:<none>)
+    models = [model for model in models if model["name"] != "oci://<none>:<none>"]
+
     # Grab the size from the inspect command
     if conman == "docker":
         # grab the size from the inspect command


### PR DESCRIPTION
when you convert model to OCI images, then using `ramalama list` is showing `<none>:<none>` models

Here we skip these items

related to https://github.com/containers/ramalama/issues/904

## Summary by Sourcery

Bug Fixes:
- Exclude '<none>:<none>' images from the model list to prevent confusion