### PR TITLE
Update black target version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ include-package-data = true
 line-length = 120
 skip-string-normalization = true
 preview = true
-target-version = ["py36"]
+target-version = ["py311", "py312", "py313"]
 include = '\.pyi?$'
 exclude = '''
 /(


### PR DESCRIPTION
The `black` formatter can make better formatting suggestions if it knows the correct versions of Python being targeted.

## Summary by Sourcery

Enhancements:
- Extend Black's target-version in pyproject.toml to include Python 3.10 through 3.13 instead of Python 3.6