### PR TITLE
Use python3.11 on systems with older python

### DIFF
--- a/container-images/scripts/build_rag.sh
+++ b/container-images/scripts/build_rag.sh
@@ -5,8 +5,22 @@ source /etc/os-release
 
 GPU="${1-cpu}"
 
-export PYTHON_VERSION="python3 -m"
-pyversion=$(python3 --version)
+python_version() {
+  pyversion=$(python3 --version)
+  # $2 is empty when no Python is installed, so just install python3
+  if [ -n "$pyversion" ]; then
+      string="$pyversion
+Python 3.11"
+      if [ "$string" == "$(sort --version-sort <<< "$string")" ]; then
+	  echo "python3.11"
+	  return
+      fi
+  fi
+  echo "python3"
+}
+
+export PYTHON
+PYTHON=$(python_version)
 
 version_greater() {
 	string="$1
@@ -25,28 +39,25 @@ if [[ "$ID" = "fedora" && "$VERSION_ID" -ge 42 ]] ; then
 fi
 
 update_python() {
-    if version_greater "$pyversion" "Python 3.10"; then
-	eval dnf install -y python3-pip python3-devel "${packages}"
-    else
-	eval dnf install -y python3.11 python3.11-pip python3.11-devel "${packages}"
-	export PYTHON_VERSION="/usr/bin/python3.11 -m"
+    eval dnf install -y "${PYTHON}" "${PYTHON}-pip" "${PYTHON}-devel" "${packages}"
+    if [[ "${PYTHON}" == "python3.11" ]]; then
 	ln -sf /usr/bin/python3.11 /usr/bin/python3
     fi
 }
 
 docling() {
-    ${PYTHON_VERSION} pip install --prefix=/usr docling docling-core accelerate --extra-index-url https://download.pytorch.org/whl/"$1"
+    ${PYTHON} -m pip install --prefix=/usr docling docling-core accelerate --extra-index-url https://download.pytorch.org/whl/"$1"
     # Preloads models (assumes its installed from container_build.sh)
     doc2rag load
 }
 
 rag() {
-    ${PYTHON_VERSION} pip install --prefix=/usr wheel qdrant_client fastembed openai fastapi uvicorn
+    ${PYTHON} -m pip install --prefix=/usr wheel qdrant_client fastembed openai fastapi uvicorn
     rag_framework load
 }
 
 to_gguf() {
-    ${PYTHON_VERSION} pip install --prefix=/usr "numpy~=1.26.4" "sentencepiece~=0.2.0" "transformers>=4.45.1,<5.0.0" git+https://github.com/ggml-org/llama.cpp#subdirectory=gguf-py "protobuf>=4.21.0,<5.0.0"
+    ${PYTHON} -m pip install --prefix=/usr "numpy~=1.26.4" "sentencepiece~=0.2.0" "transformers>=4.45.1,<5.0.0" git+https://github.com/ggml-org/llama.cpp#subdirectory=gguf-py "protobuf>=4.21.0,<5.0.0"
 }
 
 update_python


### PR DESCRIPTION
Fixes: https://github.com/containers/ramalama/issues/1362

## Summary by Sourcery

Enhance Python version handling in build scripts to support systems with older Python installations

New Features:
- Add a dynamic Python version selection function to choose between python3 and python3.11 based on system capabilities

Bug Fixes:
- Ensure proper Python installation and symlinking on systems with older Python versions

Enhancements:
- Modify build scripts to dynamically select and use the appropriate Python version
- Improve compatibility with systems having different Python versions