### PR TITLE
Turn on GGML_VULKAN by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ RamaLama eliminates the need to configure the host system by instead pulling a c
 |  CPU, Apple             | quay.io/ramalama/ramalama  |
 |  HIP_VISIBLE_DEVICES    | quay.io/ramalama/rocm      |
 |  CUDA_VISIBLE_DEVICES   | quay.io/ramalama/cuda      |
-|  ASAHI_VISIBLE_DEVICES  | quay.io/ramalama/asahi     |
+|  ASAHI_VISIBLE_DEVICES  | quay.io/ramalama/ramalama  |
 |  INTEL_VISIBLE_DEVICES  | quay.io/ramalama/intel-gpu |
 |  ASCEND_VISIBLE_DEVICES | quay.io/ramalama/cann      |
 |  MUSA_VISIBLE_DEVICES   | quay.io/ramalama/musa      |

--- a/container-images/asahi/Containerfile
+++ b/container-images/asahi/Containerfile
@@ -1,6 +1,0 @@
-FROM fedora:42
-
-ENV ASAHI_VISIBLE_DEVICES 1
-COPY --chmod=755 ../scripts /usr/bin
-RUN build_llama_and_whisper.sh "asahi"
-

--- a/container-images/scripts/build_llama_and_whisper.sh
+++ b/container-images/scripts/build_llama_and_whisper.sh
@@ -32,12 +32,6 @@ dnf_remove() {
   dnf -y clean all
 }
 
-dnf_install_asahi() {
-  dnf copr enable -y @asahi/fedora-remix-branding
-  dnf install -y asahi-repos
-  dnf install -y mesa-vulkan-drivers "${vulkan_rpms[@]}"
-}
-
 dnf_install_cuda() {
   dnf install -y gcc-toolset-12
   # shellcheck disable=SC1091
@@ -153,8 +147,6 @@ dnf_install() {
     fi
   elif [[ "$containerfile" =~ rocm* ]]; then
     dnf_install_rocm
-  elif [ "$containerfile" = "asahi" ]; then
-    dnf_install_asahi
   elif [ "$containerfile" = "cuda" ]; then
     dnf_install_cuda
   elif [ "$containerfile" = "intel-gpu" ]; then
@@ -226,9 +218,6 @@ configure_common_flags() {
       ;;
     cuda)
       common_flags+=("-DGGML_CUDA=ON" "-DCMAKE_EXE_LINKER_FLAGS=-Wl,--allow-shlib-undefined" "-DCMAKE_CUDA_FLAGS=\"-U__ARM_NEON -U__ARM_NEON__\"")
-      ;;
-    vulkan | asahi)
-      common_flags+=("-DGGML_VULKAN=1")
       ;;
     intel-gpu)
       common_flags+=("-DGGML_SYCL=ON" "-DCMAKE_C_COMPILER=icx" "-DCMAKE_CXX_COMPILER=icpx")
@@ -317,7 +306,7 @@ main() {
   case "$containerfile" in
     ramalama)
       if [ "$uname_m" = "x86_64" ] || [ "$uname_m" = "aarch64" ]; then
-        common_flags+=("-DGGML_KOMPUTE=ON" "-DKOMPUTE_OPT_DISABLE_VULKAN_VERSION_CHECK=ON")
+        common_flags+=("-DGGML_VULKAN=ON")
       else
         common_flags+=("-DGGML_BLAS=ON" "-DGGML_BLAS_VENDOR=OpenBLAS")
       fi

--- a/docs/ramalama.1.md
+++ b/docs/ramalama.1.md
@@ -30,7 +30,7 @@ Accelerated images:
 |  CPU, Apple             | quay.io/ramalama/ramalama  |
 |  HIP_VISIBLE_DEVICES    | quay.io/ramalama/rocm      |
 |  CUDA_VISIBLE_DEVICES   | quay.io/ramalama/cuda      |
-|  ASAHI_VISIBLE_DEVICES  | quay.io/ramalama/asahi     |
+|  ASAHI_VISIBLE_DEVICES  | quay.io/ramalama/ramalama     |
 |  INTEL_VISIBLE_DEVICES  | quay.io/ramalama/intel-gpu |
 |  ASCEND_VISIBLE_DEVICES | quay.io/ramalama/cann      |
 |  MUSA_VISIBLE_DEVICES   | quay.io/ramalama/musa      |

--- a/docs/ramalama.conf
+++ b/docs/ramalama.conf
@@ -49,7 +49,7 @@
 #[ramalama.images]
 #HIP_VISIBLE_DEVICES="quay.io/ramalama/rocm"
 #CUDA_VISIBLE_DEVICES="quay.io/ramalama/cuda"
-#ASAHI_VISIBLE_DEVICES="quay.io/ramalama/asahi"
+#ASAHI_VISIBLE_DEVICES="quay.io/ramalama/ramalama"
 #INTEL_VISIBLE_DEVICES="quay.io/ramalama/intel-gpu"
 #ASCEND_VISIBLE_DEVICES="quay.io/ramalama/cann"
 #MUSA_VISIBLE_DEVICES="quay.io/ramalama/musa"

--- a/docs/ramalama.conf.5.md
+++ b/docs/ramalama.conf.5.md
@@ -97,7 +97,7 @@ RAMALAMA_IMAGE environment variable overrides this field.
 `[[ramalama.images]]`
   HIP_VISIBLE_DEVICES    = "quay.io/ramalama/rocm"
   CUDA_VISIBLE_DEVICES   = "quay.io/ramalama/cuda"
-  ASAHI_VISIBLE_DEVICES  = "quay.io/ramalama/asahi"
+  ASAHI_VISIBLE_DEVICES  = "quay.io/ramalama/ramalama"
   INTEL_VISIBLE_DEVICES  = "quay.io/ramalama/intel-gpu"
   ASCEND_VISIBLE_DEVICES = "quay.io/ramalama/cann"
   MUSA_VISIBLE_DEVICES   = "quay.io/ramalama/musa"

--- a/ramalama/config.py
+++ b/ramalama/config.py
@@ -81,7 +81,7 @@ def load_config_defaults(config: Dict[str, Any]):
     config.setdefault(
         'images',
         {
-            "ASAHI_VISIBLE_DEVICES": "quay.io/ramalama/asahi",
+            "ASAHI_VISIBLE_DEVICES": "quay.io/ramalama/ramalama",
             "ASCEND_VISIBLE_DEVICES": "quay.io/ramalama/cann",
             "CUDA_VISIBLE_DEVICES": "quay.io/ramalama/cuda",
             "HIP_VISIBLE_DEVICES": "quay.io/ramalama/rocm",

--- a/test/ci.sh
+++ b/test/ci.sh
@@ -36,7 +36,6 @@ version_checks() {
   local arg_llama_cpp
   arg_llama_cpp=$(get_arg_llama_cpp)
   grep "$arg_llama_cpp" container-images/cuda/Containerfile
-  grep "$arg_llama_cpp" container-images/asahi/Containerfile
 }
 
 check_packaging() {

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -62,7 +62,7 @@ def test_load_config_from_env(env, config, expected):
                 "env": [],
                 "image": "quay.io/ramalama/ramalama",
                 "images": {
-                    "ASAHI_VISIBLE_DEVICES": "quay.io/ramalama/asahi",
+                    "ASAHI_VISIBLE_DEVICES": "quay.io/ramalama/ramalama",
                     "ASCEND_VISIBLE_DEVICES": "quay.io/ramalama/cann",
                     "CUDA_VISIBLE_DEVICES": "quay.io/ramalama/cuda",
                     "HIP_VISIBLE_DEVICES": "quay.io/ramalama/rocm",


### PR DESCRIPTION
Also consolidate asahi image with ramalama image.

## Summary by Sourcery

Turn on GGML_VULKAN by default in the ramalama image and consolidate the asahi backend into it, removing all separate asahi-specific build steps, CI checks, and documentation references.

Enhancements:
- Enable GGML_VULKAN by default in the ramalama container, replacing previous asahi- and vulkan-specific flags

Build:
- Remove the separate asahi installation function and delete the standalone asahi Containerfile

CI:
- Remove asahi-specific checks from the CI test script

Documentation:
- Update README, man pages, and sample configs to point ASAHI_VISIBLE_DEVICES at quay.io/ramalama/ramalama

Tests:
- Adjust unit tests to expect ASAHI_VISIBLE_DEVICES set to quay.io/ramalama/ramalama