### PR TITLE
feat: s390x build commands

### DIFF
--- a/container-images/scripts/build_llama_and_whisper.sh
+++ b/container-images/scripts/build_llama_and_whisper.sh
@@ -217,7 +217,7 @@ set_install_prefix() {
 }
 
 configure_common_flags() {
-  common_flags=("-DGGML_NATIVE=OFF")
+  common_flags=("-DGGML_NATIVE=OFF" "-DGGML_CMAKE_BUILD_TYPE=Release")
   case "$containerfile" in
   rocm*)
     if [ "${ID}" = "fedora" ]; then
@@ -314,12 +314,16 @@ main() {
   fi
 
   setup_build_env
-  clone_and_build_whisper_cpp
+  if [ "$uname_m" != "s390x" ]; then
+    clone_and_build_whisper_cpp
+  fi
   common_flags+=("-DLLAMA_CURL=ON" "-DGGML_RPC=ON")
   case "$containerfile" in
   ramalama)
     if [ "$uname_m" = "x86_64" ] || [ "$uname_m" = "aarch64" ]; then
       common_flags+=("-DGGML_VULKAN=ON")
+    elif [ "$uname_m" = "s390x" ]; then
+      common_flags+=("-DGGML_VXE=ON" "-DGGML_BLAS=ON" "-DGGML_BLAS_VENDOR=OpenBLAS")
     else
       common_flags+=("-DGGML_BLAS=ON" "-DGGML_BLAS_VENDOR=OpenBLAS")
     fi


### PR DESCRIPTION
currently it builds correctly on s390x but we should enforce the -DGGML_VXE=ON flag. we also want to disable whisper.cpp for now until we can bring up support for it, otherwise it will be a product that none of us have experience in.

## Summary by Sourcery

Extend container build script to enforce Release builds, enable GGML VXE support on s390x, and disable Whisper.cpp builds on s390x.

New Features:
- Add s390x-specific build flags (`-DGGML_VXE=ON`, `-DGGML_BLAS=ON`, `-DGGML_BLAS_VENDOR=OpenBLAS`) under the `ramalama` container flow.

Enhancements:
- Enforce `-DGGML_CMAKE_BUILD_TYPE=Release` in common CMake flags.

Build:
- Conditionally skip cloning and building Whisper.cpp on s390x architectures.