### PR TITLE
Add ramalama chat command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1041,6 +1041,7 @@ $ cat /usr/share/ramalama/shortnames.conf
 | ------------------------------------------------------ | ---------------------------------------------------------- |
 | [ramalama(1)](https://github.com/containers/ramalama/blob/main/docs/ramalama.1.md)                      | primary RamaLama man page                                  |
 | [ramalama-bench(1)](https://github.com/containers/ramalama/blob/main/docs/ramalama-bench.1.md)| benchmark specified AI Model                                         |
+| [ramalama-chat(1)](https://github.com/containers/ramalama/blob/main/docs/ramalama-chat.1.md)| chat with specified OpenAI RESTAPI                         |
 | [ramalama-containers(1)](https://github.com/containers/ramalama/blob/main/docs/ramalama-containers.1.md)| list all RamaLama containers                               |
 | [ramalama-convert(1)](https://github.com/containers/ramalama/blob/main/docs/ramalama-convert.1.md)      | convert AI Model from local storage to OCI Image           |
 | [ramalama-info(1)](https://github.com/containers/ramalama/blob/main/docs/ramalama-info.1.md)            | display RamaLama configuration information                 |

--- a/README.md
+++ b/README.md
@@ -1041,7 +1041,7 @@ $ cat /usr/share/ramalama/shortnames.conf
 | ------------------------------------------------------ | ---------------------------------------------------------- |
 | [ramalama(1)](https://github.com/containers/ramalama/blob/main/docs/ramalama.1.md)                      | primary RamaLama man page                                  |
 | [ramalama-bench(1)](https://github.com/containers/ramalama/blob/main/docs/ramalama-bench.1.md)| benchmark specified AI Model                                         |
-| [ramalama-chat(1)](https://github.com/containers/ramalama/blob/main/docs/ramalama-chat.1.md)| chat with specified OpenAI RESTAPI                         |
+| [ramalama-chat(1)](https://github.com/containers/ramalama/blob/main/docs/ramalama-chat.1.md)| chat with specified OpenAI REST API                        |
 | [ramalama-containers(1)](https://github.com/containers/ramalama/blob/main/docs/ramalama-containers.1.md)| list all RamaLama containers                               |
 | [ramalama-convert(1)](https://github.com/containers/ramalama/blob/main/docs/ramalama-convert.1.md)      | convert AI Model from local storage to OCI Image           |
 | [ramalama-info(1)](https://github.com/containers/ramalama/blob/main/docs/ramalama-info.1.md)            | display RamaLama configuration information                 |

--- a/docs/ramalama-chat.1.md
+++ b/docs/ramalama-chat.1.md
@@ -1,0 +1,45 @@
+% ramalama-chat 1
+
+## NAME
+ramalama\-chat - OpenAI chat with the specified RESTAPI URL
+
+## SYNOPSIS
+**ramalama chat** [*options*] [arg...]
+
+positional arguments:
+  ARGS                  overrides the default prompt, and the output is
+                        returned without entering the chatbot
+
+## DESCRIPTION
+Specify one or more AI Models to be removed from local storage
+
+## OPTIONS
+
+#### **--color**
+Indicate whether or not to use color in the chat.
+Possible values are "never", "always" and "auto". (default: auto)
+
+#### **--help**, **-h**
+Show this help message and exit
+
+#### **--prefix**
+Prefix for the user prompt (default: 🦭 > )
+
+#### **--url**=URL
+The host to send requests to (default: http://127.0.0.1:8080)
+
+## EXAMPLES
+
+```
+$ ramalama chat
+🦭 >
+
+$ ramalama chat http://localhost:1234
+🐋 >
+```
+
+## SEE ALSO
+**[ramalama(1)](ramalama.1.md)**
+
+## HISTORY
+Jun 2025, Originally compiled by Dan Walsh <dwalsh@redhat.com>

--- a/docs/ramalama-chat.1.md
+++ b/docs/ramalama-chat.1.md
@@ -1,7 +1,7 @@
 % ramalama-chat 1
 
 ## NAME
-ramalama\-chat - OpenAI chat with the specified RESTAPI URL
+ramalama\-chat - OpenAI chat with the specified REST API URL
 
 ## SYNOPSIS
 **ramalama chat** [*options*] [arg...]
@@ -11,7 +11,7 @@ positional arguments:
                         returned without entering the chatbot
 
 ## DESCRIPTION
-Specify one or more AI Models to be removed from local storage
+Chat with an OpenAI Rest API
 
 ## OPTIONS
 
@@ -30,11 +30,14 @@ The host to send requests to (default: http://127.0.0.1:8080)
 
 ## EXAMPLES
 
+Communicate with the default local OpenAI REST API. (http://127.0.0.1:8080)
+With Podman containers.
 ```
 $ ramalama chat
 🦭 >
 
-$ ramalama chat http://localhost:1234
+Communicate with an alternative OpenAI REST API URL. With Docker containers.
+$ ramalama chat --url http://localhost:1234
 🐋 >
 ```
 

--- a/docs/ramalama-serve.1.md
+++ b/docs/ramalama-serve.1.md
@@ -36,14 +36,14 @@ For REST API endpoint documentation, see: [https://github.com/ggml-org/llama.cpp
 ## OPTIONS
 
 #### **--api**=**llama-stack** | none**
-unified API layer for Inference, RAG, Agents, Tools, Safety, Evals, and Telemetry.(default: none)
+Unified API layer for Inference, RAG, Agents, Tools, Safety, Evals, and Telemetry.(default: none)
 The default can be overridden in the ramalama.conf file.
 
 #### **--authfile**=*password*
-path of the authentication file for OCI registries
+Path of the authentication file for OCI registries
 
 #### **--ctx-size**, **-c**
-size of the prompt context (default: 2048, 0 = loaded from model)
+Size of the prompt context (default: 2048, 0 = loaded from model)
 
 #### **--detach**, **-d**
 Run the container in the background and print the new container ID.

--- a/docs/ramalama.1.md
+++ b/docs/ramalama.1.md
@@ -178,7 +178,7 @@ It adds support for model versioning and multiple files such as chat templates. 
 | Command                                           | Description                                                |
 | ------------------------------------------------- | ---------------------------------------------------------- |
 | [ramalama-bench(1)](ramalama-bench.1.md)          | benchmark specified AI Model                               |
-| [ramalama-chat(1)](ramalama-chat.1.md)            |  OpenAI chat with the specified RESTAPI URL                |
+| [ramalama-chat(1)](ramalama-chat.1.md)            |  OpenAI chat with the specified REST API URL                |
 | [ramalama-client(1)](ramalama-client.1.md)        | interact with the AI Model server (experimental)           |
 | [ramalama-containers(1)](ramalama-containers.1.md)| list all RamaLama containers                               |
 | [ramalama-convert(1)](ramalama-convert.1.md)      | convert AI Models from local storage to OCI Image          |

--- a/docs/ramalama.1.md
+++ b/docs/ramalama.1.md
@@ -178,6 +178,7 @@ It adds support for model versioning and multiple files such as chat templates. 
 | Command                                           | Description                                                |
 | ------------------------------------------------- | ---------------------------------------------------------- |
 | [ramalama-bench(1)](ramalama-bench.1.md)          | benchmark specified AI Model                               |
+| [ramalama-chat(1)](ramalama-chat.1.md)            |  OpenAI chat with the specified RESTAPI URL                |
 | [ramalama-client(1)](ramalama-client.1.md)        | interact with the AI Model server (experimental)           |
 | [ramalama-containers(1)](ramalama-containers.1.md)| list all RamaLama containers                               |
 | [ramalama-convert(1)](ramalama-convert.1.md)      | convert AI Models from local storage to OCI Image          |

--- a/ramalama/chat.py
+++ b/ramalama/chat.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+
+import cmd
+import itertools
+import json
+import os
+import signal
+import sys
+import time
+import urllib.error
+import urllib.request
+
+from ramalama.config import CONFIG
+from ramalama.console import EMOJI
+
+
+def should_colorize():
+    t = os.getenv("TERM")
+    return t and t != "dumb" and sys.stdout.isatty()
+
+
+def res(response, color):
+    color_default = ""
+    color_yellow = ""
+    if (color == "auto" and should_colorize()) or color == "always":
+        color_default = "\033[0m"
+        color_yellow = "\033[33m"
+
+    print("\r", end="")
+    assistant_response = ""
+    for line in response:
+        line = line.decode("utf-8").strip()
+        if line.startswith("data: {"):
+            line = line[len("data: ") :]
+            choice = json.loads(line)["choices"][0]["delta"]
+            if "content" in choice:
+                choice = choice["content"]
+            else:
+                continue
+
+            if choice:
+                print(f"{color_yellow}{choice}{color_default}", end="", flush=True)
+                assistant_response += choice
+
+    print("")
+    return assistant_response
+
+
+def default_prefix():
+    if "LLAMA_PROMPT_PREFIX" in os.environ:
+        return os.environ["LLAMA_PROMPT_PREFIX"]
+
+    if not EMOJI:
+        return ""
+
+    engine = CONFIG.engine
+
+    if os.path.basename(engine) == "podman":
+        return "🦭 > "
+
+    if os.path.basename(engine) == "docker":
+        return "🐋 > "
+
+    return "> "
+
+
+class RamaLamaShell(cmd.Cmd):
+    def __init__(self, args):
+        super().__init__()
+        self.conversation_history = []
+        self.args = args
+        self.request_in_process = False
+        self.prompt = args.prefix
+
+        self.url = f"{args.url}/v1/chat/completions"
+        self.models_url = f"{args.url}/v1/models"
+        self.models = []
+
+    def model(self, index=0):
+        try:
+            if len(self.models) == 0:
+                self.models = self.get_models()
+            return self.models[index]
+        except urllib.error.URLError:
+            return ""
+
+    def get_models(self):
+        request = urllib.request.Request(self.models_url, method="GET")
+        response = urllib.request.urlopen(request)
+        for line in response:
+            line = line.decode("utf-8").strip()
+            return [d['id'] for d in json.loads(line)["data"]]
+
+    def handle_args(self):
+        if self.args.ARGS:
+            self.default(" ".join(self.args.ARGS))
+            self.kills()
+            return True
+
+        return False
+
+    def do_EOF(self, user_content):
+        print("")
+        return True
+
+    def default(self, user_content):
+        if user_content in ["/bye", "exit"]:
+            return True
+
+        self.conversation_history.append({"role": "user", "content": user_content})
+        self.request_in_process = True
+        response = self._req()
+        if not response:
+            return True
+
+        self.conversation_history.append({"role": "assistant", "content": response})
+        self.request_in_process = False
+
+    def _make_request_data(self):
+        data = {
+            "stream": True,
+            "messages": self.conversation_history,
+            "model": self.model(),
+        }
+        json_data = json.dumps(data).encode("utf-8")
+        headers = {
+            "Content-Type": "application/json",
+        }
+        request = urllib.request.Request(self.url, data=json_data, headers=headers, method="POST")
+
+        return request
+
+    def _req(self):
+        request = self._make_request_data()
+
+        i = 0.01
+        total_time_slept = 0
+        response = None
+        for c in itertools.cycle(['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏']):
+            try:
+                response = urllib.request.urlopen(request)
+                break
+            except Exception:
+                if sys.stdout.isatty():
+                    print(f"\r{c}", end="", flush=True)
+
+                if total_time_slept > 16:
+                    break
+
+                total_time_slept += i
+                time.sleep(i)
+
+                i = min(i * 2, 0.1)
+
+        if response:
+            return res(response, self.args.color)
+
+        print(f"\rError: could not connect to: {self.url}", file=sys.stderr)
+        self.kills()
+
+        return None
+
+    def kills(self):
+        if self.args.pid2kill:
+            os.kill(self.args.pid2kill, signal.SIGINT)
+            os.kill(self.args.pid2kill, signal.SIGTERM)
+            os.kill(self.args.pid2kill, signal.SIGKILL)
+
+    def loop(self):
+        while True:
+            self.request_in_process = False
+            try:
+                self.cmdloop()
+            except KeyboardInterrupt:
+                print("")
+                if not self.request_in_process:
+                    print("Use Ctrl + d or /bye or exit to quit.")
+
+                continue
+
+            break


### PR DESCRIPTION
For now we will just add the chat command, next PR will remove the external chat command and just use this internal one.

## Summary by Sourcery

Introduce a new internal "ramalama chat" CLI command to enable OpenAI chat over REST API and update documentation accordingly.

New Features:
- Add "chat" subcommand and associated CLI logic (chat_parser and chat_cli) for interacting with OpenAI via REST API.

Documentation:
- Add ramalama-chat(1) man page and integrate it into the docs index.
- Update README and main man page to list the new "ramalama chat" command.