### PR TITLE
Fix cuda builds installation of python3.11

### DIFF
--- a/container-images/cuda/Containerfile
+++ b/container-images/cuda/Containerfile
@@ -15,6 +15,8 @@ COPY --chmod=755 ../scripts /usr/bin
 # Workaround for CUDA libraries not in the ld path in base container
 RUN echo "/usr/local/cuda-12.8/compat" > /etc/ld.so.conf.d/99_cuda_compat.conf && ldconfig
 
-RUN dnf install -y python3
+RUN dnf install -y python3.11 python3.11-pip python3.11-devel && \
+    dnf -y clean all && \
+    ln -sf /usr/bin/python3.11 /usr/bin/python3
 
 ENTRYPOINT []


### PR DESCRIPTION
## Summary by Sourcery

Update CUDA container and build scripts to support Python 3.11 installation, correct GPU package patterns, and clean up package caches.

Bug Fixes:
- Fix Python 3.11 and pip installation in the CUDA Containerfile and ensure the python3 symlink points to python3.11
- Correct the glob pattern for cuda-cupti-12 packages in build_rag.sh

Enhancements:
- Clean dnf cache after installing Python in the Containerfile
- Include GPU-related packages in the update_python function install command without stray quotes