### PR TITLE
Add options to force preferred IP family.

### DIFF
--- a/docs/ramalama.1.md
+++ b/docs/ramalama.1.md
@@ -173,6 +173,12 @@ The default can be overridden in the ramalama.conf file.
 Use the recently introduced model store for organizing and storing models.
 It adds support for model versioning and multiple files such as chat templates. In addition, it improves performance through optimized caching and fast model access, enhanced reliability, and simplified maintenance thanks to a centralized, structured directory layout.
 
+#### **--ipv4**
+Use IPv4 only connection.
+
+#### **--ipv6**
+Use IPv6 only connection.
+
 ## COMMANDS
 
 | Command                                           | Description                                                |


### PR DESCRIPTION
Add option to force either IPv4 or IPv6 as preferred way of communation with model store. It is useful when user would like to overwrite OS family preference for example for testing. Fixes #1443.

## Summary by Sourcery

Add CLI flags to force preferred IP family for model store connections.

New Features:
- Add mutually exclusive --ipv4 and --ipv6 options to force IPv4 or IPv6 connections respectively.

Documentation:
- Document the new --ipv4 and --ipv6 flags in the command-line manual.