### PR TITLE
Fix stopping of llama-stack based containers by name

### DIFF
--- a/ramalama/engine.py
+++ b/ramalama/engine.py
@@ -255,7 +255,7 @@ def inspect(args, name, format=None, ignore_stderr=False):
         conman_args += ["--format", format]
 
     conman_args += [name]
-    return run_cmd(conman_args, ignore_stderr=ignore_stderr, debug=args.debug).stdout.decode("utf-8").strip()
+    return run_cmd(conman_args, ignore_stderr=ignore_stderr).stdout.decode("utf-8").strip()
 
 
 def stop_container(args, name):
@@ -269,8 +269,11 @@ def stop_container(args, name):
     pod = ""
     try:
         pod = inspect(args, name, format="{{ .Pod }}", ignore_stderr=True)
-    except Exception:  # Ignore errors, the stop command will handle it.
-        pass
+    except Exception:
+        try:
+            pod = inspect(args, f"{name}-pod-model-server", format="{{ .Pod }}", ignore_stderr=True)
+        except Exception:  # Ignore errors, the stop command will handle it.
+            pass
 
     if pod != "":
         conman_args = [conman, "pod", "rm", "-t=0", "--ignore", "--force", pod]

--- a/test/system/040-serve.bats
+++ b/test/system/040-serve.bats
@@ -338,7 +338,7 @@ verify_begin=".*run --rm"
     is "$output" ".*command: \[\".*serve.*\"\]" "Should command"
     is "$output" ".*hostPort: 1234" "Should container container port"
     is "$output" ".*llama stack run --image-type venv /etc/ramalama/ramalama-run.yaml" "Should container llama-stack"
-
+    run_ramalama stop ${name}
     rm /tmp/$name.yaml
 }
 


### PR DESCRIPTION
## Summary by Sourcery

Enable stopping of llama-stack based containers by name and update tests to verify the stop operation

Bug Fixes:
- Fix stopping of llama-stack based containers by adding a fallback inspect for pods with '-pod-model-server' suffix

Enhancements:
- Simplify inspect function by removing the debug flag from run_cmd invocation

Tests:
- Update serve system test to invoke 'ramalama stop' on the served container after startup