### PR TITLE
feat(model_store): prevent model endianness mismatch on download

### DIFF
--- a/ramalama/endian.py
+++ b/ramalama/endian.py
@@ -4,3 +4,13 @@ from enum import IntEnum
 class GGUFEndian(IntEnum):
     LITTLE = 0
     BIG = 1
+
+    little = LITTLE
+    big = BIG
+
+    def __str__(self):
+        return self.name
+
+
+class EndianMismatchError(Exception):
+    pass


### PR DESCRIPTION
At current when non-native endian models are downloaded, it does not check if the endianness matches the host system and passes through. When the non-native endian model is loaded, Llama.cpp or the backend server would load indefinitely and eventually crash with "Cannot connect to..." which is expected because the system does not know how to read the model.

We're putting this check in-place for now until we can get transparent byteswapping on save completed, just a temporary measure.

Tested on x86 and s390x, both working as intended.

## Summary by Sourcery

Enforce host-model endianness compatibility when downloading GGUF models by checking byte-order, removing mismatches, and raising an explicit error until transparent byteswapping is implemented, while updating the parser to handle endianness-aware reading.

New Features:
- Add optional endianness verification for downloaded GGUF models to prevent loading non-native byte-order files

Bug Fixes:
- Remove and error-out on mismatched-endian model downloads to avoid indefinite loads

Enhancements:
- Extend GGUF parser methods to read strings and numbers according to model endianness
- Add GGUFEndian enum enhancements with string conversion and define EndianMismatchError exception