### PR TITLE
rename "nopull" boolean to "pull"

### DIFF
--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -191,7 +191,7 @@ The RAMALAMA_CONTAINER_ENGINE environment variable modifies default behaviour.""
     )
     parser.add_argument(
         "--image",
-        default=accel_image(CONFIG, nopull=True),
+        default=accel_image(CONFIG, pull=False),
         help="OCI container image to run with the specified AI model",
         action=OverrideDefaultAction,
         completer=local_images,

--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -627,7 +627,7 @@ class AccelImageArgsOtherRuntimeRAG(Protocol):
 AccelImageArgs = None | AccelImageArgsVLLMRuntime | AccelImageArgsOtherRuntime | AccelImageArgsOtherRuntimeRAG
 
 
-def accel_image(config: Config, nopull=False) -> str:
+def accel_image(config: Config, pull=True) -> str:
     """
     Selects and the appropriate image based on config, arguments, environment.
     """
@@ -650,7 +650,7 @@ def accel_image(config: Config, nopull=False) -> str:
         return "registry.redhat.io/rhelai1/ramalama-vllm"
 
     vers = minor_release()
-    if nopull or attempt_to_use_versioned(config.engine, image, vers, True):
+    if not pull or attempt_to_use_versioned(config.engine, image, vers, True):
         return f"{image}:{vers}"
 
     return f"{image}:latest"


### PR DESCRIPTION
Rename `nopull` to `pull` for improved clarity and readability. This avoids the double-negative, making the logic more straightforward to reason about. `pull = True` now means "pull the image", and `pull = False` means "don't pull the image."

## Summary by Sourcery

Rename the `nopull` flag to `pull` in the `accel_image` function and update its default and logic checks, along with adjusting the CLI argument to use the new flag name.

Enhancements:
- Rename `nopull` parameter to `pull` in `accel_image` and invert its default value for clearer semantics
- Update conditional logic to use `pull` instead of double-negative `nopull` checks
- Adjust CLI argument default to reflect the renamed `pull` flag and its inverted default