### PR TITLE
Switch default ramalama image build to use VULKAN

### DIFF
--- a/container-images/scripts/build_llama_and_whisper.sh
+++ b/container-images/scripts/build_llama_and_whisper.sh
@@ -317,7 +317,7 @@ main() {
   case "$containerfile" in
   ramalama)
     if [ "$uname_m" = "x86_64" ] || [ "$uname_m" = "aarch64" ]; then
-      common_flags+=("-DGGML_KOMPUTE=ON" "-DKOMPUTE_OPT_DISABLE_VULKAN_VERSION_CHECK=ON")
+      common_flags+=("-DGGML_VULKAN=ON")
     else
       common_flags+=("-DGGML_BLAS=ON" "-DGGML_BLAS_VENDOR=OpenBLAS")
     fi


### PR DESCRIPTION
podman 5.5 and Podman Desktop have been updated, this should give us better performance then previous versions on MAC.

## Summary by Sourcery

Enable Vulkan support in ramalama container builds to simplify flags and improve performance

Enhancements:
- Replace GGML Kompute backend with Vulkan in ramalama build configuration

Build:
- Update build_llama_and_whisper.sh to use "-DGGML_VULKAN=ON" for x86_64 and aarch64 architectures