### PR TITLE
Fix #1382

### DIFF
--- a/container-images/scripts/build-cli.sh
+++ b/container-images/scripts/build-cli.sh
@@ -24,7 +24,9 @@ dnf_install() {
 install_ramalama() {
   # link podman-remote to podman for use by RamaLama
   ln -sf /usr/bin/podman-remote /usr/bin/podman
-  python3 -m pip install /run/ramalama --prefix=/usr
+  if [ -e "/run/ramalama" ]; then
+    python3 -m pip install /run/ramalama --prefix=/usr
+  fi
 }
 
 main() {

--- a/container_build.sh
+++ b/container_build.sh
@@ -29,8 +29,14 @@ add_build_platform() {
 
 
   conman_build+=("--platform" "$platform")
-  conman_build+=("--volume=${RAMALAMA_DIR}:/run/ramalama")
-  conman_build+=("--security-opt=label=disable")
+  case $conman_bin in
+    podman)
+      conman_build+=("--volume=${RAMALAMA_DIR}:/run/ramalama")
+      conman_build+=("--security-opt=label=disable")
+      ;;
+    docker)
+      ;;
+  esac
   if [ -n "$version" ]; then
       conman_build+=("--build-arg" "VERSION=$version")
       conman_build+=("-t" "$REGISTRY_PATH/${target}-${version}")


### PR DESCRIPTION
### Behavior Change

`ramalama` is no longer installed in containers built using `docker`.

### Testing Done

```bash
❯ make build
./container_build.sh  build ramalama -v ""
docker build --no-cache --platform linux/x86_64 -t quay.io/ramalama/ramalama -f ramalama/Containerfile .
[+] Building 394.6s (8/8) FINISHED                                                                             docker:default
 => [internal] load build definition from Containerfile                                                                  0.0s
 => => transferring dockerfile: 35B                                                                                      0.0s
 => [internal] load .dockerignore                                                                                        0.0s
 => => transferring context: 2B                                                                                          0.0s
 => [internal] load metadata for registry.access.redhat.com/ubi9/ubi:9.5-1745848351                                      1.3s
 => [internal] load build context                                                                                        0.0s
 => => transferring context: 1.15kB                                                                                      0.0s
 => CACHED [1/3] FROM registry.access.redhat.com/ubi9/ubi:9.5-1745848351@sha256:3ef6a09c90ba5abb6011d0e5d2a797dd44f4c44  0.0s
 => [2/3] COPY --chmod=755 ../scripts /usr/bin                                                                           0.0s
 => [3/3] RUN build_llama_and_whisper.sh "ramalama"                                                                    387.8s
 => exporting to image                                                                                                   5.5s 
 => => exporting layers                                                                                                  5.5s 
 => => writing image sha256:f9101beeef4bcd9acb94b794c1c6d50488d6243d557767270179cd74e9f8fada                             0.0s 
 => => naming to quay.io/ramalama/ramalama                                                                               0.0s 
docker images --filter reference=quay.io/ramalama/ramalama                                                                    
REPOSITORY                  TAG       IMAGE ID       CREATED         SIZE                                                     
quay.io/ramalama/ramalama   latest    f9101beeef4b   6 seconds ago   1.27GB
quay.io/ramalama/ramalama   0.8       ec308db59613   6 days ago      1.26GB
docker build --no-cache -t quay.io/ramalama/ramalama-whisper-server -f /tmp/tmp.lAFnbgowrE .
[+] Building 0.1s (5/5) FINISHED                                                                               docker:default
 => [internal] load build definition from tmp.lAFnbgowrE                                                                 0.0s
 => => transferring dockerfile: 116B                                                                                     0.0s
 => [internal] load .dockerignore                                                                                        0.0s
 => => transferring context: 2B                                                                                          0.0s
 => [internal] load metadata for quay.io/ramalama/ramalama:latest                                                        0.0s
 => [1/1] FROM quay.io/ramalama/ramalama                                                                                 0.0s
 => exporting to image                                                                                                   0.0s
 => => exporting layers                                                                                                  0.0s
 => => writing image sha256:f05179407f5ed7a0fc61b12d8f0809880ee5b4476af882ed4adc53311ab69447                             0.0s
 => => naming to quay.io/ramalama/ramalama-whisper-server                                                                0.0s
docker build --no-cache -t quay.io/ramalama/ramalama-llama-server -f /tmp/tmp.FiLmwtUsE1 .
[+] Building 0.1s (5/5) FINISHED                                                                               docker:default
 => [internal] load build definition from tmp.FiLmwtUsE1                                                                 0.0s
 => => transferring dockerfile: 114B                                                                                     0.0s
 => [internal] load .dockerignore                                                                                        0.0s
 => => transferring context: 2B                                                                                          0.0s
 => [internal] load metadata for quay.io/ramalama/ramalama:latest                                                        0.0s
 => CACHED [1/1] FROM quay.io/ramalama/ramalama                                                                          0.0s
 => exporting to image                                                                                                   0.0s
 => => exporting layers                                                                                                  0.0s
 => => writing image sha256:2deba554d69e7f94cf6929e67a432acfcfd5f5ac20721b7a45fc8f5f93cec41c                             0.0s
 => => naming to quay.io/ramalama/ramalama-llama-server                                                                  0.0s
docker build --no-cache -t quay.io/ramalama/ramalama-rag -f /tmp/tmp.YkjDqKkphQ .
[+] Building 430.9s (8/8) FINISHED                                                                             docker:default
 => [internal] load build definition from tmp.YkjDqKkphQ                                                                 0.0s
 => => transferring dockerfile: 203B                                                                                     0.0s
 => [internal] load .dockerignore                                                                                        0.0s
 => => transferring context: 2B                                                                                          0.0s
 => [internal] load metadata for quay.io/ramalama/ramalama:latest                                                        0.0s
 => CACHED [1/3] FROM quay.io/ramalama/ramalama                                                                          0.0s
 => [internal] load build context                                                                                        0.0s
 => => transferring context: 327B                                                                                        0.0s
 => [2/3] COPY --chmod=755 ../scripts/ /usr/bin/                                                                         0.0s
 => [3/3] RUN /usr/bin/build_rag.sh cpu                                                                                415.2s
 => exporting to image                                                                                                  15.6s
 => => exporting layers                                                                                                 15.6s
 => => writing image sha256:a6c5af5813c4e61d4d84cb04da5cd7f7873726e2dc39fea06e512ea493603de0                             0.0s 
 => => naming to quay.io/ramalama/ramalama-rag      
```

## Summary by Sourcery

Remove ramalama installation from Docker-based container builds and update build scripts to ensure compatibility with both Podman and Docker.

Bug Fixes:
- Prevent installation of ramalama in containers built with Docker.

Enhancements:
- Update build scripts to conditionally install ramalama only when appropriate for the container runtime.