### PR TITLE
Upgrade podman

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,6 @@ jobs:
 
       - name: run bats
         run: |
-           export TMPDIR=$(mktemp -d)
            make validate
            make bats
 
@@ -143,7 +142,6 @@ jobs:
 
       - name: bats-nocontainer
         run: |
-           export TMPDIR=$(mktemp -d)
            make bats-nocontainer
 
   docker:
@@ -228,7 +226,6 @@ jobs:
       - name: Run a one-line script
         shell: bash
         run: |
-           export TMPDIR=$(mktemp -d)
            make install-requirements
            make validate
            make bats-nocontainer

--- a/Makefile
+++ b/Makefile
@@ -40,16 +40,16 @@ help:
 	@echo
 
 install-detailed-cov-requirements:
-	uv pip install ".[cov-detailed]"
+	pip install ".[cov-detailed]"
 
 .PHONY: install-cov-requirements
 install-cov-requirements:
-	uv pip install ".[cov]"
+	pip install ".[cov]"
 
 .PHONY: install-requirements
 install-requirements:
 	./install-uv.sh
-	uv pip install ".[dev]"
+	pip install ".[dev]"
 
 .PHONY: install-completions
 install-completions: completions


### PR DESCRIPTION
Use ubuntu plucky repo for podman

## Summary by Sourcery

CI:
- Update add-apt-repository commands to use the "plucky" universe repository instead of "oracular" across CI, latest, nightly, and ci-images workflows.