### PR TITLE
Throw exception when using OCI without engine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         shell: bash
         run: |
           sudo apt-get update
-          sudo apt-get install -y bash codespell python3-argcomplete
+          sudo apt-get install -y bash codespell python3-argcomplete pipx podman
           make install-requirements
 
       - name: Run unit tests

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -652,13 +652,13 @@ def convert_cli(args):
         raise ValueError("convert command cannot be run with the --nocontainer option.")
 
     target = args.TARGET
-    source_model = _get_source_model(args)
-
     tgt = shortnames.resolve(target)
     if not tgt:
         tgt = target
 
     model = ModelFactory(tgt, args).create_oci()
+
+    source_model = _get_source_model(args)
     model.convert(source_model, args)
 
 

--- a/ramalama/oci.py
+++ b/ramalama/oci.py
@@ -133,6 +133,9 @@ class OCI(Model):
         super().__init__(model)
 
         self.type = "OCI"
+        if not conman:
+            raise ValueError("RamaLama OCI Images requires a container engine")
+
         self.conman = conman
         self.ignore_stderr = ignore_stderr
 

--- a/test/unit/test_model.py
+++ b/test/unit/test_model.py
@@ -77,6 +77,7 @@ ms_granite_blob = "https://modelscope.cn/models/ibm-granite/granite-3b-code-base
 )
 def test_extract_model_identifiers(model_input: str, expected_name: str, expected_tag: str, expected_orga: str):
     args = ARGS()
+    args.engine = "podman"
     name, tag, orga = ModelFactory(model_input, args).create().extract_model_identifiers()
     assert name == expected_name
     assert tag == expected_tag

--- a/test/unit/test_model_factory.py
+++ b/test/unit/test_model_factory.py
@@ -69,7 +69,7 @@ hf_granite_blob = "https://huggingface.co/ibm-granite/granite-3b-code-base-2k-GG
         (Input("file:///tmp/models/granite-3b-code-base.Q4_K_M.gguf", False, "", ""), URL, None),
         (Input("granite-code", False, "huggingface", ""), Huggingface, None),
         (Input("granite-code", False, "ollama", ""), Ollama, None),
-        (Input("granite-code", False, "oci", ""), OCI, None),
+        (Input("granite-code", False, "oci", ""), OCI, ValueError),
     ],
 )
 def test_model_factory_create(input: Input, expected: type[Union[Huggingface, Ollama, URL, OCI]], error):


### PR DESCRIPTION
Fixes: https://github.com/containers/ramalama/issues/1463

## Summary by Sourcery

Bug Fixes:
- Raise ValueError when OCI is initialized without a container engine to prevent invalid usage