### PR TITLE
chore: remove unclear else from llama and whisper build

### DIFF
--- a/container-images/scripts/build_llama_and_whisper.sh
+++ b/container-images/scripts/build_llama_and_whisper.sh
@@ -324,8 +324,6 @@ main() {
       common_flags+=("-DGGML_VULKAN=ON")
     elif [ "$uname_m" = "s390x" ]; then
       common_flags+=("-DGGML_VXE=ON" "-DGGML_BLAS=ON" "-DGGML_BLAS_VENDOR=OpenBLAS")
-    else
-      common_flags+=("-DGGML_BLAS=ON" "-DGGML_BLAS_VENDOR=OpenBLAS")
     fi
     ;;
   esac


### PR DESCRIPTION
Ref: https://github.com/containers/ramalama/pull/1459#discussion_r2124350835

## Summary by Sourcery

Chores:
- Remove the unclear else block that added default GGML_BLAS flags for non-s390x architectures