### PR TITLE
Make model argument mandatory

### DIFF
--- a/ramalama/chat.py
+++ b/ramalama/chat.py
@@ -71,23 +71,6 @@ class RamaLamaShell(cmd.Cmd):
         self.prompt = args.prefix
 
         self.url = f"{args.url}/v1/chat/completions"
-        self.models_url = f"{args.url}/v1/models"
-        self.models = []
-
-    def model(self, index=0):
-        try:
-            if len(self.models) == 0:
-                self.models = self.get_models()
-            return self.models[index]
-        except urllib.error.URLError:
-            return ""
-
-    def get_models(self):
-        request = urllib.request.Request(self.models_url, method="GET")
-        response = urllib.request.urlopen(request)
-        for line in response:
-            line = line.decode("utf-8").strip()
-            return [d['id'] for d in json.loads(line)["data"]]
 
     def handle_args(self):
         if self.args.ARGS:
@@ -117,7 +100,7 @@ class RamaLamaShell(cmd.Cmd):
         data = {
             "stream": True,
             "messages": self.conversation_history,
-            "model": self.model(),
+            "model": self.args.MODEL,
         }
         json_data = json.dumps(data).encode("utf-8")
         headers = {

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -921,6 +921,7 @@ def chat_parser(subparsers):
     )
     parser.add_argument("--prefix", type=str, help="prefix for the user prompt", default=default_prefix())
     parser.add_argument("--url", type=str, default="http://127.0.0.1:8080", help="the host to send requests to")
+    parser.add_argument("MODEL", completer=local_models)  # positional argument
     parser.add_argument(
         "ARGS", nargs="*", help="overrides the default prompt, and the output is returned without entering the chatbot"
     )


### PR DESCRIPTION
To be consistent with "ramalama run" experience. Inferencing
servers that have implemented model-swapping require this. In the
case of servers like llama-server that only load one server, any
value is sufficient.