### PR TITLE
Call set_gpu_type_env_vars rather than set_accel_env_vars

### DIFF
--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -526,6 +526,13 @@ def set_accel_env_vars():
     get_accel()
 
 
+def set_gpu_type_env_vars():
+    if get_gpu_type_env_vars():
+        return
+
+    get_accel()
+
+
 def get_gpu_type_env_vars():
     gpu_vars = (
         "ASAHI_VISIBLE_DEVICES",
@@ -553,6 +560,7 @@ def get_accel_env_vars():
     for k in accel_vars:
         if k in os.environ:
             env_vars[k] = os.environ[k]
+
     return env_vars
 
 
@@ -669,7 +677,7 @@ def accel_image(config, args):
 
     conman = config['engine']
     images = config['images']
-    set_accel_env_vars()
+    set_gpu_type_env_vars()
     if gpu_type_env_vars := get_gpu_type_env_vars():
         gpu_type, _ = next(iter(gpu_type_env_vars.items()))
     else:


### PR DESCRIPTION
For GPU detection.

## Summary by Sourcery

Extract GPU-specific environment variable setup into a new helper and update the accel_image workflow to use it for GPU detection

Enhancements:
- Introduce set_gpu_type_env_vars to encapsulate GPU environment variable initialization
- Modify accel_image to invoke set_gpu_type_env_vars instead of set_accel_env_vars for GPU detection