### PR TITLE
ci(fix): macOS runner didn't have bats

### DIFF
--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -68,14 +68,10 @@ jobs:
       - name: Checkout ramalama
         uses: actions/checkout@v4
 
-      - name: Install golang
-        shell: bash
-        run: brew install go
-
       - name: Install end-to-end test requirements
         shell: bash
         run: |
-          brew install shellcheck
+          brew install go shellcheck bats
           make install-requirements
 
       - name: Run end-to-end tests

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -67,14 +67,10 @@ jobs:
       - name: Checkout ramalama
         uses: actions/checkout@v4
 
-      - name: Install golang
-        shell: bash
-        run: brew install go
-
       - name: Install end-to-end test requirements
         shell: bash
         run: |
-          brew install shellcheck
+          brew install go shellcheck bats
           make install-requirements
 
       - name: Run end-to-end tests


### PR DESCRIPTION
couldn't run e2e tests

also consolidated all package installs into one step

## Summary by Sourcery

Fix CI workflows by ensuring all required packages, including bats, are installed on macOS runners and streamline the installation process.

CI:
- Add bats installation to macOS CI runners to enable e2e tests.
- Consolidate package installations into a single step in CI workflows.