### PR TITLE
Build a Vulkan image

### DIFF
--- a/container-images/scripts/build_llama_and_whisper.sh
+++ b/container-images/scripts/build_llama_and_whisper.sh
@@ -161,6 +161,8 @@ dnf_install() {
     dnf_install_intel_gpu
   elif [ "$containerfile" = "cann" ]; then
     dnf_install_cann
+  elif [ "$containerfile" = "vulkan" ]; then
+      dnf_install_mesa # we use vulkan via mesa
   fi
 
   dnf_install_ffmpeg

--- a/container-images/vulkan/Containerfile
+++ b/container-images/vulkan/Containerfile
@@ -1,0 +1,4 @@
+FROM registry.access.redhat.com/ubi9/ubi:9.6-1747219013
+
+COPY --chmod=755 ../scripts /usr/bin
+RUN build_llama_and_whisper.sh "vulkan"


### PR DESCRIPTION
This PR adds the `ggml-vulkan` backend image to the images built by Ramalama, until this backend becomes part of the default image.

Build tested locally with the Fedora base image (I don't access the UBI image on this machine)

## Summary by Sourcery

Build:
- Add Containerfile for the ggml-vulkan backend image based on Fedora 42