### PR TITLE
Add verbose rule for complete output on unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,6 +168,10 @@ ci:
 unit-tests:
 	PYTHONPATH=. pytest test/unit/ -vv
 
+.PHONY: unit-tests-verbose
+unit-tests-verbose:
+	PYTHONPATH=. pytest test/unit/ -vv --full-trace --capture=tee-sys
+
 .PHONY: cov-run
 cov-run: install-cov-requirements
 	PYTHONPATH=. coverage run -m pytest test/unit/


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Add a new Makefile target 'unit-tests-verbose' to run unit tests with verbose output, full trace, and system capture