### PR TITLE
fix(gguf_parser): fix big endian model parsing

### DIFF
--- a/container-images/scripts/build_rag.sh
+++ b/container-images/scripts/build_rag.sh
@@ -61,6 +61,8 @@ main() {
     # shellcheck disable=SC1091
     source /etc/os-release
 
+    local arch
+    arch="$(uname -m)"
     local gpu="${1-cpu}"
     local python
     python=$(python_version)
@@ -80,8 +82,14 @@ main() {
 
     update_python
     to_gguf
-    rag
-    docling "${gpu}"
+
+    # Temporarily disable build for s390x
+    if [[ "$arch" != "s390x" ]]; then
+        rag
+        docling "${gpu}"
+    else
+        echo "skipping rag and docling build for s390x architecture: build temporarily disabled."
+    fi
 
     if available dnf; then
         dnf -y clean all

--- a/ramalama/endian.py
+++ b/ramalama/endian.py
@@ -1,0 +1,6 @@
+from enum import IntEnum
+
+
+class GGUFEndian(IntEnum):
+    LITTLE = 0
+    BIG = 1

--- a/ramalama/model_inspect.py
+++ b/ramalama/model_inspect.py
@@ -4,6 +4,8 @@ import sys
 from dataclasses import dataclass
 from typing import Any, Dict
 
+from ramalama.endian import GGUFEndian
+
 
 def get_terminal_width():
     if sys.stdout.isatty():
@@ -60,7 +62,7 @@ class GGUFModelInfo(ModelInfoBase):
         Path: str,
         metadata: Dict[str, Any],
         tensors: list[Tensor],
-        uses_little_endian: bool,
+        endianness: GGUFEndian,
     ):
         super().__init__(Name, Registry, Path)
 
@@ -68,7 +70,7 @@ class GGUFModelInfo(ModelInfoBase):
         self.Version = GGUFModelInfo.VERSION
         self.Metadata: Dict[str, Any] = metadata
         self.Tensors: list[Tensor] = tensors
-        self.LittleEndian: bool = uses_little_endian
+        self.Endianness: GGUFEndian = endianness
 
     def get_chat_template(self) -> str:
         return self.Metadata.get("chat_template", "")
@@ -80,7 +82,7 @@ class GGUFModelInfo(ModelInfoBase):
         ret = super().serialize()
         ret = ret + adjust_new_line(f"   Format: {GGUFModelInfo.MAGIC_NUMBER}")
         ret = ret + adjust_new_line(f"   Version: {GGUFModelInfo.VERSION}")
-        ret = ret + adjust_new_line(f"   Endianness: {'little' if self.LittleEndian else 'big'}")
+        ret = ret + adjust_new_line(f"   Endianness: {'little' if self.Endianness == GGUFEndian.LITTLE else 'big'}")
         metadata_header = "   Metadata: "
         if not all:
             metadata_header = metadata_header + f"{len(self.Metadata)} entries"


### PR DESCRIPTION
This PR fixes the `gguf_parser.py` code to properly process Big-Endian models on Big-Endian systems. Please note that while this PR fixes the GGUF parsing, it does not do any byteswapping for the actual model file; Little-Endian models will only work on Little-Endian systems, and likewise for Big-Endian.

A future PR will be created for byteswapping the model file on save.

### Verification
To ensure that this implementation did not break anything, this PR has been tested on the following machines:
* Tested IBM z15 Mainframe (16 IFLs / 160 GB RAIM / NOSMT / LPAR)
* Tested x86 server (16 vCPUs / 32 GB RAM / SMT)
* Kindly request additional systems to be tested for this PR

> [!NOTE]
> Tests were conducted on an IBM z15 Mainframe with 16 IFLs (cores) and 160 GB Memory on an LPAR.

Please review this pull request and consider merging into the main repository. Thank you!

## Summary by Sourcery

Fix GGUF parser to detect and process both little- and big-endian models correctly and adjust the container build script to skip rag and docling steps on s390x architectures

Bug Fixes:
- Add GGUFEndian enum and refactor read methods to use endianness indicator for proper big-endian model parsing

Enhancements:
- Detect model endianness by peeking and backtracking when reading the GGUF version header

Build:
- Extend build_rag.sh to detect s390x architecture and skip rag and docling steps on it