### PR TITLE
Normalize hf repo quant/tag

### DIFF
--- a/ramalama/huggingface.py
+++ b/ramalama/huggingface.py
@@ -245,6 +245,14 @@ class Huggingface(Model):
                 pass
         raise KeyError(f"Failed to pull model: {str(previous_exception)}")
 
+    def extract_model_identifiers(self):
+        model_name, model_tag, model_organization = super().extract_model_identifiers()
+        if '/' not in model_organization:
+            # if it is a repo then normalize the case insensitive quantization tag
+            if model_tag != "latest":
+                model_tag = model_tag.upper()
+        return model_name, model_tag, model_organization
+
     def pull(self, args):
         if self.store is not None:
             return self._pull_with_model_store(args)


### PR DESCRIPTION
The huggingface repo tag refers to the quantization and is case insensitive. Normalize this to uppercase.

Fixes: #1421