### PR TITLE
fix: remove unneeded dependency from Llama Stack container

### DIFF
--- a/container-images/llama-stack/Containerfile
+++ b/container-images/llama-stack/Containerfile
@@ -10,7 +10,7 @@ RUN dnf -y update && \
     dnf -y clean all
 
 RUN uv venv && \
-    uv pip install ramalama-stack==0.2.0 blobfile
+    uv pip install ramalama-stack==0.2.0
 
 COPY --chmod=755 llama-stack/entrypoint.sh /usr/bin/entrypoint.sh
 


### PR DESCRIPTION
partially reverts https://github.com/containers/ramalama/pull/1484

`blobfile` dependency is already included in ramalama-stack version 0.2.0

adding it explicitly is unnecessarily