### PR TITLE
This script is not macOS only

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,10 +94,10 @@ RamaLama is available via PyPi at [https://pypi.org/project/ramalama](https://py
 pip install ramalama
 ```
 
-### Install on Mac
+### Install script (Linux and macOS)
 Install RamaLama by running:
 ```
-curl -fsSL https://raw.githubusercontent.com/containers/ramalama/s/install.sh | bash
+curl -fsSL https://ramalama.ai/install.sh | bash
 ```
 
 #### Default Container Engine


### PR DESCRIPTION
This script works for many platforms and generally does the right thing.

## Summary by Sourcery

Clarify installation instructions to cover multiple platforms and use the new centralized install script URL

Documentation:
- Clarify that the install script supports both Linux and macOS and update its header
- Update the install.sh URL to point to ramalama.ai