### PR TITLE
Update ramalama-serve.1.md, Signed-off-by:  Xiaoqiang Xiong <xxiong@r…

### DIFF
--- a/docs/ramalama-serve.1.md
+++ b/docs/ramalama-serve.1.md
@@ -30,7 +30,7 @@ URL support means if a model is on a web site or even on your local system, you 
 ## REST API ENDPOINTS
 Under the hood, `ramalama-serve` uses the `LLaMA.cpp` HTTP server by default.
 
-For REST API endpoint documentation, see: [https://github.com/ggml-org/llama.cpp/blob/master/examples/server/README.md#api-endpoints](https://github.com/ggml-org/llama.cpp/blob/master/examples/server/README.md#api-endpoints)
+For REST API endpoint documentation, see: [https://github.com/ggml-org/llama.cpp/blob/master/tools/server/README.md#api-endpoints](https://github.com/ggml-org/llama.cpp/blob/master/tools/server/README.md#api-endpoints)
 
 ## OPTIONS
 


### PR DESCRIPTION
according to  Commit 1d36b36, the files path was changed
ggml-org/llama.cpp@1d36b36

Signed-off-by:  Xiaoqiang Xiong <xxiong@redhat.com>

## Summary by Sourcery

Documentation:
- Updated the REST API endpoint documentation link to point to the correct path in the llama.cpp repository