### PR TITLE
fix(run): Ensure 'run' subcommand works with host proxy settings.

### DIFF
--- a/libexec/ramalama/ramalama-run-core
+++ b/libexec/ramalama/ramalama-run-core
@@ -60,6 +60,23 @@ def initialize_args():
 
 
 def main(args):
+    # This logic ensures that for internal HTTP calls (to 127.0.0.1), the system's proxy settings are bypassed.
+    no_proxy_essentials = {"localhost", "127.0.0.1"}
+
+    current_no_proxy_upper = os.environ.get('NO_PROXY', '')
+    existing_parts_upper = set(part.strip() for part in current_no_proxy_upper.split(',') if part.strip())
+    final_no_proxy_parts_upper = existing_parts_upper.union(no_proxy_essentials)
+    os.environ['NO_PROXY'] = ",".join(sorted(list(final_no_proxy_parts_upper)))
+
+    current_no_proxy_lower = os.environ.get('no_proxy', '')
+    existing_parts_lower = set(part.strip() for part in current_no_proxy_lower.split(',') if part.strip())
+    final_no_proxy_parts_lower = existing_parts_lower.union(no_proxy_essentials)
+    os.environ['no_proxy'] = ",".join(sorted(list(final_no_proxy_parts_lower)))
+
+    for proxy_var in ['http_proxy', 'https_proxy', 'HTTP_PROXY', 'HTTPS_PROXY']:
+        if proxy_var in os.environ:
+            del os.environ[proxy_var]
+
     sys.path.append('./')
     from ramalama.cli import serve_cli
     from ramalama.common import exec_cmd


### PR DESCRIPTION
When 'ramalama run' is used with '--network none', it was inheriting host proxy environment variables. This caused the interanl client to fail when connecting to the internal llama-server on 127.0.0.1, as it tried to route loopback traffic through the unreachable proxy.

This change modifies engine.py to:
- Correctly set NO_PROXY/no_proxy for localhost and 127.0.0.1.
- Explicitly unset http_proxy, https_proxy, HTTP_PROXY, and HTTPS_PROXY variables for the container when the 'run' subcommand is invoked.

This allows the internal client to connect directly to the internal server, resolving the connection error.

Fixes: #1414

**Testings before the change:**
```
$ env|grep "proxy"
no_proxy=localhost,127.0.0.0/8,::1
https_proxy=http://proxy4.squi-001.prod.rdu2.dc.redhat.com:3128/
HTTPS_PROXY=http://proxy4.squi-001.prod.rdu2.dc.redhat.com:3128/
HTTP_PROXY=http://proxy4.squi-001.prod.rdu2.dc.redhat.com:3128/
http_proxy=http://proxy4.squi-001.prod.rdu2.dc.redhat.com:3128/

$ ramalama run granite3-moe
🦭 > how are you?
Error: could not connect to: http://127.0.0.1:8080/v1/chat/completions

```

**Testings after the change:**
```
$ env|grep "proxy"
no_proxy=localhost,127.0.0.0/8,::1
https_proxy=http://proxy4.squi-001.prod.rdu2.dc.redhat.com:3128/
HTTPS_PROXY=http://proxy4.squi-001.prod.rdu2.dc.redhat.com:3128/
HTTP_PROXY=http://proxy4.squi-001.prod.rdu2.dc.redhat.com:3128/
http_proxy=http://proxy4.squi-001.prod.rdu2.dc.redhat.com:3128/

$ ramalama list
NAME                                      MODIFIED   SIZE     
ollama://granite3-moe/granite3-moe:latest 5 days ago 783.77 MB
ollama://tinyllama/tinyllama:latest       5 days ago 608.16 MB

$ ramalama run granite3-moe
🦭 > how are you?
I'm an artificial intelligence, so I don't have feelings, but I'm here and ready to assist you with any questions you have. How can I help you today?
🦭 > what is the longest river and highest montain in the world?
1. The longest river in the world is the Nile River, which runs through Africa. It is approximately 4,135 miles (6,650 kilometers) long.

2. The highest mountain in the world is Mount Everest. It is an extinct volcano located in the Himalayas on the border of Nepal and Tibet. It stands at an elevation of approximately 29,029 feet (8,848 meters) above sea level.
🦭 > 

$ ramalama serve granite3-moe
serving on port 8080
build: 5335 (d8919424) with cc (GCC) 11.5.0 20240719 (Red Hat 11.5.0-5) for x86_64-redhat-linux
system info: n_threads = 4, n_threads_batch = 4, total_threads = 8

system_info: n_threads = 4 (n_threads_batch = 4) / 8 | CPU : SSE3 = 1 | SSSE3 = 1 | AVX = 1 | AVX2 = 1 | F16C = 1 | FMA = 1 | BMI2 = 1 | LLAMAFILE = 1 | OPENMP = 1 | AARCH64_REPACK = 1 | 

main: binding port with default address family
main: HTTP server is listening, hostname: 0.0.0.0, port: 8080, http threads: 7

```

## Summary by Sourcery

Ensure 'run' subcommand bypasses host proxy settings to allow internal client to connect to the local llama server

Bug Fixes:
- Prevent host proxy environment variables from interfering with internal loopback connections by unsetting http_proxy, https_proxy, HTTP_PROXY, and HTTPS_PROXY in the 'run' subcommand
- Extend NO_PROXY/no_proxy to include localhost and 127.0.0.1 for containers when 'run' is invoked

Enhancements:
- Include debug flag in the image pull step and emit a debug-only note if the pull command fails