### PR TITLE
fix: removed ocr print statement and updated ocr description

### DIFF
--- a/container-images/scripts/doc2rag
+++ b/container-images/scripts/doc2rag
@@ -103,7 +103,7 @@ parser = argparse.ArgumentParser(
 
 parser.add_argument("target", nargs="?", help="Target database")
 parser.add_argument("source", nargs="*", help="Source files")
-parser.add_argument("--ocr", action='store_true', help="PDF Image processing")
+parser.add_argument("--ocr", action='store_true', help="Enable embedded image text extraction from PDF (Increases RAM Usage significantly)")
 
 def perror(*args, **kwargs):
     print(*args, file=sys.stderr, **kwargs)
@@ -118,7 +118,6 @@ try:
     if args.target == "load":
         load()
     else:
-        print("OCR",args.ocr)
         converter = Converter(args.target, args.source, args.ocr)
         converter.convert()
 except docling.exceptions.ConversionError as e:

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -1018,7 +1018,7 @@ formatted files to be processed""",
         dest="ocr",
         default=CONFIG["ocr"],
         action="store_true",
-        help="Toggle PDF image processing",
+        help="Enable embedded image text extraction from PDF (Increases RAM Usage significantly)",
     )
     parser.set_defaults(func=rag_cli)
 


### PR DESCRIPTION
## Summary by Sourcery

Update OCR flag help description and remove unnecessary OCR print statement

Bug Fixes:
- Remove redundant print statement from OCR processing to prevent unwanted output

Enhancements:
- Clarify OCR CLI flag help text to note increased RAM usage