### PR TITLE
Bump llama.cpp to fix rocm bug

### DIFF
--- a/container-images/scripts/build_llama_and_whisper.sh
+++ b/container-images/scripts/build_llama_and_whisper.sh
@@ -262,7 +262,7 @@ clone_and_build_whisper_cpp() {
 }
 
 clone_and_build_llama_cpp() {
-  local llama_cpp_sha="d8919424f1dee7dc1638349c616f2ef5d2ee16fb"
+  local llama_cpp_sha="e298d2fbd082a52c0f6ed02729f94e9bf630cf17"
   local install_prefix
   install_prefix=$(set_install_prefix)
   git clone https://github.com/ggml-org/llama.cpp


### PR DESCRIPTION
Last bump unfortunately bring a bug to rocm/hip support bumping the version to include the fix.

[0] https://github.com/ggml-org/llama.cpp/issues/13437

## Summary by Sourcery

Bump llama.cpp revision in the build script to include the upstream ROCm/HIP support bug fix.

Bug Fixes:
- Pull in upstream fix for ROCm/HIP support by updating llama.cpp commit SHA

Build:
- Update llama.cpp SHA in build_llama_and_whisper.sh to the fixed version