### PR TITLE
chore(common/intel_gpus): detect arc a770, a750

### DIFF
--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -482,6 +482,8 @@ def check_intel():
     intel_gpus = (
         b"0xe20b",
         b"0xe20c",
+        b"0x56a0",
+        b"0x56a1",
         b"0x7d51",
         b"0x7dd5",
         b"0x7d55",


### PR DESCRIPTION
closed #1515

## Summary by Sourcery

Enhancements:
- Include device IDs 0x56a0 and 0x56a1 to recognize Intel Arc A770 and A750 GPUs in the intel_gpus list