### PR TITLE
Adds milvus support json output and progress indicators

### DIFF
--- a/container-images/scripts/build_rag.sh
+++ b/container-images/scripts/build_rag.sh
@@ -46,7 +46,7 @@ docling() {
 }
 
 rag() {
-    ${python} -m pip install --prefix=/usr wheel qdrant_client fastembed openai fastapi uvicorn
+    ${python} -m pip install --prefix=/usr wheel qdrant_client fastembed pymilvus openai fastapi uvicorn
     rag_framework load
 }
 

--- a/container-images/scripts/doc2rag
+++ b/container-images/scripts/doc2rag
@@ -174,7 +174,7 @@ class Converter:
             schema=schema,
             index_params=index_params
         )
-        # Chunk and add chunks to colleciton 1 by 1
+        # Chunk and add chunks to collection 1 by 1
         chunks, ids = self.chunk(docs)
         data = []
         for i, (chunk, id) in enumerate(zip(chunks, ids)):

--- a/container-images/scripts/doc2rag
+++ b/container-images/scripts/doc2rag
@@ -1,18 +1,27 @@
 #!/usr/bin/env python3
-
+import json
 import argparse
 import hashlib
 import os
 import sys
 import uuid
+from pathlib import Path
+import time
+import threading
+import itertools
 
-import qdrant_client
-from qdrant_client import models
 import docling
 from docling.chunking import HybridChunker
 from docling.document_converter import DocumentConverter, PdfFormatOption
 from docling.datamodel.base_models import InputFormat
 from docling.datamodel.pipeline_options import PdfPipelineOptions
+
+# Vectordb imports
+import qdrant_client
+from qdrant_client import models
+from pymilvus import MilvusClient, DataType
+from fastembed import TextEmbedding, SparseTextEmbedding
+
 # Global Vars
 EMBED_MODEL = os.getenv("EMBED_MODEL", "jinaai/jina-embeddings-v2-small-en")
 SPARSE_MODEL = os.getenv("SPARSE_MODEL", "prithivida/Splade_PP_en_v1")
@@ -34,33 +43,59 @@ class Converter:
         for target in targets:
             self.add(target)
         self.output = output
-        self.client = qdrant_client.QdrantClient(path=output)
-        self.client.set_model(EMBED_MODEL)
-        self.client.set_sparse_model(SPARSE_MODEL)
-        # optimizations to reduce ram
-        self.client.create_collection(
-            collection_name=COLLECTION_NAME,
-            vectors_config=self.client.get_fastembed_vector_params(on_disk=True),
-            sparse_vectors_config= self.client.get_fastembed_sparse_vector_params(on_disk=True),
-            quantization_config=models.ScalarQuantization(
-                scalar=models.ScalarQuantizationConfig(
-                    type=models.ScalarType.INT8,
-                    always_ram=True,
-                ),
-            ),
-        )
 
     def add(self, file_path):
         if os.path.isdir(file_path):
             self.walk(file_path)  # Walk directory and process all files
         else:
             self.targets.append(file_path)  # Process the single file
+    
+    def show_progress(self, message, stop_event):
+            spinner = itertools.cycle([".", "..", "..."])
+            while not stop_event.is_set():
+                sys.stdout.write(f"\r{message} {next(spinner)}   ")
+                sys.stdout.flush()
+                time.sleep(0.5)
+            sys.stdout.write("\r" + " " * 50 + "\r")
 
-    def convert(self):
-        result = self.doc_converter.convert_all(self.targets)
-        documents, metadata, ids = [], [], []
+    def convert(self, choice):
+        results = []
+        names = []
+
+        for target in self.targets:
+            name = self.get_name(str(target))
+            names.append(name)
+            stop_event = threading.Event()
+            progress_thread = threading.Thread(target=self.show_progress, args=(f"Converting {name}.pdf to json", stop_event))
+            progress_thread.start()
+        
+            try:
+                results.append(self.doc_converter.convert(target))
+            finally:
+                stop_event.set()
+                progress_thread.join()
+            
+            print(f"Finished converting {name}.pdf to {name}.json")
+
+        if choice == "json":
+            self.export_json(results, names)
+        elif choice == "milvus":
+            self.export_milvus(results)
+        else:
+            self.export_qdrant(results)
+    
+    def generate_hash(self, document: str) -> int:
+        """Generate a unique int64 hash from the document text."""
+        sha256_hash = hashlib.sha256(document.encode('utf-8')).hexdigest()
+        uuid_val = uuid.UUID(sha256_hash[:32])
+        # Convert to signed int64 (Milvus requires signed 64-bit)
+        return uuid_val.int & ((1 << 63) - 1)
+    
+    def chunk(self, docs):
         chunker = HybridChunker(tokenizer=EMBED_MODEL, overlap=100, merge_peers=True)
-        for file in result:
+        documents, ids = [], []
+        
+        for file in docs:
             chunk_iter = chunker.chunk(dl_doc=file.document)
             for chunk in chunk_iter:
                 # Extract the enriched text from the chunk
@@ -70,7 +105,102 @@ class Converter:
                 # Generate unique ID for the chunk
                 doc_id = self.generate_hash(doc_text)
                 ids.append(doc_id)
-        return self.client.add(COLLECTION_NAME, documents=documents, ids=ids, batch_size=1)
+        return documents, ids
+    
+    def export_json(self, docs, names):
+        print("Exporting to JSON")
+        output_dir = Path(self.output)
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        for file, name in zip(docs, names):
+            doc = file.document.export_to_dict()
+            output_path = output_dir / f"{name}.json"
+            with output_path.open("w") as fp:
+                fp.write(json.dumps(doc))
+
+    def export_qdrant(self, docs):
+        print("Exporting to Qdrant")
+        output_dir = Path(self.output)
+        output_dir.mkdir(parents=True, exist_ok=True)
+        client = qdrant_client.QdrantClient(path=self.output)
+        client.set_model(EMBED_MODEL)
+        client.set_sparse_model(SPARSE_MODEL)
+        chunks, ids = self.chunk(docs)
+        client.add(COLLECTION_NAME, documents=chunks, ids=ids, batch_size=1)
+        
+    def export_milvus(self, docs):
+        print("Exporting to Milvus")
+        output_dir = Path(self.output)
+        output_dir.mkdir(parents=True, exist_ok=True)
+        # Setup collection
+        milvus_client = MilvusClient(uri=os.path.join(self.output, "milvus.db"))
+        collection_name = COLLECTION_NAME
+
+        # Setup embedding models
+        dmodel = TextEmbedding(model_name=EMBED_MODEL)
+        smodel = SparseTextEmbedding(model_name=SPARSE_MODEL)
+
+        test_embedding = next(dmodel.embed("This is a test"))
+        embedding_dim = len(test_embedding)
+
+        # Create Schema
+        schema = MilvusClient.create_schema(
+            auto_id=False,
+            enable_dynamic_field=True,
+        )
+
+        # Add fields to schema
+        schema.add_field(field_name="id", datatype=DataType.INT64, is_primary=True)
+        schema.add_field(field_name="text", datatype=DataType.VARCHAR, max_length=1000)
+        schema.add_field(field_name="sparse", datatype=DataType.SPARSE_FLOAT_VECTOR)
+        schema.add_field(field_name="dense", datatype=DataType.FLOAT_VECTOR, dim=embedding_dim)
+
+        # Prepare index
+        index_params = milvus_client.prepare_index_params()
+        index_params.add_index(
+            field_name="dense",
+            index_name="dense_index",
+            index_type="AUTOINDEX"
+        )
+
+        index_params.add_index(
+            field_name="sparse",
+            index_name="sparse_index",
+            index_type="SPARSE_INVERTED_INDEX"
+        )
+        # Create collection
+        milvus_client.create_collection(
+            collection_name=collection_name,
+            schema=schema,
+            index_params=index_params
+        )
+        # Chunk and add chunks to colleciton 1 by 1
+        chunks, ids = self.chunk(docs)
+        data = []
+        for i, (chunk, id) in enumerate(zip(chunks, ids)):
+            dense_embedding = next(dmodel.embed([chunk]))
+            sparse_embedding = next(smodel.embed([chunk]))
+            sparse_vector = sparse_embedding.as_dict()
+            milvus_client.insert(
+                collection_name=collection_name,
+                data=[{
+                    "id": id,
+                    "text": chunk,
+                    "sparse": sparse_vector,
+                    "dense": dense_embedding
+                }]
+            )
+            # Flush every 100 records to reduce RAM usage
+            if i % 100 == 0: 
+                milvus_client.flush(collection_name=collection_name)
+            
+            print(f"\rProcessed chunk {i+1}/{len(chunks)}", end='', flush=True) 
+
+        milvus_client.flush(collection_name=collection_name)
+        print("\n")
+                    
+    def get_name(self, path):
+        return Path(path).stem
 
     def walk(self, path):
         for root, dirs, files in os.walk(path, topdown=True):
@@ -80,14 +210,6 @@ class Converter:
                 file = os.path.join(root, f)
                 if os.path.isfile(file):
                     self.targets.append(file)
-
-    def generate_hash(self, document: str) -> str:
-        """Generate a unique hash for a document."""
-        sha256_hash = hashlib.sha256(document.encode('utf-8')).hexdigest()
-
-        # Use the first 32 characters of the hash to create a UUID
-        return str(uuid.UUID(sha256_hash[:32]))
-
 def load():
     # Dummy code to preload models
     client = qdrant_client.QdrantClient(":memory:")
@@ -104,10 +226,10 @@ parser = argparse.ArgumentParser(
 parser.add_argument("target", nargs="?", help="Target database")
 parser.add_argument("source", nargs="*", help="Source files")
 parser.add_argument("--ocr", action='store_true', help="Enable embedded image text extraction from PDF (Increases RAM Usage significantly)")
+parser.add_argument("--db", choices=["json", "qdrant", "milvus"], default="qdrant", help="Conversion output type")
 
 def perror(*args, **kwargs):
     print(*args, file=sys.stderr, **kwargs)
-
 
 def eprint(e, exit_code):
     perror("Error: " + str(e).strip("'\""))
@@ -119,7 +241,7 @@ try:
         load()
     else:
         converter = Converter(args.target, args.source, args.ocr)
-        converter.convert()
+        converter.convert(args.db)
 except docling.exceptions.ConversionError as e:
     eprint(e, 1)
 except FileNotFoundError as e:

--- a/container-images/scripts/rag_framework
+++ b/container-images/scripts/rag_framework
@@ -5,9 +5,6 @@ import cmd
 import openai
 from fastembed.rerank.cross_encoder import TextCrossEncoder
 from fastembed import TextEmbedding, SparseTextEmbedding
-from docling.document_converter import DocumentConverter
-from docling.chunking import HybridChunker
-from docling_core.types.doc import DoclingDocument
 # Vectordb imports
 import qdrant_client
 from pymilvus import MilvusClient, AnnSearchRequest, RRFRanker

--- a/container-images/scripts/rag_framework
+++ b/container-images/scripts/rag_framework
@@ -2,20 +2,23 @@
 
 # AI imports
 import cmd
-import qdrant_client
 import openai
 from fastembed.rerank.cross_encoder import TextCrossEncoder
+from fastembed import TextEmbedding, SparseTextEmbedding
+from docling.document_converter import DocumentConverter
+from docling.chunking import HybridChunker
+from docling_core.types.doc import DoclingDocument
+# Vectordb imports
+import qdrant_client
+from pymilvus import MilvusClient, AnnSearchRequest, RRFRanker
 # Regular imports
 import uuid
 import os
 import hashlib
 import argparse
-
-from fastapi import FastAPI, HTTPException
-from fastapi.responses import JSONResponse
-from pydantic import BaseModel
-from fastapi import FastAPI
-import uvicorn
+from pathlib import Path
+import json
+import sys
 
 # Global Vars
 EMBED_MODEL = os.getenv("EMBED_MODEL", "jinaai/jina-embeddings-v2-small-en")
@@ -27,30 +30,93 @@ os.environ["TOKENIZERS_PARALLELISM"] = "true"
 
 
 def eprint(e, exit_code):
-    print("Error: " + str(e).strip("'\""))
+    print("Error:", str(e).strip("'\""), file=sys.stderr)
     sys.exit(exit_code)
 
 # Helper Classes and Functions
 
-class QueryRequest(BaseModel):
-    model: str
-    messages: list
-    max_tokens: int = 150  # Default to 150 tokens
-
-class Rag(cmd.Cmd):
-    prompt = "> "
+class qdrant:
     def __init__(self, vector_path):
-        # Initlialze the cmd class
-        super().__init__()
-        
         self.client = qdrant_client.QdrantClient(path=vector_path)
         self.client.set_model(EMBED_MODEL)
         self.client.set_sparse_model(SPARSE_MODEL)
+    
+    def query(self, prompt):
+        results = self.client.query(
+            collection_name="rag",
+            query_text=prompt,
+            limit=20,
+        )
+        return [r.document for r in results] 
+
+class milvus:
+    def __init__(self, vector_path):
+        self.milvus_client = MilvusClient(uri=os.path.join(vector_path, "milvus.db"))
+        self.dmodel = TextEmbedding(model_name=EMBED_MODEL)
+        self.smodel = SparseTextEmbedding(model_name=SPARSE_MODEL)
+    
+    def query(self, prompt):
+        dense_embedding = next(self.dmodel.embed([prompt]))
+        sparse_embedding = next(self.smodel.embed([prompt])).as_dict()
+
+        search_param_dense = {
+            "data": [dense_embedding],
+            "anns_field": "dense",
+            "param": {
+                "metric_type": "IP",
+                "params": {"nprobe": 10}
+            },
+            "limit": 10
+        }
+
+        request_dense = AnnSearchRequest(**search_param_dense)
+
+        search_param_sparse = {
+            "data": [sparse_embedding],
+            "anns_field": "sparse",
+            "param": {
+                "metric_type": "IP",
+                "params": {"drop_ratio_build": 0.2}
+            },
+            "limit": 10
+        }
+
+        request_sparse = AnnSearchRequest(**search_param_sparse)
+
+        reqs = [request_dense, request_sparse]
+
+        ranker = RRFRanker(100)
+        
+        results = self.milvus_client.hybrid_search(
+            collection_name=COLLECTION_NAME,
+            reqs=reqs,
+            ranker=ranker,
+            limit=20,
+            output_fields=["text"],
+        )
+        return [hit["entity"]["text"] for hit in results[0]]
+
+class Rag(cmd.Cmd):
+    prompt = "🦭  > "
+    def __init__(self, vector_path):
+        # Initlialze the cmd class
+        super().__init__()
+
         self.reranker = TextCrossEncoder(model_name=RANK_MODEL)
+
+        if self.is_milvus(vector_path):
+            # setup mivlus
+            self.vectordb = milvus(vector_path)
+        else:
+            # setup qdrant
+            self.vectordb = qdrant(vector_path)
 
         # Setup openai api
         self.llm = openai.OpenAI(api_key="your-api-key", base_url="http://localhost:8080")
         self.chat_history = []  # Store chat history
+    
+    def is_milvus(self, vector_path):
+        return any(f.suffix == ".db" and f.is_file() for f in Path(vector_path).iterdir())
 
     def do_EOF(self, user_content):
         print("")
@@ -64,13 +130,8 @@ class Rag(cmd.Cmd):
         if len(self.chat_history) > 10:
             self.chat_history.pop(0)  # Remove the oldest message
         
-        # Query the Qdrant client for relevant context
-        results = self.client.query(
-            collection_name="rag",
-            query_text=prompt,
-            limit=20,
-        )
-        result = [r.document for r in results] 
+        # Query the Vectordb
+        result = self.vectordb.query(prompt)
         # reranker code to have the first 5 queries 
         reranked_context = " ".join(
             str(result[i]) for i, _ in sorted(
@@ -79,8 +140,6 @@ class Rag(cmd.Cmd):
                 reverse=True
             )[:5]
         )
-
-        # context = "\n".join(r.document for r in results)
 
         # Prepare the metaprompt with chat history and context
         metaprompt = f"""
@@ -141,40 +200,6 @@ class Rag(cmd.Cmd):
             return True
 
         self.query(user_content)
-
-    def serve(self):
-        app = FastAPI()
-
-        @app.post("/v1/chat/completions")
-        async def query(request: QueryRequest):
-            """API endpoint to query the Rag instance and return OpenAI-like response."""
-            
-            if not request.messages:
-                raise HTTPException(status_code=400, detail="Messages are required")
-            
-            try:
-                response_text = self.query(request.messages)
-                
-                return JSONResponse(content={
-                    "id": str(uuid.uuid4()),
-                    "object": "chat.completion",
-                    "created": 1678901234,  # Static, could use a timestamp
-                    "model": request.model,
-                    "choices": [
-                        {
-                            "message": {
-                                "role": "assistant",
-                                "content": response_text
-                            },
-                            "finish_reason": "stop",
-                            "index": 0
-                        }
-                    ]
-                })
-            except Exception as e:
-                raise HTTPException(status_code=500, detail=str(e))
-        
-        uvicorn.run(app, host="0.0.0.0", port=8080)
 
 def run_rag(vector_path):
     rag = Rag(vector_path)

--- a/docs/ramalama-rag.1.md
+++ b/docs/ramalama-rag.1.md
@@ -23,6 +23,13 @@ positional arguments:
 
 ## OPTIONS
 
+#### **--db**=*format*
+Sets the vector database output format for the converted documents. For Milvus and Qdrant both formats use the same embedding models via fastembed and use hybrid search.
+
+- **json**: Output the converted documents to a docling JSON format. Allows for immediate ingestion for pipelines that use docling.
+- **milvus**: Outputs the converted documents to a Milvus vector database. 
+- **qdrant**: Outputs the converted documents to a Qdrant vector database. (Default)
+
 #### **--env**=
 
 Set environment variables inside of the container.
@@ -61,6 +68,10 @@ c857ebc65c641084b34e39b740fdb6a2d9d2d97be320e6aa9439ed0ab8780fe0
 
 ```
 ramalama rag --ocr README.md https://mysight.edu/document quay.io/rhatdan/myrag
+```
+
+```
+ramalama rag --db milvus README.md https://mysight.edu/document quay.io/rhatdan/myrag
 ```
 
 ## SEE ALSO

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -1028,6 +1028,14 @@ formatted files to be processed""",
         action="store_true",
         help="Enable embedded image text extraction from PDF (Increases RAM Usage significantly)",
     )
+    parser.add_argument(
+        "--db",
+        dest="db",
+        type=str,
+        default='qdrant',
+        choices=["json", "qdrant", "milvus"],
+        help='pull image policy',
+    )
     parser.set_defaults(func=rag_cli)
 
 

--- a/ramalama/rag.py
+++ b/ramalama/rag.py
@@ -111,10 +111,10 @@ COPY {src} /vector.db
         self.engine.add(["doc2rag", "/output", "/docs/"])
         if args.ocr:
             self.engine.add(["--ocr"])
-        if args.db:
-            self.engine.add(["--db", args.db])
         if len(self.urls) > 0:
             self.engine.add(self.urls)
+        if args.db:
+            self.engine.add(["--db", args.db])
         if args.dryrun:
             self.engine.dryrun()
             return

--- a/ramalama/rag.py
+++ b/ramalama/rag.py
@@ -111,6 +111,8 @@ COPY {src} /vector.db
         self.engine.add(["doc2rag", "/output", "/docs/"])
         if args.ocr:
             self.engine.add(["--ocr"])
+        if args.db:
+            self.engine.add(["--db", args.db])
         if len(self.urls) > 0:
             self.engine.add(self.urls)
         if args.dryrun:


### PR DESCRIPTION
based on work from https://github.com/containers/ramalama/pull/1385

this should go in first https://github.com/containers/ramalama/pull/1400/files

This adds a new argument --db to select the choice of json qdrant or milvus for vector db

Wih the rag proxy incoming rag_framework wont need to use openai to fork llama.cpp server and generate a response that will be handled by the new ramalama-serve-core. Rag-framework will turn into a script that will just setup the prompt with rag. 

Maybe this PR should be on hold till I finish Rag proxy? 