### PR TITLE
Separate build image into its own VM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,13 +34,52 @@ jobs:
         run: |
           make lint
 
+  build-image:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install the latest version of uv and activate the environment
+        uses: astral-sh/setup-uv@v6
+        with:
+          activate-environment: true
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          df -h
+          sudo apt-get update
+          sudo apt-get install -y bash codespell python3-argcomplete pipx podman
+          make install-requirements
+
+      - name: Upgrade to podman 5
+        run: |
+           set -e
+           # /mnt has ~ 65 GB free disk space. / is too small.
+           sudo mkdir -m a=rwx -p /mnt/tmp /mnt/runner
+           sudo mkdir -m o=rwx -p /home/runner/.local
+           sudo chown runner:runner /mnt/runner /home/runner/.local
+           sudo mount --bind /mnt/runner /home/runner/.local
+           # Enable universe repository which contains podman
+           sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu oracular universe"
+           # Update package lists
+           sudo apt-get update
+           sudo apt-get purge firefox
+           # Install specific podman version
+           sudo apt-get upgrade
+
+      - name: Build a container for CPU inferencing
+        shell: bash
+        run: |
+          ./container_build.sh build -s ramalama
+
   unit-test:
     name: Unit Tests
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-      
       - name: Install the latest version of uv and activate the environment
         uses: astral-sh/setup-uv@v6
         with:
@@ -107,9 +146,6 @@ jobs:
            sudo apt-get purge firefox
            # Install specific podman version
            sudo apt-get upgrade
-
-      - name: Build a container for CPU inferencing
-        run: ./container_build.sh build ramalama
 
       - name: run bats
         run: |
@@ -208,9 +244,6 @@ jobs:
            cat /etc/docker/daemon.json
            sudo systemctl restart docker.service
            df -h
-
-      - name: Build a container for CPU inferencing
-        run: ./container_build.sh build ramalama
 
       - name: bats-docker
         run: |

--- a/container_build.sh
+++ b/container_build.sh
@@ -119,9 +119,11 @@ build() {
 	  ramalama-cli | llama-stack | openvino)
 	  ;;
 	  *)
-	      add_entrypoints "${conman[@]}" "${REGISTRY_PATH}"/"${target}" "${version}"
-	      add_rag "${conman[@]}" "${target}" "${version}"
-	      rm_container_image
+	      if [ "${build_all}" -eq 1 ]; then
+		  add_entrypoints "${conman[@]}" "${REGISTRY_PATH}"/"${target}" "${version}"
+		  add_rag "${conman[@]}" "${target}" "${version}"
+		  rm_container_image
+	      fi
       esac
       ;;
     push)
@@ -182,6 +184,10 @@ parse_arguments() {
       -r)
         rm_after_build="true"
         nocache=""
+        shift
+        ;;
+      -s) # Only build initial image
+        build_all=0
         shift
         ;;
       -v)
@@ -277,6 +283,7 @@ main() {
   local target=""
   local command=""
   local dryrun=""
+  local build_all=1
   local rm_after_build="false"
   local ci="false"
   local version=""


### PR DESCRIPTION
## Summary by Sourcery

Separate the container image build into its own CI job and enhance the build script for selective image construction.

Enhancements:
- Introduce `-s` flag and `build_all` variable in `container_build.sh` to support selective image building.

CI:
- Remove container build steps from existing `ci` and `docker` jobs.
- Add a new standalone `build` job on Ubuntu 24.04 that sets up Podman 5 and runs image construction.