### PR TITLE
Fix default prefix for systems with no engines

### DIFF
--- a/ramalama/chat.py
+++ b/ramalama/chat.py
@@ -47,17 +47,18 @@ def default_prefix():
         return os.environ["LLAMA_PROMPT_PREFIX"]
 
     if not EMOJI:
-        return ""
+        return "> "
 
     engine = CONFIG.engine
 
-    if os.path.basename(engine) == "podman":
-        return "🦭 > "
+    if engine:
+        if os.path.basename(engine) == "podman":
+            return "🦭 > "
 
-    if os.path.basename(engine) == "docker":
-        return "🐋 > "
+        if os.path.basename(engine) == "docker":
+            return "🐋 > "
 
-    return "> "
+    return "🦙 > "
 
 
 class RamaLamaShell(cmd.Cmd):


### PR DESCRIPTION
Fixes: https://github.com/containers/ramalama/issues/1552

## Summary by Sourcery

Fix default_prefix function to provide proper fallback prefixes when no engine is configured or when emojis are disabled.

Bug Fixes:
- Return "> " instead of an empty string when EMOJI is disabled
- Use 🦙 > as the default prefix when no engine is detected

Enhancements:
- Only perform engine basename checks if CONFIG.engine is defined