### PR TITLE
Fix partial model listing

### DIFF
--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -1030,8 +1030,11 @@ def rm_cli(args):
     if len(args.MODEL) > 0:
         raise IndexError("can not specify --all as well MODEL")
 
-    models = [k['name'] for k in _list_models(args)]
-    return _rm_model(models, args)
+    models = GlobalModelStore(args.store).list_models(
+        engine=args.engine, debug=args.debug, show_container=args.container
+    )
+
+    return _rm_model([model for model in models.keys()], args)
 
 
 def New(model, args, transport=CONFIG["transport"]):

--- a/ramalama/model_factory.py
+++ b/ramalama/model_factory.py
@@ -49,7 +49,12 @@ class ModelFactory:
             return Ollama, self.create_ollama
         if self.model.startswith("oci://") or self.model.startswith("docker://"):
             return OCI, self.create_oci
-        if self.model.startswith("http://") or self.model.startswith("https://") or self.model.startswith("file://"):
+        if (
+            self.model.startswith("http://")
+            or self.model.startswith("https://")
+            or self.model.startswith("file://")
+            or self.model.startswith("url://")
+        ):
             return URL, self.create_url
 
         if self.transport == "huggingface":

--- a/test/unit/test_model_factory.py
+++ b/test/unit/test_model_factory.py
@@ -64,6 +64,7 @@ hf_granite_blob = "https://huggingface.co/ibm-granite/granite-3b-code-base-2k-GG
             None,
         ),
         (Input("file:///tmp/models/granite-3b-code-base.Q4_K_M.gguf", False, "", ""), URL, None),
+        (Input("url:///tmp/models/granite-3b-code-base.Q4_K_M.gguf", False, "", ""), URL, None),
         (Input("granite-code", False, "huggingface", ""), Huggingface, None),
         (Input("granite-code", False, "ollama", ""), Ollama, None),
         (Input("granite-code", False, "oci", ""), OCI, None),
@@ -145,6 +146,10 @@ def test_validate_oci_model_input(input: Input, error):
         ),
         (
             Input("file:///tmp/models/granite-3b-code-base.Q4_K_M.gguf", False, "", ""),
+            "/tmp/models/granite-3b-code-base.Q4_K_M.gguf",
+        ),
+        (
+            Input("url:///tmp/models/granite-3b-code-base.Q4_K_M.gguf", False, "", ""),
             "/tmp/models/granite-3b-code-base.Q4_K_M.gguf",
         ),
         (Input("granite-code", False, "huggingface", ""), "granite-code"),


### PR DESCRIPTION
Relates to: https://github.com/containers/ramalama/issues/1325
    
In the list models function only the url:// prefix is present. Passing a listed model to the factory can not map this model input correctly to the URL model class. Therefore, this gets extended and the unit tests updated by appropriate cases.

Also, instead of appending the (partial) identifier directly, the returned ModelFile class is extended to indicate if the file is partially downloaded or not.

## Summary by Sourcery

Improve model listing and handling by adding support for partial model downloads and extending URL model detection

New Features:
- Add support for detecting 'url://' prefix in model factory
- Introduce 'is_partial' flag for ModelFile to indicate partially downloaded models

Bug Fixes:
- Fix model listing to correctly handle and identify partially downloaded models

Enhancements:
- Modify model listing to track partial model downloads more accurately
- Update model removal to work with the new model listing approach

Tests:
- Add test case for 'url://' model input validation