### PR TITLE
Adds the ability to pass files to `ramalama run`

### DIFF
--- a/docs/ramalama-chat.1.md
+++ b/docs/ramalama-chat.1.md
@@ -29,8 +29,12 @@ Show this help message and exit
 #### **--prefix**
 Prefix for the user prompt (default: 🦭 > )
 
+#### **--rag**=path
+A file or directory of files to be loaded and provided as local context in the chat history.
+
 #### **--url**=URL
 The host to send requests to (default: http://127.0.0.1:8080)
+
 
 ## EXAMPLES
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ version = "0.9.3"
 description = "RamaLama is a command line tool for working with AI LLM models."
 readme = "README.md"
 requires-python = ">=3.10"
-license = { file = "LICENSE" }
 keywords = ["ramalama", "llama", "AI"]
 dependencies = [
   "argcomplete",
@@ -18,6 +17,8 @@ maintainers = [
    { name="Eric Curtin", email = "ecurtin@redhat.com" },
 ]
 
+[project.license]
+text = "MIT"
 
 [project.optional-dependencies]
 dev = [
@@ -56,6 +57,7 @@ ramalama = "ramalama.cli:main"
 
 [tool.setuptools]
 include-package-data = true
+license-files = ["LICENSE"]
 
 [tool.black]
 line-length = 120
@@ -93,7 +95,7 @@ log_cli_date_format = "%Y-%m-%d %H:%M:%S"
 
 
 [tool.setuptools.packages.find]
-include = ["ramalama"]
+include = ["ramalama", "ramalama.*"]
 
 [tool.setuptools.data-files]
 "share/ramalama" = ["shortnames/shortnames.conf"]

--- a/ramalama/chat.py
+++ b/ramalama/chat.py
@@ -14,6 +14,7 @@ from datetime import timedelta
 from ramalama.config import CONFIG
 from ramalama.console import EMOJI, should_colorize
 from ramalama.engine import dry_run, stop_container
+from ramalama.file_upload.file_loader import FileUpLoader
 from ramalama.logger import logger
 
 
@@ -72,6 +73,16 @@ class RamaLamaShell(cmd.Cmd):
         self.prompt = args.prefix
 
         self.url = f"{args.url}/chat/completions"
+        self.prep_rag_message()
+
+    def prep_rag_message(self):
+        if (context := getattr(self.args, "rag", None)) is None:
+            return
+
+        if not (message_content := FileUpLoader(context).load()):
+            return
+
+        self.conversation_history.append({"role": "system", "content": message_content})
 
     def handle_args(self):
         prompt = " ".join(self.args.ARGS) if self.args.ARGS else None

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -905,6 +905,7 @@ def chat_parser(subparsers):
         help='possible values are "never", "always" and "auto".',
     )
     parser.add_argument("--prefix", type=str, help="prefix for the user prompt", default=default_prefix())
+    parser.add_argument("--rag", type=str, help="a file or directory to use as context for the chat")
     parser.add_argument("--url", type=str, default="http://127.0.0.1:8080/v1", help="the url to send requests to")
     parser.add_argument("MODEL", completer=local_models)  # positional argument
     parser.add_argument(
@@ -925,6 +926,7 @@ def run_parser(subparsers):
     )
     parser.add_argument("--prefix", type=str, help="prefix for the user prompt", default=default_prefix())
     parser.add_argument("MODEL", completer=local_models)  # positional argument
+
     parser.add_argument(
         "ARGS",
         nargs="*",

--- a/ramalama/file_upload/__init__.py
+++ b/ramalama/file_upload/__init__.py
@@ -1,0 +1,3 @@
+from ramalama.file_upload import file_loader, file_types
+
+__all__ = ["file_loader", "file_types"]

--- a/ramalama/file_upload/file_loader.py
+++ b/ramalama/file_upload/file_loader.py
@@ -1,0 +1,57 @@
+import os
+from string import Template
+from warnings import warn
+
+from ramalama.file_upload.file_types import base, txt
+
+SUPPORTED_EXTENSIONS = {
+    '.txt': txt.TXTFileUpload,
+    '.sh': txt.TXTFileUpload,
+    '.md': txt.TXTFileUpload,
+    '.yaml': txt.TXTFileUpload,
+    '.yml': txt.TXTFileUpload,
+    '.json': txt.TXTFileUpload,
+    '.csv': txt.TXTFileUpload,
+    '.toml': txt.TXTFileUpload,
+}
+
+
+class BaseFileUploader:
+    """
+    Base class for file upload handlers.
+    This class should be extended by specific file type handlers.
+    """
+
+    def __init__(self, files: list[base.BaseFileUpload], delim_string: str = "<!--start_document $name-->"):
+        self.files = files
+        self.document_delimiter: Template = Template(delim_string)
+
+    def load(self) -> str:
+        """
+        Generate the output string by concatenating the processed files.
+        """
+        output = (f"\n{self.document_delimiter.substitute(name=f.file)}\n{f.load()}" for f in self.files)
+        return "".join(output)
+
+
+class FileUpLoader(BaseFileUploader):
+    def __init__(self, file_path: str):
+        if not os.path.exists(file_path):
+            raise ValueError(f"{file_path} does not exist.")
+
+        if not os.path.isdir(file_path):
+            files = [file_path]
+        else:
+            files = [os.path.join(root, name) for root, _, files in os.walk(file_path) for name in files]
+
+        extensions = [os.path.splitext(f)[1].lower() for f in files]
+
+        if set(extensions) - set(SUPPORTED_EXTENSIONS):
+            warning_message = (
+                f"Unsupported file types found: {set(extensions) - set(SUPPORTED_EXTENSIONS)}\n"
+                f"Supported types are: {set(SUPPORTED_EXTENSIONS.keys())}"
+            )
+            warn(warning_message)
+
+        files = [SUPPORTED_EXTENSIONS[ext](file=f) for ext, f in zip(extensions, files) if ext in SUPPORTED_EXTENSIONS]
+        super().__init__(files=files)

--- a/ramalama/file_upload/file_types/__init__.py
+++ b/ramalama/file_upload/file_types/__init__.py
@@ -1,0 +1,3 @@
+from ramalama.file_upload.file_types import base, txt
+
+__all__ = ["base", "txt"]

--- a/ramalama/file_upload/file_types/base.py
+++ b/ramalama/file_upload/file_types/base.py
@@ -1,0 +1,19 @@
+from abc import ABC, abstractmethod
+
+
+class BaseFileUpload(ABC):
+    """
+    Base class for file upload handlers.
+    This class should be extended by specific file type handlers.
+    """
+
+    def __init__(self, file):
+        self.file = file
+
+    @abstractmethod
+    def load(self) -> str:
+        """
+        Load the content of the file.
+        This method should be implemented by subclasses to handle specific file types.
+        """
+        pass

--- a/ramalama/file_upload/file_types/pdf.py
+++ b/ramalama/file_upload/file_types/pdf.py
@@ -1,0 +1,10 @@
+from ramalama.file_upload.file_types.base import BaseFileUpload
+
+
+class PDFFileUpload(BaseFileUpload):
+    def load(self) -> str:
+        """
+        Load the content of the PDF file.
+        This method should be implemented to handle PDF file reading.
+        """
+        return ""

--- a/ramalama/file_upload/file_types/txt.py
+++ b/ramalama/file_upload/file_types/txt.py
@@ -1,0 +1,12 @@
+from ramalama.file_upload.file_types.base import BaseFileUpload
+
+
+class TXTFileUpload(BaseFileUpload):
+    def load(self) -> str:
+        """
+        Load the content of the text file.
+        """
+
+        # TODO: Support for non-default encodings?
+        with open(self.file, 'r') as f:
+            return f.read()

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -1,0 +1,6 @@
+# # tests/conftest.py
+# import pytest
+
+# @pytest.fixture(autouse=True)
+# def set_container_engine_env(monkeypatch):
+#     monkeypatch.setenv("RAMALAMA_CONTAINER_ENGINE", "docker")

--- a/test/unit/data/test_file_upload/sample.csv
+++ b/test/unit/data/test_file_upload/sample.csv
@@ -1,0 +1,6 @@
+name,age,city,occupation
+John Doe,30,New York,Engineer
+Jane Smith,25,San Francisco,Designer
+Bob Johnson,35,Chicago,Manager
+Alice Brown,28,Boston,Developer
+Charlie Wilson,32,Seattle,Analyst 

--- a/test/unit/data/test_file_upload/sample.json
+++ b/test/unit/data/test_file_upload/sample.json
@@ -1,0 +1,20 @@
+{
+  "name": "test_data",
+  "version": "1.0.0",
+  "description": "Sample JSON data for testing file upload functionality",
+  "features": [
+    "text_processing",
+    "file_upload",
+    "chat_integration"
+  ],
+  "metadata": {
+    "author": "Test User",
+    "created": "2024-01-01",
+    "tags": ["test", "sample", "json"]
+  },
+  "config": {
+    "enabled": true,
+    "max_file_size": 1048576,
+    "supported_formats": [".txt", ".md", ".json", ".yaml", ".yml", ".csv", ".toml", ".pdf"]
+  }
+} 

--- a/test/unit/data/test_file_upload/sample.md
+++ b/test/unit/data/test_file_upload/sample.md
@@ -1,0 +1,20 @@
+# Sample Markdown File
+
+This is a sample markdown file for testing the file upload functionality.
+
+## Features
+
+- **Bold text** and *italic text*
+- Lists with bullets
+- Code blocks: `inline code`
+- Links: [Example](https://example.com)
+
+## Code Example
+
+```python
+def hello_world():
+    print("Hello, World!")
+    return "Success"
+```
+
+This file should be processed by the TXTFileUpload class since markdown is treated as text. 

--- a/test/unit/data/test_file_upload/sample.sh
+++ b/test/unit/data/test_file_upload/sample.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Sample shell script for testing file upload functionality
+
+echo "Hello, World! This is a test script."
+
+# Function to demonstrate script functionality
+test_function() {
+    local message="$1"
+    echo "Testing: $message"
+    return 0
+}
+
+# Variables
+NAME="Test Script"
+VERSION="1.0.0"
+
+# Main execution
+echo "Running $NAME version $VERSION"
+
+# Test the function
+test_function "file upload functionality"
+
+# Conditional logic
+if [ -f "test_file.txt" ]; then
+    echo "Test file exists"
+else
+    echo "Test file does not exist"
+fi
+
+# Loop example
+for i in {1..3}; do
+    echo "Iteration $i"
+done
+
+echo "Script completed successfully!" 

--- a/test/unit/data/test_file_upload/sample.toml
+++ b/test/unit/data/test_file_upload/sample.toml
@@ -1,0 +1,23 @@
+# Sample TOML configuration file
+name = "test_config"
+version = "1.0.0"
+description = "Sample TOML data for testing file upload functionality"
+
+[metadata]
+author = "Test User"
+created = "2024-01-01"
+tags = ["test", "sample", "toml"]
+
+[config]
+enabled = true
+max_file_size = 1048576
+supported_formats = [".txt", ".md", ".json", ".yaml", ".yml", ".csv", ".toml", ".pdf"]
+
+[features]
+text_processing = true
+file_upload = true
+chat_integration = true
+toml_support = true
+
+[nested.structure]
+with_deep_nesting = true 

--- a/test/unit/data/test_file_upload/sample.txt
+++ b/test/unit/data/test_file_upload/sample.txt
@@ -1,0 +1,9 @@
+This is a sample text file for testing the file upload functionality.
+
+It contains multiple lines of text to test how the system handles:
+- Plain text content
+- Multiple lines
+- Special characters like: !@#$%^&*()
+- Numbers: 1234567890
+
+This file should be processed by the TXTFileUpload class. 

--- a/test/unit/data/test_file_upload/sample.yaml
+++ b/test/unit/data/test_file_upload/sample.yaml
@@ -1,0 +1,37 @@
+# Sample YAML configuration file
+name: test_config
+version: 1.0.0
+description: Sample YAML data for testing file upload functionality
+
+features:
+  - text_processing
+  - file_upload
+  - chat_integration
+  - yaml_support
+
+metadata:
+  author: Test User
+  created: 2024-01-01
+  tags:
+    - test
+    - sample
+    - yaml
+
+config:
+  enabled: true
+  max_file_size: 1048576
+  supported_formats:
+    - .txt
+    - .md
+    - .json
+    - .yaml
+    - .yml
+    - .csv
+    - .toml
+    - .pdf
+
+nested:
+  structure:
+    with:
+      deep:
+        nesting: true 

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -153,7 +153,8 @@ class TestGetDefaultEngine:
     def test_get_default_engine_with_podman_available(self, platform, expected):
         with patch("ramalama.config.available", side_effect=lambda x: x == "podman"):
             with patch("sys.platform", platform):
-                assert get_default_engine() == expected
+                with patch("ramalama.config.apple_vm", return_value=False):
+                    assert get_default_engine() == expected
 
     def test_get_default_engine_with_podman_available_osx_apple_vm_has_podman(self):
         with patch("ramalama.config.available", side_effect=lambda x: x == "podman"):

--- a/test/unit/test_file_upload.py
+++ b/test/unit/test_file_upload.py
@@ -1,0 +1,280 @@
+import os
+import tempfile
+from unittest.mock import MagicMock, mock_open, patch
+
+import pytest
+
+from ramalama.file_upload.file_loader import SUPPORTED_EXTENSIONS, BaseFileUploader, FileUpLoader
+from ramalama.file_upload.file_types.base import BaseFileUpload
+from ramalama.file_upload.file_types.txt import TXTFileUpload
+
+
+class TestBaseFileUpload:
+    """Test the abstract base class for file upload handlers."""
+
+    def test_base_file_upload_is_abstract(self):
+        """Test that BaseFileUpload cannot be instantiated directly."""
+        with pytest.raises(TypeError):
+            BaseFileUpload("/path/to/file.txt")
+
+
+class TestTXTFileUpload:
+    """Test the text file upload handler."""
+
+    def test_txt_file_upload_initialization(self):
+        """Test that TXTFileUpload can be initialized."""
+        file_path = "/path/to/test.txt"
+        uploader = TXTFileUpload(file_path)
+        assert uploader.file == file_path
+        assert isinstance(uploader, BaseFileUpload)
+
+    def test_txt_file_upload_load_content(self):
+        """Test loading content from a text file."""
+        test_content = "This is test content\nwith multiple lines."
+
+        with patch("builtins.open", mock_open(read_data=test_content)):
+            uploader = TXTFileUpload("/path/to/test.txt")
+            result = uploader.load()
+
+        assert result == test_content
+
+    def test_txt_file_upload_load_empty_file(self):
+        """Test loading content from an empty text file."""
+        with patch("builtins.open", mock_open(read_data="")):
+            uploader = TXTFileUpload("/path/to/empty.txt")
+            result = uploader.load()
+
+        assert result == ""
+
+    def test_txt_file_upload_load_unicode_content(self):
+        """Test loading Unicode content from a text file."""
+        test_content = "Hello 世界! 🌍\nUnicode test: éñü"
+
+        with patch("builtins.open", mock_open(read_data=test_content)):
+            uploader = TXTFileUpload("/path/to/unicode.txt")
+            result = uploader.load()
+
+        assert result == test_content
+
+
+class TestBaseFileUploader:
+    """Test the base file uploader class."""
+
+    def test_base_file_uploader_initialization(self):
+        """Test that BaseFileUploader can be initialized with files and delimiter."""
+        mock_files = [MagicMock(), MagicMock()]
+        uploader = BaseFileUploader(files=mock_files)
+
+        assert uploader.files == mock_files
+        assert uploader.document_delimiter is not None
+
+    def test_base_file_uploader_initialization_custom_delimiter(self):
+        """Test that BaseFileUploader can be initialized with custom delimiter."""
+        mock_files = [MagicMock()]
+        custom_delimiter = "---START $name---"
+        uploader = BaseFileUploader(files=mock_files, delim_string=custom_delimiter)
+
+        assert uploader.files == mock_files
+        assert uploader.document_delimiter.template == custom_delimiter
+
+    def test_base_file_uploader_load_single_file(self):
+        """Test loading a single file."""
+        mock_file = MagicMock()
+        mock_file.file = "test.txt"
+        mock_file.load.return_value = "Test content"
+
+        uploader = BaseFileUploader(files=[mock_file])
+        result = uploader.load()
+
+        expected = "\n<!--start_document test.txt-->\nTest content"
+        assert result == expected
+
+    def test_base_file_uploader_load_multiple_files(self):
+        """Test loading multiple files."""
+        mock_file1 = MagicMock()
+        mock_file1.file = "test1.txt"
+        mock_file1.load.return_value = "Content 1"
+
+        mock_file2 = MagicMock()
+        mock_file2.file = "test2.txt"
+        mock_file2.load.return_value = "Content 2"
+
+        uploader = BaseFileUploader(files=[mock_file1, mock_file2])
+        result = uploader.load()
+
+        expected = "\n<!--start_document test1.txt-->\nContent 1\n<!--start_document test2.txt-->\nContent 2"
+        assert result == expected
+
+    def test_base_file_uploader_load_empty_file_list(self):
+        """Test loading with empty file list."""
+        uploader = BaseFileUploader(files=[])
+        result = uploader.load()
+
+        assert result == ""
+
+
+class TestFileUpLoader:
+    """Test the main file uploader class."""
+
+    def test_file_uploader_initialization_single_file(self):
+        """Test initializing FileUpLoader with a single file."""
+        with tempfile.NamedTemporaryFile(suffix=".txt") as tmp_file:
+            with open(tmp_file.name, "w") as f:
+                f.write("Test content")
+
+            uploader = FileUpLoader(tmp_file.name)
+            assert len(uploader.files) == 1
+            assert isinstance(uploader.files[0], TXTFileUpload)
+            assert uploader.files[0].file == tmp_file.name
+
+    def test_file_uploader_initialization_directory(self):
+        """Test initializing FileUpLoader with a directory."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            txt_file = os.path.join(tmp_dir, "test.txt")
+            with open(txt_file, "w") as f:
+                f.write("Text content")
+
+            md_file = os.path.join(tmp_dir, "test.md")
+            with open(md_file, "w") as f:
+                f.write("# Markdown content")
+
+            uploader = FileUpLoader(tmp_dir)
+            assert len(uploader.files) == 2
+            assert {txt_file, md_file} == {f.file for f in uploader.files}
+
+    def test_file_uploader_initialization_nonexistent_file(self):
+        """Test initializing FileUpLoader with a non-existent file."""
+        with pytest.raises(ValueError, match="does not exist"):
+            FileUpLoader("/nonexistent/file.txt")
+
+    def test_file_uploader_initialization_nonexistent_directory(self):
+        """Test initializing FileUpLoader with a non-existent directory."""
+        with pytest.raises(ValueError, match="does not exist"):
+            FileUpLoader("/nonexistent/directory")
+
+    def test_file_uploader_load_single_text_file(self):
+        """Test loading a single text file."""
+        with tempfile.NamedTemporaryFile(suffix=".txt") as tmp_file:
+            with open(tmp_file.name, "w") as f:
+                f.write("Test content\nwith multiple lines")
+
+            uploader = FileUpLoader(tmp_file.name)
+            result = uploader.load()
+
+            expected = f"\n<!--start_document {tmp_file.name}-->\nTest content\nwith multiple lines"
+            assert result == expected
+
+    def test_file_uploader_load_multiple_files(self):
+        """Test loading multiple files from a directory."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            txt_file = os.path.join(tmp_dir, "test.txt")
+            with open(txt_file, "w") as f:
+                f.write("Text content")
+
+            md_file = os.path.join(tmp_dir, "test.md")
+            with open(md_file, "w") as f:
+                f.write("# Markdown content")
+
+            uploader = FileUpLoader(tmp_dir)
+            result = uploader.load()
+
+            assert "<!--start_document" in result
+            assert "Text content" in result
+            assert "# Markdown content" in result
+            assert "test.txt" in result
+            assert "test.md" in result
+
+    def test_file_uploader_unsupported_file_types(self):
+        """Test handling of unsupported file types."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            unsupported_file = os.path.join(tmp_dir, "test.xyz")
+            with open(unsupported_file, "w") as f:
+                f.write("Unsupported content")
+
+            uploader = FileUpLoader(tmp_dir)
+            assert len(uploader.files) == 0
+
+    def test_file_uploader_mixed_supported_unsupported_files(self):
+        """Test handling of mixed supported and unsupported file types."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            txt_file = os.path.join(tmp_dir, "test.txt")
+            with open(txt_file, "w") as f:
+                f.write("Supported content")
+
+            unsupported_file = os.path.join(tmp_dir, "test.xyz")
+            with open(unsupported_file, "w") as f:
+                f.write("Unsupported content")
+
+            uploader = FileUpLoader(tmp_dir)
+
+            assert len(uploader.files) == 1
+            assert uploader.files[0].file == txt_file
+
+    def test_file_uploader_empty_directory(self):
+        """Test handling of empty directory."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            uploader = FileUpLoader(tmp_dir)
+            assert len(uploader.files) == 0
+            result = uploader.load()
+            assert result == ""
+
+    def test_file_uploader_case_insensitive_extensions(self):
+        """Test that file extensions are handled case-insensitively."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            txt_file = os.path.join(tmp_dir, "test.TXT")
+            with open(txt_file, "w") as f:
+                f.write("Uppercase extension")
+
+            md_file = os.path.join(tmp_dir, "test.MD")
+            with open(md_file, "w") as f:
+                f.write("Uppercase markdown")
+
+            uploader = FileUpLoader(tmp_dir)
+
+            assert len(uploader.files) == 2
+
+
+class TestSupportedExtensions:
+    """Test the supported extensions mapping."""
+
+    def test_supported_extensions_mapping(self):
+        """Test that all supported extensions map to correct classes."""
+        assert SUPPORTED_EXTENSIONS['.txt'] == TXTFileUpload
+        assert SUPPORTED_EXTENSIONS['.sh'] == TXTFileUpload
+        assert SUPPORTED_EXTENSIONS['.md'] == TXTFileUpload
+        assert SUPPORTED_EXTENSIONS['.yaml'] == TXTFileUpload
+        assert SUPPORTED_EXTENSIONS['.yml'] == TXTFileUpload
+        assert SUPPORTED_EXTENSIONS['.json'] == TXTFileUpload
+        assert SUPPORTED_EXTENSIONS['.csv'] == TXTFileUpload
+        assert SUPPORTED_EXTENSIONS['.toml'] == TXTFileUpload
+
+
+class TestFileUploadIntegration:
+    """Test integration scenarios for file upload functionality."""
+
+    def test_file_upload_with_various_text_formats(self):
+        """Test uploading various text-based file formats."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            files_content = {
+                "test.txt": "Plain text content",
+                "script.sh": "#!/bin/bash\necho 'Hello World'",
+                "readme.md": "# Test Markdown\n\nThis is a test.",
+                "config.yaml": "key: value\nlist:\n  - item1\n  - item2",
+                "data.json": '{"name": "test", "value": 42}',
+                "data.csv": "name,value\ntest,42",
+                "config.toml": "[section]\nkey = 'value'",
+            }
+
+            for filename, content in files_content.items():
+                file_path = os.path.join(tmp_dir, filename)
+                with open(file_path, "w") as f:
+                    f.write(content)
+
+            uploader = FileUpLoader(tmp_dir)
+            result = uploader.load()
+
+            for content in files_content.values():
+                assert content in result
+
+            for filename in files_content.keys():
+                assert filename in result

--- a/test/unit/test_file_upload_integration.py
+++ b/test/unit/test_file_upload_integration.py
@@ -1,0 +1,267 @@
+import os
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ramalama.chat import RamaLamaShell, chat
+
+
+class TestFileUploadChatIntegration:
+    """Test integration between file upload functionality and chat functionality."""
+
+    @patch('urllib.request.urlopen')
+    def test_chat_with_file_input_single_file(self, mock_urlopen):
+        """Test chat functionality with a single file input."""
+        # Mock the models endpoint response
+        mock_response = MagicMock()
+        mock_response.__iter__.return_value = [b'{"data": [{"id": "test-model"}]}']
+        mock_urlopen.return_value = mock_response
+
+        with tempfile.NamedTemporaryFile(suffix=".txt") as tmp_file:
+            with open(tmp_file.name, "w") as f:
+                f.write("This is test content for chat input")
+
+            mock_args = MagicMock()
+            mock_args.rag = tmp_file.name
+            mock_args.ARGS = ["Please analyze this content:"]
+            mock_args.dryrun = False
+
+            shell = RamaLamaShell(mock_args)
+
+            # Check that the system message was added to conversation history
+            assert len(shell.conversation_history) == 1
+            system_message = shell.conversation_history[0]
+            assert system_message["role"] == "system"
+            assert "This is test content for chat input" in system_message["content"]
+            assert f"<!--start_document {tmp_file.name}-->" in system_message["content"]
+
+    @patch('urllib.request.urlopen')
+    def test_chat_with_file_input_directory(self, mock_urlopen):
+        """Test chat functionality with a directory input."""
+        # Mock the models endpoint response
+        mock_response = MagicMock()
+        mock_response.__iter__.return_value = [b'{"data": [{"id": "test-model"}]}']
+        mock_urlopen.return_value = mock_response
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            txt_file = os.path.join(tmp_dir, "test.txt")
+            with open(txt_file, "w") as f:
+                f.write("Text file content")
+
+            md_file = os.path.join(tmp_dir, "readme.md")
+            with open(md_file, "w") as f:
+                f.write("# Markdown Content\n\nThis is a test.")
+
+            mock_args = MagicMock()
+            mock_args.rag = tmp_dir
+            mock_args.ARGS = ["Please analyze these files:"]
+            mock_args.dryrun = False
+
+            shell = RamaLamaShell(mock_args)
+
+            # Check that the system message was added to conversation history
+            assert len(shell.conversation_history) == 1
+            system_message = shell.conversation_history[0]
+            assert system_message["role"] == "system"
+            assert "Text file content" in system_message["content"]
+            assert "# Markdown Content" in system_message["content"]
+            assert "test.txt" in system_message["content"]
+            assert "readme.md" in system_message["content"]
+            assert "<!--start_document" in system_message["content"]
+
+    @patch('urllib.request.urlopen')
+    def test_chat_with_file_input_no_files(self, mock_urlopen):
+        """Test chat functionality with input directory containing no supported files."""
+        # Mock the models endpoint response
+        mock_response = MagicMock()
+        mock_response.__iter__.return_value = [b'{"data": [{"id": "test-model"}]}']
+        mock_urlopen.return_value = mock_response
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            unsupported_file = os.path.join(tmp_dir, "test.xyz")
+            with open(unsupported_file, "w") as f:
+                f.write("Unsupported content")
+
+            mock_args = MagicMock()
+            mock_args.rag = tmp_dir
+            mock_args.ARGS = ["Please analyze:"]
+            mock_args.dryrun = False
+
+            shell = RamaLamaShell(mock_args)
+
+            # Check that no system message was added since no supported files
+            assert len(shell.conversation_history) == 0
+
+    def test_chat_with_file_input_nonexistent_file(self):
+        """Test chat functionality with non-existent file input."""
+        mock_args = MagicMock()
+        mock_args.rag = "/nonexistent/file.txt"
+        mock_args.ARGS = ["Please analyze:"]
+        mock_args.dryrun = False
+
+        with pytest.raises(ValueError, match="does not exist"):
+            RamaLamaShell(mock_args)
+
+    @patch('urllib.request.urlopen')
+    def test_chat_with_file_input_empty_file(self, mock_urlopen):
+        """Test chat functionality with an empty file."""
+        # Mock the models endpoint response
+        mock_response = MagicMock()
+        mock_response.__iter__.return_value = [b'{"data": [{"id": "test-model"}]}']
+        mock_urlopen.return_value = mock_response
+
+        with tempfile.NamedTemporaryFile(suffix=".txt") as tmp_file:
+            with open(tmp_file.name, "w") as f:
+                f.write("")
+
+            mock_args = MagicMock()
+            mock_args.rag = tmp_file.name
+            mock_args.ARGS = ["Please analyze:"]
+            mock_args.dryrun = False
+
+            shell = RamaLamaShell(mock_args)
+
+            # Check that the system message was added to conversation history
+            assert len(shell.conversation_history) == 1
+            system_message = shell.conversation_history[0]
+            assert system_message["role"] == "system"
+            assert f"<!--start_document {tmp_file.name}-->" in system_message["content"]
+            # Empty file should still have the delimiter but no content
+            assert system_message["content"].endswith(f"\n<!--start_document {tmp_file.name}-->\n")
+
+    @patch('urllib.request.urlopen')
+    def test_chat_with_file_input_unicode_content(self, mock_urlopen):
+        """Test chat functionality with Unicode content in files."""
+        # Mock the models endpoint response
+        mock_response = MagicMock()
+        mock_response.__iter__.return_value = [b'{"data": [{"id": "test-model"}]}']
+        mock_urlopen.return_value = mock_response
+
+        with tempfile.NamedTemporaryFile(suffix=".txt") as tmp_file:
+            unicode_content = "Hello 世界! 🌍\nUnicode test: éñü\nEmoji: 🚀🎉"
+            with open(tmp_file.name, "w") as f:
+                f.write(unicode_content)
+
+            mock_args = MagicMock()
+            mock_args.rag = tmp_file.name
+            mock_args.ARGS = ["Please analyze:"]
+            mock_args.dryrun = False
+
+            shell = RamaLamaShell(mock_args)
+
+            # Check that the system message was added to conversation history
+            assert len(shell.conversation_history) == 1
+            system_message = shell.conversation_history[0]
+            assert system_message["role"] == "system"
+            assert unicode_content in system_message["content"]
+            assert f"<!--start_document {tmp_file.name}-->" in system_message["content"]
+
+    @patch('urllib.request.urlopen')
+    def test_chat_with_file_input_mixed_content_types(self, mock_urlopen):
+        """Test chat functionality with mixed content types."""
+        # Mock the models endpoint response
+        mock_response = MagicMock()
+        mock_response.__iter__.return_value = [b'{"data": [{"id": "test-model"}]}']
+        mock_urlopen.return_value = mock_response
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            txt_file = os.path.join(tmp_dir, "english.txt")
+            with open(txt_file, "w") as f:
+                f.write("English content")
+
+            json_file = os.path.join(tmp_dir, "data.json")
+            with open(json_file, "w") as f:
+                f.write('{"key": "value", "number": 42}')
+
+            yaml_file = os.path.join(tmp_dir, "config.yaml")
+            with open(yaml_file, "w") as f:
+                f.write("setting: enabled\nvalues:\n  - one\n  - two")
+
+            mock_args = MagicMock()
+            mock_args.rag = tmp_dir
+            mock_args.ARGS = ["Please analyze these files:"]
+            mock_args.dryrun = False
+
+            shell = RamaLamaShell(mock_args)
+
+            # Check that the system message was added to conversation history
+            assert len(shell.conversation_history) == 1
+            system_message = shell.conversation_history[0]
+            assert system_message["role"] == "system"
+            assert "English content" in system_message["content"]
+            assert '{"key": "value", "number": 42}' in system_message["content"]
+            assert "setting: enabled" in system_message["content"]
+            assert "values:" in system_message["content"]
+            assert "english.txt" in system_message["content"]
+            assert "data.json" in system_message["content"]
+            assert "config.yaml" in system_message["content"]
+
+    @patch('urllib.request.urlopen')
+    def test_chat_with_file_input_no_input_specified(self, mock_urlopen):
+        """Test chat functionality when no input file is specified."""
+        # Mock the models endpoint response
+        mock_response = MagicMock()
+        mock_response.__iter__.return_value = [b'{"data": [{"id": "test-model"}]}']
+        mock_urlopen.return_value = mock_response
+
+        mock_args = MagicMock()
+        mock_args.rag = None
+        mock_args.ARGS = ["Please analyze:"]
+        mock_args.dryrun = False
+
+        shell = RamaLamaShell(mock_args)
+
+        # Check that no system message was added since no rag specified
+        assert len(shell.conversation_history) == 0
+
+    @patch('urllib.request.urlopen')
+    def test_chat_with_file_input_empty_args(self, mock_urlopen):
+        """Test chat functionality with empty ARGS but file input."""
+        # Mock the models endpoint response
+        mock_response = MagicMock()
+        mock_response.__iter__.return_value = [b'{"data": [{"id": "test-model"}]}']
+        mock_urlopen.return_value = mock_response
+
+        with tempfile.NamedTemporaryFile(suffix=".txt") as tmp_file:
+            with open(tmp_file.name, "w") as f:
+                f.write("File content")
+
+            mock_args = MagicMock()
+            mock_args.rag = tmp_file.name
+            mock_args.ARGS = None
+            mock_args.dryrun = False
+
+            shell = RamaLamaShell(mock_args)
+
+            # Check that the system message was added to conversation history
+            assert len(shell.conversation_history) == 1
+            system_message = shell.conversation_history[0]
+            assert system_message["role"] == "system"
+            assert "File content" in system_message["content"]
+            assert f"<!--start_document {tmp_file.name}-->" in system_message["content"]
+
+    def test_chat_function_with_rag_and_dryrun(self):
+        """Test that chat function works correctly with rag and dryrun."""
+        with tempfile.NamedTemporaryFile(suffix=".txt") as tmp_file:
+            with open(tmp_file.name, "w") as f:
+                f.write("Test content")
+
+            mock_args = MagicMock()
+            mock_args.rag = tmp_file.name
+            mock_args.ARGS = ["Please analyze:"]
+            mock_args.dryrun = True
+
+            with patch('ramalama.chat.dry_run') as mock_dry_run:
+                with patch('builtins.print') as mock_print:
+                    chat(mock_args)
+
+                    # dry_run should only be called with ARGS, not the file content
+                    mock_dry_run.assert_called_once()
+                    call_args = ' '.join(mock_dry_run.call_args[0][0])
+                    assert call_args == "Please analyze:"
+                    # File content should not be in the dry_run call
+                    assert "Test content" not in call_args
+                    assert f"<!--start_document {tmp_file.name}-->" not in call_args
+
+                    mock_print.assert_called()

--- a/test/unit/test_file_upload_with_data.py
+++ b/test/unit/test_file_upload_with_data.py
@@ -1,0 +1,191 @@
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from ramalama.file_upload.file_loader import FileUpLoader
+
+
+class TestFileUploadWithDataFiles:
+    """Test file upload functionality using sample data files."""
+
+    @pytest.fixture
+    def data_dir(self):
+        """Get the path to the test data directory."""
+        current_dir = Path(__file__).parent
+        return current_dir / "data" / "test_file_upload"
+
+    def test_load_single_text_file(self, data_dir):
+        """Test loading a single text file from the data directory."""
+        txt_file = data_dir / "sample.txt"
+
+        uploader = FileUpLoader(str(txt_file))
+        result = uploader.load()
+
+        assert "This is a sample text file" in result
+        assert "TXTFileUpload class" in result
+        assert "Special characters like: !@#$%^&*()" in result
+        assert f"<!--start_document {txt_file}-->" in result
+
+    def test_load_single_markdown_file(self, data_dir):
+        """Test loading a single markdown file from the data directory."""
+        md_file = data_dir / "sample.md"
+
+        uploader = FileUpLoader(str(md_file))
+        result = uploader.load()
+
+        assert "# Sample Markdown File" in result
+        assert "**Bold text** and *italic text*" in result
+        assert "```python" in result
+        assert "def hello_world():" in result
+        assert f"<!--start_document {md_file}-->" in result
+
+    def test_load_single_json_file(self, data_dir):
+        """Test loading a single JSON file from the data directory."""
+        json_file = data_dir / "sample.json"
+
+        uploader = FileUpLoader(str(json_file))
+        result = uploader.load()
+
+        assert '"name": "test_data"' in result
+        assert '"version": "1.0.0"' in result
+        assert '"text_processing"' in result
+        assert '"supported_formats"' in result
+        assert f"<!--start_document {json_file}-->" in result
+
+    def test_load_single_yaml_file(self, data_dir):
+        """Test loading a single YAML file from the data directory."""
+        yaml_file = data_dir / "sample.yaml"
+
+        uploader = FileUpLoader(str(yaml_file))
+        result = uploader.load()
+
+        assert "name: test_config" in result
+        assert "version: 1.0.0" in result
+        assert "- text_processing" in result
+        assert "- yaml_support" in result
+        assert "deep:" in result
+        assert f"<!--start_document {yaml_file}-->" in result
+
+    def test_load_single_csv_file(self, data_dir):
+        """Test loading a single CSV file from the data directory."""
+        csv_file = data_dir / "sample.csv"
+
+        uploader = FileUpLoader(str(csv_file))
+        result = uploader.load()
+
+        assert "name,age,city,occupation" in result
+        assert "John Doe,30,New York,Engineer" in result
+        assert "Jane Smith,25,San Francisco,Designer" in result
+        assert "Bob Johnson,35,Chicago,Manager" in result
+        assert f"<!--start_document {csv_file}-->" in result
+
+    def test_load_single_toml_file(self, data_dir):
+        """Test loading a single TOML file from the data directory."""
+        toml_file = data_dir / "sample.toml"
+
+        uploader = FileUpLoader(str(toml_file))
+        result = uploader.load()
+
+        assert 'name = "test_config"' in result
+        assert 'version = "1.0.0"' in result
+        assert 'text_processing = true' in result
+        assert 'toml_support = true' in result
+        assert 'with_deep_nesting = true' in result
+        assert f"<!--start_document {toml_file}-->" in result
+
+    def test_load_single_shell_script(self, data_dir):
+        """Test loading a single shell script from the data directory."""
+        sh_file = data_dir / "sample.sh"
+
+        uploader = FileUpLoader(str(sh_file))
+        result = uploader.load()
+
+        assert "#!/bin/bash" in result
+        assert "Hello, World! This is a test script." in result
+        assert "test_function()" in result
+        assert "for i in {1..3}" in result
+        assert "Script completed successfully!" in result
+        assert f"<!--start_document {sh_file}-->" in result
+
+    def test_load_entire_data_directory(self, data_dir):
+        """Test loading all files from the data directory."""
+        uploader = FileUpLoader(str(data_dir))
+        result = uploader.load()
+
+        assert "This is a sample text file" in result  # sample.txt
+        assert "# Sample Markdown File" in result  # sample.md
+        assert '"name": "test_data"' in result  # sample.json
+        assert "name: test_config" in result  # sample.yaml
+        assert "name,age,city,occupation" in result  # sample.csv
+        assert 'name = "test_config"' in result  # sample.toml
+        assert "#!/bin/bash" in result  # sample.sh
+
+        assert "<!--start_document" in result
+        assert "sample.txt" in result
+        assert "sample.md" in result
+        assert "sample.json" in result
+        assert "sample.yaml" in result
+        assert "sample.csv" in result
+        assert "sample.toml" in result
+        assert "sample.sh" in result
+
+    def test_file_content_integrity(self, data_dir):
+        """Test that file content is preserved exactly."""
+        txt_file = data_dir / "sample.txt"
+
+        with open(txt_file, 'r') as f:
+            original_content = f.read()
+
+        uploader = FileUpLoader(str(txt_file))
+        result = uploader.load()
+
+        content_start = result.find('\n', result.find('<!--start_document')) + 1
+        extracted_content = result[content_start:]
+
+        assert extracted_content == original_content
+
+    def test_multiple_files_content_integrity(self, data_dir):
+        """Test that content from multiple files is preserved correctly."""
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            files_to_copy = ['sample.txt', 'sample.md', 'sample.json']
+            for filename in files_to_copy:
+                src_file = data_dir / filename
+                dst_file = os.path.join(tmp_dir, filename)
+                with open(src_file, 'r') as src, open(dst_file, 'w') as dst:
+                    dst.write(src.read())
+
+            uploader = FileUpLoader(tmp_dir)
+            result = uploader.load()
+
+            assert "This is a sample text file" in result  # sample.txt
+            assert "# Sample Markdown File" in result  # sample.md
+            assert '"name": "test_data"' in result  # sample.json
+
+            assert "<!--start_document" in result
+            assert "sample.txt" in result
+            assert "sample.md" in result
+            assert "sample.json" in result
+
+    def test_unsupported_file_handling(self, data_dir):
+        """Test that unsupported files are handled correctly."""
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            src_file = data_dir / "sample.txt"
+            dst_file = os.path.join(tmp_dir, "sample.txt")
+            with open(src_file, 'r') as src, open(dst_file, 'w') as dst:
+                dst.write(src.read())
+
+            unsupported_file = os.path.join(tmp_dir, "sample.xyz")
+            with open(unsupported_file, 'w') as f:
+                f.write("This is an unsupported file type")
+
+            uploader = FileUpLoader(tmp_dir)
+            result = uploader.load()
+
+            assert "This is a sample text file" in result
+            assert "This is an unsupported file type" not in result
+            assert "sample.txt" in result
+            assert "sample.xyz" not in result


### PR DESCRIPTION
## Summary by Sourcery

Enable users to pass files or directories into the ramalama commands by introducing a new --input flag, implementing a file upload loader with supported file-type handlers, integrating file contents into chat prompts, and covering the functionality with extensive tests.

New Features:
- Add --input option to accept single file or directory for ramalama run/chat commands
- Implement FileUpLoader and BaseFileUploader with pluggable file-type handlers (.txt, .md, .json, .yaml/.yml, .toml, .csv, .pdf) to load and prefix file contents into prompts

Enhancements:
- Handle file extension mapping case-insensitively and warn on unsupported types

Tests:
- Add comprehensive unit tests and sample data fixtures for file loading, type-specific handlers, and chat integration with file inputs