### PR TITLE
Choice could be not set and should not be used

### DIFF
--- a/libexec/ramalama/ramalama-client-core
+++ b/libexec/ramalama/ramalama-client-core
@@ -45,8 +45,9 @@ def res(response, color):
             else:
                 continue
 
-            print(f"{color_yellow}{choice}{color_default}", end="", flush=True)
-            assistant_response += choice
+            if choice:
+                print(f"{color_yellow}{choice}{color_default}", end="", flush=True)
+                assistant_response += choice
 
     print("")
     return assistant_response


### PR DESCRIPTION
Fixes: https://github.com/containers/ramalama/issues/1445

## Summary by Sourcery

Prevent using unset choice in the client core by adding validation and error handling for missing choices

Bug Fixes:
- Add checks to ensure a choice is set before it is used
- Emit an appropriate error when attempting to use an unset choice and exit with failure