### PR TITLE
Support Moore Threads GPU #3

### DIFF
--- a/container-images/musa/Containerfile
+++ b/container-images/musa/Containerfile
@@ -1,13 +1,13 @@
 ARG VERSION=rc4.0.1
 ARG UBUNTU_VERSION=22.04
 # Base image with MUSA for compilation
-FROM docker.io/mthreads/musa:${VERSION}-devel-ubuntu${UBUNTU_VERSION} AS builder
+FROM docker.io/mthreads/musa:${VERSION}-mudnn-devel-ubuntu${UBUNTU_VERSION} AS builder
 
 COPY --chmod=755 ../scripts /usr/bin
 RUN build_llama_and_whisper.sh "musa"
 
 # Final runtime image
-FROM docker.io/mthreads/musa:${VERSION}-runtime-ubuntu${UBUNTU_VERSION}
+FROM docker.io/mthreads/musa:${VERSION}-mudnn-runtime-ubuntu${UBUNTU_VERSION}
 
 # Copy the entire installation directory from the builder
 COPY --from=builder /tmp/install /usr


### PR DESCRIPTION
This PR updates base images (MUSA backend now requires MUDNN in llama.cpp) for Moore Threads GPUs (https://github.com/containers/ramalama/issues/1390) in ramalama.

### Testing Done

- [x] `IMAGE=musa make build`

## Summary by Sourcery

Enhancements:
- Switch Musa Containerfile base images to MUDNN-enabled 'mudnn-devel' and 'mudnn-runtime' tags