### PR TITLE
small improvements to the build of the ramalama-rag image

### DIFF
--- a/container-images/scripts/build-cli.sh
+++ b/container-images/scripts/build-cli.sh
@@ -8,13 +8,13 @@ dnf_remove() {
   dnf remove -y \
       python3-devel \
       python3-pip \
-      git 
+      git-core
   dnf -y clean all
 }
 
 dnf_install() {
   local rpm_list=("podman-remote" "python3" "python3-pip" \
-		  "python3-argcomplete" "python3-devel" "git" \
+		  "python3-argcomplete" "python3-devel" "git-core" \
 		  "vim" "procps-ng" \
                   )
   dnf install -y "${rpm_list[@]}"

--- a/container-images/scripts/build_llama_and_whisper.sh
+++ b/container-images/scripts/build_llama_and_whisper.sh
@@ -32,7 +32,7 @@ dnf_install_cuda() {
 
 dnf_install_cann() {
   # just for openeuler build environment, does not need to push to ollama github
-  dnf install -y git \
+  dnf install -y git-core \
       gcc \
       gcc-c++ \
       make \
@@ -118,7 +118,7 @@ dnf_install_ffmpeg() {
 dnf_install() {
   local rpm_list=("python3" "python3-pip" \
                   "python3-argcomplete" "python3-dnf-plugin-versionlock" \
-                  "python3-devel" "gcc-c++" "cmake" "vim" "procps-ng" "git" \
+                  "python3-devel" "gcc-c++" "cmake" "vim" "procps-ng" "git-core" \
                   "dnf-plugins-core" "libcurl-devel" "gawk")
   local vulkan_rpms=("vulkan-headers" "vulkan-loader-devel" "vulkan-tools" \
                      "spirv-tools" "glslc" "glslang")

--- a/container-images/scripts/build_rag.sh
+++ b/container-images/scripts/build_rag.sh
@@ -14,21 +14,21 @@ $2"
     [ "$string" != "$(sort --version-sort <<< "$string")" ]
 }
 
-packages="git gcc gcc-c++ python3-devel"
+packages="git gcc gcc-c++"
 if [ "${GPU}" = "cuda" ]; then
     packages+=" libcudnn9-devel-cuda-12 libcusparselt0 cuda-cupti-12\*"
 fi
 
-if [[ "$VERSION_ID" -ge 42 ]] ; then
+if [[ "$ID" = "fedora" && "$VERSION_ID" -ge 42 ]] ; then
     packages+=" python3-sentencepiece-0.2.0"
 
 fi
 
 update_python() {
     if version_greater "$pyversion" "Python 3.10"; then
-	eval dnf install -y python3-pip "${packages}"
+	eval dnf install -y python3-pip python3-devel "${packages}"
     else
-	eval dnf install -y python3.11 python3.11-pip "${packages}"
+	eval dnf install -y python3.11 python3.11-pip python3.11-devel "${packages}"
 	export PYTHON_VERSION="/usr/bin/python3.11 -m"
 	ln -sf /usr/bin/python3.11 /usr/bin/python3
     fi

--- a/container-images/scripts/build_rag.sh
+++ b/container-images/scripts/build_rag.sh
@@ -14,7 +14,7 @@ $2"
     [ "$string" != "$(sort --version-sort <<< "$string")" ]
 }
 
-packages="git gcc gcc-c++"
+packages="git-core gcc gcc-c++"
 if [ "${GPU}" = "cuda" ]; then
     packages+=" libcudnn9-devel-cuda-12 libcusparselt0 cuda-cupti-12\*"
 fi

--- a/container-images/scripts/build_rag.sh
+++ b/container-images/scripts/build_rag.sh
@@ -35,18 +35,18 @@ update_python() {
 }
 
 docling() {
-    ${PYTHON_VERSION} pip install wheel qdrant_client fastembed docling docling-core accelerate --extra-index-url https://download.pytorch.org/whl/"$1"
+    ${PYTHON_VERSION} pip install --prefix=/usr docling docling-core accelerate --extra-index-url https://download.pytorch.org/whl/"$1"
     # Preloads models (assumes its installed from container_build.sh)
     doc2rag load
 }
 
 rag() {
-    ${PYTHON_VERSION} pip install wheel qdrant_client fastembed openai fastapi uvicorn
+    ${PYTHON_VERSION} pip install --prefix=/usr wheel qdrant_client fastembed openai fastapi uvicorn
     rag_framework load
 }
 
 to_gguf() {
-    ${PYTHON_VERSION} pip install "numpy~=1.26.4" "sentencepiece~=0.2.0" "transformers>=4.45.1,<5.0.0" git+https://github.com/ggml-org/llama.cpp#subdirectory=gguf-py "protobuf>=4.21.0,<5.0.0"
+    ${PYTHON_VERSION} pip install --prefix=/usr "numpy~=1.26.4" "sentencepiece~=0.2.0" "transformers>=4.45.1,<5.0.0" git+https://github.com/ggml-org/llama.cpp#subdirectory=gguf-py "protobuf>=4.21.0,<5.0.0"
 }
 
 update_python


### PR DESCRIPTION
There was a logic error in `build_rag.sh` that assumed `$VERSION_ID` was an integer, and checked if it was `-ge 42` to determine whether or not to install a package via `dnf`. That worked on Fedora but not on a UBI9 image, where `$VERSION_ID` is `9.5`. Checking that `$ID` is `fedora` before comparing `$VERSION_ID` fixes the issue.

Install `python3.11-devel` explicitly when installing `python3.11`. Otherwise the `python3-devel` requirement is filled by the already-installed `python3.9-devel` package.

Install `git-core` instead of `git` to avoid pulling in a lot of unnecessary `perl` packages, which should slightly improve build times.

When building the `rag` image, set the `pip` installation prefix to `/usr` for consistency with the `ramalama` image.

## Summary by Sourcery

Improve build scripts for container images by fixing package installation logic and optimizing package selection

Bug Fixes:
- Fixed version check logic for package installation to work correctly on different Linux distributions
- Ensure correct Python development package is installed with Python 3.11

Enhancements:
- Optimize package installation by using git-core instead of git to reduce unnecessary dependencies
- Set consistent pip installation prefix to /usr across images

Chores:
- Update build scripts to handle version checks more robustly
- Streamline package installation across multiple build scripts