### PR TITLE
Fix typo (RAMALAMA_TRANSPORTS->RAMALAMA_TRANSPORT)

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ How to change transports.
 </summary>
 <br>
 
-Use the RAMALAMA_TRANSPORTS environment variable to modify the default. `export RAMALAMA_TRANSPORT=huggingface` Changes RamaLama to use huggingface transport.
+Use the RAMALAMA_TRANSPORT environment variable to modify the default. `export RAMALAMA_TRANSPORT=huggingface` Changes RamaLama to use huggingface transport.
 
 Individual model transports can be modified when specifying a model via the `huggingface://`, `oci://`, or `ollama://` prefix.
 


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Corrected the environment variable name from RAMALAMA_TRANSPORTS to RAMALAMA_TRANSPORT in the README