### PR TITLE
Shorten url in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ pip install ramalama
 ### Install on Mac
 Install RamaLama by running:
 ```
-curl -fsSL https://raw.githubusercontent.com/containers/ramalama/s/install.sh | bash
+curl -fsSL https://ramalama.ai/install.sh | bash
 ```
 
 #### Default Container Engine


### PR DESCRIPTION
This is now installable via https://ramalama.ai/install.sh

## Summary by Sourcery

Documentation:
- Update the curl command to fetch install.sh from https://ramalama.ai/install.sh instead of the GitHub raw URL