### PR TITLE
Check nvidia-container-runtime executable also in engine.py

### DIFF
--- a/ramalama/engine.py
+++ b/ramalama/engine.py
@@ -74,7 +74,7 @@ class Engine:
         if check_nvidia() == "cuda":
             if self.use_docker:
                 self.exec_args += ["--runtime", "nvidia"]
-            else:
+            elif os.access("/usr/bin/nvidia-container-runtime", os.X_OK):
                 self.exec_args += ["--runtime", "/usr/bin/nvidia-container-runtime"]
 
     def add_privileged_options(self):


### PR DESCRIPTION
Extra fix needed for #1206

## Summary by Sourcery

Add an additional check for nvidia-container-runtime executable before adding it as a runtime option

Bug Fixes:
- Prevent potential runtime configuration errors by checking executable access

Enhancements:
- Improve runtime selection for NVIDIA containers by verifying executable permissions