### PR TITLE
Add install command via homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,11 @@ RamaLama is available via PyPi at [https://pypi.org/project/ramalama](https://py
 pip install ramalama
 ```
 
+### Install via Homebrew
+```
+brew install ramalama
+```
+
 ### Install script (Linux and macOS)
 Install RamaLama by running:
 ```


### PR DESCRIPTION
The purpose of this PR is to add the command line that allows users to install easily via Homebrew.

## Summary by Sourcery

Documentation:
- Introduce a new “Install via Homebrew” section with the brew install ramalama command