### PR TITLE
Don't pull image when doing ramalama --help call

### DIFF
--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -192,7 +192,7 @@ The RAMALAMA_CONTAINER_ENGINE environment variable modifies default behaviour.""
     )
     parser.add_argument(
         "--image",
-        default=accel_image(CONFIG),
+        default=accel_image(CONFIG, nopull=True),
         help="OCI container image to run with the specified AI model",
         action=OverrideDefaultAction,
         completer=local_images,

--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -627,7 +627,7 @@ class AccelImageArgsOtherRuntimeRAG(Protocol):
 AccelImageArgs = None | AccelImageArgsVLLMRuntime | AccelImageArgsOtherRuntime | AccelImageArgsOtherRuntimeRAG
 
 
-def accel_image(config: Config) -> str:
+def accel_image(config: Config, nopull=False) -> str:
     """
     Selects and the appropriate image based on config, arguments, environment.
     """
@@ -650,7 +650,7 @@ def accel_image(config: Config) -> str:
         return "registry.redhat.io/rhelai1/ramalama-vllm"
 
     vers = minor_release()
-    if attempt_to_use_versioned(config.engine, image, vers, True):
+    if nopull or attempt_to_use_versioned(config.engine, image, vers, True):
         return f"{image}:{vers}"
 
     return f"{image}:latest"


### PR DESCRIPTION
Fixes: https://github.com/containers/ramalama/issues/1587

## Summary by Sourcery

Add a `nopull` option to the image selection logic and apply it in the CLI so that running `ramalama --help` (or other non-runtime invocations) no longer triggers a container image pull.

Bug Fixes:
- Prevent unnecessary image pull when calling `ramalama --help`

Enhancements:
- Introduce a `nopull` parameter to `accel_image` to bypass pulling the container image
- Invoke `accel_image` with `nopull=True` when setting the CLI’s default `--image` value