### PR TITLE
Create tempdir when run as non-root user

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
       - name: run bats
         run: |
            # /mnt has ~ 65 GB free disk space. / is too small.
-           mkdir -p /mnt/tmp
+           sudo mkdir -m a=rwx -p /mnt/tmp
            TEMPDIR=/mnt/tmp
            make validate
            make bats


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Use sudo with explicit permissions to create /mnt/tmp in the CI job