### PR TITLE
Support older version of Docker

### DIFF
--- a/container_build.sh
+++ b/container_build.sh
@@ -151,7 +151,11 @@ determine_platform() {
       platform="$(podman info --format '{{ .Version.OsArch }}' 2>/dev/null)"
       ;;
     docker)
-      platform="$(docker info --format '{{ .ClientInfo.Os }}/{{ .ClientInfo.Arch }}' 2>/dev/null)"
+      if docker info --format '{{ .ClientInfo.Os }}' &>/dev/null; then
+        platform="$(docker info --format '{{ .ClientInfo.Os }}/{{ .ClientInfo.Arch }}' 2>/dev/null)"
+      else
+        platform="$(docker info --format '{{ .OSType }}/{{ .Architecture }}' 2>/dev/null)"
+      fi
       ;;
   esac
 


### PR DESCRIPTION
I'm still using an older version of Docker...

```bash
❯ docker version
Client:
 Version:           unknown-version
 API version:       1.41 (downgraded from 1.42)
 Go version:        go1.19.8
 Git commit:        unknown-commit
 Built:             unknown-buildtime
 OS/Arch:           linux/amd64
 Context:           default

Server:
 Engine:
  Version:          20.10.21
  API version:      1.41 (minimum version 1.12)
  Go version:       go1.18.1
  Git commit:       20.10.21-0ubuntu1~20.04.2
  Built:            Thu Apr 27 05:37:01 2023
  OS/Arch:          linux/amd64
  Experimental:     true
 containerd:
  Version:          1.7.24
  GitCommit:        
 mthreads:
  Version:          1.1.1
  GitCommit:        v1.1.0-20-g52de29d7
 docker-init:
  Version:          0.19.0
  GitCommit:        
❯ docker info --format json
{"ID":"UGA7:MTL7:DLKA:77SP:THHR:OOJN:GLVH:SHDS:LHB6:RPWX:NDL2:LUMG","Containers":12,"ContainersRunning":2,"ContainersPaused":0,"ContainersStopped":10,"Images":243,"Driver":"overlay2","DriverStatus":[["Backing Filesystem","extfs"],["Supports d_type","true"],["Native Overlay Diff","true"],["userxattr","false"]],"Plugins":{"Volume":["local"],"Network":["bridge","host","ipvlan","macvlan","null","overlay"],"Authorization":null,"Log":["awslogs","fluentd","gcplogs","gelf","journald","json-file","local","logentries","splunk","syslog"]},"MemoryLimit":true,"SwapLimit":false,"KernelMemory":true,"KernelMemoryTCP":true,"CpuCfsPeriod":true,"CpuCfsQuota":true,"CPUShares":true,"CPUSet":true,"PidsLimit":true,"IPv4Forwarding":true,"BridgeNfIptables":true,"BridgeNfIp6tables":true,"Debug":false,"NFd":35,"OomKillDisable":true,"NGoroutines":42,"SystemTime":"2025-05-10T20:54:09.207258126+08:00","LoggingDriver":"json-file","CgroupDriver":"cgroupfs","CgroupVersion":"1","NEventsListener":0,"KernelVersion":"5.4.0-42-generic","OperatingSystem":"Ubuntu 20.04.5 LTS","OSVersion":"20.04","OSType":"linux","Architecture":"x86_64","IndexServerAddress":"https://index.docker.io/v1/","RegistryConfig":{"AllowNondistributableArtifactsCIDRs":[],"AllowNondistributableArtifactsHostnames":[],"InsecureRegistryCIDRs":["127.0.0.0/8"],"IndexConfigs":{"docker.io":{"Name":"docker.io","Mirrors":[],"Secure":true,"Official":true}},"Mirrors":[]},"NCPU":12,"MemTotal":33407283200,"GenericResources":null,"DockerRootDir":"/var/lib/docker","HttpProxy":"","HttpsProxy":"","NoProxy":"","Name":"xiaodongye-s80","Labels":[],"ExperimentalBuild":true,"ServerVersion":"20.10.21","Runtimes":{"io.containerd.runc.v2":{"path":"runc"},"io.containerd.runtime.v1.linux":{"path":"runc"},"mthreads":{"path":"/usr/bin/musa/mthreads-container-runtime"},"mthreads-experimental":{"path":"/usr/bin/musa/mthreads-container-runtime-experimental"},"runc":{"path":"runc"}},"DefaultRuntime":"mthreads","Swarm":{"NodeID":"","NodeAddr":"","LocalNodeState":"inactive","ControlAvailable":false,"Error":"","RemoteManagers":null},"LiveRestoreEnabled":false,"Isolation":"","InitBinary":"docker-init","ContainerdCommit":{"ID":"","Expected":""},"RuncCommit":{"ID":"v1.1.0-20-g52de29d7","Expected":"v1.1.0-20-g52de29d7"},"InitCommit":{"ID":"","Expected":""},"SecurityOptions":["name=apparmor","name=seccomp,profile=default"],"Warnings":["WARNING: No swap limit support"],"ClientInfo":{"Debug":false,"Context":"default","Plugins":[{"SchemaVersion":"0.1.0","Vendor":"Docker Inc.","Version":"v0.12.1","ShortDescription":"Docker Buildx","Name":"buildx","Path":"/home/xiaodongye/.docker/cli-plugins/docker-buildx"},{"SchemaVersion":"0.1.0","Vendor":"Docker Inc.","Version":"v2.29.6","ShortDescription":"Docker Compose","Name":"compose","Path":"/home/xiaodongye/.docker/cli-plugins/docker-compose"}],"Warnings":null}}
```

## Summary by Sourcery

Enhancements:
- Update Docker info command parsing to work with older Docker versions that have different output formats