### PR TITLE
chore: bump ramalama-stack to 0.2.1

### DIFF
--- a/container-images/llama-stack/Containerfile
+++ b/container-images/llama-stack/Containerfile
@@ -2,15 +2,15 @@ FROM registry.fedoraproject.org/fedora:42
 
 # hack that should be removed when the following bug is addressed
 # https://github.com/containers/ramalama-stack/issues/53
-RUN curl --create-dirs --output ~/.llama/providers.d/remote/inference/ramalama.yaml https://raw.githubusercontent.com/containers/ramalama-stack/refs/tags/v0.2.0/src/ramalama_stack/providers.d/remote/inference/ramalama.yaml && \
-    curl --create-dirs --output /etc/ramalama/ramalama-run.yaml https://raw.githubusercontent.com/containers/ramalama-stack/refs/tags/v0.2.0/src/ramalama_stack/ramalama-run.yaml
+RUN curl --create-dirs --output ~/.llama/providers.d/remote/inference/ramalama.yaml https://raw.githubusercontent.com/containers/ramalama-stack/refs/tags/v0.2.1/src/ramalama_stack/providers.d/remote/inference/ramalama.yaml && \
+    curl --create-dirs --output /etc/ramalama/ramalama-run.yaml https://raw.githubusercontent.com/containers/ramalama-stack/refs/tags/v0.2.1/src/ramalama_stack/ramalama-run.yaml
 
 RUN dnf -y update && \
     dnf -y install uv cmake gcc gcc-c++ python3-devel pkg-config sentencepiece-devel && \
     dnf -y clean all
 
 RUN uv venv && \
-    uv pip install ramalama-stack==0.2.0
+    uv pip install ramalama-stack==0.2.1
 
 COPY --chmod=755 llama-stack/entrypoint.sh /usr/bin/entrypoint.sh
 


### PR DESCRIPTION
adds RAG capabilities

## Summary by Sourcery

Bump ramalama-stack to v0.2.1 in the container image to incorporate RAG capabilities

New Features:
- Add RAG capabilities via the upgraded ramalama-stack 0.2.1

Build:
- Update Containerfile to fetch v0.2.1 provider and run configuration YAML
- Upgrade pip installation of ramalama-stack to version 0.2.1