### PR TITLE
Support Moore Threads GPU #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ RamaLama eliminates the need to configure the host system by instead pulling a c
 |  ASAHI_VISIBLE_DEVICES  | quay.io/ramalama/asahi     |
 |  INTEL_VISIBLE_DEVICES  | quay.io/ramalama/intel-gpu |
 |  ASCEND_VISIBLE_DEVICES | quay.io/ramalama/cann      |
+|  MUSA_VISIBLE_DEVICES   | quay.io/ramalama/musa      |
 
 ### GPU support inspection
 On first run, RamaLama inspects your system for GPU support, falling back to CPU if none are present. RamaLama uses container engines like Podman or Docker to pull the appropriate OCI image with all necessary software to run an AI Model for your system setup.
@@ -62,6 +63,7 @@ RamaLama then pulls AI Models from model registries, starting a chatbot or REST 
 | AMD GPU (rocm)                     | &check;                     |
 | Ascend NPU (Linux)                 | &check;                     |
 | Intel ARC GPUs (Linux)             | &check; See note below      |
+| Moore Threads GPU (musa / Linux)   | &check; See note below      |
 
 ### Nvidia GPUs
 On systems with NVIDIA GPUs, see [ramalama-cuda](docs/ramalama-cuda.7.md) documentation for the correct host system configuration.
@@ -80,6 +82,9 @@ The following Intel GPUs are auto-detected by RamaLama:
 See the [Intel hardware table](https://dgpu-docs.intel.com/devices/hardware-table.html) for more information.
 <br>
 <br>
+
+### Moore Threads GPUs
+On systems with Moore Threads GPUs, see [ramalama-musa](docs/ramalama-musa.7.md) documentation for the correct host system configuration.
 
 ## Install
 ### Install on Fedora

--- a/docs/ramalama-cuda.7.md
+++ b/docs/ramalama-cuda.7.md
@@ -1,4 +1,4 @@
-% ramalama 7
+% ramalama-cuda 7
 
 # Setting Up RamaLama with CUDA Support on Linux systems
 

--- a/docs/ramalama-musa.7.md
+++ b/docs/ramalama-musa.7.md
@@ -1,4 +1,4 @@
-% ramalama 7
+% ramalama-musa 7
 
 # Setting Up RamaLama with MUSA Support on Linux systems
 

--- a/docs/ramalama-musa.7.md
+++ b/docs/ramalama-musa.7.md
@@ -1,0 +1,76 @@
+% ramalama 7
+
+# Setting Up RamaLama with MUSA Support on Linux systems
+
+This guide walks through the steps required to set up RamaLama with MUSA support.
+
+## Install the MT Linux Driver
+
+Download the appropriate [MUSA SDK](https://developer.mthreads.com/sdk/download/musa) and follow the installation instructions provided in the [MT Linux Driver installation guide](https://docs.mthreads.com/musa-sdk/musa-sdk-doc-online/install_guide#2%E9%A9%B1%E5%8A%A8%E5%AE%89%E8%A3%85).
+
+## Install the MT Container Toolkit
+
+Obtain the latest [MT CloudNative Toolkits](https://developer.mthreads.com/sdk/download/CloudNative) and follow the installation instructions provided in the [MT Container Toolkit installation guide](https://docs.mthreads.com/cloud-native/cloud-native-doc-online/install_guide/#%E6%91%A9%E5%B0%94%E7%BA%BF%E7%A8%8B%E5%AE%B9%E5%99%A8%E8%BF%90%E8%A1%8C%E6%97%B6%E5%A5%97%E4%BB%B6).
+
+## Setting Up MUSA Support
+
+   ```bash
+   $ (cd /usr/bin/musa && sudo ./docker setup $PWD)
+   $ docker info | grep mthreads
+   Runtimes: mthreads mthreads-experimental runc
+   Default Runtime: mthreads
+   ```
+
+## Testing the Setup
+
+# **Test the Installation**
+
+   Run the following command to verify setup:
+
+   ```bash
+   docker run --rm --env MTHREADS_VISIBLE_DEVICES=all ubuntu:22.04 mthreads-gmi
+   ```
+
+# **Expected Output**
+
+   Verify everything is configured correctly, with output similar to this:
+
+   ```text
+   Thu May 15 01:53:39 2025
+   ---------------------------------------------------------------
+       mthreads-gmi:2.0.0           Driver Version:3.0.0
+   ---------------------------------------------------------------
+   ID   Name           |PCIe                |%GPU  Mem
+        Device Type    |Pcie Lane Width     |Temp  MPC Capable
+                                            |      ECC Mode
+   +-------------------------------------------------------------+
+   0    MTT S80        |00000000:01:00.0    |0%    3419MiB(16384MiB)
+        Physical       |16x(16x)            |59C   YES
+                                            |      N/A
+   ---------------------------------------------------------------
+
+   ---------------------------------------------------------------
+   Processes:
+   ID   PID       Process name                         GPU Memory
+                                                            Usage
+   +-------------------------------------------------------------+
+      No running processes found
+   ---------------------------------------------------------------
+   ```
+
+### MUSA_VISIBLE_DEVICES
+
+RamaLama respects the `MUSA_VISIBLE_DEVICES` environment variable if it's already set in your environment. If not set, RamaLama will default to using all the GPU detected by mthreads-gmi.
+
+You can specify which GPU devices should be visible to RamaLama by setting this variable before running RamaLama commands:
+
+```bash
+export MUSA_VISIBLE_DEVICES="0,1"  # Use GPUs 0 and 1
+ramalama run granite
+```
+
+This is particularly useful in multi-GPU systems where you want to dedicate specific GPUs to different workloads.
+
+## HISTORY
+
+May 2025, Originally compiled by Xiaodong Ye <yeahdongcn@gmail.com>

--- a/docs/ramalama.1.md
+++ b/docs/ramalama.1.md
@@ -33,6 +33,7 @@ Accelerated images:
 |  ASAHI_VISIBLE_DEVICES  | quay.io/ramalama/asahi     |
 |  INTEL_VISIBLE_DEVICES  | quay.io/ramalama/intel-gpu |
 |  ASCEND_VISIBLE_DEVICES | quay.io/ramalama/cann      |
+|  MUSA_VISIBLE_DEVICES   | quay.io/ramalama/musa      |
 
 RamaLama pulls AI Models from model registries. Starting a chatbot or a rest API service from a simple single command. Models are treated similarly to how Podman and Docker treat container images.
 

--- a/docs/ramalama.conf
+++ b/docs/ramalama.conf
@@ -52,6 +52,7 @@
 #ASAHI_VISIBLE_DEVICES="quay.io/ramalama/asahi"
 #INTEL_VISIBLE_DEVICES="quay.io/ramalama/intel-gpu"
 #ASCEND_VISIBLE_DEVICES="quay.io/ramalama/cann"
+#MUSA_VISIBLE_DEVICES="quay.io/ramalama/musa"
 
 # IP address for llama.cpp to listen on.
 #

--- a/docs/ramalama.conf.5.md
+++ b/docs/ramalama.conf.5.md
@@ -95,11 +95,12 @@ OCI container image to run with the specified AI model
 RAMALAMA_IMAGE environment variable overrides this field.
 
 `[[ramalama.images]]`
-  HIP_VISIBLE_DEVICES   = "quay.io/ramalama/rocm"
-  CUDA_VISIBLE_DEVICES  = "quay.io/ramalama/cuda"
-  ASAHI_VISIBLE_DEVICES = "quay.io/ramalama/asahi"
-  INTEL_VISIBLE_DEVICES = "quay.io/ramalama/intel-gpu"
-  ASCEND_VISIBLE_DEVICES  = "quay.io/ramalama/cann"
+  HIP_VISIBLE_DEVICES    = "quay.io/ramalama/rocm"
+  CUDA_VISIBLE_DEVICES   = "quay.io/ramalama/cuda"
+  ASAHI_VISIBLE_DEVICES  = "quay.io/ramalama/asahi"
+  INTEL_VISIBLE_DEVICES  = "quay.io/ramalama/intel-gpu"
+  ASCEND_VISIBLE_DEVICES = "quay.io/ramalama/cann"
+  MUSA_VISIBLE_DEVICES   = "quay.io/ramalama/musa"
 
 Alternative images to use when RamaLama recognizes specific hardware
 


### PR DESCRIPTION
This PR adds docs for Moore Threads GPUs (https://github.com/containers/ramalama/issues/1390) in ramalama.
Please also see: https://github.com/containers/ramalama/pull/1407 for code changes.

## Summary by Sourcery

Document support for Moore Threads GPUs by adding MUSA_VISIBLE_DEVICES configuration references in samples and README, and providing a dedicated man page with setup instructions.

Documentation:
- Add MUSA_VISIBLE_DEVICES examples to ramalama.conf, ramalama.conf.5.md, and ramalama.1.md
- Update README.md to include Moore Threads GPU in the supported devices table
- Introduce docs/ramalama-musa.7.md man page with installation and usage instructions for Moore Threads GPUs.