### PR TITLE
[th/honor-image] cli: honor --image parameter in rag mode

### DIFF
--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -190,8 +190,8 @@ The RAMALAMA_CONTAINER_ENGINE environment variable modifies default behaviour.""
     )
     parser.add_argument(
         "--image",
-        default=accel_image(CONFIG, None),
-        help="OCI container image to run with the specified AI model",
+        default=None,
+        help=f"OCI container image to run with the specified AI model. The default (no-rag) image is {repr(accel_image(CONFIG, None))}.",
         action=OverrideDefaultAction,
         completer=local_images,
     )
@@ -264,6 +264,13 @@ def parse_arguments(parser):
 
 def post_parse_setup(args):
     """Perform additional setup after parsing arguments."""
+
+    if args.func is rag_cli:
+        args.rag = "rag"
+
+    if args.image is None:
+        args.image = accel_image(CONFIG, args)
+
     if hasattr(args, "MODEL") and args.subcommand != "rm":
         resolved_model = shortnames.resolve(args.MODEL)
         if resolved_model:

--- a/ramalama/rag.py
+++ b/ramalama/rag.py
@@ -4,8 +4,7 @@ import subprocess
 import tempfile
 from urllib.parse import urlparse
 
-from ramalama.common import accel_image, get_accel_env_vars, run_cmd, set_accel_env_vars
-from ramalama.config import CONFIG
+from ramalama.common import get_accel_env_vars, run_cmd, set_accel_env_vars
 from ramalama.engine import Engine
 from ramalama.logger import logger
 
@@ -74,11 +73,6 @@ COPY {src} /vector.db
     def generate(self, args):
         args.nocapdrop = True
         self.engine = Engine(args)
-        # force accel_image to use -rag version. Drop TAG if it exists
-        # so that accel_image will add -rag to the image specification.
-        args.rag = "rag"
-        args.image = args.image.split(":")[0]
-        args.image = accel_image(CONFIG, args)
 
         if not args.container:
             raise KeyError("rag command requires a container. Can not be run with --nocontainer option.")


### PR DESCRIPTION
Previously, to account for "--rag" option and the "rag" mode, the
args.image was mangled at a late point. At that point, args.image does
not indicate whether the value was chosen by default (and needs
adjustment for "-rag") or whether it was explicitly specified by the
user. In the latter case, we would not want to overwrite the user's
choice.

In those cases, the parameter was not ignored entirely, but rather the
tag was stripped, "-rag" appended, and the default tag added.
Nonetheless, we should honor the original image. Granted, the user must
choose an image that is suitable (e.g. for "--rag" mode).

Similarly, the "run" mode entirely ignored the "--image" argument.

Now, image selection happens early while parsing command line arguments.
It is based on CONFIG, the cli args and the hardware detection in
common.py.

---

Fixes: https://github.com/containers/ramalama/issues/1525
See-also: https://github.com/containers/ramalama/issues/1521#issue-3142998375

## Summary by Sourcery

Honor user-specified --image in both rag and run modes by moving image resolution upstream and eliminating late-stage overrides

Bug Fixes:
- Ensure --image is no longer ignored or overwritten in run mode
- Prevent automatic replacement of a user-specified image when using --rag

Enhancements:
- Centralize image selection in post_parse_setup based on args.image, args.rag, and CONFIG
- Remove legacy handle_rag_mode logic and inline accel_image calls across model and rag modules
- Change CLI --image default to None and update help text to display the default no-rag image