### PR TITLE
fix: vLLM serving and model mounting

### DIFF
--- a/docs/ramalama-perplexity.1.md
+++ b/docs/ramalama-perplexity.1.md
@@ -29,7 +29,7 @@ URL support means if a model is on a web site or even on your local system, you 
 #### **--authfile**=*password*
 path of the authentication file for OCI registries
 
-#### **--ctx-size**, **-c** **--max-model-len**
+#### **--ctx-size**, **-c**, **--max-model-len**
 size of the prompt context, applies to llama.cpp and vllm regardless of alias (default: 2048, 0 = loaded from model)
 
 #### **--device**

--- a/docs/ramalama-perplexity.1.md
+++ b/docs/ramalama-perplexity.1.md
@@ -29,8 +29,8 @@ URL support means if a model is on a web site or even on your local system, you 
 #### **--authfile**=*password*
 path of the authentication file for OCI registries
 
-#### **--ctx-size**, **-c**, **--max-model-len**
-size of the prompt context, applies to llama.cpp and vllm regardless of alias (default: 2048, 0 = loaded from model)
+#### **--ctx-size**, **-c**
+size of the prompt context. This option is also available as **--max-model-len**. Applies to llama.cpp and vllm regardless of alias (default: 2048, 0 = loaded from model)
 
 #### **--device**
 Add a host device to the container. Optional permissions parameter can

--- a/docs/ramalama-perplexity.1.md
+++ b/docs/ramalama-perplexity.1.md
@@ -29,8 +29,8 @@ URL support means if a model is on a web site or even on your local system, you 
 #### **--authfile**=*password*
 path of the authentication file for OCI registries
 
-#### **--ctx-size**, **-c**
-size of the prompt context (default: 2048, 0 = loaded from model)
+#### **--ctx-size**, **-c** **--max-model-len**
+size of the prompt context, applies to llama.cpp and vllm regardless of alias (default: 2048, 0 = loaded from model)
 
 #### **--device**
 Add a host device to the container. Optional permissions parameter can

--- a/docs/ramalama-run.1.md
+++ b/docs/ramalama-run.1.md
@@ -37,8 +37,8 @@ path of the authentication file for OCI registries
 Indicate whether or not to use color in the chat.
 Possible values are "never", "always" and "auto". (default: auto)
 
-#### **--ctx-size**, **-c**, **--max-model-len**
-size of the prompt context, applies to llama.cpp and vllm regardless of alias (default: 2048, 0 = loaded from model)
+#### **--ctx-size**, **-c**
+size of the prompt context. This option is also available as **--max-model-len**. Applies to llama.cpp and vllm regardless of alias (default: 2048, 0 = loaded from model)
 
 #### **--device**
 Add a host device to the container. Optional permissions parameter  can

--- a/docs/ramalama-run.1.md
+++ b/docs/ramalama-run.1.md
@@ -64,6 +64,9 @@ Show this help message and exit
 #### **--keepalive**
 duration to keep a model loaded (e.g. 5m)
 
+#### **--max-model-len**
+Maximum model length for vLLM (default: 2048)
+
 #### **--name**, **-n**
 name of the container to run the Model in
 

--- a/docs/ramalama-run.1.md
+++ b/docs/ramalama-run.1.md
@@ -37,8 +37,8 @@ path of the authentication file for OCI registries
 Indicate whether or not to use color in the chat.
 Possible values are "never", "always" and "auto". (default: auto)
 
-#### **--ctx-size**, **-c**
-size of the prompt context (default: 2048, 0 = loaded from model)
+#### **--ctx-size**, **-c** **--max-model-len**
+size of the prompt context, applies to llama.cpp and vllm regardless of alias (default: 2048, 0 = loaded from model)
 
 #### **--device**
 Add a host device to the container. Optional permissions parameter  can
@@ -63,9 +63,6 @@ Show this help message and exit
 
 #### **--keepalive**
 duration to keep a model loaded (e.g. 5m)
-
-#### **--max-model-len**
-Maximum model length for vLLM (default: 2048)
 
 #### **--name**, **-n**
 name of the container to run the Model in

--- a/docs/ramalama-run.1.md
+++ b/docs/ramalama-run.1.md
@@ -37,7 +37,7 @@ path of the authentication file for OCI registries
 Indicate whether or not to use color in the chat.
 Possible values are "never", "always" and "auto". (default: auto)
 
-#### **--ctx-size**, **-c** **--max-model-len**
+#### **--ctx-size**, **-c**, **--max-model-len**
 size of the prompt context, applies to llama.cpp and vllm regardless of alias (default: 2048, 0 = loaded from model)
 
 #### **--device**

--- a/docs/ramalama-serve.1.md
+++ b/docs/ramalama-serve.1.md
@@ -87,6 +87,9 @@ show this help message and exit
 #### **--host**="0.0.0.0"
 IP address for llama.cpp to listen on.
 
+#### **--max-model-len**
+Maximum model length for vLLM (default: 2048)
+
 #### **--model-draft**
 
 

--- a/docs/ramalama-serve.1.md
+++ b/docs/ramalama-serve.1.md
@@ -42,7 +42,7 @@ The default can be overridden in the ramalama.conf file.
 #### **--authfile**=*password*
 Path of the authentication file for OCI registries
 
-#### **--ctx-size**, **-c** **--max-model-len**
+#### **--ctx-size**, **-c**, **--max-model-len**
 size of the prompt context, applies to llama.cpp and vllm regardless of alias (default: 2048, 0 = loaded from model)
 
 #### **--detach**, **-d**

--- a/docs/ramalama-serve.1.md
+++ b/docs/ramalama-serve.1.md
@@ -42,8 +42,8 @@ The default can be overridden in the ramalama.conf file.
 #### **--authfile**=*password*
 Path of the authentication file for OCI registries
 
-#### **--ctx-size**, **-c**
-Size of the prompt context (default: 2048, 0 = loaded from model)
+#### **--ctx-size**, **-c** **--max-model-len**
+size of the prompt context, applies to llama.cpp and vllm regardless of alias (default: 2048, 0 = loaded from model)
 
 #### **--detach**, **-d**
 Run the container in the background and print the new container ID.
@@ -86,9 +86,6 @@ show this help message and exit
 
 #### **--host**="0.0.0.0"
 IP address for llama.cpp to listen on.
-
-#### **--max-model-len**
-Maximum model length for vLLM (default: 2048)
 
 #### **--model-draft**
 

--- a/docs/ramalama-serve.1.md
+++ b/docs/ramalama-serve.1.md
@@ -42,8 +42,8 @@ The default can be overridden in the ramalama.conf file.
 #### **--authfile**=*password*
 Path of the authentication file for OCI registries
 
-#### **--ctx-size**, **-c**, **--max-model-len**
-size of the prompt context, applies to llama.cpp and vllm regardless of alias (default: 2048, 0 = loaded from model)
+#### **--ctx-size**, **-c**
+size of the prompt context. This option is also available as **--max-model-len**. Applies to llama.cpp and vllm regardless of alias (default: 2048, 0 = loaded from model)
 
 #### **--detach**, **-d**
 Run the container in the background and print the new container ID.

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -771,6 +771,7 @@ def runtime_options(parser, command):
         parser.add_argument(
             "-c",
             "--ctx-size",
+            "--max-model-len",
             dest="context",
             default=CONFIG.ctx_size,
             help="size of the prompt context (0 = loaded from model)",
@@ -856,13 +857,6 @@ def runtime_options(parser, command):
     if command in ["run", "serve"]:
         parser.add_argument(
             "--rag", help="RAG vector database or OCI Image to be served with the model", completer=local_models
-        )
-        parser.add_argument(
-            "--max-model-len",
-            dest="vllm_max_model_len",
-            type=int,
-            help="Maximum model length for vLLM",
-            completer=suppressCompleter,
         )
     if command in ["perplexity", "run", "serve"]:
         parser.add_argument(

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -857,6 +857,13 @@ def runtime_options(parser, command):
         parser.add_argument(
             "--rag", help="RAG vector database or OCI Image to be served with the model", completer=local_models
         )
+        parser.add_argument(
+            "--max-model-len",
+            dest="vllm_max_model_len",
+            type=int,
+            help="Maximum model length for vLLM",
+            completer=suppressCompleter,
+        )
     if command in ["perplexity", "run", "serve"]:
         parser.add_argument(
             "--runtime-args",

--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -290,7 +290,28 @@ class Model(ModelBase):
         return True
 
     def setup_mounts(self, model_path, args):
-        if model_path and os.path.exists(model_path):
+        if args.runtime == "vllm":
+            model_base = ""
+            if self.store and hasattr(self, 'model_tag'):
+                ref_file = self.store.get_ref_file(self.model_tag)
+                if ref_file and hasattr(ref_file, 'hash'):
+                    model_base = self.store.model_base_directory
+            if not model_base:
+                # Might be needed for file:// paths directly used with vLLM.
+                if model_path and os.path.exists(model_path):
+                    if os.path.isfile(model_path):
+                        model_base = os.path.dirname(model_path)
+                    elif os.path.isdir(model_path):
+                        model_base = model_path
+            if model_base:
+                self.engine.add([f"--mount=type=bind,src={model_base},destination={MNT_DIR},ro"])
+            else:
+                raise ValueError(
+                    f'Could not determine a valid host directory to mount for model {self.model}'
+                    + 'Ensure the model path is correct or the model store is properly configured.'
+                )
+
+        elif model_path and os.path.exists(model_path):
             if hasattr(self, 'split_model'):
                 self.engine.add([f"--mount=type=bind,src={model_path},destination={MNT_DIR}/{self.mnt_path},ro"])
 
@@ -531,9 +552,38 @@ class Model(ModelBase):
     def handle_runtime(self, args, exec_args, exec_model_path):
         set_accel_env_vars()
         if args.runtime == "vllm":
-            exec_model_path = os.path.dirname(exec_model_path)
-            # Left out "vllm", "serve" the image entrypoint already starts it
-            exec_args = ["--port", args.port, "--model", MNT_FILE, "--max_model_len", "2048"]
+            container_model_path = ""
+            ref_file = None
+            if self.store:
+                ref_file = self.store.get_ref_file(self.model_tag)
+
+            if ref_file and ref_file.hash:
+                snapshot_dir_name = ref_file.hash
+                container_model_path = os.path.join(MNT_DIR, "snapshots", snapshot_dir_name)
+            else:
+                current_model_host_path = self.get_model_path(args)
+                if os.path.isdir(current_model_host_path):
+                    container_model_path = MNT_DIR
+                else:
+                    container_model_path = os.path.join(MNT_DIR, os.path.basename(current_model_host_path))
+
+            vllm_max_model_len = 2048
+            if args.vllm_max_model_len:
+                vllm_max_model_len = args.vllm_max_model_len
+
+            exec_args = [
+                "--port",
+                str(args.port),
+                "--model",
+                str(container_model_path),
+                "--max_model_len",
+                str(vllm_max_model_len),
+                "--served-model-name",
+                self.model_name,
+            ]
+
+            if hasattr(args, 'runtime_args') and args.runtime_args:
+                exec_args.extend(args.runtime_args)
         else:
             gpu_args = self.gpu_args(args=args)
             if gpu_args is not None:

--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -296,13 +296,11 @@ class Model(ModelBase):
                 ref_file = self.store.get_ref_file(self.model_tag)
                 if ref_file and hasattr(ref_file, 'hash'):
                     model_base = self.store.model_base_directory
-            if not model_base:
-                # Might be needed for file:// paths directly used with vLLM.
-                if model_path and os.path.exists(model_path):
-                    if os.path.isfile(model_path):
-                        model_base = os.path.dirname(model_path)
-                    elif os.path.isdir(model_path):
-                        model_base = model_path
+            if not model_base and (model_path and os.path.exists(model_path)):
+                if os.path.isfile(model_path):
+                    model_base = os.path.dirname(model_path)
+                elif os.path.isdir(model_path):
+                    model_base = model_path
             if model_base:
                 self.engine.add([f"--mount=type=bind,src={model_base},destination={MNT_DIR},ro"])
             else:
@@ -568,8 +566,8 @@ class Model(ModelBase):
                     container_model_path = os.path.join(MNT_DIR, os.path.basename(current_model_host_path))
 
             vllm_max_model_len = 2048
-            if args.vllm_max_model_len:
-                vllm_max_model_len = args.vllm_max_model_len
+            if args.context:
+                vllm_max_model_len = args.context
 
             exec_args = [
                 "--port",

--- a/test/system/040-serve.bats
+++ b/test/system/040-serve.bats
@@ -255,7 +255,7 @@ verify_begin=".*run --rm"
     run_ramalama rm oci://${ociimage}
     done
     stop_registry
-    skip "vLLM cant serve GGUFs, needs tiny safetensor"
+    skip "vLLM can't serve GGUFs, needs tiny safetensor"
 
 	run_ramalama --runtime=vllm serve --authfile=$authfile --tls-verify=false --name=${name} --port 1234 --generate=kube oci://${ociimage}
 	is "$output" ".*Generating Kubernetes YAML file: ${name}.yaml" "generate .yaml file"

--- a/test/system/040-serve.bats
+++ b/test/system/040-serve.bats
@@ -250,6 +250,11 @@ verify_begin=".*run --rm"
 	   rm $name.image
 	fi
 
+    run_ramalama rm oci://${ociimage}
+    done
+    stop_registry
+    skip "vLLM cant serve GGUFs, needs tiny safetensor"
+
 	run_ramalama --runtime=vllm serve --authfile=$authfile --tls-verify=false --name=${name} --port 1234 --generate=kube oci://${ociimage}
 	is "$output" ".*Generating Kubernetes YAML file: ${name}.yaml" "generate .yaml file"
 
@@ -265,10 +270,7 @@ verify_begin=".*run --rm"
 	is "$output" ".*reference: ${ociimage}" "AI image should be created"
 	is "$output" ".*pullPolicy: IfNotPresent" "pullPolicy should exist"
 
-	run_ramalama rm oci://${ociimage}
-	rm $name.yaml
-    done
-    stop_registry
+    rm $name.yaml
 }
 
 


### PR DESCRIPTION
This pull request effectively introduces support for the vLLM runtime. The changes include logic for mounting safetensor directories, handling model paths correctly whether they are store-backed or direct file paths (both individual files and directories), and exposing vLLM's maximum model length via a new `--max-model-len` CLI flag. The documentation has been updated accordingly, and test adjustments were made to reflect the inability for vLLM to serve GGUFs.

Once the ramalama-vllm images are building, I can submit tests for vllm serving but I also have a series of bugs to submit on kube generation in general.

Example output with Mac ARM:
```
❯ ramalama --runtime vllm --image quay.io/kugupta/vllm-cpu-arm --container serve hf://TinyLlama/TinyLlama-1.1B-Chat-v1.0
INFO 06-20 02:16:56 [__init__.py:239] Automatically detected platform cpu.
INFO 06-20 02:16:57 [api_server.py:1043] vLLM API server version 0.1.dev5905+g686623c
INFO 06-20 02:16:57 [api_server.py:1044] args: Namespace(host=None, port=8080, uvicorn_log_level='info', disable_uvicorn_access_log=False, allow_credentials=False, allowed_origins=['*'], allowed_methods=['*'], allowed_headers=['*'], api_key=None, lora_modules=None, prompt_adapters=None, chat_template=None, chat_template_content_format='auto', response_role='assistant', ssl_keyfile=None, ssl_certfile=None, ssl_ca_certs=None, enable_ssl_refresh=False, ssl_cert_reqs=0, root_path=None, middleware=[], return_tokens_as_token_ids=False, disable_frontend_multiprocessing=False, enable_request_id_headers=False, enable_auto_tool_choice=False, tool_call_parser=None, tool_parser_plugin='', model='/mnt/models/snapshots/sha256-9737c9ce5074907aa44d575918c5367cd877471f', task='auto', tokenizer=None, hf_config_path=None, skip_tokenizer_init=False, revision=None, code_revision=None, tokenizer_revision=None, tokenizer_mode='auto', trust_remote_code=False, allowed_local_media_path=None, load_format='auto', download_dir=None, model_loader_extra_config={}, use_tqdm_on_load=True, config_format=<ConfigFormat.AUTO: 'auto'>, dtype='auto', kv_cache_dtype='auto', max_model_len=2048, guided_decoding_backend='auto', reasoning_parser=None, logits_processor_pattern=None, model_impl='auto', distributed_executor_backend=None, pipeline_parallel_size=1, tensor_parallel_size=1, data_parallel_size=1, enable_expert_parallel=False, max_parallel_loading_workers=None, ray_workers_use_nsight=False, disable_custom_all_reduce=False, block_size=None, enable_prefix_caching=None, prefix_caching_hash_algo='builtin', disable_sliding_window=False, use_v2_block_manager=True, seed=None, swap_space=4, cpu_offload_gb=0, gpu_memory_utilization=0.9, num_gpu_blocks_override=None, max_logprobs=20, disable_log_stats=False, quantization=None, rope_scaling=None, rope_theta=None, hf_token=None, hf_overrides=None, enforce_eager=False, max_seq_len_to_capture=8192, tokenizer_pool_size=0, tokenizer_pool_type='ray', tokenizer_pool_extra_config={}, limit_mm_per_prompt={}, mm_processor_kwargs=None, disable_mm_preprocessor_cache=False, enable_lora=False, enable_lora_bias=False, max_loras=1, max_lora_rank=16, lora_extra_vocab_size=256, lora_dtype='auto', long_lora_scaling_factors=None, max_cpu_loras=None, fully_sharded_loras=False, enable_prompt_adapter=False, max_prompt_adapters=1, max_prompt_adapter_token=0, device='auto', num_scheduler_steps=1, speculative_config=None, ignore_patterns=[], preemption_mode=None, served_model_name=['TinyLlama-1.1B-Chat-v1.0'], qlora_adapter_name_or_path=None, show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None, disable_async_output_proc=False, max_num_batched_tokens=None, max_num_seqs=None, max_num_partial_prefills=1, max_long_partial_prefills=1, long_prefill_token_threshold=0, num_lookahead_slots=0, scheduler_delay_factor=0.0, enable_chunked_prefill=None, multi_step_stream_outputs=True, scheduling_policy='fcfs', disable_chunked_mm_input=False, scheduler_cls='vllm.core.scheduler.Scheduler', override_neuron_config=None, override_pooler_config=None, compilation_config=None, kv_transfer_config=None, worker_cls='auto', worker_extension_cls='', generation_config='auto', override_generation_config=None, enable_sleep_mode=False, calculate_kv_scales=False, additional_config=None, enable_reasoning=False, disable_cascade_attn=False, disable_log_requests=False, max_log_len=None, disable_fastapi_docs=False, enable_prompt_tokens_details=False, enable_server_load_tracking=False)
INFO 06-20 02:17:00 [config.py:713] This model supports multiple tasks: {'reward', 'score', 'embed', 'generate', 'classify'}. Defaulting to 'generate'.
WARNING 06-20 02:17:00 [arg_utils.py:1736] device type=cpu is not supported by the V1 Engine. Falling back to V0. 
INFO 06-20 02:17:00 [config.py:1776] Disabled the custom all-reduce kernel because it is not supported on current platform.
WARNING 06-20 02:17:00 [cpu.py:106] Environment variable VLLM_CPU_KVCACHE_SPACE (GiB) for CPU backend is not set, using 4 by default.
WARNING 06-20 02:17:00 [cpu.py:119] uni is not supported on CPU, fallback to mp distributed executor backend.
INFO 06-20 02:17:00 [api_server.py:246] Started engine process with PID 15
INFO 06-20 02:17:01 [__init__.py:239] Automatically detected platform cpu.
INFO 06-20 02:17:01 [llm_engine.py:243] Initializing a V0 LLM engine (v0.1.dev5905+g686623c) with config: model='/mnt/models/snapshots/sha256-9737c9ce5074907aa44d575918c5367cd877471f', speculative_config=None, tokenizer='/mnt/models/snapshots/sha256-9737c9ce5074907aa44d575918c5367cd877471f', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, override_neuron_config=None, tokenizer_revision=None, trust_remote_code=False, dtype=torch.bfloat16, max_seq_len=2048, download_dir=None, load_format=auto, tensor_parallel_size=1, pipeline_parallel_size=1, disable_custom_all_reduce=True, quantization=None, enforce_eager=True, kv_cache_dtype=auto,  device_config=cpu, decoding_config=DecodingConfig(guided_decoding_backend='auto', reasoning_backend=None), observability_config=ObservabilityConfig(show_hidden_metrics=False, otlp_traces_endpoint=None, collect_model_forward_time=False, collect_model_execute_time=False), seed=None, served_model_name=TinyLlama-1.1B-Chat-v1.0, num_scheduler_steps=1, multi_step_stream_outputs=True, enable_prefix_caching=None, chunked_prefill_enabled=False, use_async_output_proc=False, disable_mm_preprocessor_cache=False, mm_processor_kwargs=None, pooler_config=None, compilation_config={"splitting_ops":[],"compile_sizes":[],"cudagraph_capture_sizes":[256,248,240,232,224,216,208,200,192,184,176,168,160,152,144,136,128,120,112,104,96,88,80,72,64,56,48,40,32,24,16,8,4,2,1],"max_capture_size":256}, use_cached_outputs=True, 
INFO 06-20 02:17:02 [cpu.py:45] Using Torch SDPA backend.
INFO 06-20 02:17:02 [importing.py:16] Triton not installed or not compatible; certain GPU-related functions will not be available.
INFO 06-20 02:17:02 [parallel_state.py:946] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, TP rank 0
Loading safetensors checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:01<00:00,  1.91s/it]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:01<00:00,  1.91s/it]

INFO 06-20 02:17:04 [loader.py:458] Loading weights took 1.94 seconds
INFO 06-20 02:17:04 [executor_base.py:112] # cpu blocks: 11915, # CPU blocks: 0
INFO 06-20 02:17:04 [executor_base.py:117] Maximum concurrency for 2048 tokens per request: 93.09x
INFO 06-20 02:17:05 [llm_engine.py:449] init engine (profile, create kv cache, warmup model) took 1.32 seconds
INFO 06-20 02:17:05 [api_server.py:1090] Starting vLLM API server on http://0.0.0.0:8080
INFO 06-20 02:17:05 [launcher.py:28] Available routes are:
INFO 06-20 02:17:05 [launcher.py:36] Route: /openapi.json, Methods: HEAD, GET
INFO 06-20 02:17:05 [launcher.py:36] Route: /docs, Methods: HEAD, GET
INFO 06-20 02:17:05 [launcher.py:36] Route: /docs/oauth2-redirect, Methods: HEAD, GET
INFO 06-20 02:17:05 [launcher.py:36] Route: /redoc, Methods: HEAD, GET
INFO 06-20 02:17:05 [launcher.py:36] Route: /health, Methods: GET
INFO 06-20 02:17:05 [launcher.py:36] Route: /load, Methods: GET
INFO 06-20 02:17:05 [launcher.py:36] Route: /ping, Methods: POST, GET
INFO 06-20 02:17:05 [launcher.py:36] Route: /tokenize, Methods: POST
INFO 06-20 02:17:05 [launcher.py:36] Route: /detokenize, Methods: POST
INFO 06-20 02:17:05 [launcher.py:36] Route: /v1/models, Methods: GET
INFO 06-20 02:17:05 [launcher.py:36] Route: /version, Methods: GET
INFO 06-20 02:17:05 [launcher.py:36] Route: /v1/chat/completions, Methods: POST
INFO 06-20 02:17:05 [launcher.py:36] Route: /v1/completions, Methods: POST
INFO 06-20 02:17:05 [launcher.py:36] Route: /v1/embeddings, Methods: POST
INFO 06-20 02:17:05 [launcher.py:36] Route: /pooling, Methods: POST
INFO 06-20 02:17:05 [launcher.py:36] Route: /score, Methods: POST
INFO 06-20 02:17:05 [launcher.py:36] Route: /v1/score, Methods: POST
INFO 06-20 02:17:05 [launcher.py:36] Route: /v1/audio/transcriptions, Methods: POST
INFO 06-20 02:17:05 [launcher.py:36] Route: /rerank, Methods: POST
INFO 06-20 02:17:05 [launcher.py:36] Route: /v1/rerank, Methods: POST
INFO 06-20 02:17:05 [launcher.py:36] Route: /v2/rerank, Methods: POST
INFO 06-20 02:17:05 [launcher.py:36] Route: /invocations, Methods: POST
INFO 06-20 02:17:05 [launcher.py:36] Route: /metrics, Methods: GET
INFO:     Started server process [2]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
```

## Summary by Sourcery

Enable full support for vLLM runtime by resolving mount points for store-backed and direct model paths, configuring serve arguments including a new max model length flag, and updating documentation and system tests to reflect vLLM limitations.

New Features:
- Add vLLM runtime mode with dedicated mount logic for both store-backed and local model paths
- Introduce --max-model-len CLI option to expose vLLM's maximum model length

Enhancements:
- Resolve container model path from snapshots or host paths and merge custom runtime args for vLLM serving
- Add error handling when a valid host directory cannot be determined for vLLM mounts

Documentation:
- Document the --max-model-len flag in run and serve CLI man pages

Tests:
- Skip GGUF serving in vLLM system tests and adjust cleanup steps in 040-serve.bats