### PR TITLE
Add support for llama-stack

### DIFF
--- a/docs/ramalama-run.1.md
+++ b/docs/ramalama-run.1.md
@@ -26,6 +26,10 @@ URL support means if a model is on a web site or even on your local system, you 
 
 ## OPTIONS
 
+#### **--api**=**llama-stack** | none**
+unified API layer for Inference, RAG, Agents, Tools, Safety, Evals, and Telemetry.(default: none)
+The default can be overridden in the ramalama.conf file.
+
 #### **--authfile**=*password*
 path of the authentication file for OCI registries
 

--- a/docs/ramalama-serve.1.md
+++ b/docs/ramalama-serve.1.md
@@ -35,6 +35,10 @@ For REST API endpoint documentation, see: [https://github.com/ggml-org/llama.cpp
 
 ## OPTIONS
 
+#### **--api**=**llama-stack** | none**
+unified API layer for Inference, RAG, Agents, Tools, Safety, Evals, and Telemetry.(default: none)
+The default can be overridden in the ramalama.conf file.
+
 #### **--authfile**=*password*
 path of the authentication file for OCI registries
 

--- a/docs/ramalama.conf
+++ b/docs/ramalama.conf
@@ -17,6 +17,11 @@
 
 [ramalama]
 
+# unified API layer for for Inference, RAG, Agents, Tools, Safety, Evals, and Telemetry.
+# Options: llama-stack, none
+#
+# api = "none"
+
 # OCI model car image
 # Image to use when building and pushing --type=car models
 #

--- a/docs/ramalama.conf.5.md
+++ b/docs/ramalama.conf.5.md
@@ -60,6 +60,11 @@ The ramalama table contains settings to configure and manage the OCI runtime.
 
 `[[ramalama]]`
 
+**api**="none"
+
+Unified API layer for Inference, RAG, Agents, Tools, Safety, Evals, and Telemetry.
+Options: llama-stack, none
+
 **carimage**="registry.access.redhat.com/ubi9-micro:latest"
 
 OCI model car image

--- a/ramalama/config.py
+++ b/ramalama/config.py
@@ -89,6 +89,7 @@ def load_config_defaults(config: Dict[str, Any]):
             "MUSA_VISIBLE_DEVICES": "quay.io/ramalama/musa",
         },
     )
+    config.setdefault('api', 'none')
     config.setdefault('keep_groups', False)
     config.setdefault('ngl', -1)
     config.setdefault('threads', -1)

--- a/ramalama/model_store.py
+++ b/ramalama/model_store.py
@@ -203,7 +203,7 @@ class GlobalModelStore:
     def path(self) -> str:
         return self._store_base_path
 
-    def list_models(self, engine: str, debug: bool, show_container: bool) -> Dict[str, List[ModelFile]]:
+    def list_models(self, engine: str, show_container: bool) -> Dict[str, List[ModelFile]]:
         models: Dict[str, List[ModelFile]] = {}
 
         for root, subdirs, _ in os.walk(self.path):
@@ -247,7 +247,6 @@ class GlobalModelStore:
                 dotdict(
                     {
                         "engine": engine,
-                        "debug": debug,
                     }
                 )
             )

--- a/ramalama/oci.py
+++ b/ramalama/oci.py
@@ -231,6 +231,7 @@ RUN rm -rf /{model_name}-f16.gguf /models/{model_name}
         # Open the file for writing.
         with open(containerfile.name, 'w') as c:
             c.write(content)
+            c.flush()
 
         build_cmd = [
             self.conman,

--- a/ramalama/rag.py
+++ b/ramalama/rag.py
@@ -34,7 +34,10 @@ COPY {src} /vector.db
         # Open the file for writing.
         with open(containerfile.name, 'w') as c:
             c.write(cfile)
+            c.flush()
+
         logger.debug(f"\nContainerfile: {containerfile.name}\n{cfile}")
+
         exec_args = [
             args.engine,
             "build",

--- a/ramalama/shortnames.py
+++ b/ramalama/shortnames.py
@@ -47,4 +47,5 @@ class Shortnames:
             c.write('[shortnames]\n')
             for shortname in self.shortnames:
                 c.write('"%s"="%s"\n' % (shortname, self.shortnames.get(shortname)))
+            c.flush()
         return shortnamefile.name

--- a/ramalama/stack.py
+++ b/ramalama/stack.py
@@ -1,0 +1,183 @@
+import os
+import tempfile
+
+from ramalama.common import (
+    exec_cmd,
+    genname,
+    tagged_image,
+)
+from ramalama.engine import add_labels
+from ramalama.model import compute_serving_port
+from ramalama.model_factory import ModelFactory, New
+
+
+class Stack:
+    """Stack class"""
+
+    type = "Stack"
+
+    def __init__(self, args):
+        self.args = args
+        self.name = args.name if hasattr(args, "name") and args.name else genname()
+        if os.path.basename(args.engine) != "podman":
+            raise ValueError("llama-stack requires use of the Podman container engine")
+        self.host = "127.0.0.1"
+        model = ModelFactory(args.MODEL, args)
+        self.model = model.prune_model_input()
+        model = New(args.MODEL, args)
+        self.model_type = model.type
+        self.model_path = model.get_model_path(args)
+        self.model_port = str(int(self.args.port) + 1)
+        self.stack_image = tagged_image("quay.io/ramalama/llama-stack")
+        self.labels = ""
+
+    def add_label(self, label):
+        cleanlabel = label.replace("=", ": ", 1)
+        self.labels = f"{self.labels}\n        {cleanlabel}"
+
+    def generate(self):
+        add_labels(self.args, self.add_label)
+        volume_mounts = """
+        - mountPath: /mnt/models/model.file
+          name: model
+        - mountPath: /dev/dri
+          name: dri"""
+
+        if self.model_type == "OCI":
+            volume_mounts = """
+        - mountPath: /mnt/models
+          subPath: /models
+          name: model
+        - mountPath: /dev/dri
+          name: dri"""
+
+        volumes = f"""
+      - hostPath:
+          path: {self.model_path}
+        name: model
+      - hostPath:
+          path: /dev/dri
+        name: dri"""
+
+        llama_cmd = [
+            'llama-server',
+            '--port',
+            self.model_port,
+            '--model',
+            '/mnt/models/model.file',
+            '--alias',
+            self.model,
+            '--ctx-size',
+            self.args.context,
+            '--temp',
+            self.args.temp,
+            '--jinja',
+            '--cache-reuse',
+            '256',
+            '-v',
+            '--threads',
+            self.args.threads,
+            '--host',
+            self.host,
+        ]
+
+        security = """
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - CAP_CHOWN
+            - CAP_FOWNER
+            - CAP_FSETID
+            - CAP_KILL
+            - CAP_NET_BIND_SERVICE
+            - CAP_SETFCAP
+            - CAP_SETGID
+            - CAP_SETPCAP
+            - CAP_SETUID
+            - CAP_SYS_CHROOT
+            add:
+            - CAP_DAC_OVERRIDE
+          seLinuxOptions:
+            type: spc_t"""
+
+        self.stack_yaml = f"""
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: {self.name}
+  labels:
+    app: {self.name}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {self.name}
+  template:
+    metadata:
+      labels:
+        ai.ramalama: ""
+        app: {self.name}{self.labels}
+    spec:
+      containers:
+      - name: model-server
+        image: {self.args.image}
+        command: ["/usr/libexec/ramalama/ramalama-serve-core"]
+        args: {llama_cmd}\
+        {security}
+        volumeMounts:{volume_mounts}
+      - name: llama-stack
+        image: {self.stack_image}
+        args:
+        - /bin/sh
+        - -c
+        - llama stack run --image-type venv /etc/ramalama/ramalama-run.yaml
+        env:
+        - name: RAMALAMA_URL
+          value: http://127.0.0.1:{self.model_port}
+        - name: INFERENCE_MODEL
+          value: {self.model}\
+        {security}
+        ports:
+        - containerPort: 8321
+          hostPort: {self.args.port}
+      volumes:{volumes}"""
+        return self.stack_yaml
+
+    def serve(self):
+        self.args.port = compute_serving_port(self.args, quiet=self.args.generate)
+        yaml = self.generate()
+        if self.args.dryrun:
+            print(yaml)
+            return
+        yaml_file = tempfile.NamedTemporaryFile(prefix='RamaLama_', delete=not self.args.debug)
+        with open(yaml_file.name, 'w') as c:
+            c.write(yaml)
+            c.flush()
+
+        exec_args = [
+            self.args.engine,
+            "kube",
+            "play",
+            "--replace",
+        ]
+        if not self.args.detach:
+            exec_args.append("--wait")
+
+        exec_args.append(yaml_file.name)
+        exec_cmd(exec_args)
+
+    def stop(self):
+        yaml_file = tempfile.NamedTemporaryFile(prefix='RamaLama_', delete=not self.args.debug)
+        with open(yaml_file.name, 'w') as c:
+            c.write(self.generate())
+            c.flush()
+
+        exec_args = [
+            self.args.engine,
+            "kube",
+            "down",
+            yaml_file.name,
+        ]
+
+        exec_cmd(exec_args)

--- a/test/system/040-serve.bats
+++ b/test/system/040-serve.bats
@@ -11,7 +11,6 @@ verify_begin=".*run --rm"
 
     if is_container; then
         run_ramalama -q --dryrun serve ${model}
-        assert "$output" =~ "serving on port .*"
         is "$output" "${verify_begin}.*" "dryrun correct"
         is "$output" ".*--name ramalama_.*" "dryrun correct"
         is "$output" ".*${model}" "verify model name"
@@ -83,7 +82,6 @@ verify_begin=".*run --rm"
     assert "$output" =~ "No closing quotation" "error for improperly quoted runtime arguments"
 
     run_ramalama 1 serve MODEL
-    assert "$output" =~ "serving on port .*"
     assert "$output" =~ "Error: Manifest for MODEL:latest was not found in the Ollama registry"
 }
 

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -55,6 +55,7 @@ def test_load_config_from_env(env, config, expected):
         (
             {},
             {
+                "api": "none",
                 "nocontainer": False,
                 "carimage": "registry.access.redhat.com/ubi9-micro:latest",
                 "container": True,
@@ -86,12 +87,14 @@ def test_load_config_from_env(env, config, expected):
         ),
         (
             {
+                "api": "llama-stack",
                 "nocontainer": True,
                 "images": {
                     "HIP_VISIBLE_DEVICES": "quay.io/repo/rocm",
                 },
             },
             {
+                "api": "llama-stack",
                 "nocontainer": True,
                 "carimage": "registry.access.redhat.com/ubi9-micro:latest",
                 "container": True,

--- a/test/unit/test_engine.py
+++ b/test/unit/test_engine.py
@@ -2,7 +2,7 @@ import unittest
 from argparse import Namespace
 from unittest.mock import patch
 
-from ramalama.engine import Engine, containers, dry_run, images, stop_container
+from ramalama.engine import Engine, containers, dry_run, images
 
 
 class TestEngine(unittest.TestCase):
@@ -84,12 +84,6 @@ class TestEngine(unittest.TestCase):
         result = containers(args)
         self.assertEqual(result, ["container1", "container2"])
         mock_run_cmd.assert_called_once()
-
-    @patch('ramalama.engine.run_cmd')
-    def test_stop_container(self, mock_run_cmd):
-        args = Namespace(engine="podman", debug=False, ignore=False)
-        stop_container(args, "test-container")
-        mock_run_cmd.assert_called_with(["podman", "stop", "-t=0", "test-container"], ignore_stderr=False)
 
     def test_dry_run(self):
         with patch('sys.stdout') as mock_stdout:

--- a/test/unit/test_model.py
+++ b/test/unit/test_model.py
@@ -1,4 +1,5 @@
 import socket
+from argparse import Namespace
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
@@ -114,6 +115,7 @@ def test_extract_model_identifiers(model_input: str, expected_name: str, expecte
 def test_compute_serving_port(
     inputPort: str, expectedRandomizedResult: list, expectedRandomPortsAvl: list, expectedOutput: str, expectedErr
 ):
+    args = Namespace(port=inputPort, debug=False, api="")
     mock_socket = socket.socket
     mock_socket.bind = MagicMock(side_effect=expectedRandomPortsAvl)
     mock_compute_ports = Mock(return_value=expectedRandomizedResult)
@@ -122,8 +124,8 @@ def test_compute_serving_port(
         with patch('socket.socket', mock_socket):
             if expectedErr:
                 with pytest.raises(expectedErr):
-                    outputPort = compute_serving_port(inputPort, False)
+                    outputPort = compute_serving_port(args, False)
                     assert outputPort == expectedOutput
             else:
-                outputPort = compute_serving_port(inputPort, False)
+                outputPort = compute_serving_port(args, False)
                 assert outputPort == expectedOutput


### PR DESCRIPTION
Add new option --api which allows users to specify the API Server either llama-stack or none.  With None, we just generate a service with serve command. With `--api llama-stack`, RamaLama will generate an API Server listening on port 8321 and a openai server listening on port 8080.

## Summary by Sourcery

Add support for a unified API layer with a new --api option, implement llama-stack mode via a Stack class that generates and deploys a Kubernetes pod stack, refactor engine command helpers and label handling, update compute_serving_port and model_factory helpers, and refresh documentation and tests accordingly

New Features:
- Add --api option with choices llama-stack or none to unify API layer handling
- Implement llama-stack mode to generate and deploy a multi-container Kubernetes stack for API serving

Enhancements:
- Refactor engine label handling into a generic add_labels helper and simplify container manager commands (inspect, stop_container, container_connection)
- Refactor compute_serving_port to accept args, respect the api option, and display appropriate REST API endpoints
- Introduce New and Serve helpers in model_factory for consistent model instantiation

Documentation:
- Document the new api option in ramalama.conf and update CLI manpages for run and serve commands

Tests:
- Add tests for compute_serving_port behavior with args and api settings and remove outdated stop_container test
- Update config loading tests to include default and overridden api values