### PR TITLE
Only enumerate ROCm-capable AMD GPUs

### DIFF
--- a/ramalama/amdkfd.py
+++ b/ramalama/amdkfd.py
@@ -1,0 +1,19 @@
+"""utilities for working with AMDKFD driver"""
+
+import glob
+
+def parse_props(path):
+    """Returns a dict corresponding to a KFD properties file"""
+    with open(path) as file:
+        return {key: int(value) for key, _, value in (line.partition(' ') for line in file)}
+
+def gpus():
+    """Yields GPU nodes within KFD topology and their properties"""
+    for np in sorted(glob.glob('/sys/devices/virtual/kfd/kfd/topology/nodes/*')):
+        props = parse_props(np + '/properties')
+
+        # Skip CPUs
+        if props['gfx_target_version'] == 0:
+            continue
+
+        yield np, props

--- a/ramalama/amdkfd.py
+++ b/ramalama/amdkfd.py
@@ -2,10 +2,12 @@
 
 import glob
 
+
 def parse_props(path):
     """Returns a dict corresponding to a KFD properties file"""
     with open(path) as file:
         return {key: int(value) for key, _, value in (line.partition(' ') for line in file)}
+
 
 def gpus():
     """Yields GPU nodes within KFD topology and their properties"""

--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -36,6 +36,8 @@ HTTP_RANGE_NOT_SATISFIABLE = 416  # "Range Not Satisfiable" error (file already 
 
 DEFAULT_IMAGE = "quay.io/ramalama/ramalama"
 
+MIN_VRAM_BYTES = 1073741824 # 1GiB
+
 
 _engine = -1  # -1 means cached variable not set yet
 _nvidia = -1  # -1 means cached variable not set yet
@@ -463,7 +465,7 @@ def check_rocm_amd():
             if bank_props['heap_type'] in [1, 2]:
                 mem_bytes += int(bank_props['size_in_bytes'])
 
-        if mem_bytes > 1073741824 and mem_bytes > gpu_bytes:
+        if mem_bytes > MIN_VRAM_BYTES and mem_bytes > gpu_bytes:
             gpu_bytes = mem_bytes
             gpu_num = i
 

--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -36,7 +36,7 @@ HTTP_RANGE_NOT_SATISFIABLE = 416  # "Range Not Satisfiable" error (file already 
 
 DEFAULT_IMAGE = "quay.io/ramalama/ramalama"
 
-MIN_VRAM_BYTES = 1073741824 # 1GiB
+MIN_VRAM_BYTES = 1073741824  # 1GiB
 
 
 _engine = -1  # -1 means cached variable not set yet


### PR DESCRIPTION
Discover AMD graphics devices using AMDKFD topology instead of enumerating the PCIe bus. This interface exposes a lot more information about potential devices, allowing RamaLama to filter out unsupported devices.

Currently, devices older than GFX9 are filtered, as they are no longer supported by ROCm.

Ref: #1482