### PR TITLE
fix: broken link in CI dashboard

### DIFF
--- a/test/report.md
+++ b/test/report.md
@@ -6,4 +6,4 @@
 | [CI](https://github.com/containers/ramalama/actions/workflows/ci.yml) | ![CI](https://github.com/containers/ramalama/actions/workflows/ci.yml/badge.svg?branch=main) |
 | [CI Images](https://github.com/containers/ramalama/actions/workflows/ci-images.yml) | ![CI Images](https://github.com/containers/ramalama/actions/workflows/ci-images.yml/badge.svg?branch=main) |
 | [Latest Images](https://github.com/containers/ramalama/actions/workflows/latest.yml) | ![Latest Images](https://github.com/containers/ramalama/actions/workflows/latest.yml/badge.svg?branch=main) |
-| [Nightly Images](https://github.com/containers/ramalama-stack/actions/workflows/pypi.yml) | ![Nightly Images](https://github.com/containers/ramalama/actions/workflows/nightly.yml/badge.svg?branch=main) |
+| [Nightly Images](https://github.com/containers/ramalama/actions/workflows/nightly.yml) | ![Nightly Images](https://github.com/containers/ramalama/actions/workflows/nightly.yml/badge.svg?branch=main) |


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Correct the Nightly Images hyperlink to point at the proper CI workflow