### PR TITLE
add support for running bats in a container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ PATH := $(PATH):$(HOME)/.local/bin
 IMAGE ?= ramalama
 PYTHON_FILES := $(shell find . -path "./.venv" -prune -o -name "*.py" -print) $(shell find . -name ".venv" -prune -o -type f -perm +111 -exec grep -l "^\#!/usr/bin/env python3" {} \; 2>/dev/null || true)
 PYTEST_COMMON_CMD ?= PYTHONPATH=. pytest test/unit/ -vv
+BATS_IMAGE ?= localhost/bats:latest
 
 default: help
 
@@ -160,6 +161,30 @@ bats-nocontainer:
 .PHONY: bats-docker
 bats-docker:
 	_RAMALAMA_TEST_OPTS=--engine=docker RAMALAMA=$(CURDIR)/bin/ramalama bats -T test/system/
+
+.PHONY: bats-image
+bats-image:
+	podman inspect $(BATS_IMAGE) &> /dev/null || \
+		podman build -t $(BATS_IMAGE) -f container-images/bats/Containerfile .
+
+.PHONY: bats-in-container
+bats-in-container: bats-image
+	podman run -it --rm \
+		--userns=keep-id:size=200000 \
+		--security-opt unmask=/proc/* \
+		--security-opt label=disable \
+		--security-opt=mask=/sys/bus/pci/drivers/i915 \
+		--device /dev/net/tun \
+		-v $(CURDIR):/src \
+		$(BATS_IMAGE) make bats
+
+.PHONY: bats-nocontainer-in-container
+bats-nocontainer-in-container: bats-image
+	podman run -it --rm \
+		--userns=keep-id:size=200000 \
+		--security-opt=mask=/sys/bus/pci/drivers/i915 \
+		-v $(CURDIR):/src \
+		$(BATS_IMAGE) make bats-nocontainer
 
 .PHONY: ci
 ci:

--- a/Makefile
+++ b/Makefile
@@ -167,24 +167,16 @@ bats-image:
 	podman inspect $(BATS_IMAGE) &> /dev/null || \
 		podman build -t $(BATS_IMAGE) -f container-images/bats/Containerfile .
 
-.PHONY: bats-in-container
-bats-in-container: bats-image
+bats-in-container: extra-opts = --security-opt unmask=/proc/* --device /dev/net/tun
+
+%-in-container: bats-image
 	podman run -it --rm \
 		--userns=keep-id:size=200000 \
-		--security-opt unmask=/proc/* \
 		--security-opt label=disable \
 		--security-opt=mask=/sys/bus/pci/drivers/i915 \
-		--device /dev/net/tun \
+		$(extra-opts) \
 		-v $(CURDIR):/src \
-		$(BATS_IMAGE) make bats
-
-.PHONY: bats-nocontainer-in-container
-bats-nocontainer-in-container: bats-image
-	podman run -it --rm \
-		--userns=keep-id:size=200000 \
-		--security-opt=mask=/sys/bus/pci/drivers/i915 \
-		-v $(CURDIR):/src \
-		$(BATS_IMAGE) make bats-nocontainer
+		$(BATS_IMAGE) make $*
 
 .PHONY: ci
 ci:

--- a/container-images/bats/Containerfile
+++ b/container-images/bats/Containerfile
@@ -1,0 +1,24 @@
+FROM quay.io/fedora/fedora:42
+
+ENV HOME=/tmp \
+    XDG_RUNTIME_DIR=/tmp \
+    STORAGE_DRIVER=vfs
+WORKDIR /src
+ENTRYPOINT ["/usr/bin/entrypoint.sh"]
+
+RUN dnf -y install make bats jq iproute podman openssl httpd-tools \
+    ollama python3-huggingface-hub \
+    # for building llama-bench
+    git-core cmake gcc-c++ curl-devel && \
+    dnf -y clean all
+RUN rpm --restore shadow-utils
+RUN git clone --depth=1 https://github.com/ggml-org/llama.cpp && \
+    pushd llama.cpp && \
+    cmake -B build -DGGML_NATIVE=OFF -DGGML_RPC=ON -DGGML_CCACHE=OFF -DGGML_CMAKE_BUILD_TYPE=Release -DLLAMA_CURL=ON -DCMAKE_INSTALL_PREFIX=/usr && \
+    cmake --build build --config Release --parallel $(nproc) && \
+    cmake --install build && \
+    popd && rm -rf llama.cpp
+
+COPY container-images/bats/entrypoint.sh /usr/bin
+COPY container-images/bats/containers.conf /etc/containers
+RUN chmod a+rw /etc/subuid /etc/subgid

--- a/container-images/bats/Containerfile
+++ b/container-images/bats/Containerfile
@@ -8,6 +8,10 @@ ENTRYPOINT ["/usr/bin/entrypoint.sh"]
 
 RUN dnf -y install make bats jq iproute podman openssl httpd-tools \
     ollama python3-huggingface-hub \
+    # for validate and unit-tests
+    black codespell shellcheck \
+    python3-flake8 python3-isort python3-pip python3-pytest \
+    perl-Clone perl-FindBin \
     # for building llama-bench
     git-core cmake gcc-c++ curl-devel && \
     dnf -y clean all

--- a/container-images/bats/containers.conf
+++ b/container-images/bats/containers.conf
@@ -1,0 +1,8 @@
+[containers]
+utsns="host"
+cgroups="disabled"
+log_driver="k8s-file"
+
+[engine]
+events_logger="file"
+infra_image="quay.io/libpod/k8s-pause:3.5"

--- a/container-images/bats/entrypoint.sh
+++ b/container-images/bats/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+echo "$(id -u):10000:100000" > /etc/subuid
+echo "$(id -g):10000:100000" > /etc/subgid
+
+if [ $# -gt 0 ]; then
+    exec "$@"
+else
+    exec /bin/bash
+fi

--- a/container_build.sh
+++ b/container_build.sh
@@ -116,7 +116,7 @@ build() {
       echo "${conman_show_size[@]}"
       "${conman_show_size[@]}"
       case ${target} in
-	  ramalama-cli | llama-stack | openvino)
+	  ramalama-cli | llama-stack | openvino | bats)
 	  ;;
 	  *)
 	      add_entrypoints "${conman[@]}" "${REGISTRY_PATH}"/"${target}" "${version}"

--- a/docs/ramalama-serve.1.md
+++ b/docs/ramalama-serve.1.md
@@ -60,6 +60,9 @@ Example: --device=/dev/dri/renderD128:/dev/xvdc:rwm
 
 The device specification is passed directly to the underlying container engine. See documentation of the supported container engine for more information.
 
+#### **--dri**=*on* | *off*
+Enable or disable mounting `/dev/dri` into the container when running with `--api=llama-stack` (enabled by default). Use to prevent access to the host device when not required, or avoid errors in environments where `/dev/dri` is not available.
+
 #### **--env**=
 
 Set environment variables inside of the container.

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -903,6 +903,13 @@ def runtime_options(parser, command):
             default="on",
             help="enable or disable the web UI (default: on)",
         )
+        parser.add_argument(
+            "--dri",
+            dest="dri",
+            choices=["on", "off"],
+            default="on",
+            help="mount /dev/dri into the container when running llama-stack (default: on)",
+        )
 
 
 def default_threads():

--- a/ramalama/stack.py
+++ b/ramalama/stack.py
@@ -39,24 +39,26 @@ class Stack:
 
     def generate(self):
         add_labels(self.args, self.add_label)
-        volume_mounts = """
-        - mountPath: /mnt/models/model.file
-          name: model
-        - mountPath: /dev/dri
-          name: dri"""
-
         if self.model_type == "OCI":
             volume_mounts = """
         - mountPath: /mnt/models
           subPath: /models
-          name: model
+          name: model"""
+        else:
+            volume_mounts = """
+        - mountPath: /mnt/models/model.file
+          name: model"""
+        if self.args.dri == "on":
+            volume_mounts += """
         - mountPath: /dev/dri
           name: dri"""
 
         volumes = f"""
       - hostPath:
           path: {self.model_path}
-        name: model
+        name: model"""
+        if self.args.dri == "on":
+            volumes += """
       - hostPath:
           path: /dev/dri
         name: dri"""

--- a/test/system/040-serve.bats
+++ b/test/system/040-serve.bats
@@ -338,7 +338,7 @@ verify_begin=".*run --rm"
     model=tiny
     name=c_$(safename)
     run_ramalama pull ${model}
-    run_ramalama serve -d --name=${name} --api llama-stack --port 1234 ${model}
+    run_ramalama serve -d --name=${name} --api llama-stack --dri off --port 1234 ${model}
     is "$output" ".*Llama Stack RESTAPI: http://localhost:1234" "reveal llama stack url"
     is "$output" ".*OpenAI RESTAPI: http://localhost:1234/v1/openai" "reveal openai url"
 


### PR DESCRIPTION
The `bats-in-container` and `bats-nocontainer-in-container` will run the `bats` tests in a local container. In the case of `bats-container`, this uses podman-in-podman to run the test suite as realistically as possible.

Also includes a new `--dri` option to `ramalama serve --api llama-stack`, to allow disabling mounting `/dev/dri` into the container. This is required for podman-in-podman to work.

This is a prerequisite to getting `bats` tests running in Konflux on each pull request, and working around the out-of-space issues in the current CI setup.

## Summary by Sourcery

Add support for running the BATS test suite inside a Podman container and make DRI mounting configurable for llama-stack containers.

New Features:
- Introduce bats-image, bats-in-container, and bats-nocontainer-in-container Makefile targets to build and run BATS tests in a container.
- Add a --dri CLI flag to ramalama serve --api llama-stack to enable or disable mounting /dev/dri into the container.

Enhancements:
- Provide a Containerfile, entrypoint script, and containers.conf to build a dedicated bats test image.
- Exclude the bats container definition directory in container_build.sh.

Tests:
- Update the system test for llama-stack serve to include the --dri off option when verifying endpoints.