### PR TITLE
Add colors to "ramalama serve" if we can

### DIFF
--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -50,6 +50,11 @@ with the default RamaLama
 $(error)s"""
 
 
+def should_colorize():
+    t = os.getenv("TERM")
+    return t and t != "dumb" and sys.stdout.isatty()
+
+
 def is_split_file_model(model_path):
     """returns true if ends with -%05d-of-%05d.gguf"""
     return bool(re.match(SPLIT_MODEL_RE, model_path))
@@ -532,6 +537,9 @@ class Model(ModelBase):
                 exec_args += ["--mmproj", mmproj_path]
             else:
                 exec_args += ["--jinja"]
+
+            if should_colorize():
+                exec_args += ["--log-colors"]
 
             exec_args += [
                 "--alias",


### PR DESCRIPTION
I don't notice any difference but a lot of things are LOG_INFO in llama.cpp

## Summary by Sourcery

Add automatic detection and enabling of colored logs in the `ramalama serve` command when run in a color-capable terminal.

New Features:
- Enable colored logging in `ramalama serve` by appending the `--log-colors` flag when the terminal supports ANSI colors.

Enhancements:
- Introduce a `should_colorize` helper that checks the `TERM` environment variable and `isatty()` status to determine if color output is supported.