### PR TITLE
Trying to save space

### DIFF
--- a/test/system/040-serve.bats
+++ b/test/system/040-serve.bats
@@ -178,25 +178,27 @@ verify_begin=".*run --rm"
 }
 
 @test "ramalama serve --generate=quadlet" {
-    model=tiny
+    model="smollm"
+    model_quant="$model:135m"
+    quadlet="$model.container"
     name=c_$(safename)
-    run_ramalama pull ${model}
-    run_ramalama -q serve --port 1234 --generate=quadlet ${model}
-    is "$output" "Generating quadlet file: tinyllama.container" "generate tinllama.container"
+    run_ramalama pull $model_quant
+    run_ramalama -q serve --port 1234 --generate=quadlet $model
+    is "$output" "Generating quadlet file: $quadlet" "generate $quadlet"
 
-    run cat tinyllama.container
+    run cat $quadlet
     is "$output" ".*PublishPort=1234:1234" "PublishPort should match"
     is "$output" ".*Exec=.*llama-server --port 1234 --model .*" "Exec line should be correct"
-    is "$output" ".*Mount=type=bind,.*tinyllama" "Mount line should be correct"
+    is "$output" ".*Mount=type=bind,.*$model" "Mount line should be correct"
 
-    HIP_VISIBLE_DEVICES=99 run_ramalama -q serve --port 1234 --generate=quadlet ${model}
-    is "$output" "Generating quadlet file: tinyllama.container" "generate tinllama.container"
+    HIP_VISIBLE_DEVICES=99 run_ramalama -q serve --port 1234 --generate=quadlet $model
+    is "$output" "Generating quadlet file: $quadlet" "generate $quadlet"
 
-    run cat tinyllama.container
+    run cat $quadlet
     is "$output" ".*Environment=HIP_VISIBLE_DEVICES=99" "Should contain env property"
 
-    rm tinyllama.container
-    run_ramalama 2 serve --name=${name} --port 1234 --generate=bogus tiny
+    rm $quadlet
+    run_ramalama 2 serve --name=${name} --port 1234 --generate=bogus $model
     is "$output" ".*error: argument --generate: invalid choice: .*bogus.* (choose from.*quadlet.*kube.*quadlet/kube.*)" "Should fail"
 }
 
@@ -273,17 +275,18 @@ verify_begin=".*run --rm"
 
 
 @test "ramalama serve --generate=kube" {
-    model=tiny
+    model="smollm"
+    model_quant="$model:135m"
     name=c_$(safename)
-    run_ramalama pull ${model}
-    run_ramalama serve --name=${name} --port 1234 --generate=kube ${model}
+    run_ramalama pull $model_quant
+    run_ramalama serve --name=${name} --port 1234 --generate=kube $model_quant
     is "$output" ".*Generating Kubernetes YAML file: ${name}.yaml" "generate .yaml file"
 
     run cat $name.yaml
     is "$output" ".*command: \[\".*serve.*\"\]" "Should command"
     is "$output" ".*containerPort: 1234" "Should container container port"
 
-    HIP_VISIBLE_DEVICES=99 run_ramalama serve --name=${name} --port 1234 --generate=kube ${model}
+    HIP_VISIBLE_DEVICES=99 run_ramalama serve --name=${name} --port 1234 --generate=kube $model_quant
     is "$output" ".*Generating Kubernetes YAML file: ${name}.yaml" "generate .yaml file"
 
     run cat $name.yaml
@@ -291,7 +294,7 @@ verify_begin=".*run --rm"
     is "$output" ".*name: HIP_VISIBLE_DEVICES" "Should contain env name"
     is "$output" ".*value: 99" "Should contain env value"
 
-    run_ramalama serve --name=${name} --port 1234 --generate=quadlet/kube ${model}
+    run_ramalama serve --name=${name} --port 1234 --generate=quadlet/kube $model_quant
     is "$output" ".*Generating Kubernetes YAML file: ${name}.yaml" "generate .yaml file"
     is "$output" ".*Generating quadlet file: ${name}.kube" "generate .kube file"
 
@@ -299,7 +302,7 @@ verify_begin=".*run --rm"
     is "$output" ".*command: \[\".*serve.*\"\]" "Should command"
     is "$output" ".*containerPort: 1234" "Should container container port"
 
-    HIP_VISIBLE_DEVICES=99 run_ramalama serve --name=${name} --port 1234 --generate=quadlet/kube ${model}
+    HIP_VISIBLE_DEVICES=99 run_ramalama serve --name=${name} --port 1234 --generate=quadlet/kube $model_quant
     is "$output" ".*Generating Kubernetes YAML file: ${name}.yaml" "generate .yaml file"
 
     run cat $name.yaml


### PR DESCRIPTION
tiny is is not so tiny, it's 600M

## Summary by Sourcery

Refactor the 040-serve.bats system test to dynamically derive model and quadlet container names, replace hard-coded references, and update assertions to support the smollm:135m model.

Enhancements:
- Parameterize the model name and quadlet file name in the Bats system tests instead of using hard-coded values
- Switch the test model from 'tiny' to 'smollm:135m' to reflect updated model sizing

Tests:
- Update output assertions to reference dynamic variables for quadlet file name, mount line, and environment settings
- Adjust error-case invocation to use the parameterized model variable