### PR TITLE
Add --all option to ramalama ls

### DIFF
--- a/docs/ramalama-list.1.md
+++ b/docs/ramalama-list.1.md
@@ -13,6 +13,9 @@ List all the AI Models in local storage
 
 ## OPTIONS
 
+#### **--all**
+include partially downloaded Models
+
 #### **--help**, **-h**
 show this help message and exit
 
@@ -30,7 +33,7 @@ $ ramalama list
 NAME                                                                MODIFIED     SIZE
 ollama://smollm:135m                                                16 hours ago 5.5M
 huggingface://afrideva/Tiny-Vicuna-1B-GGUF/tiny-vicuna-1b.q2_k.gguf 14 hours ago 460M
-ollama://granite-code:3b                                            5 days ago   1.9G
+ollama://granite-code:3b (partial)                                  5 days ago   1.9G
 ollama://granite-code:latest                                        1 day ago    1.9G
 ollama://moondream:latest                                           6 days ago   791M
 ```

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -476,13 +476,13 @@ def _list_models_from_store(args):
     local_timezone = datetime.now().astimezone().tzinfo
 
     for model, files in models.items():
-        is_partially_downloaded = any([file.is_partial for file in files])
+        is_partially_downloaded = any(file.is_partial for file in files)
         if not args.all and is_partially_downloaded:
             continue
 
-        if str(model).startswith("huggingface://"):
-            model = str(model).replace("huggingface://", "hf://", 1)
-            model = str(model).removesuffix(":latest")
+        if model.startswith("huggingface://"):
+            model = model.replace("huggingface://", "hf://", 1)
+            model = model.removesuffix(":latest")
 
         size_sum = 0
         last_modified = 0.0

--- a/ramalama/model_store.py
+++ b/ramalama/model_store.py
@@ -237,11 +237,9 @@ class GlobalModelStore:
                             )
                             if not os.path.exists(blobs_partial_file_path):
                                 continue
-                            snapshot_file_path = blobs_partial_file_path
 
-                            # append indication for partial downloaded model
-                            if not model_name.endswith("(partial)"):
-                                is_partially_downloaded = True
+                            snapshot_file_path = blobs_partial_file_path
+                            is_partially_downloaded = True
 
                         last_modified = os.path.getmtime(snapshot_file_path)
                         file_size = os.path.getsize(snapshot_file_path)


### PR DESCRIPTION
Relates to: https://github.com/containers/ramalama/issues/1278

By default, ramalama ls should not display partially downloaded AI Models. In order to enable users to view all models, the new option --all for the ls command has been introduced.

## Summary by Sourcery

Add an --all flag to ramalama ls/list to show partially downloaded models (excluded by default), annotate them in the output, and update documentation and model-store logic accordingly.

New Features:
- Add --all option to the list (ls) command to include partially downloaded AI models
- Annotate partially downloaded models with a “(partial)” suffix in the output

Enhancements:
- Exclude partially downloaded models from listing by default
- Streamline partial download detection logic in the model store

Documentation:
- Document the --all option in the CLI manual and update listing examples