### PR TITLE
:latest tag should not be assumed for non-OCI artefacts

### DIFF
--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -483,6 +483,8 @@ def _list_models_from_store(args):
 
         if model.startswith("huggingface://"):
             model = model.replace("huggingface://", "hf://", 1)
+
+        if not model.startswith("ollama://") and not model.startswith("oci://"):
             model = model.removesuffix(":latest")
 
         size_sum = 0

--- a/test/system/050-pull.bats
+++ b/test/system/050-pull.bats
@@ -141,7 +141,7 @@ load setup_suite
       run_ramalama pull $file_url
       run_ramalama list
       # remove the additional slash character
-      expected_url=$(sed "s/file\:\//file\:/" <<< $file_url):latest
+      expected_url=$(sed "s/file\:\//file\:/" <<< $file_url)
       is "$output" ".*$expected_url" "URL exists"
       run_ramalama rm $file_url
       run_ramalama list
@@ -163,7 +163,7 @@ load setup_suite
       touch $model
       url=file://${model}
       # remove the additional slash character
-      expected_url=$(sed "s/file\:\//file\:/" <<< $url):latest
+      expected_url=$(sed "s/file\:\//file\:/" <<< $url)
 
       run_ramalama pull $url
       run_ramalama list


### PR DESCRIPTION
I see people showing things like:

```
file://srv/llm/modles/unsloth/Qwen3-235B-A22B-GGUF/UD_Q2_K_XL/Qwen3-235B-A22B-UD-Q2_K_XL-00001-of-00002.gguf:latest 1 month ago  46.42 GB file://srv/llm/modles/unsloth/Qwen3-235B-A22B-GGUF/UD_Q2_K_XL/Qwen3-235B-A22B-UD-Q2_K_XL-00002-of-00002.gguf:latest 1 month ago  35.55 GB
file://srv/llm/modles/unsloth/Qwen3-235B-A22B-GGUF/Q8_0/Qwen3-235B-A22B-Q8_0-00001-of-00006.gguf:latest             1 week ago   46.44 GB
file://srv/llm/modles/unsloth/Qwen3-235B-A22B-GGUF/Q8_0/Qwen3-235B-A22B-Q8_0-00002-of-00006.gguf:latest             1 week ago   46.0 GB
file://srv/llm/modles/unsloth/Qwen3-235B-A22B-GGUF/Q8_0/Qwen3-235B-A22B-Q8_0-00003-of-00006.gguf:latest             1 week ago   45.93 GB
file://srv/llm/modles/unsloth/Qwen3-235B-A22B-GGUF/Q8_0/Qwen3-235B-A22B-Q8_0-00004-of-00006.gguf:latest             1 week ago   46.0 GB
file://srv/llm/modles/unsloth/Qwen3-235B-A22B-GGUF/Q8_0/Qwen3-235B-A22B-Q8_0-00005-of-00006.gguf:latest             1 week ago   46.0 GB
file://srv/llm/modles/unsloth/Qwen3-235B-A22B-GGUF/Q8_0/Qwen3-235B-A22B-Q8_0-00006-of-00006.gguf:latest             1 week ago   2.39 GB
```

## Summary by Sourcery

Enhancements:
- Only remove the ':latest' suffix for model references that are not using the ollama:// or oci:// schemes