### PR TITLE
Change the FROM for asahi container image

### DIFF
--- a/container-images/asahi/Containerfile
+++ b/container-images/asahi/Containerfile
@@ -1,4 +1,4 @@
-FROM fedora:42
+FROM quay.io/fedora/fedora:42
 
 ENV ASAHI_VISIBLE_DEVICES 1
 COPY --chmod=755 ../scripts /usr/bin


### PR DESCRIPTION
Explicitly add quay.io

## Summary by Sourcery

Enhancements:
- Change base image reference from `fedora:42` to `quay.io/fedora/fedora:42`