### PR TITLE
Allow docling to handle URLs rather then handling locally

### DIFF
--- a/install-uv.sh
+++ b/install-uv.sh
@@ -1425,7 +1425,7 @@ shotgun_install_dir_to_path() {
             fi
         done
 
-        # Fall through to previous "create + write to first file in list" behavior
+        # Fall through to previous "create + write to first file in list" behaviour
 	    if [ "$_found" = false ]; then
             add_install_dir_to_path "$_install_dir_expr" "$_env_script_path" "$_env_script_path_expr" "$_rcfiles" "$_shell"
         fi


### PR DESCRIPTION
Docling has support for pulling html pages, and we were not pulling them correctly.

Also support --dryrun

## Summary by Sourcery

Enhance docling's URL handling and add dry-run support for the RAG (Retrieval-Augmented Generation) functionality

New Features:
- Add support for handling URLs directly in the RAG process
- Implement --dryrun option to preview RAG commands without executing them

Bug Fixes:
- Fix URL downloading and handling mechanism for documentation sources

Enhancements:
- Refactor path handling to better support different URL and file schemes
- Improve error handling for non-existent files