### PR TITLE
Multimodal/vision support

### DIFF
--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -25,6 +25,7 @@ logging.basicConfig(level=logging.WARNING, format="%(asctime)s - %(levelname)s -
 
 MNT_DIR = "/mnt/models"
 MNT_FILE = f"{MNT_DIR}/model.file"
+MNT_MMPROJ_FILE = f"{MNT_DIR}/mmproj.file"
 MNT_FILE_DRAFT = f"{MNT_DIR}/draft_model.file"
 MNT_CHAT_TEMPLATE_FILE = f"{MNT_DIR}/chat_template.file"
 

--- a/ramalama/model_store.py
+++ b/ramalama/model_store.py
@@ -25,6 +25,7 @@ class SnapshotFileType(IntEnum):
     Model = 1
     ChatTemplate = 2
     Other = 3
+    Mmproj = 4
 
 
 class SnapshotFile:
@@ -83,28 +84,35 @@ class LocalSnapshotFile(SnapshotFile):
 def validate_snapshot_files(snapshot_files: list[SnapshotFile]):
     model_files = []
     chat_template_files = []
+    mmproj_files = []
     for file in snapshot_files:
         if file.type == SnapshotFileType.Model:
             model_files.append(file)
         if file.type == SnapshotFileType.ChatTemplate:
             chat_template_files.append(file)
+        if file.type == SnapshotFileType.Mmproj:
+            mmproj_files.append(file)
 
     if len(model_files) > 1:
         raise Exception(f"Only one model file supported, got {len(model_files)}: {model_files}")
     if len(chat_template_files) > 1:
         raise Exception(f"Only one chat template file supported, got {len(chat_template_files)}: {chat_template_files}")
+    if len(mmproj_files) > 1:
+        raise Exception(f"Only one mmproj file supported, got {len(mmproj_files)}: {mmproj_files}")
 
 
 class RefFile:
     SEP = "---"
     MODEL_SUFFIX = "model"
     CHAT_TEMPLATE_SUFFIX = "chat"
+    MMPROJ_SUFFIX = "mmproj"
 
     def __init__(self):
         self.hash: str = ""
         self.filenames: list[str] = []
         self.model_name: str = ""
         self.chat_template_name: str = ""
+        self.mmproj_name: str = ""
         self._path: str = ""
 
     @property
@@ -129,6 +137,8 @@ class RefFile:
                     ref_file.model_name = parts[0]
                 if parts[1] == RefFile.CHAT_TEMPLATE_SUFFIX:
                     ref_file.chat_template_name = parts[0]
+                if parts[1] == RefFile.MMPROJ_SUFFIX:
+                    ref_file.mmproj_name = parts[0]
 
                 filename = file.readline().strip()
         return ref_file
@@ -141,6 +151,8 @@ class RefFile:
                 self.chat_template_name = ""
             if self.model_name == name:
                 self.model_name = ""
+            if self.mmproj_name == name:
+                self.mmproj_name = ""
 
     def serialize(self) -> str:
         lines = [self.hash]
@@ -150,6 +162,8 @@ class RefFile:
                 line = line + RefFile.MODEL_SUFFIX
             if filename == self.chat_template_name:
                 line = line + RefFile.CHAT_TEMPLATE_SUFFIX
+            if filename == self.mmproj_name:
+                line = line + RefFile.MMPROJ_SUFFIX
             lines.append(line)
         return "\n".join(lines)
 
@@ -407,6 +421,8 @@ class ModelStore:
                     ref_file.model_name = file.name
                 if file.type == SnapshotFileType.ChatTemplate:
                     ref_file.chat_template_name = file.name
+                if file.type == SnapshotFileType.Mmproj:
+                    ref_file.mmproj_name = file.name
             ref_file.write_to_file()
 
         snapshot_directory = self.get_snapshot_directory(snapshot_hash)
@@ -524,6 +540,8 @@ class ModelStore:
                 ref_file.model_name = file.name
             if file.type == SnapshotFileType.ChatTemplate:
                 ref_file.chat_template_name = file.name
+            if file.type == SnapshotFileType.Mmproj:
+                ref_file.mmproj_name = file.name
 
         ref_file.write_to_file()
 

--- a/ramalama/modelscope.py
+++ b/ramalama/modelscope.py
@@ -268,7 +268,7 @@ class ModelScope(Model):
             if not args.quiet:
                 self.print_pull_message(f"ms://{name}:{tag}")
 
-            ms_repo = ModelScopeRepository(name, organization, tag)
+            ms_repo = ModelScopeRepository(name, organization)
             snapshot_hash = ms_repo.model_hash
             files = ms_repo.get_file_list(cached_files)
             self.store.new_snapshot(tag, snapshot_hash, files)


### PR DESCRIPTION
Add support for pulling hf repos vs individual models, replicating the `llama.cpp -hf <model>` logic.
Add support for mmproj file in model store snapshot. If an mmproj file is available pass it on the llama.cpp command line. Structure classes to continue support for modelscope as ModelScopeRepository inherits from HuggingfaceRepository.

Example usage:
  $ ramalama serve huggingface://ggml-org/gemma-3-4b-it-GGUF
    ...
Open webui, upload a picture, ask for a description.

Fixes: #1405

## Summary by Sourcery

Add multimodal vision support by enabling pulling full Huggingface repos, extracting both model and mmproj artifacts into snapshots, and extending the serve workflow to mount and pass mmproj files to the llama-server.

New Features:
- Support pulling complete Huggingface repositories via llama.cpp -hf logic
- Include .mmproj files in model snapshots and serve them to the llama-server

Enhancements:
- Refactor repository handling by introducing HuggingfaceRepositoryModel and consolidating metadata fetching for Huggingface and ModelScope
- Add a new Mmproj snapshot file type and extend the snapshot store to validate and include mmproj artifacts
- Update serve command to mount mmproj files and pass a --mmproj flag when available
- Infer repository class from URI style and unify snapshot hash determination