### PR TITLE
Don't warmup by default

### DIFF
--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -524,7 +524,7 @@ class Model(ModelBase):
                 draft_model = self.draft_model.get_model_path(args)
                 draft_model_path = MNT_FILE_DRAFT if args.container or args.generate else draft_model
 
-            exec_args += ["llama-server", "--port", args.port, "--model", exec_model_path]
+            exec_args += ["llama-server", "--port", args.port, "--model", exec_model_path, "--no-warmup"]
             if mmproj_path:
                 exec_args += ["--mmproj", mmproj_path]
             else:


### PR DESCRIPTION
llama-server by default warms up the model with an empty run for performance reasons. We can warm up ourselves with a real query. Warming up was causing issues and delays start time.

## Summary by Sourcery

Disable model warmup by default in llama-server invocation

Bug Fixes:
- Prevent default empty-run warmup that caused startup delays and issues

Enhancements:
- Add `--no-warmup` flag to disable automatic warmup and allow real-query warmup