### PR TITLE
Some of our tests are running for hours, need to be timed out

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
   lint:
     name: Lint Code
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       
@@ -36,6 +37,7 @@ jobs:
   unit-test:
     name: Unit Tests
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       
@@ -69,6 +71,7 @@ jobs:
 
   bats:
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
       
@@ -116,6 +119,7 @@ jobs:
 
   bats-nocontainer:
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
       
@@ -155,6 +159,7 @@ jobs:
 
   docker:
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
       
@@ -214,6 +219,7 @@ jobs:
 
   macos:
     runs-on: macos-14
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
       


### PR DESCRIPTION
None of our tests should take more then 1 hour, so time them out and then need to figure out what is causing the issue.

## Summary by Sourcery

CI:
- Add timeout-minutes settings to all CI jobs (10 minutes for lint and unit-test jobs, 60 minutes for bats, bats-nocontainer, docker, and macOS jobs)