### PR TITLE
Run bats test with TMPDIR pointing at /mnt/tmp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,9 @@ jobs:
 
       - name: run bats
         run: |
+	   # /mnt has ~ 65 GB free disk space. / is too small.
+           mkdir -p /mnt/tmp
+           TEMPDIR=/mnt/tmp
            make validate
            make bats
 


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Create a /mnt/tmp directory and set TEMPDIR to /mnt/tmp before running bats tests in CI to avoid disk space issues