### PR TITLE
update the shortnames path according to the shortnames.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,12 +165,22 @@ More information on shortnames.
 RamaLama reads shortnames.conf files if they exist. These files contain a list of name-value pairs that specify the model. The following table specifies the order in which RamaLama reads the files. Any duplicate names that exist override previously defined shortnames.
 <br>
 
-| Shortnames type | Path                                     |
-| :-------------- | :--------------------------------------- |
-| Distribution    | /usr/share/ramalama/shortnames.conf      |
-| Administrators  | /etc/ramalama/shortnames.conf            |
-| Users           | $HOME/.config/ramalama/shortnames.conf   |
+| Shortnames type    | Path                                                       |
+| :----------------  | :-------------------------------------------               |
+| System Data Path   | ${data_path}/share/ramalama/shortnames.conf                |
+| Distribution       | /usr/share/ramalama/shortnames.conf                        |
+| Local Distribution | /usr/local/share/ramalama/shortnames.conf                  |
+| Administrators     | /etc/ramalama/shortnames.conf                              |
+| User (Local Share) | ~/.local/share/ramalama/shortnames.conf                    |
+| User (Config)      | ~/.config/ramalama/shortnames.conf                         |
+| Pipx Environment   | ~/.local/pipx/venvs/ramalama/share/ramalama/shortnames.conf|
+| Development        | ./shortnames/shortnames.conf                               |
+| Development        | ./shortnames.conf                                          |
 <br>
+
+#### Notes:
+- `System Data Path` refers to the Python installation's system data directory.
+- Development paths are primarily for testing and local development use.
 
 ```
 $ cat /usr/share/ramalama/shortnames.conf


### PR DESCRIPTION
I used `pip install ramalama`, then tried to see the shortnames.conf configuration. Firstly, I am not able to find the file according to the README.md. Finally,  I found its path is `~/.local/share/ramalama/shortnames.conf` instead of `~/.config/ramalama/shortnames.conf`, so I made this change to make the README.md clearer according to shortnames.py. 

```
$ pip install ramalama
$ ramalama info|grep "shortnames"
            "~/.local/share/ramalama/shortnames.conf"
```

This is how shortname.py defined the path:
```
file_paths = [
            f"{data_path}/share/ramalama/shortnames.conf",
            "/usr/share/ramalama/shortnames.conf",
            "/usr/local/share/ramalama/shortnames.conf",
            "/etc/ramalama/shortnames.conf",
            os.path.expanduser("~/.local/share/ramalama/shortnames.conf"),
            os.path.expanduser("~/.config/ramalama/shortnames.conf"),
            os.path.expanduser("~/.local/pipx/venvs/ramalama/share/ramalama/shortnames.conf"),
            "./shortnames/shortnames.conf",  # for development
            "./shortnames.conf",  # for development
        ]
```

