### PR TITLE
Bump to 0.8.3

### DIFF
--- a/container-images/scripts/build_llama_and_whisper.sh
+++ b/container-images/scripts/build_llama_and_whisper.sh
@@ -5,7 +5,7 @@ python_version() {
   # $2 is empty when no Python is installed, so just install python3
   if [ -n "$pyversion" ]; then
       string="$pyversion
-Python 3.11"
+Python 3.10"
       if [ "$string" == "$(sort --version-sort <<< "$string")" ]; then
 	  echo "python3.11"
 	  return

--- a/container-images/scripts/build_rag.sh
+++ b/container-images/scripts/build_rag.sh
@@ -10,7 +10,7 @@ python_version() {
   # $2 is empty when no Python is installed, so just install python3
   if [ -n "$pyversion" ]; then
       string="$pyversion
-Python 3.11"
+Python 3.10"
       if [ "$string" == "$(sort --version-sort <<< "$string")" ]; then
 	  echo "python3.11"
 	  return
@@ -39,10 +39,12 @@ if [[ "$ID" = "fedora" && "$VERSION_ID" -ge 42 ]] ; then
 fi
 
 update_python() {
-    eval dnf install -y "${PYTHON}" "${PYTHON}-pip" "${PYTHON}-devel" "${packages}"
+    dnf update -y
+    dnf install -y "${PYTHON}" "${PYTHON}-pip" "${PYTHON}-devel" "${packages}"
     if [[ "${PYTHON}" == "python3.11" ]]; then
 	ln -sf /usr/bin/python3.11 /usr/bin/python3
     fi
+    rm -rf /usr/local/python3.10
 }
 
 docling() {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ramalama"
-version = "0.8.2"
+version = "0.8.3"
 description = "RamaLama is a command line tool for working with AI LLM models."
 readme = "README.md"
 requires-python = ">=3.8"

--- a/ramalama/version.py
+++ b/ramalama/version.py
@@ -2,8 +2,7 @@
 
 
 def version():
-    version = "0.8.2"
-    return version
+    return "0.8.3"
 
 
 def print_version(args):

--- a/rpm/python-ramalama.spec
+++ b/rpm/python-ramalama.spec
@@ -1,7 +1,7 @@
 %global pypi_name ramalama
 %global forgeurl  https://github.com/containers/%{pypi_name}
 # see ramalama/version.py
-%global version0  0.8.2
+%global version0  0.8.3
 %forgemeta
 
 %global summary   RamaLama is a command line tool for working with AI LLM models

--- a/scripts/newver.sh
+++ b/scripts/newver.sh
@@ -5,4 +5,4 @@ if [[ "$#" != 2 ]]; then
 fi
 curversion=$1
 newversion=$2
-sed "s/${curversion}/${newversion}/g" -i pyproject.toml setup.py ramalama/version.py rpm/python-ramalama.spec scripts/release.sh scripts/release-image.sh
+sed "s/${curversion}/${newversion}/g" -i pyproject.toml ramalama/version.py rpm/python-ramalama.spec

--- a/scripts/release-image.sh
+++ b/scripts/release-image.sh
@@ -31,10 +31,12 @@ release-arm() {
 }
 
 release-ramalama() {
+    version=$(bin/ramalama -q version)
+    minor_version=${version%.*}
     digest=$(podman image inspect "${REPO}/$1" --format '{{ .Digest }}' | cut -f2 -d':')
     podman push "${REPO}/$1" "${REPO}/$1:${digest}"
-    podman push "${REPO}/$1" "${REPO}/$1":0.8.2
-    podman push "${REPO}/$1" "${REPO}/$1":0.8
+    podman push "${REPO}/$1" "${REPO}/$1:${version}"
+    podman push "${REPO}/$1" "${REPO}/$1:${minor_version}"
     podman push "${REPO}/$1"
 }
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -18,6 +18,8 @@ export ARMREPO=${ARMREPO:-"quay.io/rhatdan"}
 export REPO=${REPO:-"quay.io/ramalama"}
 
 release() {
+    version=$(bin/ramalama -q version)
+    minor_version=${version%.*}
     DEST=${REPO}/"$1"
     podman manifest rm "$1" 2>/dev/null|| true
     podman manifest create "$1"
@@ -28,8 +30,8 @@ release() {
     podman manifest inspect "$1"
     digest=$(podman image inspect "${DEST}" --format '{{ .Digest }}' | cut -f2 -d':')
     podman manifest push --all "$1" "${DEST}:${digest}"
-    podman manifest push --all "$1" "${DEST}":0.8.2
-    podman manifest push --all "$1" "${DEST}":0.8
+    podman manifest push --all "$1" "${DEST}:${version}"
+    podman manifest push --all "$1" "${DEST}:${minor_version}"
     podman manifest push --all "$1" "${DEST}"
     podman manifest rm "$1"
 }


### PR DESCRIPTION
## Summary by Sourcery

Bump project version to 0.8.3 and enhance release and container build scripts for dynamic version tagging, updated Python handling, and streamlined version updates.

Enhancements:
- Automate image and manifest tagging in release scripts using the current and minor project version
- Update container build scripts to default to Python 3.10, include a system update before installation, and clean up local Python installations
- Simplify the version bump script to only update version references in core project files

Build:
- Bump project version to 0.8.3 in pyproject.toml, ramalama/version.py, and RPM spec