### PR TITLE
Fix vulkan container build by using Python 3.11 for ramalama installa…

### DIFF
--- a/container-images/scripts/build_llama_and_whisper.sh
+++ b/container-images/scripts/build_llama_and_whisper.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -x
 
 available() {
   command -v "$1" >/dev/null
@@ -112,8 +113,8 @@ dnf_install_ffmpeg() {
 
 dnf_install() {
   local rpm_list=("podman-remote" "python3" "python3-pip" "python3-argcomplete" \
-                  "python3-dnf-plugin-versionlock" "python3-devel" "gcc-c++" "cmake" "vim" \
-                  "procps-ng" "git" "dnf-plugins-core" "libcurl-devel" "gawk")
+                  "python3-dnf-plugin-versionlock" "python3-devel" "python3.11" "python3.11-pip" \
+                  "gcc-c++" "cmake" "vim" "procps-ng" "git" "dnf-plugins-core" "libcurl-devel" "gawk")
   local vulkan_rpms=("vulkan-headers" "vulkan-loader-devel" "vulkan-tools" \
                      "spirv-tools" "glslc" "glslang")
   if [ "${containerfile}" = "ramalama" ] || [[ "${containerfile}" =~ rocm* ]] || \
@@ -253,7 +254,7 @@ clone_and_build_ramalama() {
   git clone https://github.com/containers/ramalama
   cd ramalama
   git submodule update --init --recursive
-  python3 -m pip install . --prefix="$1"
+  python3.11 -m pip install . --prefix="$1"
   cd ..
   rm -rf ramalama
 }


### PR DESCRIPTION
Title:
  Fix vulkan container build by using Python 3.11 for ramalama installation

  Description:
  ## Summary
  Fixes the vulkan container build failure caused by Python version incompatibility.

  ## Problem
  The vulkan container build was failing with the error:
  ERROR: Package 'ramalama' requires a different Python: 3.9.21 not in '>=3.10'

  This occurred because:
  - The current ramalama version requires Python >= 3.10
  - The UBI 9 base image only provides Python 3.9 as the default
  - The build script was attempting to install ramalama using the incompatible Python 3.9

  ## Solution
  This PR resolves the issue by:

  - **Installing Python 3.11 packages**: Added `python3.11` and `python3.11-pip` to the RPM installation list
  - **Using Python 3.11 for ramalama**: Modified `clone_and_build_ramalama()` to use `python3.11` instead of `python3`
  - **Maintaining compatibility**: Kept `python3` (3.9) for other pip packages to ensure compatibility with existing scripts
  like `rag_framework`

  ## Test plan
  - [x] Successfully built vulkan container image
  - [x] Verified all vulkan variants build correctly:
    - `quay.io/ramalama/vulkan` - Base vulkan image
    - `quay.io/ramalama/vulkan-llama-server` - Vulkan with LLaMA server
    - `quay.io/ramalama/vulkan-whisper-server` - Vulkan with Whisper server
    - `quay.io/ramalama/vulkan-rag` - Vulkan with RAG framework
  - [x] Confirmed rag_framework functionality works with existing Python 3.9

  The changes are minimal and focused, addressing the specific Python version compatibility issue while maintaining backward
  compatibility.

## Summary by Sourcery

Use Python 3.11 in the Vulkan container build to install ramalama properly while retaining Python 3.9 for other components.

Bug Fixes:
- Resolve build failure by using Python 3.11 for ramalama installation to satisfy its >=3.10 requirement.

Enhancements:
- Enable debug tracing in the build script with set -x.

Build:
- Add python3.11 and python3.11-pip to the DNF installation list and switch pip invocation to python3.11 for ramalama.