### PR TITLE
Wait for upto 16 seconds for model to load

### DIFF
--- a/libexec/ramalama/ramalama-client-core
+++ b/libexec/ramalama/ramalama-client-core
@@ -93,23 +93,25 @@ class RamaLamaShell(cmd.Cmd):
         )
         self.request_in_process = False
 
-    def _req(self):
+    def _make_request_data(self):
         data = {
             "stream": True,
             "messages": self.conversation_history,
             "model": self.model(),
         }
-
         json_data = json.dumps(data).encode("utf-8")
         headers = {
             "Content-Type": "application/json",
         }
-
-        # Create a request
         request = urllib.request.Request(self.url, data=json_data, headers=headers, method="POST")
 
-        # Send request
+        return request
+
+    def _req(self):
+        request = self._make_request_data()
+
         i = 0.01
+        total_time_slept = 0
         response = None
         for c in itertools.cycle(['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏']):
             try:
@@ -119,11 +121,13 @@ class RamaLamaShell(cmd.Cmd):
                 if sys.stdout.isatty():
                     print(f"\r{c}", end="", flush=True)
 
-                if i > 512:
+                if total_time_slept > 16:
                     break
 
-                time.sleep(min(i, 0.1))
-                i *= 2
+                total_time_slept += i
+                time.sleep(i)
+
+                i = min(i * 2, 0.1)
 
         if response:
             return res(response, self.parsed_args.color)


### PR DESCRIPTION
Trying to put this timeout to bed once and for all. There is a chance a really large model on certain hardware could take more than 16 seconds to load.

## Summary by Sourcery

Enhancements:
- Increase the model load timeout from 6 seconds to 16 seconds to reduce premature timeout errors.

## Summary by Sourcery

Enhancements:
- Increase model load timeout from 6 seconds to 16 seconds to reduce premature timeout errors on large models