### PR TITLE
Make minimum version of Python consistent

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ This section describes how to make a contribution to RamaLama.
 
 ### Prepare your environment
 
-The minimum version of Python required to use RamaLama is Python 3.11
+The minimum version of Python required to use RamaLama is Python 3.10
 
 ### Fork and clone RamaLama
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ include-package-data = true
 line-length = 120
 skip-string-normalization = true
 preview = true
-target-version = ["py311", "py312", "py313"]
+target-version = ["py310", "py311", "py312", "py313"]
 include = '\.pyi?$'
 exclude = '''
 /(

--- a/ramalama/__init__.py
+++ b/ramalama/__init__.py
@@ -7,7 +7,7 @@ from ramalama.cli import HelpException, init_cli, print_version
 from ramalama.common import apple_vm, perror
 from ramalama.config import CONFIG
 
-assert sys.version_info >= (3, 11), "Python 3.11 or greater is required."
+assert sys.version_info >= (3, 10), "Python 3.10 or greater is required."
 
 
 def initialize_environment():


### PR DESCRIPTION
Change documentation and code to consistently use 3.10 as the minimum python version