### PR TITLE
Switch python3-ramalama to ramalama

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ On systems with Moore Threads GPUs, see [ramalama-musa](docs/ramalama-musa.7.md)
 ### Install on Fedora
 RamaLama is available in [Fedora 40](https://fedoraproject.org/) and later. To install it, run:
 ```
-sudo dnf install python3-ramalama
+sudo dnf install ramalama
 ```
 
 ### Install via PyPi

--- a/install.sh
+++ b/install.sh
@@ -143,7 +143,7 @@ main() {
   local sudo=""
   check_platform
   if ! $local_install && [ -z "$BRANCH" ]; then
-    if available dnf && dnf_install "python3-ramalama"; then
+    if available dnf && dnf_install "ramalama"; then
       return 0
     fi
 

--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -3,4 +3,4 @@ discover:
     how: shell
 execute:
     how: tmt
-    script: rpm -qi python3-ramalama
+    script: rpm -qi ramalama


### PR DESCRIPTION
Because we are a python application rather than a python library, we have this option, it's more intuitive in general and puts us in line with `brew install ramalama`. We want to alias python3-ramalama.

## Summary by Sourcery

Alias python3-ramalama to ramalama across installation instructions and scripts

Enhancements:
- Modify install script to install the `ramalama` package name with dnf

Documentation:
- Update README install commands to use `ramalama` instead of `python3-ramalama`