### PR TITLE
Allow std input

### DIFF
--- a/ramalama/chat.py
+++ b/ramalama/chat.py
@@ -74,10 +74,19 @@ class RamaLamaShell(cmd.Cmd):
         self.url = f"{args.url}/chat/completions"
 
     def handle_args(self):
-        if self.args.ARGS:
-            self.default(" ".join(self.args.ARGS))
+        prompt = " ".join(self.args.ARGS) if self.args.ARGS else None
+        if not sys.stdin.isatty():
+            stdin = sys.stdin.read()
+            if prompt:
+                prompt += f"\n\n{stdin}"
+            else:
+                prompt = stdin
+
+        if prompt:
+            self.default(prompt)
             self.kills()
             return True
+
         return False
 
     def do_EOF(self, user_content):


### PR DESCRIPTION
We used to have this feature, got dropped recently accidentally, can do things like:

`cat text_file_with_prompt.txt | ramalama run smollm:135m`

or

`cat some_doc | ramalama run smollm:135m Explain this document:`

## Summary by Sourcery

Allow reading from standard input for prompts, merging it with any provided CLI arguments and passing the combined text to the chat handler.

New Features:
- Restore support for reading prompt content from stdin when piped to the CLI

Enhancements:
- Combine command-line arguments and stdin input into a single prompt