### PR TITLE
fix: update references to Python 3.8 to Python 3.11

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ This section describes how to make a contribution to RamaLama.
 
 ### Prepare your environment
 
-The minimum version of Python required to use RamaLama is Python 3.8
+The minimum version of Python required to use RamaLama is Python 3.11
 
 ### Fork and clone RamaLama
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "ramalama"
 version = "0.8.5"
 description = "RamaLama is a command line tool for working with AI LLM models."
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.11"
 license = { file = "LICENSE" }
 keywords = ["ramalama", "llama", "AI"]
 dependencies = [


### PR DESCRIPTION
followup on https://github.com/containers/ramalama/pull/1420

prev commit made Python 3.11 the min version for ramalama, but not all references in the project were updated to reflect this