### PR TITLE
Rename: RepoFile=>HFStyleRepoFile, BaseRepository=>HFStyleRepository, BaseRepoModel=>HFStyleRepoModel

### DIFF
--- a/ramalama/hf_style_repo_base.py
+++ b/ramalama/hf_style_repo_base.py
@@ -12,7 +12,7 @@ from ramalama.model_store import SnapshotFile, SnapshotFileType
 from ramalama.ollama_repo_utils import repo_pull
 
 
-class RepoFile(SnapshotFile):
+class HFStyleRepoFile(SnapshotFile):
     def __init__(
         self, url, header, hash, name, type, should_show_progress=False, should_verify_checksum=False, required=True
     ):
@@ -57,7 +57,7 @@ def fetch_checksum_from_api_base(checksum_api_url, headers=None, extractor_func=
         raise KeyError(f"failed to pull {checksum_api_url}: {str(e).strip()}")
 
 
-class BaseRepository(ABC):
+class HFStyleRepository(ABC):
     FILE_NAME_CONFIG = "config.json"
     FILE_NAME_GENERATION_CONFIG = "generation_config.json"
     FILE_NAME_TOKENIZER_CONFIG = "tokenizer_config.json"
@@ -147,7 +147,7 @@ class BaseRepository(ABC):
         )
 
 
-class BaseRepoModel(Model, ABC):
+class HFStyleRepoModel(Model, ABC):
     def __init__(self, model):
         super().__init__(model)
 

--- a/ramalama/huggingface.py
+++ b/ramalama/huggingface.py
@@ -4,9 +4,14 @@ import pathlib
 import urllib.request
 
 from ramalama.common import available, perror, run_cmd
+from ramalama.hf_style_repo_base import (
+    HFStyleRepoFile,
+    HFStyleRepoModel,
+    HFStyleRepository,
+    fetch_checksum_from_api_base,
+)
 from ramalama.logger import logger
 from ramalama.model_store import SnapshotFileType
-from ramalama.repo_model_base import BaseRepoModel, BaseRepository, RepoFile, fetch_checksum_from_api_base
 
 missing_huggingface = """
 Optional: Huggingface models require the huggingface-cli module.
@@ -73,11 +78,11 @@ def fetch_repo_manifest(repo_name: str, tag: str = "latest"):
         return json.loads(repo_manifest)
 
 
-class HuggingfaceCLIFile(RepoFile):
+class HuggingfaceCLIFile(HFStyleRepoFile):
     pass
 
 
-class HuggingfaceRepository(BaseRepository):
+class HuggingfaceRepository(HFStyleRepository):
     REGISTRY_URL = "https://huggingface.co"
 
     def fetch_metadata(self):
@@ -133,7 +138,7 @@ def handle_repo_info(repo_name, repo_info, runtime):
         )
 
 
-class Huggingface(BaseRepoModel):
+class Huggingface(HFStyleRepoModel):
     REGISTRY_URL = "https://huggingface.co/v2/"
     ACCEPT = "Accept: application/vnd.docker.distribution.manifest.v2+json"
 

--- a/ramalama/modelscope.py
+++ b/ramalama/modelscope.py
@@ -2,8 +2,13 @@ import json
 import os
 
 from ramalama.common import available, run_cmd
+from ramalama.hf_style_repo_base import (
+    HFStyleRepoFile,
+    HFStyleRepoModel,
+    HFStyleRepository,
+    fetch_checksum_from_api_base,
+)
 from ramalama.model_store import SnapshotFileType
-from ramalama.repo_model_base import BaseRepoModel, BaseRepository, RepoFile, fetch_checksum_from_api_base
 
 missing_modelscope = """
 Optional: ModelScope models require the modelscope module.
@@ -37,7 +42,7 @@ def fetch_checksum_from_api(organization, file):
     return fetch_checksum_from_api_base(checksum_api_url, None, extract_modelscope_checksum)
 
 
-class ModelScopeRepository(BaseRepository):
+class ModelScopeRepository(HFStyleRepository):
 
     REGISTRY_URL = "https://modelscope.cn"
 
@@ -47,7 +52,7 @@ class ModelScopeRepository(BaseRepository):
         self.model_filename = self.name
 
 
-class ModelScope(BaseRepoModel):
+class ModelScope(HFStyleRepoModel):
 
     REGISTRY_URL = "https://modelscope.cn/"
     ACCEPT = "Accept: application/vnd.docker.distribution.manifest.v2+json"
@@ -132,9 +137,9 @@ class ModelScope(BaseRepoModel):
         )
         return proc.stdout.decode("utf-8")
 
-    def _collect_cli_files(self, tempdir: str) -> tuple[str, list[RepoFile]]:
+    def _collect_cli_files(self, tempdir: str) -> tuple[str, list[HFStyleRepoFile]]:
         cache_dir = os.path.join(tempdir, ".cache", "modelscope", "download")
-        files: list[RepoFile] = []
+        files: list[HFStyleRepoFile] = []
         snapshot_hash = ""
         for entry in os.listdir(tempdir):
             entry_path = os.path.join(tempdir, entry)
@@ -155,7 +160,7 @@ class ModelScope(BaseRepoModel):
                 snapshot_hash = sha256
                 continue
 
-            ms_file = RepoFile(
+            ms_file = HFStyleRepoFile(
                 url=entry_path,
                 header={},
                 hash=sha256,


### PR DESCRIPTION
This PR addresses comments from @olliewalsh

## Summary by Sourcery

Refactor core repository model classes by renaming and relocating the base module and updating all references to use the new HFStyle* class names

Enhancements:
- Rename RepoFile to HFStyleRepoFile, BaseRepository to HFStyleRepository, and BaseRepoModel to HFStyleRepoModel
- Move and rename repo_model_base.py to hf_style_repo_base.py and adjust its exports
- Update imports, subclass declarations, and type annotations in modelscope.py and huggingface.py to use the renamed classes