### PR TITLE
Update demos to show serving models.

### DIFF
--- a/docs/demo/ramalama.sh
+++ b/docs/demo/ramalama.sh
@@ -71,7 +71,7 @@ run() {
     echo_color "Serve granite via RamaLama run"
     exec_color "ramalama --dryrun run granite | grep --color podman"
     echo ""
-    exec_color "ramalama --dryrun run granite | grep --color quay.io.*latest"
+    exec_color "ramalama --dryrun run granite | grep --color \"quay.io[^ ]*\""
     echo ""
     exec_color "ramalama --dryrun run granite | grep --color -- --cap-drop.*privileges"
     echo ""
@@ -88,7 +88,7 @@ run() {
 
 serve() {
     echo_color "Serve granite via RamaLama model service"
-    exec_color "ramalama serve --name granite-service -d granite"
+    exec_color "ramalama serve --port 8080 --name granite-service -d granite"
     echo ""
 
     echo_color "List RamaLama containers"
@@ -98,6 +98,23 @@ serve() {
     echo_color "list containers via Podman"
     exec_color "podman ps "
     echo ""
+
+    echo_color "Use web browser to show interaction"
+    exec_color "firefox http://localhost:8080"
+
+    echo_color "Stop the ramalama container"
+    exec_color "ramalama stop granite-service"
+    echo ""
+
+    echo_color "Serve granite via RamaLama model service"
+    exec_color "ramalama serve --port 8085 --api llama-stack --name granite-service -d granite"
+    echo ""
+
+    echo_color "Use web browser to show interaction"
+    exec_color "firefox http://localhost:8085"
+
+    echo_color "Use web browser to show interaction"
+    exec_color "firefox http://localhost:8085/v1/openai"
 
     echo_color "Stop the ramalama container"
     exec_color "ramalama stop granite-service"
@@ -160,6 +177,8 @@ version
 pull
 
 run
+
+serve
 
 kubernetes
 


### PR DESCRIPTION
## Summary by Sourcery

Enhance the serve command to safely handle generation flags and update demos and tests to showcase model serving endpoints with port and API options

Enhancements:
- Add guard around generation logic in serve() to avoid attribute errors when no generate flag is provided

Documentation:
- Revise demo script to include --port and --api options for ramalama serve, open service endpoints in a browser, and adjust quay.io grep pattern
- Invoke serve steps at script end for a complete demo flow

Tests:
- Extend system tests to exercise ramalama serve with --api llama-stack and --port options and stop commands