### PR TITLE
Add support for modelscope and update doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ RamaLama supports multiple AI model registries types called transports.
 | Transports               |  Web Site                                            |
 | :-------------           | :--------------------------------------------------- |
 | HuggingFace              | [`huggingface.co`](https://www.huggingface.co)       |
+| ModelScope               | [`modelscope.cn`](https://www.modelscope.cn)         |
 | Ollama                   | [`ollama.com`](https://www.ollama.com)               |
 | OCI Container Registries | [`opencontainers.org`](https://opencontainers.org)   |
 |                          |Examples: [`quay.io`](https://quay.io),  [`Docker Hub`](https://docker.io), [`Pulp`](https://pulpproject.org), and [`Artifactory`](https://jfrog.com/artifactory/)|
@@ -145,7 +146,7 @@ How to change transports.
 
 Use the RAMALAMA_TRANSPORT environment variable to modify the default. `export RAMALAMA_TRANSPORT=huggingface` Changes RamaLama to use huggingface transport.
 
-Individual model transports can be modified when specifying a model via the `huggingface://`, `oci://`, or `ollama://` prefix.
+Individual model transports can be modified when specifying a model via the `huggingface://`, `oci://`, `modelscope://`, or `ollama://` prefix.
 
 Example:
 ```

--- a/docs/ramalama-bench.1.md
+++ b/docs/ramalama-bench.1.md
@@ -10,9 +10,10 @@ ramalama\-bench - benchmark specified AI Model
 
 | Transports    | Prefix | Web Site                                            |
 | ------------- | ------ | --------------------------------------------------- |
-| URL based    | https://, http://, file:// | `https://web.site/ai.model`, `file://tmp/ai.model`|
-| HuggingFace   | huggingface://, hf://, hf.co/ | [`huggingface.co`](https://www.huggingface.co)      |
-| Ollama        | ollama:// | [`ollama.com`](https://www.ollama.com)              |
+| URL based     | https://, http://, file:// | `https://web.site/ai.model`, `file://tmp/ai.model`|
+| HuggingFace   | huggingface://, hf://, hf.co/ | [`huggingface.co`](https://www.huggingface.co)|
+| ModelScope    | modelscope://, ms:// | [`modelscope.cn`](https://modelscope.cn/)|
+| Ollama        | ollama:// | [`ollama.com`](https://www.ollama.com)|
 | OCI Container Registries | oci:// | [`opencontainers.org`](https://opencontainers.org)|
 |||Examples: [`quay.io`](https://quay.io),  [`Docker Hub`](https://docker.io),[`Artifactory`](https://artifactory.com)|
 

--- a/docs/ramalama-list.1.md
+++ b/docs/ramalama-list.1.md
@@ -28,7 +28,7 @@ List all Models downloaded to users homedir
 ```
 $ ramalama list
 NAME                                                                MODIFIED     SIZE
-ollama://smollm:135m                                            16 hours ago 5.5M
+ollama://smollm:135m                                                16 hours ago 5.5M
 huggingface://afrideva/Tiny-Vicuna-1B-GGUF/tiny-vicuna-1b.q2_k.gguf 14 hours ago 460M
 ollama://granite-code:3b                                            5 days ago   1.9G
 ollama://granite-code:latest                                        1 day ago    1.9G

--- a/docs/ramalama-login.1.md
+++ b/docs/ramalama-login.1.md
@@ -56,6 +56,14 @@ $ ramalama login --token=XYZ
 ```
 Logging in to Hugging Face requires the `huggingface-cli` tool. For installation and usage instructions, see the documentation of the Hugging Face command line interface: [*https://huggingface.co/docs/huggingface_hub/en/guides/cli*](https://huggingface.co/docs/huggingface_hub/en/guides/cli).
 
+Login to ModelScope registry
+```
+$ export RAMALAMA_TRANSPORT=modelscope
+$ ramalama login --token=XYZ
+```
+
+Logging in to ModelScope requires the `modelscope` tool. For installation and usage instructions, see the documentation of the ModelScope command line interface: [*https://www.modelscope.cn/docs/Beginner-s-Guide/Environment-Setup*](https://www.modelscope.cn/docs/Beginner-s-Guide/Environment-Setup).
+
 ## SEE ALSO
 **[ramalama(1)](ramalama.1.md)**
 

--- a/docs/ramalama-perplexity.1.md
+++ b/docs/ramalama-perplexity.1.md
@@ -10,9 +10,10 @@ ramalama\-perplexity - calculate the perplexity value of an AI Model
 
 | Transports    | Prefix | Web Site                                            |
 | ------------- | ------ | --------------------------------------------------- |
-| URL based    | https://, http://, file:// | `https://web.site/ai.model`, `file://tmp/ai.model`|
-| HuggingFace   | huggingface://, hf://, hf.co/ | [`huggingface.co`](https://www.huggingface.co)      |
-| Ollama        | ollama:// | [`ollama.com`](https://www.ollama.com)              |
+| URL based     | https://, http://, file:// | `https://web.site/ai.model`, `file://tmp/ai.model`|
+| HuggingFace   | huggingface://, hf://, hf.co/ | [`huggingface.co`](https://www.huggingface.co)|
+| ModelScope    | modelscope://, ms:// | [`modelscope.cn`](https://modelscope.cn/)|
+| Ollama        | ollama:// | [`ollama.com`](https://www.ollama.com)|
 | OCI Container Registries | oci:// | [`opencontainers.org`](https://opencontainers.org)|
 |||Examples: [`quay.io`](https://quay.io),  [`Docker Hub`](https://docker.io),[`Artifactory`](https://artifactory.com)|
 

--- a/docs/ramalama-run.1.md
+++ b/docs/ramalama-run.1.md
@@ -10,9 +10,10 @@ ramalama\-run - run specified AI Model as a chatbot
 
 | Transports    | Prefix | Web Site                                            |
 | ------------- | ------ | --------------------------------------------------- |
-| URL based    | https://, http://, file:// | `https://web.site/ai.model`, `file://tmp/ai.model`|
-| HuggingFace   | huggingface://, hf://, hf.co/ | [`huggingface.co`](https://www.huggingface.co)      |
-| Ollama        | ollama:// | [`ollama.com`](https://www.ollama.com)              |
+| URL based     | https://, http://, file:// | `https://web.site/ai.model`, `file://tmp/ai.model`|
+| HuggingFace   | huggingface://, hf://, hf.co/ | [`huggingface.co`](https://www.huggingface.co)|
+| ModelScope    | modelscope://, ms:// | [`modelscope.cn`](https://modelscope.cn/)|
+| Ollama        | ollama:// | [`ollama.com`](https://www.ollama.com)|
 | OCI Container Registries | oci:// | [`opencontainers.org`](https://opencontainers.org)|
 |||Examples: [`quay.io`](https://quay.io),  [`Docker Hub`](https://docker.io),[`Artifactory`](https://artifactory.com)|
 

--- a/docs/ramalama-serve.1.md
+++ b/docs/ramalama-serve.1.md
@@ -14,9 +14,10 @@ registry if it does not exist in local storage.
 
 | Transports    | Prefix | Web Site                                            |
 | ------------- | ------ | --------------------------------------------------- |
-| URL based    | https://, http://, file:// | `https://web.site/ai.model`, `file://tmp/ai.model`|
-| HuggingFace   | huggingface://, hf://, hf.co/ | [`huggingface.co`](https://www.huggingface.co)      |
-| Ollama        | ollama:// | [`ollama.com`](https://www.ollama.com)              |
+| URL based     | https://, http://, file:// | `https://web.site/ai.model`, `file://tmp/ai.model`|
+| HuggingFace   | huggingface://, hf://, hf.co/ | [`huggingface.co`](https://www.huggingface.co)|
+| ModelScope    | modelscope://, ms:// | [`modelscope.cn`](https://modelscope.cn/)|
+| Ollama        | ollama:// | [`ollama.com`](https://www.ollama.com)|
 | OCI Container Registries | oci:// | [`opencontainers.org`](https://opencontainers.org)|
 |||Examples: [`quay.io`](https://quay.io),  [`Docker Hub`](https://docker.io),[`Artifactory`](https://artifactory.com)|
 
@@ -112,7 +113,7 @@ On Nvidia based GPU systems, RamaLama defaults to using the
 `nvidia-container-runtime`. Use this option to override this selection.
 
 #### **--port**, **-p**
-port for AI Model server to listen on. It must be available. If not specified, 
+port for AI Model server to listen on. It must be available. If not specified,
 the serving port will be 8080 if available, otherwise a free port in 8081-8090 range.
 
 #### **--privileged**

--- a/docs/ramalama.1.md
+++ b/docs/ramalama.1.md
@@ -72,9 +72,10 @@ RamaLama supports multiple AI model registries types called transports. Supporte
 
 | Transports    | Prefix | Web Site                                            |
 | ------------- | ------ | --------------------------------------------------- |
-| URL based    | https://, http://, file:// | `https://web.site/ai.model`, `file://tmp/ai.model`|
-| HuggingFace   | huggingface://, hf://, hf.co/ | [`huggingface.co`](https://www.huggingface.co)      |
-| Ollama        | ollama:// | [`ollama.com`](https://www.ollama.com)              |
+| URL based     | https://, http://, file:// | `https://web.site/ai.model`, `file://tmp/ai.model`|
+| HuggingFace   | huggingface://, hf://, hf.co/ | [`huggingface.co`](https://www.huggingface.co)|
+| ModelScope    | modelscope://, ms:// | [`modelscope.cn`](https://modelscope.cn/)|
+| Ollama        | ollama:// | [`ollama.com`](https://www.ollama.com)|
 | OCI Container Registries | oci:// | [`opencontainers.org`](https://opencontainers.org)|
 |||Examples: [`quay.io`](https://quay.io),  [`Docker Hub`](https://docker.io),[`Artifactory`](https://artifactory.com)|
 

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -261,7 +261,7 @@ def normalize_registry(registry):
     if not registry or registry == "" or registry.startswith("oci://"):
         return "oci://"
 
-    if registry in ["ollama", "hf", "huggingface"]:
+    if registry in ["ollama", "hf", "huggingface", "ms", "modelscope"]:
         return registry
 
     return "oci://" + registry

--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -243,6 +243,28 @@ def verify_checksum(filename):
     return sha256_hash.hexdigest() == expected_checksum
 
 
+def download_and_verify(url, target_path, max_retries=2):
+    """
+    Downloads a file from a given URL and verifies its checksum.
+    If the checksum does not match, it retries the download.
+    Args:
+        url (str): The URL to download from.
+        target_path (str): The path to save the downloaded file.
+        max_retries (int): Maximum number of retries for download.
+    Raises:
+        ValueError: If checksum verification fails after multiple attempts.
+    """
+
+    for attempt in range(max_retries):
+        download_file(url, target_path, headers={}, show_progress=True)
+        if verify_checksum(target_path):
+            break
+        print(f"Checksum mismatch for {target_path}, retrying download... (Attempt {attempt + 1}/{max_retries})")
+        os.remove(target_path)
+    else:
+        raise ValueError(f"Checksum verification failed for {target_path} after multiple attempts")
+
+
 # default_image function should figure out which GPU the system uses t
 # then running appropriate container image.
 def default_image():

--- a/ramalama/huggingface.py
+++ b/ramalama/huggingface.py
@@ -174,7 +174,7 @@ class Huggingface(Model):
     def _attempt_url_pull(self, args, model_path, directory_path):
         try:
             return self.url_pull(args, model_path, directory_path)
-        except (urllib.error.HTTPError, urllib.error.URLError, KeyError) as e:
+        except (urllib.error.HTTPError, urllib.error.URLError, KeyError, ValueError) as e:
             return self._attempt_url_pull_hf_cli(args, model_path, directory_path, e)
 
     def _attempt_url_pull_hf_cli(self, args, model_path, directory_path, previous_exception):

--- a/ramalama/huggingface.py
+++ b/ramalama/huggingface.py
@@ -5,7 +5,7 @@ import shutil
 import tempfile
 import urllib.request
 
-from ramalama.common import available, download_file, exec_cmd, generate_sha256, perror, run_cmd, verify_checksum
+from ramalama.common import available, download_and_verify, exec_cmd, generate_sha256, perror, run_cmd, verify_checksum
 from ramalama.model import Model
 from ramalama.model_store import SnapshotFile, SnapshotFileType
 from ramalama.ollama_repo_utils import repo_pull
@@ -274,6 +274,13 @@ class Huggingface(Model):
         os.symlink(relative_target_path, model_path)
         return model_path
 
+    def _update_symlink(self, model_path, target_path):
+        relative_target_path = os.path.relpath(target_path, start=os.path.dirname(model_path))
+        if not self.check_valid_model_path(relative_target_path, model_path):
+            pathlib.Path(model_path).unlink(missing_ok=True)
+            os.symlink(relative_target_path, model_path)
+        return model_path
+
     def url_pull(self, args, model_path, directory_path):
         # Fetch the SHA-256 checksum from the API
         sha256_checksum = fetch_checksum_from_api(self.directory, self.filename)
@@ -284,30 +291,12 @@ class Huggingface(Model):
             self.in_existing_cache(args, target_path, sha256_checksum)
 
         if os.path.exists(target_path) and verify_checksum(target_path):
-            relative_target_path = os.path.relpath(target_path, start=os.path.dirname(model_path))
-            if not self.check_valid_model_path(relative_target_path, model_path):
-                pathlib.Path(model_path).unlink(missing_ok=True)
-                os.symlink(relative_target_path, model_path)
-            return model_path
+            return self._update_symlink(model_path, target_path)
 
         # Download the model file to the target path
         url = f"https://huggingface.co/{self.directory}/resolve/main/{self.filename}"
-        download_file(url, target_path, headers={}, show_progress=True)
-        if not verify_checksum(target_path):
-            print(f"Checksum mismatch for {target_path}, retrying download...")
-            os.remove(target_path)
-            download_file(url, target_path, headers={}, show_progress=True)
-            if not verify_checksum(target_path):
-                raise ValueError(f"Checksum verification failed for {target_path}")
-
-        relative_target_path = os.path.relpath(target_path, start=os.path.dirname(model_path))
-        if self.check_valid_model_path(relative_target_path, model_path):
-            # Symlink is already correct, no need to update it
-            return model_path
-
-        pathlib.Path(model_path).unlink(missing_ok=True)
-        os.symlink(relative_target_path, model_path)
-        return model_path
+        download_and_verify(url, target_path)
+        return self._update_symlink(model_path, target_path)
 
     def push(self, _, args):
         if not self.hf_cli_available:
@@ -344,9 +333,14 @@ class Huggingface(Model):
             if os.path.isdir(entry_path) or entry == ".gitattributes":
                 continue
             sha256 = ""
-            with open(os.path.join(cache_dir, f"{entry}.metadata")) as metafile:
-                metafile.readline()
-                sha256 = f"sha256:{metafile.readline().strip()}"
+            metadata_path = os.path.join(cache_dir, f"{entry}.metadata")
+            if not os.path.exists(metadata_path):
+                continue
+            with open(metadata_path) as metafile:
+                lines = metafile.readlines()
+                if len(lines) < 2:
+                    continue
+                sha256 = f"sha256:{lines[1].strip()}"
             if sha256 == "sha256:":
                 continue
             if entry.lower() == "readme.md":

--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -29,7 +29,7 @@ from ramalama.model_store import ModelStore
 from ramalama.quadlet import Quadlet
 from ramalama.version import version
 
-MODEL_TYPES = ["file", "https", "http", "oci", "huggingface", "hf", "ollama"]
+MODEL_TYPES = ["file", "https", "http", "oci", "huggingface", "hf", "modelscope", "ms", "ollama"]
 
 
 file_not_found = """\

--- a/ramalama/model_factory.py
+++ b/ramalama/model_factory.py
@@ -5,9 +5,9 @@ from urllib.parse import urlparse
 
 from ramalama.common import rm_until_substring
 from ramalama.huggingface import Huggingface
-from ramalama.modelscope import ModelScope
 from ramalama.model import MODEL_TYPES
 from ramalama.model_store import GlobalModelStore, ModelStore
+from ramalama.modelscope import ModelScope
 from ramalama.oci import OCI
 from ramalama.ollama import Ollama
 from ramalama.url import URL

--- a/ramalama/model_factory.py
+++ b/ramalama/model_factory.py
@@ -5,6 +5,7 @@ from urllib.parse import urlparse
 
 from ramalama.common import rm_until_substring
 from ramalama.huggingface import Huggingface
+from ramalama.modelscope import ModelScope
 from ramalama.model import MODEL_TYPES
 from ramalama.model_store import GlobalModelStore, ModelStore
 from ramalama.oci import OCI
@@ -28,8 +29,8 @@ class ModelFactory:
         self.ignore_stderr = ignore_stderr
         self.container = args.container
 
-        self.model_cls: type[Union[Huggingface, Ollama, OCI, URL]]
-        self.create: Callable[[], Union[Huggingface, Ollama, OCI, URL]]
+        self.model_cls: type[Union[Huggingface, ModelScope, Ollama, OCI, URL]]
+        self.create: Callable[[], Union[Huggingface, ModelScope, Ollama, OCI, URL]]
         self.model_cls, self.create = self.detect_model_model_type()
 
         self.pruned_model = self.prune_model_input()
@@ -44,6 +45,8 @@ class ModelFactory:
     ) -> Tuple[type[Union[Huggingface, Ollama, OCI, URL]], Callable[[], Union[Huggingface, Ollama, OCI, URL]]]:
         if self.model.startswith("huggingface://") or self.model.startswith("hf://") or self.model.startswith("hf.co/"):
             return Huggingface, self.create_huggingface
+        if self.model.startswith("modelscope://") or self.model.startswith("ms://"):
+            return ModelScope, self.create_modelscope
         if self.model.startswith("ollama://") or "ollama.com/library/" in self.model:
             return Ollama, self.create_ollama
         if self.model.startswith("oci://") or self.model.startswith("docker://"):
@@ -53,12 +56,14 @@ class ModelFactory:
 
         if self.transport == "huggingface":
             return Huggingface, self.create_huggingface
+        if self.transport == "modelscope":
+            return ModelScope, self.create_modelscope
         if self.transport == "ollama":
             return Ollama, self.create_ollama
         if self.transport == "oci":
             return OCI, self.create_oci
 
-        raise KeyError(f'transport "{self.transport}" not supported. Must be oci, huggingface, or ollama.')
+        raise KeyError(f'transport "{self.transport}" not supported. Must be oci, huggingface, modelscope, or ollama.')
 
     def prune_model_input(self) -> str:
         # remove protocol from model input
@@ -66,6 +71,8 @@ class ModelFactory:
 
         if self.model_cls == Huggingface:
             pruned_model_input = rm_until_substring(pruned_model_input, "hf.co/")
+        elif self.model_cls == ModelScope:
+            pruned_model_input = rm_until_substring(pruned_model_input, "modelscope.cn/")
         elif self.model_cls == Ollama:
             pruned_model_input = rm_until_substring(pruned_model_input, "ollama.com/library/")
 
@@ -79,13 +86,19 @@ class ModelFactory:
             if self.model.startswith(t + "://"):
                 raise ValueError(f"{self.model} invalid: Only OCI Model types supported")
 
-    def set_optional_model_store(self, model: Union[Huggingface, Ollama, OCI, URL]):
+    def set_optional_model_store(self, model: Union[Huggingface, ModelScope, Ollama, OCI, URL]):
         if self.use_model_store:
             name, _, orga = model.extract_model_identifiers()
             model.store = ModelStore(GlobalModelStore(self.store_path), name, model.model_type, orga)
 
     def create_huggingface(self) -> Huggingface:
         model = Huggingface(self.pruned_model)
+        self.set_optional_model_store(model)
+        model.draft_model = self.draft_model
+        return model
+
+    def create_modelscope(self) -> ModelScope:
+        model = ModelScope(self.pruned_model)
         self.set_optional_model_store(model)
         model.draft_model = self.draft_model
         return model

--- a/ramalama/modelscope.py
+++ b/ramalama/modelscope.py
@@ -37,10 +37,8 @@ def fetch_checksum_from_api(organization, file):
         if not sha256_checksum:
             raise ValueError("SHA-256 checksum not found in the API response.")
         return sha256_checksum
-    except urllib.error.HTTPError as e:
-        raise KeyError(f"failed to pull {checksum_api_url}: " + str(e).strip("'"))
-    except urllib.error.URLError as e:
-        raise KeyError(f"failed to pull {checksum_api_url}: " + str(e).strip("'"))
+    except (json.JSONDecodeError, urllib.error.HTTPError, urllib.error.URLError) as e:
+        raise KeyError(f"failed to pull {checksum_api_url}: {str(e).strip()}")
 
 
 class ModelScopeRepository(HuggingfaceRepository):
@@ -55,7 +53,7 @@ class ModelScopeRepository(HuggingfaceRepository):
 
 class ModelScope(Model):
 
-    REGISTRY_URL = "https://modelscope.cn"
+    REGISTRY_URL = "https://modelscope.cn/"
     ACCEPT = "Accept: application/vnd.docker.distribution.manifest.v2+json"
 
     def __init__(self, model):
@@ -83,7 +81,7 @@ class ModelScope(Model):
     def _attempt_url_pull(self, args, model_path, directory_path):
         try:
             return self.url_pull(args, model_path, directory_path)
-        except (urllib.error.HTTPError, urllib.error.URLError, KeyError) as e:
+        except (urllib.error.HTTPError, urllib.error.URLError, KeyError, ValueError) as e:
             return self._attempt_url_pull_ms(args, model_path, directory_path, e)
 
     def _attempt_url_pull_ms(self, args, model_path, directory_path, previous_exception):

--- a/ramalama/modelscope.py
+++ b/ramalama/modelscope.py
@@ -1,0 +1,300 @@
+import json
+import os
+import pathlib
+import tempfile
+import urllib.request
+
+from ramalama.common import available, download_file, exec_cmd, perror, run_cmd, verify_checksum
+from ramalama.model import Model
+from ramalama.model_store import SnapshotFileType
+from ramalama.ollama_repo_utils import repo_pull
+from ramalama.huggingface import HuggingfaceRepository, HuggingfaceCLIFile
+
+missing_modelscope = """
+Optional: ModelScope models require the modelscope module.
+These modules can be installed via PyPi tools like pip, pip3, pipx, or via
+distribution package managers like dnf or apt. Example:
+pip install modelscope
+"""
+
+
+def is_modelscope_available():
+    """Check if modelscope is available on the system."""
+    return available("modelscope")
+
+
+def fetch_checksum_from_api(organization, file):
+    """Fetch the SHA-256 checksum from the model's metadata API for a given file."""
+    checksum_api_url = f"{ModelScopeRepository.REGISTRY_URL}/api/v1/models/{organization}/repo/raw?Revision=master&FilePath={file}&Needmeta=true"
+    try:
+        with urllib.request.urlopen(checksum_api_url) as response:
+            data = json.loads(response.read().decode())
+        # Extract the SHA-256 checksum from the JSON
+        return data.get("Data", {}).get("MetaContent", {}).get("Sha256", None) or \
+               ValueError("SHA-256 checksum not found in the API response.")
+    except urllib.error.HTTPError as e:
+        raise KeyError(f"failed to pull {checksum_api_url}: " + str(e).strip("'"))
+    except urllib.error.URLError as e:
+        raise KeyError(f"failed to pull {checksum_api_url}: " + str(e).strip("'"))
+
+
+class ModelScopeRepository(HuggingfaceRepository):
+
+    REGISTRY_URL = "https://modelscope.cn"
+
+    def __init__(self, name: str, organization: str):
+        super().__init__(name, organization)
+
+        self.blob_url = f"{ModelScopeRepository.REGISTRY_URL}/{self.organization}/resolve/master"
+
+class ModelScope(Model):
+
+    REGISTRY_URL = "https://modelscope.cn"
+    ACCEPT = "Accept: application/vnd.docker.distribution.manifest.v2+json"
+
+    def __init__(self, model):
+        super().__init__(model)
+
+        self.type = "modelscope"
+        self.ms_available = is_modelscope_available()
+
+    def login(self, args):
+        if not self.ms_available:
+            raise NotImplementedError(missing_modelscope)
+        conman_args = ["modelscope", "login"]
+        if args.token:
+            conman_args.extend(["--token", args.token])
+        self.exec(conman_args, args)
+
+    def logout(self, args):
+        if not self.ms_available:
+            raise NotImplementedError(missing_modelscope)
+        conman_args = ["modelscope", "logout"]
+        if args.token:
+            conman_args.extend(["--token", args.token])
+        self.exec(conman_args, args)
+
+    def _attempt_url_pull(self, args, model_path, directory_path):
+        try:
+            return self.url_pull(args, model_path, directory_path)
+        except (urllib.error.HTTPError, urllib.error.URLError, KeyError) as e:
+            return self._attempt_url_pull_ms(args, model_path, directory_path, e)
+
+    def _attempt_url_pull_ms(self, args, model_path, directory_path, previous_exception):
+        if self.ms_available:
+            try:
+                return self.ms_pull(args, model_path, directory_path)
+            except Exception:
+                pass
+        raise KeyError(f"Failed to pull model: {str(previous_exception)}")
+
+    def pull(self, args):
+        if self.store is not None:
+            return self._pull_with_model_store(args)
+
+        model_path = self.model_path(args)
+        directory_path = os.path.join(args.store, "repos", "modelscope", self.directory, self.filename)
+        os.makedirs(directory_path, exist_ok=True)
+
+        symlink_dir = os.path.dirname(model_path)
+        os.makedirs(symlink_dir, exist_ok=True)
+
+        # First try to interpret the argument as a user/repo:tag
+        try:
+            if self.directory.count("/") == 0:
+
+                model_name, model_tag, _ = self.extract_model_identifiers()
+                repo_name = self.directory + "/" + model_name
+                registry_head = f"{ModelScope.REGISTRY_URL}{repo_name}"
+
+                show_progress = not args.quiet
+                return repo_pull(
+                    os.path.join(args.store, "repos", "modelscope"),
+                    ModelScope.ACCEPT,
+                    registry_head,
+                    model_name,
+                    model_tag,
+                    os.path.join(args.store, "models", "modelscope"),
+                    model_path,
+                    self.model,
+                    show_progress,
+                )
+
+        except urllib.error.HTTPError:
+            if model_tag != "latest":
+                # The user explicitly requested a tag, so raise an error
+                raise KeyError(f"{self.model} was not found in the ModelScope registry")
+            else:
+                # The user did not explicitly request a tag, so assume they want the whole repository
+                pass
+
+        # Interpreting as a tag did not work.  Attempt to download as a url.
+        return self._attempt_url_pull(args, model_path, directory_path)
+
+    def _fetch_cache_path(self, cache_dir, namespace, repo):
+        def normalize_repo_name(repo):
+            return repo.replace(".", "___")
+        return os.path.join(cache_dir, 'models', namespace, normalize_repo_name(repo))
+
+    def in_existing_cache(self, args, target_path, sha256_checksum):
+        if not self.ms_available:
+            return False
+
+        default_ms_caches = [os.path.join(os.environ['HOME'], '.cache/modelscope/hub')]
+        namespace, repo = os.path.split(str(self.directory))
+
+        for cache_dir in default_ms_caches:
+            cache_path = self._fetch_cache_path(cache_dir, namespace, repo)
+            if not cache_path or not os.path.exists(cache_path):
+                continue
+
+            file_path = os.path.join(cache_path, self.filename)
+            if not os.path.exists(file_path):
+                continue
+
+            os.symlink(file_path, target_path)
+            return True
+        return False
+
+    def ms_pull(self, args, model_path, directory_path):
+        conman_args = ["modelscope", "download", "--local_dir", directory_path, self.model]
+        run_cmd(conman_args, debug=args.debug)
+
+        relative_target_path = os.path.relpath(directory_path, start=os.path.dirname(model_path))
+        pathlib.Path(model_path).unlink(missing_ok=True)
+        os.symlink(relative_target_path, model_path)
+        return model_path
+
+    def url_pull(self, args, model_path, directory_path):
+        # Fetch the SHA-256 checksum from the API
+        sha256_checksum = fetch_checksum_from_api(self.directory, self.filename)
+
+        target_path = os.path.join(directory_path, f"sha256:{sha256_checksum}")
+
+        if not os.path.exists(target_path):
+            self.in_existing_cache(args, target_path, sha256_checksum)
+
+        if os.path.exists(target_path) and verify_checksum(target_path):
+            relative_target_path = os.path.relpath(target_path, start=os.path.dirname(model_path))
+            if not self.check_valid_model_path(relative_target_path, model_path):
+                pathlib.Path(model_path).unlink(missing_ok=True)
+                os.symlink(relative_target_path, model_path)
+            return model_path
+
+        # Download the model file to the target path
+        url = f"https://modelscope.cn/{self.directory}/resolve/main/{self.filename}"
+        download_file(url, target_path, headers={}, show_progress=True)
+        if not verify_checksum(target_path):
+            print(f"Checksum mismatch for {target_path}, retrying download...")
+            os.remove(target_path)
+            download_file(url, target_path, headers={}, show_progress=True)
+            if not verify_checksum(target_path):
+                raise ValueError(f"Checksum verification failed for {target_path}")
+
+        relative_target_path = os.path.relpath(target_path, start=os.path.dirname(model_path))
+        if self.check_valid_model_path(relative_target_path, model_path):
+            # Symlink is already correct, no need to update it
+            return model_path
+
+        pathlib.Path(model_path).unlink(missing_ok=True)
+        os.symlink(relative_target_path, model_path)
+        return model_path
+
+    def push(self, _, args):
+        if not self.ms_available:
+            raise NotImplementedError(missing_modelscope)
+        proc = run_cmd(
+            [
+                "modelscope",
+                "upload",
+                "--repo-type",
+                "model",
+                self.directory,
+                self.filename,
+                "--cache_dir",
+                os.path.join(args.store, "repos", "modelscope", ".cache"),
+                "--local_dir",
+                os.path.join(args.store, "repos", "modelscope", self.directory),
+            ],
+            debug=args.debug,
+        )
+        return proc.stdout.decode("utf-8")
+
+    def exec(self, cmd_args, args):
+        try:
+            exec_cmd(cmd_args, debug=args.debug)
+        except FileNotFoundError as e:
+            print(f"{str(e).strip()}\n{missing_modelscope}")
+
+    def _collect_cli_files(self, tempdir: str) -> tuple[str, list[HuggingfaceCLIFile]]:
+        cache_dir = os.path.join(tempdir, ".cache", "modelscope", "download")
+        files: list[HuggingfaceCLIFile] = []
+        snapshot_hash = ""
+        for entry in os.listdir(tempdir):
+            entry_path = os.path.join(tempdir, entry)
+            if os.path.isdir(entry_path) or entry == ".gitattributes":
+                continue
+            sha256 = ""
+            with open(os.path.join(cache_dir, f"{entry}.metadata")) as metafile:
+                metafile.readline()
+                sha256 = f"sha256:{metafile.readline().strip()}"
+            if sha256 == "sha256:":
+                continue
+            if entry.lower() == "readme.md":
+                snapshot_hash = sha256
+                continue
+
+            hf_file = HuggingfaceCLIFile(
+                url=entry_path,
+                header={},
+                hash=sha256,
+                type=SnapshotFileType.Other,
+                name=entry,
+            )
+            # try to identify the model file in the pulled repo
+            if entry.endswith(".safetensors") or entry.endswith(".gguf"):
+                hf_file.type = SnapshotFileType.Model
+            files.append(hf_file)
+
+        return snapshot_hash, files
+
+    def _pull_with_model_store(self, args, debug: bool = False):
+        name, tag, organization = self.extract_model_identifiers()
+        hash, cached_files, all = self.store.get_cached_files(tag)
+        if all:
+            if not args.quiet:
+                print(f"Using cached modelscope://{name}:{tag} ...")
+            return self.store.get_snapshot_file_path(hash, name)
+
+        try:
+            # Fetch the SHA-256 checksum of model from the API and use as snapshot hash
+            snapshot_hash = f"sha256:{fetch_checksum_from_api(organization, name)}"
+
+            if not args.quiet:
+                print(f"Downloading modelscope://{name}:{tag} ...")
+                print(f"Trying to pull modelscope://{name}:{tag}...")
+            ms_repo = ModelScopeRepository(name, organization)
+            files = ms_repo.get_file_list(cached_files, snapshot_hash)
+            self.store.new_snapshot(tag, snapshot_hash, files)
+        except Exception as e:
+            if not self.ms_available:
+                perror("URL pull failed and modelscope not available")
+                raise KeyError(f"Failed to pull model: {str(e)}")
+
+            # Cleanup previously created snapshot
+            try:
+                self.store.remove_snapshot(tag)
+            except Exception:
+                # ignore any error when removing snapshot
+                pass
+
+            # Create temporary directory for downloading via modelscope
+            with tempfile.TemporaryDirectory() as tempdir:
+                model = f"{organization}/{name}"
+                conman_args = ["modelscope", "download", "--local_dir", tempdir, model]
+                run_cmd(conman_args, debug=debug)
+
+                snapshot_hash, files = self._collect_cli_files(tempdir)
+                self.store.new_snapshot(tag, snapshot_hash, files)
+
+        return self.store.get_snapshot_file_path(snapshot_hash, self.store.model_name)

--- a/ramalama/modelscope.py
+++ b/ramalama/modelscope.py
@@ -4,7 +4,7 @@ import pathlib
 import tempfile
 import urllib.request
 
-from ramalama.common import available, download_file, exec_cmd, perror, run_cmd, verify_checksum
+from ramalama.common import available, download_and_verify, exec_cmd, perror, run_cmd, verify_checksum
 from ramalama.huggingface import HuggingfaceCLIFile, HuggingfaceRepository
 from ramalama.model import Model
 from ramalama.model_store import SnapshotFileType
@@ -172,6 +172,13 @@ class ModelScope(Model):
         os.symlink(relative_target_path, model_path)
         return model_path
 
+    def _update_symlink(self, model_path, target_path):
+        relative_target_path = os.path.relpath(target_path, start=os.path.dirname(model_path))
+        if not self.check_valid_model_path(relative_target_path, model_path):
+            pathlib.Path(model_path).unlink(missing_ok=True)
+            os.symlink(relative_target_path, model_path)
+        return model_path
+
     def url_pull(self, args, model_path, directory_path):
         # Fetch the SHA-256 checksum from the API
         sha256_checksum = fetch_checksum_from_api(self.directory, self.filename)
@@ -182,30 +189,11 @@ class ModelScope(Model):
             self.in_existing_cache(args, target_path, sha256_checksum)
 
         if os.path.exists(target_path) and verify_checksum(target_path):
-            relative_target_path = os.path.relpath(target_path, start=os.path.dirname(model_path))
-            if not self.check_valid_model_path(relative_target_path, model_path):
-                pathlib.Path(model_path).unlink(missing_ok=True)
-                os.symlink(relative_target_path, model_path)
-            return model_path
+            return self._update_symlink(model_path, target_path)
 
-        # Download the model file to the target path
         url = f"https://modelscope.cn/{self.directory}/resolve/master/{self.filename}"
-        download_file(url, target_path, headers={}, show_progress=True)
-        if not verify_checksum(target_path):
-            print(f"Checksum mismatch for {target_path}, retrying download...")
-            os.remove(target_path)
-            download_file(url, target_path, headers={}, show_progress=True)
-            if not verify_checksum(target_path):
-                raise ValueError(f"Checksum verification failed for {target_path}")
-
-        relative_target_path = os.path.relpath(target_path, start=os.path.dirname(model_path))
-        if self.check_valid_model_path(relative_target_path, model_path):
-            # Symlink is already correct, no need to update it
-            return model_path
-
-        pathlib.Path(model_path).unlink(missing_ok=True)
-        os.symlink(relative_target_path, model_path)
-        return model_path
+        download_and_verify(url, target_path)
+        return self._update_symlink(model_path, target_path)
 
     def push(self, _, args):
         if not self.ms_available:
@@ -242,9 +230,14 @@ class ModelScope(Model):
             if os.path.isdir(entry_path) or entry == ".gitattributes":
                 continue
             sha256 = ""
-            with open(os.path.join(cache_dir, f"{entry}.metadata")) as metafile:
-                metafile.readline()
-                sha256 = f"sha256:{metafile.readline().strip()}"
+            metadata_path = os.path.join(cache_dir, f"{entry}.metadata")
+            if not os.path.exists(metadata_path):
+                continue
+            with open(metadata_path) as metafile:
+                lines = metafile.readlines()
+                if len(lines) < 2:
+                    continue
+                sha256 = f"sha256:{lines[1].strip()}"
             if sha256 == "sha256:":
                 continue
             if entry.lower() == "readme.md":

--- a/ramalama/url.py
+++ b/ramalama/url.py
@@ -5,6 +5,7 @@ from ramalama.common import download_file, generate_sha256
 from ramalama.huggingface import HuggingfaceRepository
 from ramalama.model import Model
 from ramalama.model_store import SnapshotFile, SnapshotFileType
+from ramalama.modelscope import ModelScopeRepository
 
 
 class LocalModelFile(SnapshotFile):
@@ -59,6 +60,15 @@ class URL(Model):
 
         # handling huggingface specific URLs for more precise identifiers
         if len(parts) > 2 and HuggingfaceRepository.REGISTRY_URL.endswith(parts[0]) and parts[-2] == "resolve":
+            model_organization = "/".join(parts[:-2])
+            model_tag = parts[-1]
+
+        if len(parts) > 3 and parts[-3] == "file":
+            model_organization = "/".join(parts[:-3])
+            model_tag = parts[-1]
+
+        # handling modelscope specific URLs for more precise identifiers
+        if len(parts) > 2 and ModelScopeRepository.REGISTRY_URL.endswith(parts[0]) and parts[-2] == "resolve":
             model_organization = "/".join(parts[:-2])
             model_tag = parts[-1]
 

--- a/test/system/015-help.bats
+++ b/test/system/015-help.bats
@@ -3,7 +3,7 @@
 # Tests based on 'ramalama help'
 #
 # Find all commands listed by 'ramalama --help'. Run each one, make sure it
-# provides its own --help output. 
+# provides its own --help output.
 # Any usage message that ends in '[options]' is interpreted as a command
 # that takes no further arguments; we confirm by running with 'invalid-arg'
 # and confirming that it exits with error status and message.
@@ -209,7 +209,7 @@ EOF
 @test "ramalama verify transport" {
     transport=e_$(safename)
     RAMALAMA_TRANSPORT=${transport} run_ramalama 1 pull foobar
-    is "$output" "Error: transport \"${transport}\" not supported. Must be oci, huggingface, or ollama."  "Verify bogus transport throws error"
+    is "$output" "Error: transport \"${transport}\" not supported. Must be oci, huggingface, modelscope, or ollama."  "Verify bogus transport throws error"
 
 }
 

--- a/test/unit/test_common.py
+++ b/test/unit/test_common.py
@@ -24,6 +24,8 @@ from ramalama.config import load_and_merge_config
             ".co/",
             "ibm-granite/granite-3b-code-base-2k-GGUF/blob/main/granite-3b-code-base.Q4_K_M.gguf",
         ),
+        ("modelscope://granite-code", "://", "granite-code"),
+        ("ms://granite-code", "://", "granite-code"),
         (
             "file:///tmp/models/granite-3b-code-base.Q4_K_M.gguf",
             "",

--- a/test/unit/test_model.py
+++ b/test/unit/test_model.py
@@ -15,7 +15,7 @@ class ARGS:
 
 
 hf_granite_blob = "https://huggingface.co/ibm-granite/granite-3b-code-base-2k-GGUF/blob"
-
+ms_granite_blob = "https://modelscope.cn/models/ibm-granite/granite-3b-code-base-2k-GGUF/file/view"
 
 @pytest.mark.parametrize(
     "model_input,expected_name,expected_tag,expected_orga",
@@ -33,6 +33,20 @@ hf_granite_blob = "https://huggingface.co/ibm-granite/granite-3b-code-base-2k-GG
             "granite-3b-code-base.Q4_K_M.gguf",
             "8ee52dc636b27b99caf046e717a87fb37ad9f33e",
             "huggingface.co/ibm-granite/granite-3b-code-base-2k-GGUF",
+        ),
+        ("modelscope://granite-code", "granite-code", "latest", ""),
+        ("ms://granite-code", "granite-code", "latest", ""),
+        (
+            f"{ms_granite_blob}/master/granite-3b-code-base.Q4_K_M.gguf",
+            "granite-3b-code-base.Q4_K_M.gguf",
+            "master",
+            "modelscope.cn/models/ibm-granite/granite-3b-code-base-2k-GGUF",
+        ),
+        (
+            f"{ms_granite_blob}/f823b84ec4b84f9a6742c8a1f6a893deeca75f06/granite-3b-code-base.Q4_K_M.gguf",
+            "granite-3b-code-base.Q4_K_M.gguf",
+            "f823b84ec4b84f9a6742c8a1f6a893deeca75f06",
+            "modelscope.cn/models/ibm-granite/granite-3b-code-base-2k-GGUF",
         ),
         ("ollama://granite-code", "granite-code", "latest", ""),
         (

--- a/test/unit/test_model.py
+++ b/test/unit/test_model.py
@@ -17,6 +17,7 @@ class ARGS:
 hf_granite_blob = "https://huggingface.co/ibm-granite/granite-3b-code-base-2k-GGUF/blob"
 ms_granite_blob = "https://modelscope.cn/models/ibm-granite/granite-3b-code-base-2k-GGUF/file/view"
 
+
 @pytest.mark.parametrize(
     "model_input,expected_name,expected_tag,expected_orga",
     [

--- a/test/unit/test_model_factory.py
+++ b/test/unit/test_model_factory.py
@@ -5,6 +5,7 @@ import pytest
 
 from ramalama.huggingface import Huggingface
 from ramalama.model_factory import ModelFactory
+from ramalama.modelscope import ModelScope
 from ramalama.oci import OCI
 from ramalama.ollama import Ollama
 from ramalama.url import URL
@@ -39,6 +40,8 @@ hf_granite_blob = "https://huggingface.co/ibm-granite/granite-3b-code-base-2k-GG
         (Input("huggingface://granite-code", False, "", ""), Huggingface, None),
         (Input("hf://granite-code", False, "", ""), Huggingface, None),
         (Input("hf.co/granite-code", False, "", ""), Huggingface, None),
+        (Input("modelscope://granite-code", False, "", ""), ModelScope, None),
+        (Input("ms://granite-code", False, "", ""), ModelScope, None),
         (Input("ollama://granite-code", False, "", ""), Ollama, None),
         (Input("ollama.com/library/granite-code", False, "", ""), Ollama, None),
         (Input("oci://granite-code", False, "", "podman"), OCI, None),
@@ -90,6 +93,8 @@ def test_model_factory_create(input: Input, expected: type[Union[Huggingface, Ol
         (Input("huggingface://granite-code", False, "", ""), ValueError),
         (Input("hf://granite-code", False, "", ""), ValueError),
         (Input("hf.co/granite-code", False, "", ""), None),
+        (Input("modelscope://granite-code", False, "", ""), ValueError),
+        (Input("ms://granite-code", False, "", ""), ValueError),
         (Input("ollama://granite-code", False, "", ""), ValueError),
         (Input("ollama.com/library/granite-code", False, "", ""), None),
         (Input("granite-code", False, "ollama", ""), None),
@@ -117,6 +122,12 @@ def test_validate_oci_model_input(input: Input, error):
         ),
         (Input("hf://granite-code", False, "", ""), "granite-code"),
         (Input("hf.co/granite-code", False, "", ""), "granite-code"),
+        (Input("modelscope://granite-code", False, "", ""), "granite-code"),
+        (
+            Input("modelscope://ibm-granite/granite-3b-code-base-2k-GGUF/granite-code", False, "", ""),
+            "ibm-granite/granite-3b-code-base-2k-GGUF/granite-code",
+        ),
+        (Input("ms://granite-code", False, "", ""), "granite-code"),
         (Input("ollama://granite-code", False, "", ""), "granite-code"),
         (Input("ollama.com/library/granite-code", False, "", ""), "granite-code"),
         (


### PR DESCRIPTION
https://github.com/ggml-org/llama.cpp/pull/13370

This PR adds support for [ModelScope](https://modelscope.cn/) by introducing `ramalama/modelscope.py`, which is adapted from `ramalama/huggingface.py`. It includes modifications for obtaining SHA256 hashes and determining the default CLI download location specific to ModelScope.

### Testing Done

- [x] `ramalama login`
- [x] `ramalama logout` — expected failure since `modelscope` CLI doesn’t support a `logout` subcommand
- [x] `ramalama pull` with and without `modelscope` installed
- [x] `ramalama run`
- [x] `ramalama ls`
- [x] `make unit-tests`

Logs:

```bash
❯ ramalama pull ms://QuantFactory/SmolLM-135M-GGUF/SmolLM-135M.Q2_K.gguf
Downloading modelscope://SmolLM-135M.Q2_K.gguf:latest ...
Trying to pull modelscope://SmolLM-135M.Q2_K.gguf:latest...
 98% |██████████████████████████████████████████████████████████████████████████████████████████████████  |   83.27 MB/  84.12 MB   7.05 MB/s        0s%
❯ ramalama run ms://bartowski/SmolLM-1.7B-Instruct-v0.2-GGUF/SmolLM-1.7B-Instruct-v0.2-IQ3_M.gguf
Downloading modelscope://SmolLM-1.7B-Instruct-v0.2-IQ3_M.gguf:latest ...
Trying to pull modelscope://SmolLM-1.7B-Instruct-v0.2-IQ3_M.gguf:latest...
 99% |███████████████████████████████████████████████████████████████████████████████████████████████████ |  772.48 MB/ 772.71 MB   2.86 MB/s        0sChecking for newer image quay.io/ramalama/ramalama:0.8
🐋 > Hello
Hello! How can I help you today?
🐋 > 
Use Ctrl + d or /bye or exit to quit.
🐋 > 
❯ ramalama pull huggingface://afrideva/Tiny-Vicuna-1B-GGUF/tiny-vicuna-1b.q2_k.gguf
Downloading huggingface://tiny-vicuna-1b.q2_k.gguf:latest ...
Trying to pull huggingface://tiny-vicuna-1b.q2_k.gguf:latest...
 99% |███████████████████████████████████████████████████████████████████████████████████████████████████ |  457.73 MB/ 459.81 MB  20.18 MB/s        0s%
❯ ramalama ls
NAME                                                                                              MODIFIED      SIZE     
modelscope://bartowski/SmolLM-1.7B-Instruct-v0.2-GGUF/SmolLM-1.7B-Instruct-v0.2-IQ3_M.gguf:latest 1 minute ago  772.71 MB
modelscope://QuantFactory/SmolLM-135M-GGUF/SmolLM-135M.Q2_K.gguf:latest                           5 minutes ago 84.12 MB 
huggingface://afrideva/Tiny-Vicuna-1B-GGUF/tiny-vicuna-1b.q2_k.gguf:latest                        2 minutes ago 459.81 MB
```

## Summary by Sourcery

Add support for ModelScope as a new model registry transport in RamaLama

New Features:
- Introduce ModelScope as a new model registry transport with support for downloading and managing models
- Add support for 'modelscope://' and 'ms://' URL prefixes
- Implement ModelScope-specific model pulling and authentication methods

Enhancements:
- Extend model factory to support ModelScope transport
- Implement SHA256 checksum retrieval from ModelScope API
- Add cache and download mechanisms specific to ModelScope

Documentation:
- Update documentation across multiple man pages to include ModelScope as a supported transport
- Add ModelScope login and usage instructions to documentation

## Summary by Sourcery

Add ModelScope as a supported model registry transport, enabling model download, management, and authentication via ModelScope in RamaLama.

New Features:
- Introduce ModelScope as a new model registry transport with support for downloading and managing models.
- Add support for 'modelscope://' and 'ms://' URL prefixes for model references.
- Implement ModelScope-specific model pulling, authentication, and checksum verification methods.

Enhancements:
- Extend model factory and model identifier extraction to support ModelScope transport.
- Refactor download and checksum verification logic for improved reuse across transports.

Documentation:
- Update documentation and man pages to include ModelScope as a supported transport and provide usage instructions.

Tests:
- Expand unit tests to cover ModelScope transport and model identifier extraction.