### PR TITLE
honor the user specifying the image

### DIFF
--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -926,6 +926,7 @@ def run_cli(args):
         model.serve(args, quiet=True) if args.rag else model.run(args)
 
     except KeyError as e:
+        logger.debug(e)
         try:
             args.quiet = True
             model = ModelFactory(args.MODEL, args, ignore_stderr=True).create_oci()

--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -670,7 +670,7 @@ def resolve_image_from_args_and_env(config, args):
     Resolves the base image based on arguments, environment variables, and config.
     Returns the resolved image string, or None if not found.
     """
-    if args and getattr(args, "image", None) and len(args.image.split(":")) > 1:
+    if args and getattr(args, "image", None):
         return args.image
 
     image = os.getenv("RAMALAMA_IMAGE")

--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -205,9 +205,10 @@ class Model(ModelBase):
     def base(self, args, name):
         # force accel_image to use -rag version. Drop TAG if it exists
         # so that accel_image will add -rag to the image specification.
+        if not args.image:
+            args.image = accel_image(CONFIG, args)
         if hasattr(args, "rag") and args.rag:
             args.image = args.image.split(":")[0]
-        args.image = accel_image(CONFIG, args)
         self.engine = Engine(args)
         if args.subcommand == "run" and not (hasattr(args, "ARGS") and args.ARGS) and sys.stdin.isatty():
             self.engine.add(["-i"])

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -132,4 +132,10 @@ EOF
     run_ramalama 124 --debug run --keepalive 1s tiny
 }
 
+@test "ramalama run --image bogus" {
+    skip_if_nocontainer
+    run_ramalama 125 --image bogus run --pull=never tiny
+    is "$output" "Error: bogus: image not known"
+}
+
 # vim: filetype=sh

--- a/test/system/040-serve.bats
+++ b/test/system/040-serve.bats
@@ -364,4 +364,10 @@ verify_begin=".*run --rm"
     rm /tmp/$name.yaml
 }
 
+@test "ramalama serve --image bogus" {
+    skip_if_nocontainer
+    run_ramalama 125 --image bogus serve --pull=never tiny
+    is "$output" "Error: bogus: image not known"
+}
+
 # vim: filetype=sh


### PR DESCRIPTION
Currently we are ignoreing the user specified image if it does not contain a ':'

Fixes: https://github.com/containers/ramalama/issues/1525