### PR TITLE
Add Python shebang files to linting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ PYTHON ?= $(shell command -v python3 python|head -n1)
 DESTDIR ?= /
 PATH := $(PATH):$(HOME)/.local/bin
 IMAGE ?= ramalama
+PYTHON_FILES := $(shell find . -path "./.venv" -prune -o -name "*.py" -print) $(shell find . -name ".venv" -prune -o -type f -perm +111 -exec grep -l "^\#!/usr/bin/env python3" {} \; 2>/dev/null || true)
 
 default: help
 
@@ -111,18 +112,18 @@ ifneq (,$(wildcard /usr/bin/python3))
 endif
 
 	! grep -ri --exclude-dir ".venv" --exclude-dir "*/.venv" "#\!/usr/bin/python3" .
-	flake8  */*.py */*/*.py libexec/* bin/*
+	flake8 $(PYTHON_FILES)
 	shellcheck *.sh */*.sh */*/*.sh
 
 .PHONY: check-format
 check-format:
-	black --check --diff */*.py */*/*.py libexec/* bin/*
-	isort --check --diff */*.py */*/*.py libexec/* bin/*
+	black --check --diff $(PYTHON_FILES)
+	isort --check --diff $(PYTHON_FILES)
 
 .PHONY: format
 format:
-	black */*.py */*/*.py libexec/* bin/*
-	isort */*.py */*/*.py libexec/* bin/*
+	black $(PYTHON_FILES)
+	isort $(PYTHON_FILES)
 
 .PHONY: codespell
 codespell:

--- a/container-images/scripts/doc2rag
+++ b/container-images/scripts/doc2rag
@@ -6,17 +6,19 @@ import os
 import sys
 import uuid
 
-import qdrant_client
-from qdrant_client import models
 import docling
+import qdrant_client
 from docling.chunking import HybridChunker
-from docling.document_converter import DocumentConverter, PdfFormatOption
 from docling.datamodel.base_models import InputFormat
 from docling.datamodel.pipeline_options import PdfPipelineOptions
+from docling.document_converter import DocumentConverter, PdfFormatOption
+from qdrant_client import models
+
 # Global Vars
 EMBED_MODEL = os.getenv("EMBED_MODEL", "jinaai/jina-embeddings-v2-small-en")
 SPARSE_MODEL = os.getenv("SPARSE_MODEL", "prithivida/Splade_PP_en_v1")
 COLLECTION_NAME = "rag"
+
 
 class Converter:
     """A Class designed to handle all document conversions using Docling"""
@@ -26,10 +28,8 @@ class Converter:
         pipeline_options = PdfPipelineOptions()
         pipeline_options.do_ocr = ocr
         self.doc_converter = DocumentConverter(
-                format_options={
-                    InputFormat.PDF: PdfFormatOption(pipeline_options=pipeline_options)
-                }
-            )
+            format_options={InputFormat.PDF: PdfFormatOption(pipeline_options=pipeline_options)}
+        )
         self.targets = []
         for target in targets:
             self.add(target)
@@ -41,7 +41,7 @@ class Converter:
         self.client.create_collection(
             collection_name=COLLECTION_NAME,
             vectors_config=self.client.get_fastembed_vector_params(on_disk=True),
-            sparse_vectors_config= self.client.get_fastembed_sparse_vector_params(on_disk=True),
+            sparse_vectors_config=self.client.get_fastembed_sparse_vector_params(on_disk=True),
             quantization_config=models.ScalarQuantization(
                 scalar=models.ScalarQuantizationConfig(
                     type=models.ScalarType.INT8,
@@ -58,7 +58,7 @@ class Converter:
 
     def convert(self):
         result = self.doc_converter.convert_all(self.targets)
-        documents, metadata, ids = [], [], []
+        documents, ids = [], []
         chunker = HybridChunker(tokenizer=EMBED_MODEL, overlap=100, merge_peers=True)
         for file in result:
             chunk_iter = chunker.chunk(dl_doc=file.document)
@@ -88,6 +88,7 @@ class Converter:
         # Use the first 32 characters of the hash to create a UUID
         return str(uuid.UUID(sha256_hash[:32]))
 
+
 def load():
     # Dummy code to preload models
     client = qdrant_client.QdrantClient(":memory:")
@@ -96,6 +97,7 @@ def load():
     converter = DocumentConverter()
     converter.initialize_pipeline(InputFormat.PDF)
 
+
 parser = argparse.ArgumentParser(
     prog="docling",
     description="process source files into RAG vector database",
@@ -103,7 +105,12 @@ parser = argparse.ArgumentParser(
 
 parser.add_argument("target", nargs="?", help="Target database")
 parser.add_argument("source", nargs="*", help="Source files")
-parser.add_argument("--ocr", action='store_true', help="Enable embedded image text extraction from PDF (Increases RAM Usage significantly)")
+parser.add_argument(
+    "--ocr",
+    action='store_true',
+    help="Enable embedded image text extraction from PDF (Increases RAM Usage significantly)",
+)
+
 
 def perror(*args, **kwargs):
     print(*args, file=sys.stderr, **kwargs)
@@ -112,6 +119,7 @@ def perror(*args, **kwargs):
 def eprint(e, exit_code):
     perror("Error: " + str(e).strip("'\""))
     sys.exit(exit_code)
+
 
 try:
     args = parser.parse_args()

--- a/container-images/scripts/rag_framework
+++ b/container-images/scripts/rag_framework
@@ -1,21 +1,21 @@
 #!/usr/bin/env python3
 
 # AI imports
+import argparse
 import cmd
-import qdrant_client
-import openai
-from fastembed.rerank.cross_encoder import TextCrossEncoder
+import os
+import sys
+
 # Regular imports
 import uuid
-import os
-import hashlib
-import argparse
 
+import openai
+import qdrant_client
+import uvicorn
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import JSONResponse
+from fastembed.rerank.cross_encoder import TextCrossEncoder
 from pydantic import BaseModel
-from fastapi import FastAPI
-import uvicorn
 
 # Global Vars
 EMBED_MODEL = os.getenv("EMBED_MODEL", "jinaai/jina-embeddings-v2-small-en")
@@ -30,19 +30,23 @@ def eprint(e, exit_code):
     print("Error: " + str(e).strip("'\""))
     sys.exit(exit_code)
 
+
 # Helper Classes and Functions
+
 
 class QueryRequest(BaseModel):
     model: str
     messages: list
     max_tokens: int = 150  # Default to 150 tokens
 
+
 class Rag(cmd.Cmd):
     prompt = "> "
+
     def __init__(self, vector_path):
         # Initlialze the cmd class
         super().__init__()
-        
+
         self.client = qdrant_client.QdrantClient(path=vector_path)
         self.client.set_model(EMBED_MODEL)
         self.client.set_sparse_model(SPARSE_MODEL)
@@ -55,57 +59,52 @@ class Rag(cmd.Cmd):
     def do_EOF(self, user_content):
         print("")
         return True
-    
+
     def query(self, prompt):
         # Add user query to chat history
         self.chat_history.append({"role": "user", "content": prompt})
-        
+
         # Ensure chat history does not exceed 10 messages (5 user + 5 AI)
         if len(self.chat_history) > 10:
             self.chat_history.pop(0)  # Remove the oldest message
-        
+
         # Query the Qdrant client for relevant context
         results = self.client.query(
             collection_name="rag",
             query_text=prompt,
             limit=20,
         )
-        result = [r.document for r in results] 
-        # reranker code to have the first 5 queries 
+        result = [r.document for r in results]
+        # reranker code to have the first 5 queries
         reranked_context = " ".join(
-            str(result[i]) for i, _ in sorted(
-                enumerate(self.reranker.rerank(prompt, result)),
-                key=lambda x: x[1],
-                reverse=True
-            )[:5]
+            str(result[i])
+            for i, _ in sorted(enumerate(self.reranker.rerank(prompt, result)), key=lambda x: x[1], reverse=True)[:5]
         )
 
         # context = "\n".join(r.document for r in results)
 
         # Prepare the metaprompt with chat history and context
         metaprompt = f"""
-            You are an expert software architect.  
-            Use the provided context and chat history to answer the question accurately and concisely.  
-            If the answer is not explicitly stated, infer the most reasonable answer based on the available information.  
-            If there is no relevant information, respond with "I don't know"—do not fabricate details.  
+            You are an expert software architect.
+            Use the provided context and chat history to answer the question accurately and concisely.
+            If the answer is not explicitly stated, infer the most reasonable answer based on the available information.
+            If there is no relevant information, respond with "I don't know"—do not fabricate details.
 
             ### Chat History:
             {self.format_chat_history()}
 
-            ### Context:  
-            {reranked_context.strip()}  
+            ### Context:
+            {reranked_context.strip()}
 
-            ### Question:  
-            {prompt.strip()}  
+            ### Question:
+            {prompt.strip()}
 
             ### Answer:
             """
-        
+
         # Query the LLM with the metaprompt
         response = self.llm.chat.completions.create(
-            model="your-model-name",
-            messages=[{"role": "user", "content": metaprompt}],
-            stream=True 
+            model="your-model-name", messages=[{"role": "user", "content": metaprompt}], stream=True
         )
 
         # Collect the AI response and add it to chat history
@@ -114,14 +113,14 @@ class Rag(cmd.Cmd):
             if chunk.choices[0].delta.content:
                 full_response += chunk.choices[0].delta.content
                 print(chunk.choices[0].delta.content, end="", flush=True)
-        
+
         # Add AI response to chat history
         self.chat_history.append({"role": "assistant", "content": full_response})
-        
+
         # Ensure chat history does not exceed 10 messages after adding the AI response
         if len(self.chat_history) > 10:
             self.chat_history.pop(0)  # Remove the oldest message
-        
+
         print(" ")
 
     def format_chat_history(self):
@@ -148,33 +147,33 @@ class Rag(cmd.Cmd):
         @app.post("/v1/chat/completions")
         async def query(request: QueryRequest):
             """API endpoint to query the Rag instance and return OpenAI-like response."""
-            
+
             if not request.messages:
                 raise HTTPException(status_code=400, detail="Messages are required")
-            
+
             try:
                 response_text = self.query(request.messages)
-                
-                return JSONResponse(content={
-                    "id": str(uuid.uuid4()),
-                    "object": "chat.completion",
-                    "created": 1678901234,  # Static, could use a timestamp
-                    "model": request.model,
-                    "choices": [
-                        {
-                            "message": {
-                                "role": "assistant",
-                                "content": response_text
-                            },
-                            "finish_reason": "stop",
-                            "index": 0
-                        }
-                    ]
-                })
+
+                return JSONResponse(
+                    content={
+                        "id": str(uuid.uuid4()),
+                        "object": "chat.completion",
+                        "created": 1678901234,  # Static, could use a timestamp
+                        "model": request.model,
+                        "choices": [
+                            {
+                                "message": {"role": "assistant", "content": response_text},
+                                "finish_reason": "stop",
+                                "index": 0,
+                            }
+                        ],
+                    }
+                )
             except Exception as e:
                 raise HTTPException(status_code=500, detail=str(e))
-        
+
         uvicorn.run(app, host="0.0.0.0", port=8080)
+
 
 def run_rag(vector_path):
     rag = Rag(vector_path)
@@ -183,9 +182,11 @@ def run_rag(vector_path):
     except KeyboardInterrupt:
         print("")
 
+
 def serve_rag(vector_path):
     rag = Rag(vector_path)
     rag.serve()
+
 
 def load():
     client = qdrant_client.QdrantClient(":memory:")
@@ -218,4 +219,4 @@ try:
         else:
             args.func()  # no argument for 'load'
 except ValueError as e:
-        eprint(e, 1)
+    eprint(e, 1)

--- a/libexec/ramalama/ramalama-client-core
+++ b/libexec/ramalama/ramalama-client-core
@@ -66,13 +66,13 @@ class RamaLamaShell(cmd.Cmd):
             return self.models[index]
         except urllib.error.URLError:
             return ""
-        
+
     def get_models(self):
         request = urllib.request.Request(self.models_url, method="GET")
         response = urllib.request.urlopen(request)
         for line in response:
             line = line.decode("utf-8").strip()
-            return([d['id'] for d in json.loads(line)["data"]])
+            return [d['id'] for d in json.loads(line)["data"]]
 
     def do_EOF(self, user_content):
         print("")
@@ -88,9 +88,7 @@ class RamaLamaShell(cmd.Cmd):
         if not response:
             return True
 
-        self.conversation_history.append(
-            {"role": "assistant", "content": response}
-        )
+        self.conversation_history.append({"role": "assistant", "content": response})
         self.request_in_process = False
 
     def _req(self):
@@ -183,7 +181,9 @@ def parse_arguments(args):
         help="size of the prompt context (0 = loaded from model)",
     )
     parser.add_argument("--jinja", action="store_true", help="enable jinja")
-    parser.add_argument("--kill-server", dest="pid2kill", type=int, help="server process to kill on termination of client")
+    parser.add_argument(
+        "--kill-server", dest="pid2kill", type=int, help="server process to kill on termination of client"
+    )
     parser.add_argument("--temp", default=0.8, help="temperature of the response from the AI model")
     parser.add_argument(
         "ARGS", nargs="*", help="overrides the default prompt, and the output is returned without entering the chatbot"

--- a/libexec/ramalama/ramalama-run-core
+++ b/libexec/ramalama/ramalama-run-core
@@ -1,12 +1,9 @@
 #!/usr/bin/env python3
 
 import argparse
-import atexit
 import os
 import signal
-import subprocess
 import sys
-from argparse import Namespace
 
 
 def initialize_parser():
@@ -34,11 +31,11 @@ def initialize_parser():
         "-t",
         "--threads",
         type=int,
-        help=f"number of cpu threads to use",
+        help="number of cpu threads to use",
     )
     parser.add_argument(
         "-v",
-        help=f"verbose",
+        help="verbose",
         action="store_true",
     )
     parser.add_argument("MODEL", type=str, help="Path to the model")  # positional argument
@@ -78,7 +75,6 @@ def main(args):
             del os.environ[proxy_var]
 
     sys.path.append('./')
-    from ramalama.cli import serve_cli
     from ramalama.common import exec_cmd
 
     parsed_args, port = initialize_args()
@@ -88,15 +84,39 @@ def main(args):
         signal.pthread_sigmask(signal.SIG_BLOCK, {signal.SIGINT})
         # at this point we are already in a container so, --nocontainer always makes sense
         dont_print_output = (not parsed_args.debug) and (not parsed_args.v)
-        exec_cmd(["ramalama", "--nocontainer", "serve", "--threads", str(parsed_args.threads), "--temp", parsed_args.temp, "--port", str(port), parsed_args.MODEL], stdout2null=dont_print_output, stderr2null=dont_print_output)
+        exec_cmd(
+            [
+                "ramalama",
+                "--nocontainer",
+                "serve",
+                "--threads",
+                str(parsed_args.threads),
+                "--temp",
+                parsed_args.temp,
+                "--port",
+                str(port),
+                parsed_args.MODEL,
+            ],
+            stdout2null=dont_print_output,
+            stderr2null=dont_print_output,
+        )
 
         return 0
 
     client_args = build_args(args, "ramalama-client-core")
-    client_args += ['-c', parsed_args.context, '--temp', parsed_args.temp, "--kill-server", str(pid), "http://127.0.0.1:" + str(port)] + parsed_args.ARGS
+    client_args += [
+        '-c',
+        parsed_args.context,
+        '--temp',
+        parsed_args.temp,
+        "--kill-server",
+        str(pid),
+        "http://127.0.0.1:" + str(port),
+    ] + parsed_args.ARGS
     exec_cmd(client_args)
 
     return 0
+
 
 def build_args(args, new_command):
     new_args = args.copy()
@@ -104,6 +124,7 @@ def build_args(args, new_command):
     new_args = [new_args[0]]
 
     return new_args
+
 
 if __name__ == "__main__":
     main(sys.argv)

--- a/libexec/ramalama/ramalama-serve-core
+++ b/libexec/ramalama/ramalama-serve-core
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-import argparse
 import sys
 
 


### PR DESCRIPTION
Currently, the `Makefile` lints a specific list of files, including files with the `.py` extension and a few folders containing Python scripts. This setup misses a few Python scripts that don't have a `.py` extension and aren't in one of the specified folders.

This PR changes the linting rules to use `find` to get all files with a `.py` extension and all executable files containing a Python shebang.

The find command used is:

```shell
find . -name ".venv" -prune -o -type f -perm +111 -exec grep -l "^\#!/usr/bin/env python3" {} \;
```

## Summary by Sourcery

Enhance Python linting by dynamically discovering all .py files and executable scripts with a Python shebang and updating lint targets to use the new file list

Enhancements:
- Introduce a PYTHON_FILES variable that aggregates all .py files and executable scripts with a Python shebang
- Refactor flake8, black, and isort targets to use PYTHON_FILES instead of hardcoded path globs