### PR TITLE
Fixup to work with llama-stack

### DIFF
--- a/container-images/llama-stack/Containerfile
+++ b/container-images/llama-stack/Containerfile
@@ -16,4 +16,4 @@ COPY --chmod=755 container-images/llama-stack/entrypoint.sh /usr/bin/entrypoint.
 
 ENTRYPOINT [ "/usr/bin/entrypoint.sh" ]
 
-CMD llama stack run --image-type venv /etc/ramalama/ramalama-run.yaml
+CMD [ "llama",  "stack",  "run", "--image-type", "venv", "/etc/ramalama/ramalama-run.yaml" ]

--- a/ramalama/chat.py
+++ b/ramalama/chat.py
@@ -159,11 +159,11 @@ class RamaLamaShell(cmd.Cmd):
         return None
 
     def kills(self):
-        if getattr(self.args, "pid2kill", None):
+        if getattr(self.args, "pid2kill", False):
             os.kill(self.args.pid2kill, signal.SIGINT)
             os.kill(self.args.pid2kill, signal.SIGTERM)
             os.kill(self.args.pid2kill, signal.SIGKILL)
-        elif self.args.name:
+        elif getattr(self.args, "name", None):
             stop_container(self.args, self.args.name)
 
     def loop(self):

--- a/test/system/040-serve.bats
+++ b/test/system/040-serve.bats
@@ -363,9 +363,9 @@ verify_begin=".*run --rm"
     is "$output" ".*Generating Kubernetes YAML file: ${name}.yaml" "generate .yaml file"
 
     run cat /tmp/$name.yaml
-    is "$output" ".*command: \[\".*serve.*\"\]" "Should command"
+    is "$output" ".*llama-server" "Should command"
     is "$output" ".*hostPort: 1234" "Should container container port"
-    is "$output" ".*llama stack run --image-type venv /etc/ramalama/ramalama-run.yaml" "Should container llama-stack"
+    is "$output" ".*quay.io/ramalama/llama-stack" "Should container llama-stack"
     rm /tmp/$name.yaml
 }
 


### PR DESCRIPTION
## Summary by Sourcery

Adapt ramalama stack and chat modules for compatibility with llama-stack by updating host binding, argument formatting, and command invocation patterns, and add robust attribute checks in the chat utility.

Bug Fixes:
- Add hasattr checks around optional args (pid2kill, name) in chat kills() to prevent attribute errors

Enhancements:
- Bind model server to 0.0.0.0 instead of localhost for external accessibility
- Convert port, context size, and thread count arguments to strings for consistent CLI usage
- Reformat container YAML to use JSON array and multiline args for llama-server and llama-stack commands
- Update Containerfile CMD to JSON exec form for llama-stack entrypoint