### PR TITLE
Bump to v0.9.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,10 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ramalama"
-version = "0.8.5"
+version = "0.9.0"
 description = "RamaLama is a command line tool for working with AI LLM models."
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 license = { file = "LICENSE" }
 keywords = ["ramalama", "llama", "AI"]
 dependencies = [

--- a/ramalama/version.py
+++ b/ramalama/version.py
@@ -2,7 +2,7 @@
 
 
 def version():
-    return "0.8.5"
+    return "0.9.0"
 
 
 def print_version(args):

--- a/rpm/python-ramalama.spec
+++ b/rpm/python-ramalama.spec
@@ -1,7 +1,7 @@
 %global pypi_name ramalama
 %global forgeurl  https://github.com/containers/%{pypi_name}
 # see ramalama/version.py
-%global version0  0.8.5
+%global version0  0.9.0
 %forgemeta
 
 %global summary   RamaLama is a command line tool for working with AI LLM models


### PR DESCRIPTION
Switching pyproject.toml to python 3.10 since
CANN and MUSE containerfiles only have access to those versions of python.

## Summary by Sourcery

Bump RamaLama to v0.9.0 and adjust the minimum Python requirement to 3.10 for compatibility with CANN and MUSE containers.

Enhancements:
- Bump project version to 0.9.0 in pyproject.toml, version.py, and RPM spec file
- Lower the required Python version to 3.10 in pyproject.toml