### PR TITLE
Small logging improvements

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
 max-line-length = 120
 # E203,E221,E231 conflict with black formatting
-extend-ignore = E203,E221,E231,E702
+extend-ignore = E203,E221,E231,E702,F824

--- a/libexec/ramalama/ramalama-run-core
+++ b/libexec/ramalama/ramalama-run-core
@@ -54,7 +54,7 @@ def initialize_args():
 
     parser = initialize_parser()
     parsed_args = parser.parse_args()
-    port = get_available_port_if_any(False)
+    port = get_available_port_if_any()
 
     return parsed_args, port
 

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -24,6 +24,7 @@ import ramalama.rag
 from ramalama import engine
 from ramalama.common import accel_image, exec_cmd, get_accel, get_cmd_with_wrapper, perror
 from ramalama.config import CONFIG
+from ramalama.logger import configure_logger, logger
 from ramalama.migrate import ModelStoreImport
 from ramalama.model import MODEL_TYPES
 from ramalama.model_factory import ModelFactory
@@ -269,6 +270,8 @@ def post_parse_setup(args):
             args.MODEL = resolved_model
     if hasattr(args, "runtime_args"):
         args.runtime_args = shlex.split(args.runtime_args)
+
+    configure_logger("DEBUG" if args.debug else "WARNING")
 
 
 def login_parser(subparsers):
@@ -726,8 +729,7 @@ def push_cli(args):
             m = ModelFactory(target, args).create_oci()
             m.push(source_model, args)
         except Exception as e1:
-            if args.debug:
-                print(e1)
+            logger.debug(e1)
             raise e
 
 

--- a/ramalama/console.py
+++ b/ramalama/console.py
@@ -1,5 +1,6 @@
-import logging
 import os
+
+from ramalama.logger import logger
 
 
 def is_locale_utf8():
@@ -23,16 +24,16 @@ EMOJI = os.getenv("RAMALAMA_FORCE_EMOJI", '').lower() == "true" or supports_emoj
 
 # Define emoji-aware logging messages
 def log_message(level, msg, emoji_msg):
-    return f"{emoji_msg} {msg}" if EMOJI else f"[{level}] {msg}"
+    return f"{emoji_msg} {msg}" if EMOJI else f"{msg}"
 
 
 def error(msg):
-    logging.error(log_message("ERROR", msg, "❌"))
+    logger.error(log_message("ERROR", msg, "❌"))
 
 
 def warning(msg):
-    logging.warning(log_message("WARNING", msg, "⚠️"))
+    logger.warning(log_message("WARNING", msg, "⚠️"))
 
 
 def info(msg):
-    logging.info(log_message("INFO", msg, "ℹ️"))
+    logger.info(log_message("INFO", msg, "ℹ️"))

--- a/ramalama/engine.py
+++ b/ramalama/engine.py
@@ -33,7 +33,6 @@ class Engine:
         self.add_tty_option()
         self.handle_podman_specifics()
         self.add_detach_option()
-        self.debug = args.debug
 
     def add_label(self, label):
         self.add(["--label", label])
@@ -161,10 +160,10 @@ class Engine:
         dry_run(self.exec_args)
 
     def run(self):
-        run_cmd(self.exec_args, debug=self.debug)
+        run_cmd(self.exec_args)
 
     def exec(self):
-        exec_cmd(self.exec_args, debug=self.debug)
+        exec_cmd(self.exec_args)
 
 
 def dry_run(args):
@@ -194,7 +193,7 @@ def images(args):
         conman_args += [f"--format={args.format}"]
 
     try:
-        output = run_cmd(conman_args, debug=args.debug).stdout.decode("utf-8").strip()
+        output = run_cmd(conman_args).stdout.decode("utf-8").strip()
         if output == "":
             return []
         return output.split("\n")
@@ -219,7 +218,7 @@ def containers(args):
         conman_args += [f"--format={args.format}"]
 
     try:
-        output = run_cmd(conman_args, debug=args.debug).stdout.decode("utf-8").strip()
+        output = run_cmd(conman_args).stdout.decode("utf-8").strip()
         if output == "":
             return []
         return output.split("\n")
@@ -235,7 +234,7 @@ def info(args):
 
     conman_args = [conman, "info", "--format", "json"]
     try:
-        output = run_cmd(conman_args, debug=args.debug).stdout.decode("utf-8").strip()
+        output = run_cmd(conman_args).stdout.decode("utf-8").strip()
         if output == "":
             return []
         return json.loads(output)
@@ -260,7 +259,7 @@ def stop_container(args, name):
 
     conman_args += [name]
     try:
-        run_cmd(conman_args, ignore_stderr=ignore_stderr, debug=args.debug)
+        run_cmd(conman_args, ignore_stderr=ignore_stderr)
     except subprocess.CalledProcessError:
         if args.ignore and conman == "docker":
             return

--- a/ramalama/http_client.py
+++ b/ramalama/http_client.py
@@ -6,6 +6,7 @@ import time
 import urllib.request
 
 from ramalama.file import File
+from ramalama.logger import logger
 
 
 class HttpClient:
@@ -39,6 +40,7 @@ class HttpClient:
 
     def urlopen(self, url, headers):
         headers["Range"] = f"bytes={self.file_size}-"
+        logger.debug(f"Running urlopen {url} with headers: {headers}")
         request = urllib.request.Request(url, headers=headers)
         self.response = urllib.request.urlopen(request)
 

--- a/ramalama/huggingface.py
+++ b/ramalama/huggingface.py
@@ -38,6 +38,7 @@ def huggingface_token():
 def fetch_checksum_from_api(organization, file):
     """Fetch the SHA-256 checksum from the model's metadata API for a given file."""
     checksum_api_url = f"{HuggingfaceRepository.REGISTRY_URL}/{organization}/raw/main/{file}"
+    logger.debug(f"Fetching checksum from {checksum_api_url}")
     request = urllib.request.Request(url=checksum_api_url)
     token = huggingface_token()
     if token is not None:
@@ -61,6 +62,7 @@ def fetch_repo_manifest(repo_name: str, tag: str = "latest"):
     # https://github.com/ggml-org/llama.cpp/blob/7f323a589f8684c0eb722e7309074cb5eac0c8b5/common/arg.cpp#L611
     token = huggingface_token()
     repo_manifest_url = f"{HuggingfaceRepository.REGISTRY_URL}/v2/{repo_name}/manifests/{tag}"
+    logger.debug(f"Fetching repo manifest from {repo_manifest_url}")
     request = urllib.request.Request(
         url=repo_manifest_url,
         headers={
@@ -207,6 +209,7 @@ def get_repo_info(repo_name):
     # Docs on API call:
     # https://huggingface.co/docs/hub/en/api#get-apimodelsrepoid-or-apimodelsrepoidrevisionrevision
     repo_info_url = f"https://huggingface.co/api/models/{repo_name}"
+    logger.debug(f"Fetching repo info from {repo_info_url}")
     with urllib.request.urlopen(repo_info_url) as response:
         if response.getcode() == 200:
             repo_info = response.read().decode('utf-8')

--- a/ramalama/logger.py
+++ b/ramalama/logger.py
@@ -1,0 +1,24 @@
+import logging
+import sys
+import typing
+
+logger = logging.getLogger("ramalama")
+
+
+def configure_logger(verbosity="WARNING") -> None:
+    global logger
+
+    lvl = logging.WARNING
+    if verbosity in ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"):
+        lvl = typing.cast(int, getattr(logging, verbosity))
+
+    logger.setLevel(lvl)
+
+    fmt = "%(asctime)s - %(levelname)s - %(message)s"
+    datefmt = "%Y-%m-%d %H:%M:%S"
+    formatter = logging.Formatter(fmt, datefmt)
+
+    handler = logging.StreamHandler(sys.stderr)
+    handler.setLevel(lvl)
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)

--- a/ramalama/model_store.py
+++ b/ramalama/model_store.py
@@ -1,4 +1,3 @@
-import logging
 import os
 import shutil
 import urllib
@@ -13,8 +12,7 @@ import ramalama.go2jinja as go2jinja
 import ramalama.oci
 from ramalama.common import download_file, generate_sha256, verify_checksum
 from ramalama.gguf_parser import GGUFInfoParser, GGUFModelInfo
-
-LOGGER = logging.getLogger(__name__)
+from ramalama.logger import logger
 
 
 def sanitize_filename(filename: str) -> str:
@@ -446,7 +444,7 @@ class ModelStore:
 
             if file.should_verify_checksum:
                 if not verify_checksum(dest_path):
-                    LOGGER.info(f"Checksum mismatch for blob {dest_path}, retrying download ...")
+                    logger.info(f"Checksum mismatch for blob {dest_path}, retrying download ...")
                     os.remove(dest_path)
                     file.download(dest_path, self.get_snapshot_directory(snapshot_hash))
                     if not verify_checksum(dest_path):
@@ -477,7 +475,7 @@ class ModelStore:
                     ]
                     self.update_snapshot(model_tag, snapshot_hash, files)
                 except Exception as ex:
-                    LOGGER.debug(f"Failed to convert Go Template to Jinja: {ex}")
+                    logger.debug(f"Failed to convert Go Template to Jinja: {ex}")
                 return
             if file.type == SnapshotFileType.Model:
                 model_file = file
@@ -512,7 +510,7 @@ class ModelStore:
                     LocalSnapshotFile(jinja_template, "chat_template_converted", SnapshotFileType.ChatTemplate)
                 )
             except Exception as ex:
-                LOGGER.debug(f"Failed to convert Go Template to Jinja: {ex}")
+                logger.debug(f"Failed to convert Go Template to Jinja: {ex}")
 
         self.update_snapshot(model_tag, snapshot_hash, files)
 
@@ -553,9 +551,9 @@ class ModelStore:
         try:
             if os.path.exists(blob_path) and Path(self.base_path) in blob_path.parents:
                 os.remove(blob_path)
-                LOGGER.debug(f"Removed blob for '{snapshot_file_path}'")
+                logger.debug(f"Removed blob for '{snapshot_file_path}'")
         except Exception as ex:
-            LOGGER.error(f"Failed to remove blob file '{blob_path}': {ex}")
+            logger.error(f"Failed to remove blob file '{blob_path}': {ex}")
 
     def remove_snapshot(self, model_tag: str):
         ref_file = self.get_ref_file(model_tag)

--- a/ramalama/modelscope.py
+++ b/ramalama/modelscope.py
@@ -6,6 +6,7 @@ import urllib.request
 
 from ramalama.common import available, download_and_verify, exec_cmd, perror, run_cmd, verify_checksum
 from ramalama.huggingface import HuggingfaceCLIFile, HuggingfaceRepository
+from ramalama.logger import logger
 from ramalama.model import Model
 from ramalama.model_store import SnapshotFileType
 from ramalama.ollama_repo_utils import repo_pull
@@ -163,7 +164,7 @@ class ModelScope(Model):
 
     def ms_pull(self, args, model_path, directory_path):
         conman_args = ["modelscope", "download", "--local_dir", directory_path, self.model]
-        run_cmd(conman_args, debug=args.debug)
+        run_cmd(conman_args)
 
         relative_target_path = os.path.relpath(directory_path, start=os.path.dirname(model_path))
         pathlib.Path(model_path).unlink(missing_ok=True)
@@ -209,13 +210,12 @@ class ModelScope(Model):
                 "--local_dir",
                 os.path.join(args.store, "repos", "modelscope", self.directory),
             ],
-            debug=args.debug,
         )
         return proc.stdout.decode("utf-8")
 
     def exec(self, cmd_args, args):
         try:
-            exec_cmd(cmd_args, debug=args.debug)
+            exec_cmd(cmd_args)
         except FileNotFoundError as e:
             print(f"{str(e).strip()}\n{missing_modelscope}")
 
@@ -256,7 +256,7 @@ class ModelScope(Model):
 
         return snapshot_hash, files
 
-    def _pull_with_model_store(self, args, debug: bool = False):
+    def _pull_with_model_store(self, args):
         name, tag, organization = self.extract_model_identifiers()
         hash, cached_files, all = self.store.get_cached_files(tag)
         if all:
@@ -278,8 +278,7 @@ class ModelScope(Model):
                 try:
                     self.store.remove_snapshot(tag)
                 except Exception as exc:
-                    if args.debug:
-                        perror(f"ignoring failure to remove snapshot: {exc}")
+                    logger.debug(f"ignoring failure to remove snapshot: {exc}")
                     # ignore any error when removing snapshot
                     pass
                 raise e
@@ -292,7 +291,7 @@ class ModelScope(Model):
             with tempfile.TemporaryDirectory() as tempdir:
                 model = f"{organization}/{name}"
                 conman_args = ["modelscope", "download", "--local_dir", tempdir, model]
-                run_cmd(conman_args, debug=debug)
+                run_cmd(conman_args)
 
                 snapshot_hash, files = self._collect_cli_files(tempdir)
                 self.store.new_snapshot(tag, snapshot_hash, files)

--- a/ramalama/modelscope.py
+++ b/ramalama/modelscope.py
@@ -30,6 +30,7 @@ def fetch_checksum_from_api(organization, file):
         f"{ModelScopeRepository.REGISTRY_URL}/api/v1/models/{organization}/repo/raw"
         f"?Revision=master&FilePath={file}&Needmeta=true"
     )
+    logger.debug(f"Fetching checksum from {checksum_api_url}")
     try:
         with urllib.request.urlopen(checksum_api_url) as response:
             data = json.loads(response.read().decode())

--- a/ramalama/ollama_repo_utils.py
+++ b/ramalama/ollama_repo_utils.py
@@ -3,6 +3,7 @@ import os
 import urllib.request
 
 from ramalama.common import download_file, run_cmd, verify_checksum
+from ramalama.logger import logger
 
 
 def fetch_manifest_data(registry_head, model_tag, accept):
@@ -20,6 +21,7 @@ def fetch_manifest_data(registry_head, model_tag, accept):
     url = f"{registry_head}/manifests/{model_tag}"
     headers = {"Accept": accept}
 
+    logger.debug(f"Fetching manifest data from url {url}")
     request = urllib.request.Request(url, headers=headers)
     with urllib.request.urlopen(request) as response:
         manifest_data = json.load(response)

--- a/ramalama/rag.py
+++ b/ramalama/rag.py
@@ -7,6 +7,7 @@ from urllib.parse import urlparse
 from ramalama.common import accel_image, get_accel_env_vars, run_cmd, set_accel_env_vars
 from ramalama.config import CONFIG
 from ramalama.engine import Engine
+from ramalama.logger import logger
 
 
 class Rag:
@@ -33,8 +34,7 @@ COPY {src} /vector.db
         # Open the file for writing.
         with open(containerfile.name, 'w') as c:
             c.write(cfile)
-        if args.debug:
-            print(f"\nContainerfile: {containerfile.name}\n{cfile}")
+        logger.debug(f"\nContainerfile: {containerfile.name}\n{cfile}")
         exec_args = [
             args.engine,
             "build",
@@ -50,7 +50,6 @@ COPY {src} /vector.db
         imageid = (
             run_cmd(
                 exec_args,
-                debug=args.debug,
             )
             .stdout.decode("utf-8")
             .strip()

--- a/test/unit/test_engine.py
+++ b/test/unit/test_engine.py
@@ -89,7 +89,7 @@ class TestEngine(unittest.TestCase):
     def test_stop_container(self, mock_run_cmd):
         args = Namespace(engine="podman", debug=False, ignore=False)
         stop_container(args, "test-container")
-        mock_run_cmd.assert_called_with(["podman", "stop", "-t=0", "test-container"], ignore_stderr=False, debug=False)
+        mock_run_cmd.assert_called_with(["podman", "stop", "-t=0", "test-container"], ignore_stderr=False)
 
     def test_dry_run(self):
         with patch('sys.stdout') as mock_stdout:


### PR DESCRIPTION
Add global logger to be used mainly for debug logging. On top add debug logging for http/https requests.

## Summary by Sourcery

Introduce a centralized logger to handle debug output across the codebase, remove explicit debug flags from command utilities and replace scattered print/perror calls with logger.debug, and add debug-level HTTP request tracing.

Enhancements:
- Add ramalama.logger module with configure_logger and wire it into CLI startup
- Remove debug parameters from run_cmd and exec_cmd and centralize debug output using logger.debug
- Replace print/perror debug prints with logger.debug across engine, model, common utilities, and plugin modules
- Add debug logging for HTTP and HTTPS operations in HttpClient, huggingface, modelscope, and ollama modules
- Refactor console functions to emit messages via logger
- Simplify command execution calls by dropping debug flags

Tests:
- Update unit test for stop_container to match run_cmd signature changes