### PR TITLE
Remove Model flag for safetensor files for now

### DIFF
--- a/ramalama/huggingface.py
+++ b/ramalama/huggingface.py
@@ -276,7 +276,7 @@ class Huggingface(HFStyleRepoModel):
                 name=entry,
             )
             # try to identify the model file in the pulled repo
-            if entry.endswith(".safetensors") or entry.endswith(".gguf"):
+            if entry.endswith(".gguf"):
                 hf_file.type = SnapshotFileType.Model
             files.append(hf_file)
 


### PR DESCRIPTION
Relates to: https://github.com/containers/ramalama/issues/1557

By not flagging safetensor files as Models we bypass the model store check for multiple models for now till we fully support safetensors. This should enable `ramalama convert` again.

## Summary by Sourcery

Temporarily stop treating .safetensors files as model snapshots so that the multi-model store check is bypassed and `ramalama convert` works again

Bug Fixes:
- Restore `ramalama convert` functionality by not marking .safetensors files as models

Enhancements:
- Restrict model file detection to only .gguf snapshots until safetensors support is fully implemented