### PR TITLE
according to Commit 1d36b36, the files path was changed

### DIFF
--- a/docs/ramalama-serve.1.md
+++ b/docs/ramalama-serve.1.md
@@ -30,7 +30,7 @@ URL support means if a model is on a web site or even on your local system, you 
 ## REST API ENDPOINTS
 Under the hood, `ramalama-serve` uses the `LLaMA.cpp` HTTP server by default.
 
-For REST API endpoint documentation, see: [https://github.com/ggml-org/llama.cpp/blob/master/examples/server/README.md#api-endpoints](https://github.com/ggml-org/llama.cpp/blob/master/examples/server/README.md#api-endpoints)
+For REST API endpoint documentation, see: [https://github.com/ggml-org/llama.cpp/blob/master/tools/server/README.md#api-endpoints](https://github.com/ggml-org/llama.cpp/blob/master/tools/server/README.md#api-endpoints)
 
 ## OPTIONS
 


### PR DESCRIPTION
Update ramalama-serve.1.md  REST API endpoint documentation path and link

## Summary by Sourcery

Documentation:
- Update the link to the LLaMA.cpp server API endpoints documentation to reflect the correct file location