### PR TITLE
Suggest using uv pip install to get missing module

### DIFF
--- a/ramalama/huggingface.py
+++ b/ramalama/huggingface.py
@@ -15,9 +15,9 @@ from ramalama.model_store import SnapshotFileType
 
 missing_huggingface = """
 Optional: Huggingface models require the huggingface-cli module.
-These modules can be installed via PyPi tools like pip, pip3, pipx, or via
+This module can be installed via PyPi tools like uv, pip, pip3, pipx, or via
 distribution package managers like dnf or apt. Example:
-pip install huggingface_hub
+uv pip install huggingface_hub
 """
 
 
@@ -228,7 +228,7 @@ class Huggingface(HFStyleRepoModel):
 
     def push(self, _, args):
         if not self.hf_cli_available:
-            raise NotImplementedError(missing_huggingface)
+            raise NotImplementedError(self.get_missing_message())
         proc = run_cmd(
             [
                 "huggingface-cli",

--- a/ramalama/modelscope.py
+++ b/ramalama/modelscope.py
@@ -12,9 +12,9 @@ from ramalama.model_store import SnapshotFileType
 
 missing_modelscope = """
 Optional: ModelScope models require the modelscope module.
-These modules can be installed via PyPi tools like pip, pip3, pipx, or via
+This module can be installed via PyPi tools like uv, pip, pip3, pipx, or via
 distribution package managers like dnf or apt. Example:
-pip install modelscope
+uv pip install modelscope
 """
 
 
@@ -120,7 +120,7 @@ class ModelScope(HFStyleRepoModel):
 
     def push(self, _, args):
         if not self.ms_available:
-            raise NotImplementedError(missing_modelscope)
+            raise NotImplementedError(self.get_missing_message())
         proc = run_cmd(
             [
                 "modelscope",


### PR DESCRIPTION
## Summary by Sourcery

Update missing dependency error messages for Huggingface and ModelScope integrations and refactor exception handling to use a dynamic message method.

Enhancements:
- Add “uv” to the list of supported pip installation tools in dependency instructions
- Revise example commands to use “uv pip install <package>”
- Replace hardcoded missing-module messages with a call to self.get_missing_message() for consistency