### PR TITLE
Only execute this if /run/ramalama exists

### DIFF
--- a/container-images/scripts/build_llama_and_whisper.sh
+++ b/container-images/scripts/build_llama_and_whisper.sh
@@ -255,7 +255,9 @@ clone_and_build_llama_cpp() {
 install_ramalama() {
   # link podman-remote to podman for use by RamaLama
   ln -sf /usr/bin/podman-remote /usr/bin/podman
-  python3 -m pip install /run/ramalama --prefix="$1"
+  if [ -e "/run/ramalama" ]; then
+    python3 -m pip install /run/ramalama --prefix="$1"
+  fi
 }
 
 main() {


### PR DESCRIPTION
Using this script to install llama.cpp and whisper.cpp bare metal on a bootc system, the build stops executing here:

+ ln -sf /usr/bin/podman-remote /usr/bin/podman
+ python3 -m pip install /run/ramalama --prefix=/usr ERROR: Invalid requirement: '/run/ramalama': Expected package name at the start of dependency specifier
    /run/ramalama
    ^
Hint: It looks like a path. File '/run/ramalama' does not exist. Error: building at STEP "RUN chmod a+rx /usr/bin/build_llama_and_whisper.sh && build_llama_and_whisper.sh "rocm"": while running runtime: exit status 1
