### PR TITLE
container-images: pin mesa version to COPR

### DIFF
--- a/container-images/scripts/build_llama_and_whisper.sh
+++ b/container-images/scripts/build_llama_and_whisper.sh
@@ -89,7 +89,7 @@ add_stream_repo() {
 
 rm_non_ubi_repos() {
   local dir="/etc/yum.repos.d"
-  rm -rf $dir/mirror.stream.centos.org_9-stream_* $dir/epel* $dir/_copr:*
+  rm -rf $dir/mirror.stream.centos.org_9-stream_* $dir/epel*
 }
 
 is_rhel_based() { # doesn't include openEuler
@@ -97,12 +97,14 @@ is_rhel_based() { # doesn't include openEuler
 }
 
 dnf_install_mesa() {
-  if is_rhel_based; then
-    dnf copr enable -y slp/mesa-krunkit "epel-9-$uname_m"
-    add_stream_repo "AppStream"
+  if [ "${ID}" = "fedora" ]; then
+    dnf copr enable -y slp/mesa-libkrun-vulkan
+    dnf install -y mesa-vulkan-drivers-25.0.7-100.fc42 "${vulkan_rpms[@]}"
+    dnf versionlock add mesa-vulkan-drivers-25.0.7-100.fc42
+  else
+    dnf install -y mesa-vulkan-drivers "${vulkan_rpms[@]}"
   fi
 
-  dnf install -y mesa-vulkan-drivers "${vulkan_rpms[@]}"
   rm_non_ubi_repos
 }
 

--- a/container-images/scripts/build_rag.sh
+++ b/container-images/scripts/build_rag.sh
@@ -27,7 +27,7 @@ $2"
 
 update_python() {
     if available dnf; then
-        dnf update -y --allowerasing
+        dnf update -y --allowerasing --nobest
         dnf install -y "${python}" "${python}-pip" "${python}-devel" "${pkgs[@]}"
         if [[ "${python}" == "python3.11" ]]; then
             ln -sf /usr/bin/python3.11 /usr/bin/python3


### PR DESCRIPTION
When building on RHEL-based systems make sure we install the mesa version from the COPR, which enables the virtio driver and has the patches to force alignment to 16K (needed for GPU acceleration on macOS, but harmless to other systems).

We also need to add "--nobest" to "dnf update" to ensure it doesn't get frustrated by being unable to install the mesa package from appstream.

## Summary by Sourcery

Update container image build scripts to install and maintain a specific COPR-provided mesa package for reliable GPU acceleration, preserve COPR repos during cleanup, and add the --nobest flag to dnf updates to prevent package resolution issues.

Build:
- Enable COPR and pin mesa-vulkan-drivers to a fixed version on Fedora builds
- Stop removing COPR repository files during cleanup to retain pinned repo entries
- Add --nobest to dnf update in build_rag.sh to avoid package resolution failures