### PR TITLE
Use all GPUs in CUDA_VISIBLE_DEVICES as default

### DIFF
--- a/docs/ramalama-cuda.7.md
+++ b/docs/ramalama-cuda.7.md
@@ -126,7 +126,7 @@ Follow the installation instructions provided in the [NVIDIA Container Toolkit i
 
 ### CUDA_VISIBLE_DEVICES
 
-RamaLama respects the `CUDA_VISIBLE_DEVICES` environment variable if it's already set in your environment. If not set, RamaLama will default to using GPU device "0".
+RamaLama respects the `CUDA_VISIBLE_DEVICES` environment variable if it's already set in your environment. If not set, RamaLama will default to using all the GPU detected by nvidia-smi.
 
 You can specify which GPU devices should be visible to RamaLama by setting this variable before running RamaLama commands:
 

--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -392,7 +392,17 @@ def check_nvidia():
         # ensure at least one CDI device resolves
         if resolve_cdi(['/etc/cdi', '/var/run/cdi']):
             if "CUDA_VISIBLE_DEVICES" not in os.environ:
-                os.environ["CUDA_VISIBLE_DEVICES"] = "0"
+                dev_command = ['nvidia-smi', '--query-gpu=index', '--format=csv,noheader']
+                try:
+                    result = run_cmd(dev_command)
+                    output = result.stdout.decode("utf-8").strip()
+                    if not output:
+                        raise ValueError("nvidia-smi returned empty GPU indices")
+                    devices = ','.join(output.split('\n'))
+                except Exception:
+                    devices = "0"
+
+                os.environ["CUDA_VISIBLE_DEVICES"] = devices
 
             _nvidia = "cuda"
             return _nvidia


### PR DESCRIPTION
Currently the CUDA_VISIBLE_DEVICES environment variable defaults to '0' when it's not overidden by the user. This commit updates it to include all available GPUs detected by nvidia-smi, allowing the application to utilize multiple GPUs by default.

## Summary by Sourcery

Update the default GPU selection behavior to use all available GPUs detected by nvidia-smi instead of defaulting to only GPU 0

Enhancements:
- Modify GPU detection to automatically use all available GPUs when CUDA_VISIBLE_DEVICES is not set

Documentation:
- Update documentation to reflect the new default GPU selection behavior