### PR TITLE
Tabs to spaces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
 
       - name: run bats
         run: |
-	   # /mnt has ~ 65 GB free disk space. / is too small.
+           # /mnt has ~ 65 GB free disk space. / is too small.
            mkdir -p /mnt/tmp
            TEMPDIR=/mnt/tmp
            make validate


### PR DESCRIPTION
github UI showed red, changing just in case, incorrect tabs or spaces can cause github ui to skip builds.

## Summary by Sourcery

CI:
- Correct YAML indentation in .github/workflows/ci.yml to prevent CI parsing issues due to tabs