### PR TITLE
ci: modify 'latest' job to only run on release

### DIFF
--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -1,8 +1,9 @@
 name: latest-build
 on:
-    schedule:
-    - cron: '0 0 * * *'
-    workflow_dispatch:
+  release:
+    types:
+      - published
+  workflow_dispatch:
 
 jobs:
   linux:
@@ -75,7 +76,7 @@ jobs:
     steps:
         - uses: actions/checkout@v4
           with:
-            ref: 's'
+            ref: 'main'
 
         - name: Upgrade to podman 5
           run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,8 +1,8 @@
 name: nightly-build
 on:
-    schedule:
-    - cron: '0 0 * * *'
-    workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *' 
+  workflow_dispatch:
 
 jobs:
   linux:
@@ -42,6 +42,11 @@ jobs:
 
       - name: Docker info
         run: docker info
+
+      - name: Print disk space after cleanup
+        shell: bash
+        run: |
+           df -h
 
       - name: Build a container for CPU inferencing
         run: ./container_build.sh build ramalama


### PR DESCRIPTION
With these changes:
- **nightly.yml** runs midnight UTC and does a build/test of the ramalama CPU image on Ubuntu and MacOS, if successful it then pushes the image to **quay.io/ramalama/ramalama:nightly**
- **latest.yml** runs every time a GitHub Release is published and does a build/test of the ramalama CPU image on Ubuntu and MacOS, if successful it then pushes the image to **quay.io/ramalama/ramalama:latest**

## Summary by Sourcery

Modify GitHub Actions workflows to change the trigger conditions for nightly and latest builds

CI:
- Updated nightly workflow to keep existing schedule and dispatch triggers
- Modified latest workflow to only run when a GitHub Release is published

Chores:
- Added a disk space print step to the nightly workflow
- Corrected checkout reference in latest workflow to use 'main' branch