### PR TITLE
Check if api key exists first

### DIFF
--- a/ramalama/chat.py
+++ b/ramalama/chat.py
@@ -107,7 +107,7 @@ class RamaLamaShell(cmd.Cmd):
             "Content-Type": "application/json",
         }
 
-        if self.args.api_key:
+        if hasattr(self.args, "api_key") and self.args.api_key:
             if len(self.args.api_key) < 20:
                 print("Warning: Provided API key is invalid.")
 


### PR DESCRIPTION
When "ramalama chat" is called api key always exists. When "ramalama run" is called api key doesn't exist causing "ramalama run" to be broken, prior to this change.

## Summary by Sourcery

Bug Fixes:
- Add a hasattr check around args.api_key to avoid attribute errors in commands without an API key.