### PR TITLE
Add support for generating kube.yaml and quadlet/kube files for llama…

### DIFF
--- a/ramalama/file.py
+++ b/ramalama/file.py
@@ -50,7 +50,7 @@ class UnitFile:
         self.filename = filename
         self.sections = {}
 
-    def add(self, section: str, key: str, value: str):
+    def add(self, section: str, key: str, value: str = ""):
         if section not in self.sections:
             self.sections[section] = {}
         if key not in self.sections[section]:
@@ -63,7 +63,13 @@ class UnitFile:
             self._write(f)
 
     def _write(self, f):
+        comments = self.sections.get('comment', {})
+        for section in comments:
+            f.write(f'{section}\n')
+
         for section, section_items in self.sections.items():
+            if section == "comment":
+                continue
             f.write(f'[{section}]\n')
             for key, values in section_items.items():
                 for value in values:

--- a/ramalama/kube.py
+++ b/ramalama/kube.py
@@ -133,11 +133,7 @@ class Kube:
         volume_string = self._gen_volumes()
         _version = version()
 
-        file_name = f"{self.name}.yaml"
-        print(f"Generating Kubernetes YAML file: {file_name}")
-
-        file = PlainFile(file_name)
-        file.content = f"""\
+        content = f"""\
 # Save the output of this file and use kubectl create -f to import
 # it into Kubernetes.
 #
@@ -167,4 +163,13 @@ spec:
 {port_string}
 {volume_string}"""
 
-        return file
+        return genfile(self.name, content)
+
+
+def genfile(name, content) -> PlainFile:
+    file_name = f"{name}.yaml"
+    print(f"Generating Kubernetes YAML file: {file_name}")
+
+    file = PlainFile(file_name)
+    file.content = content
+    return file

--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -742,7 +742,7 @@ def compute_serving_port(args, quiet=False) -> str:
     if not quiet:
         openai = f"http://localhost:{target_port}"
         if args.api == "llama-stack":
-            print(f"LlamaStack RESTAPI: {openai}")
+            print(f"Llama Stack RESTAPI: {openai}")
             openai = openai + "/v1/openai"
         print(f"OpenAI RESTAPI: {openai}")
     return str(target_port)

--- a/ramalama/quadlet.py
+++ b/ramalama/quadlet.py
@@ -27,17 +27,7 @@ class Quadlet:
             self.rag_name = os.path.basename(self.rag) + "-rag"
 
     def kube(self) -> UnitFile:
-        file_name = f"{self.name}.kube"
-        print(f"Generating quadlet file: {file_name}")
-
-        file = UnitFile(file_name)
-        file.add("Unit", "Description", f"RamaLama {self.model} Kubernetes YAML - AI Model Service")
-        file.add("Unit", "After", "local-fs.target")
-        file.add("Kube", "Yaml", f"{self.name}.yaml")
-        # Start by default on boot
-        file.add("Install", "WantedBy", "multi-user.target default.target")
-
-        return file
+        return kube(self.name, f"RamaLama {self.model} Kubernetes YAML - AI Model Service")
 
     def generate(self) -> list[UnitFile]:
         files = []
@@ -142,3 +132,17 @@ class Quadlet:
 
         quadlet_file.add("Container", "Mount", f"type=image,source={self.rag},destination={RAG_DIR},readwrite=false")
         return files
+
+
+def kube(name, description) -> UnitFile:
+    file_name = f"{name}.kube"
+    print(f"Generating quadlet file: {file_name}")
+
+    file = UnitFile(file_name)
+    file.add("Unit", "Description", description)
+    file.add("Unit", "After", "local-fs.target")
+    file.add("Kube", "Yaml", f"{name}.yaml")
+    # Start by default on boot
+    file.add("Install", "WantedBy", "multi-user.target default.target")
+
+    return file

--- a/ramalama/stack.py
+++ b/ramalama/stack.py
@@ -1,6 +1,8 @@
 import os
 import tempfile
 
+import ramalama.kube as kube
+import ramalama.quadlet as quadlet
 from ramalama.common import (
     exec_cmd,
     genname,
@@ -150,6 +152,22 @@ spec:
         if self.args.dryrun:
             print(yaml)
             return
+
+        if self.args.generate.gen_type == "kube":
+            kube.genfile(self.name, yaml).write(self.args.generate.output_dir)
+            return
+
+        if self.args.generate.gen_type == "quadlet/kube":
+            kube.genfile(self.name, yaml).write(self.args.generate.output_dir)
+            k = quadlet.kube(self.name, f"RamaLama {self.model} Kubernetes YAML - llama Stack AI Model Service")
+            openai = f"http://localhost:{self.args.port}"
+            k.add("comment", f"# RamaLama service for {self.model}")
+            k.add("comment", "# Serving RESTAPIs:")
+            k.add("comment", f"#    Llama Stack: {openai}")
+            k.add("comment", f"#    OpenAI:      {openai}/v1/openai\n")
+            k.write(self.args.generate.output_dir)
+            return
+
         yaml_file = tempfile.NamedTemporaryFile(prefix='RamaLama_', delete=not self.args.debug)
         with open(yaml_file.name, 'w') as c:
             c.write(yaml)

--- a/test/system/040-serve.bats
+++ b/test/system/040-serve.bats
@@ -10,65 +10,65 @@ verify_begin=".*run --rm"
     model=m_$(safename)
 
     if is_container; then
-        run_ramalama -q --dryrun serve ${model}
-        is "$output" "${verify_begin}.*" "dryrun correct"
-        is "$output" ".*--name ramalama_.*" "dryrun correct"
-        is "$output" ".*${model}" "verify model name"
-        is "$output" ".*--cache-reuse 256" "cache"
-        assert "$output" !~ ".*--no-webui"
+	run_ramalama -q --dryrun serve ${model}
+	is "$output" "${verify_begin}.*" "dryrun correct"
+	is "$output" ".*--name ramalama_.*" "dryrun correct"
+	is "$output" ".*${model}" "verify model name"
+	is "$output" ".*--cache-reuse 256" "cache"
+	assert "$output" !~ ".*--no-webui"
 
-        run_ramalama --dryrun serve --webui off ${model}
-        assert "$output" =~ ".*--no-webui"
+	run_ramalama --dryrun serve --webui off ${model}
+	assert "$output" =~ ".*--no-webui"
 
-        run_ramalama -q --dryrun serve --name foobar ${model}
-        is "$output" ".*--name foobar .*" "dryrun correct with --name"
-        assert "$output" !~ ".*--network" "--network is not part of the output"
-        is "$output" ".*--host 0.0.0.0" "verify host 0.0.0.0 is added when run within container"
-        is "$output" ".*${model}" "verify model name"
-        assert "$output" !~ ".*--seed" "assert seed does not show by default"
+	run_ramalama -q --dryrun serve --name foobar ${model}
+	is "$output" ".*--name foobar .*" "dryrun correct with --name"
+	assert "$output" !~ ".*--network" "--network is not part of the output"
+	is "$output" ".*--host 0.0.0.0" "verify host 0.0.0.0 is added when run within container"
+	is "$output" ".*${model}" "verify model name"
+	assert "$output" !~ ".*--seed" "assert seed does not show by default"
 
-        run_ramalama -q --dryrun serve --network bridge --host 127.1.2.3 --name foobar ${model}
-        assert "$output" =~ "--network bridge.*--host 127.1.2.3" "verify --host is modified when run within container"
-        is "$output" ".*${model}" "verify model name"
-        is "$output" ".*--temp 0.8" "verify temp is set"
+	run_ramalama -q --dryrun serve --network bridge --host 127.1.2.3 --name foobar ${model}
+	assert "$output" =~ "--network bridge.*--host 127.1.2.3" "verify --host is modified when run within container"
+	is "$output" ".*${model}" "verify model name"
+	is "$output" ".*--temp 0.8" "verify temp is set"
 
-        run_ramalama -q --dryrun serve --temp 0.1 ${model}
-        is "$output" ".*--temp 0.1" "verify temp is set"
+	run_ramalama -q --dryrun serve --temp 0.1 ${model}
+	is "$output" ".*--temp 0.1" "verify temp is set"
 
-        RAMALAMA_CONFIG=/dev/null run_ramalama -q --dryrun serve --seed 1234 ${model}
-        is "$output" ".*--seed 1234" "verify seed is set"
-        if not_docker; then
-            is "$output" ".*--pull newer" "verify pull is newer"
-        fi
-        assert "$output" =~ ".*--cap-drop=all" "verify --cap-add is present"
-        assert "$output" =~ ".*no-new-privileges" "verify --no-new-privs is not present"
+	RAMALAMA_CONFIG=/dev/null run_ramalama -q --dryrun serve --seed 1234 ${model}
+	is "$output" ".*--seed 1234" "verify seed is set"
+	if not_docker; then
+	    is "$output" ".*--pull newer" "verify pull is newer"
+	fi
+	assert "$output" =~ ".*--cap-drop=all" "verify --cap-add is present"
+	assert "$output" =~ ".*no-new-privileges" "verify --no-new-privs is not present"
 
-        run_ramalama -q --dryrun serve ${model}
-        is "$output" ".*--pull missing" "verify test default pull is missing"
+	run_ramalama -q --dryrun serve ${model}
+	is "$output" ".*--pull missing" "verify test default pull is missing"
 
-        run_ramalama -q --dryrun serve --pull never ${model}
-        is "$output" ".*--pull never" "verify pull is never"
+	run_ramalama -q --dryrun serve --pull never ${model}
+	is "$output" ".*--pull never" "verify pull is never"
 
-        run_ramalama 2 -q --dryrun serve --pull=bogus ${model}
-        is "$output" ".*error: argument --pull: invalid choice: 'bogus'" "verify pull can not be bogus"
+	run_ramalama 2 -q --dryrun serve --pull=bogus ${model}
+	is "$output" ".*error: argument --pull: invalid choice: 'bogus'" "verify pull can not be bogus"
 
-        run_ramalama -q --dryrun serve --privileged ${model}
-        is "$output" ".*--privileged" "verify --privileged is set"
-        assert "$output" != ".*--cap-drop=all" "verify --cap-add is not present"
-        assert "$output" != ".*no-new-privileges" "verify --no-new-privs is not present"
+	run_ramalama -q --dryrun serve --privileged ${model}
+	is "$output" ".*--privileged" "verify --privileged is set"
+	assert "$output" != ".*--cap-drop=all" "verify --cap-add is not present"
+	assert "$output" != ".*no-new-privileges" "verify --no-new-privs is not present"
     else
-        run_ramalama -q --dryrun serve ${model}
-        assert "$output" =~ ".*--host 0.0.0.0" "Outside container sets host to 0.0.0.0"
-        is "$output" ".*--cache-reuse 256" "should use cache"
-        if is_darwin; then
-           is "$output" ".*--flash-attn" "use flash-attn on Darwin metal"
-        fi
+	run_ramalama -q --dryrun serve ${model}
+	assert "$output" =~ ".*--host 0.0.0.0" "Outside container sets host to 0.0.0.0"
+	is "$output" ".*--cache-reuse 256" "should use cache"
+	if is_darwin; then
+	   is "$output" ".*--flash-attn" "use flash-attn on Darwin metal"
+	fi
 
-        run_ramalama -q --dryrun serve --seed abcd --host 127.0.0.1 ${model}
-        assert "$output" =~ ".*--host 127.0.0.1" "Outside container overrides host to 127.0.0.1"
-        assert "$output" =~ ".*--seed abcd" "Verify seed is set"
-        run_ramalama 1 --nocontainer serve --name foobar tiny
-        is "${lines[0]}"  "Error: --nocontainer and --name options conflict. The --name option requires a container." "conflict between nocontainer and --name line"
+	run_ramalama -q --dryrun serve --seed abcd --host 127.0.0.1 ${model}
+	assert "$output" =~ ".*--host 127.0.0.1" "Outside container overrides host to 127.0.0.1"
+	assert "$output" =~ ".*--seed abcd" "Verify seed is set"
+	run_ramalama 1 --nocontainer serve --name foobar tiny
+	is "${lines[0]}"  "Error: --nocontainer and --name options conflict. The --name option requires a container." "conflict between nocontainer and --name line"
     fi
 
     run_ramalama -q --dryrun serve --runtime-args="--foo -bar" ${model}
@@ -321,6 +321,23 @@ verify_begin=".*run --rm"
     run cat /tmp/$name.yaml
     is "$output" ".*command: \[\".*serve.*\"\]" "Should command"
     is "$output" ".*containerPort: 1234" "Should container container port"
+
+    rm /tmp/$name.yaml
+}
+
+@test "ramalama serve --api llama-stack --generate=kube:/tmp" {
+    skip_if_docker
+    skip_if_nocontainer
+    model=tiny
+    name=c_$(safename)
+    run_ramalama pull ${model}
+    run_ramalama serve --name=${name} --api llama-stack --port 1234 --generate=kube:/tmp ${model}
+    is "$output" ".*Generating Kubernetes YAML file: ${name}.yaml" "generate .yaml file"
+
+    run cat /tmp/$name.yaml
+    is "$output" ".*command: \[\".*serve.*\"\]" "Should command"
+    is "$output" ".*hostPort: 1234" "Should container container port"
+    is "$output" ".*llama stack run --image-type venv /etc/ramalama/ramalama-run.yaml" "Should container llama-stack"
 
     rm /tmp/$name.yaml
 }


### PR DESCRIPTION
…-stack

## Summary by Sourcery

Enable the serve command to produce Kubernetes YAML and quadlet unit files via --generate flags when using the llama-stack API, refactor file generation into shared helpers, and update documentation and tests to cover the new functionality.

New Features:
- Add CLI support for --generate=kube to output Kubernetes YAML files for llama-stack
- Add CLI support for --generate=quadlet/kube to output quadlet unit files that reference generated YAML

Bug Fixes:
- Fix label formatting in model service output to "Llama Stack RESTAPI"

Enhancements:
- Extract common file-generation logic into new genfile and kube helper functions
- Enhance file.py to preserve comment sections when writing unit files
- Refactor quadlet.py and kube.py to leverage shared helper functions

Documentation:
- Extend serve command documentation with examples for generating kube and quadlet files

Tests:
- Add system tests covering Kubernetes YAML generation for llama-stack