### PR TITLE
Only print this in the llama-stack case

### DIFF
--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -744,5 +744,5 @@ def compute_serving_port(args, quiet=False) -> str:
         if args.api == "llama-stack":
             print(f"Llama Stack RESTAPI: {openai}")
             openai = openai + "/v1/openai"
-        print(f"OpenAI RESTAPI: {openai}")
+            print(f"OpenAI RESTAPI: {openai}")
     return str(target_port)


### PR DESCRIPTION
In the llama.cpp case it doesn't make as much sense, llama-server prints this string when it's ready to be served like so:

main: server is listening on http://0.0.0.0:8080 - starting the main loop

This can be printed seconds or minutes too early potentially in the llama.cpp case.

## Summary by Sourcery

Bug Fixes:
- Only print the OpenAI RESTAPI endpoint when using the llama-stack API