### PR TITLE
Remove unused parameters from ollama_repo_utils.py

### DIFF
--- a/ramalama/ollama_repo_utils.py
+++ b/ramalama/ollama_repo_utils.py
@@ -26,7 +26,7 @@ def fetch_manifest_data(registry_head, model_tag, accept):
     return manifest_data
 
 
-def pull_config_blob(repos, accept, registry_head, manifest_data, show_progress):
+def pull_config_blob(repos, accept, registry_head, manifest_data):
     """
     Pull configuration blob for a model.
 
@@ -52,7 +52,6 @@ def pull_blob(
     layer_digest,
     accept,
     registry_head,
-    models,
     model_name,
     model_tag,
     model_path,
@@ -109,7 +108,6 @@ def repo_pull(
     model_tag,
     models,
     model_path,
-    model,
     show_progress,
     media_type="application/vnd.ollama.image.model",
     in_existing_cache_fn=None,
@@ -135,7 +133,7 @@ def repo_pull(
     """
     os.makedirs(models, exist_ok=True)
     manifest_data = fetch_manifest_data(registry_head, model_tag, accept)
-    pull_config_blob(repos, accept, registry_head, manifest_data, show_progress)
+    pull_config_blob(repos, accept, registry_head, manifest_data)
 
     for layer in manifest_data["layers"]:
         layer_digest = layer["digest"]
@@ -147,7 +145,6 @@ def repo_pull(
             layer_digest,
             accept,
             registry_head,
-            models,
             model_name,
             model_tag,
             model_path,


### PR DESCRIPTION
## Summary by Sourcery

Simplify function signatures by removing unused parameters from pull_config_blob, pull_blob, and repo_pull and update related calls to match the new signatures

Enhancements:
- Remove unused show_progress parameter from pull_config_blob
- Remove unused models parameter from pull_blob
- Remove unused model parameter from repo_pull
- Update calls to pull_config_blob and pull_blob to reflect their new signatures