### PR TITLE
cpu type rpc worker

### DIFF
--- a/container-images/cpu/Containerfile
+++ b/container-images/cpu/Containerfile
@@ -1,0 +1,5 @@
+FROM registry.fedoraproject.org/fedora:42
+
+COPY --chmod=755 ../scripts /usr/bin
+
+RUN build_llama_and_whisper.sh "cpu"


### PR DESCRIPTION
Each rpc worker only supports one type of device
if you want to use the remote machines CPU/RAM resources as well, you need to run cpu worker too.

This can be also useful in case you have a gpu rpc worker on your node and you do not want your initiator process to also use GPU.
Another use case in case you have an incompatible hardware and you want to by pass any issue regarding to partially working accelerator.

example usage 
thread option not passed, assuming default is good.

cpu and cuda nodes:
```
 ssh 192.168.141.7  podman run --rm --network host  -it quay.io/ramalama_rpc/cpu  /usr/bin/rpc-server -p 50053 -H 0.0.0.0 &
 ssh 192.168.142.5  podman run --rm --network host  -it quay.io/ramalama_rpc/cpu  /usr/bin/rpc-server -p 50053 -H 0.0.0.0 &
ssh 192.168.142.5  podman run --gpus=all --runtime /usr/bin/nvidia-container-runtime --network host quay.io/ramalama/cuda:0.9 /usr/bin/rpc-server -p 50052 -H 0.0.0.0  &
ssh 192.168.141.7  podman run --gpus=all --runtime /usr/bin/nvidia-container-runtime --network host quay.io/ramalama/cuda:0.9 /usr/bin/rpc-server -p 50052 -H 0.0.0.0  &
```
 
initiator node with rocm: 
```
RAMALAMA_LLAMACPP_RPC_NODES=192.168.142.5:50053,192.168.140.7:50053,192.168.142.5:50052,192.168.140.7:50052  ramalama serve --ctx 8192 file:///srv/llm/modles/unsloth/Qwen3-235B-A22B-GGUF/Q8_0/Qwen3-235B-A22B-Q8_0-00001-of-00006.gguf  --ngl 62 --model-draft huggingface://Qwen/Qwen3-0.6B-GGUF/Qwen3-0.6B-Q8_0.gguf:latest
```
```
srv    load_model: loading model '/mnt/models/Qwen3-235B-A22B-Q8_0-00001-of-00006.gguf'
llama_model_load_from_file_impl: using device RPC[192.168.142.5:50053] (RPC[192.168.142.5:50053]) - 64223 MiB free
llama_model_load_from_file_impl: using device RPC[192.168.140.7:50053] (RPC[192.168.140.7:50053]) - 61852 MiB free
llama_model_load_from_file_impl: using device RPC[192.168.142.5:50052] (RPC[192.168.142.5:50052]) - 23862 MiB free
llama_model_load_from_file_impl: using device RPC[192.168.140.7:50052] (RPC[192.168.140.7:50052]) - 23872 MiB free
llama_model_load_from_file_impl: using device ROCm0 (AMD Radeon RX 7900 XTX) - 24524 MiB free
llama_model_loader: additional 5 GGUFs metadata loaded.
...
load_tensors: loading model tensors, this can take a while... (mmap = true)
load_tensors: offloading 62 repeating layers to GPU
load_tensors: offloaded 62/95 layers to GPU
load_tensors: RPC[192.168.142.5:50053] model buffer size = 52967.93 MiB
load_tensors: RPC[192.168.140.7:50053] model buffer size = 47923.36 MiB
load_tensors: RPC[192.168.142.5:50052] model buffer size = 17655.98 MiB
load_tensors: RPC[192.168.140.7:50052] model buffer size = 20178.26 MiB
load_tensors:   CPU_Mapped model buffer size = 47550.55 MiB
load_tensors:   CPU_Mapped model buffer size = 34423.68 MiB
load_tensors:        ROCm0 model buffer size = 17655.98 MiB
....................................................................................................
llama_context: constructing llama_context
llama_context: n_seq_max     = 1
llama_context: n_ctx         = 8192
llama_context: n_ctx_per_seq = 8192
llama_context: n_batch       = 2048
llama_context: n_ubatch      = 512
llama_context: causal_attn   = 1
llama_context: flash_attn    = 0
llama_context: freq_base     = 1000000.0
llama_context: freq_scale    = 1
llama_context: n_ctx_per_seq (8192) < n_ctx_train (40960) -- the full capacity of the model will not be utilized
...
```

PS: the file:/// did not automatically internalized all the split files, I had to call it for each file, should be fixed later. 

Only a few token per sec, but loads a 235B model in q8_0 on 3 HEDT machine.