### PR TITLE
Move RamaLama container image to default to fedora:42

### DIFF
--- a/container-images/ramalama/Containerfile
+++ b/container-images/ramalama/Containerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi:9.6-1749542372@sha256:861e833044a903f689ecfa404424494a7e387ab39cf7949c54843285d13a9774
+FROM quay.io/fedora/fedora:42
 
 COPY . /src/ramalama
 WORKDIR /src/ramalama


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Switch the RamaLama container image’s base image from Red Hat UBI9 to Fedora:42