### PR TITLE
fix "ramalama client"

### DIFF
--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -1046,7 +1046,7 @@ def New(model, args, transport=CONFIG["transport"]):
 def client_cli(args):
     """Handle client command execution"""
     client_args = ["ramalama-client-core", "-c", "2048", "--temp", "0.8", args.HOST] + args.ARGS
-    client_args[0] = get_cmd_with_wrapper(client_args)
+    client_args[0] = get_cmd_with_wrapper(client_args[0])
     exec_cmd(client_args)
 
 


### PR DESCRIPTION
`get_cmd_with_wrapper()` was changed in 849813f8 to accept a single string argument instead of a list. Update `cli.py` to pass only the first element of the list.

## Summary by Sourcery

Bug Fixes:
- Fixed the argument passing to get_cmd_with_wrapper() to match its updated signature