### PR TITLE
Add dnf update -y to Fedora ROCm build

### DIFF
--- a/container-images/scripts/build_llama_and_whisper.sh
+++ b/container-images/scripts/build_llama_and_whisper.sh
@@ -60,6 +60,7 @@ dnf_install_cann() {
 dnf_install_rocm() {
   if [ "$containerfile" = "rocm" ]; then
     if [ "${ID}" = "fedora" ]; then
+      dnf update -y
       dnf install -y rocm-core-devel hipblas-devel rocblas-devel rocm-hip-devel
     else
       add_stream_repo "AppStream"


### PR DESCRIPTION
Trying to fix a compiler issue

## Summary by Sourcery

Build:
- Add `dnf update -y` step to the Fedora ROCm build script to update packages before installation