### PR TITLE
Add CPU based vllm inferencing

### DIFF
--- a/container-images/ramalama/Containerfile
+++ b/container-images/ramalama/Containerfile
@@ -1,6 +1,11 @@
-FROM registry.access.redhat.com/ubi9/ubi:9.6-1749542372@sha256:861e833044a903f689ecfa404424494a7e387ab39cf7949c54843285d13a9774
+FROM quay.io/rh-aiservices-bu/vllm-cpu-openai-ubi9:0.3
+
+USER 0
 
 COPY . /src/ramalama
 WORKDIR /src/ramalama
 RUN container-images/scripts/build_llama_and_whisper.sh ramalama
 WORKDIR /
+
+ENTRYPOINT []
+

--- a/container-images/scripts/build_rag.sh
+++ b/container-images/scripts/build_rag.sh
@@ -27,7 +27,7 @@ $2"
 
 update_python() {
     if available dnf; then
-        dnf update -y --allowerasing
+        dnf update -y --allowerasing --exclude=mesa*
         dnf install -y "${python}" "${python}-pip" "${python}-devel" "${pkgs[@]}"
         if [[ "${python}" == "python3.11" ]]; then
             ln -sf /usr/bin/python3.11 /usr/bin/python3


### PR DESCRIPTION
So we can do vllm enablement and testing

## Summary by Sourcery

Enable CPU-based vllm inferencing in the ramalama container by updating the base image to a vllm CPU OpenAI UBI9 image, running as root, and clearing the default entrypoint.

Enhancements:
- Switch container base image to quay.io/rh-aiservices-bu/vllm-cpu-openai-ubi9:0.3 for CPU-based vllm support

Build:
- Add USER 0 to run container processes as root
- Remove the default ENTRYPOINT to allow custom command execution