### PR TITLE
run tests during build pipelines

### DIFF
--- a/.tekton/bats/bats-pull-request.yaml
+++ b/.tekton/bats/bats-pull-request.yaml
@@ -34,6 +34,8 @@ spec:
     value: container-images/bats/Containerfile
   pipelineRef:
     name: pull-request-pipeline
+  timeouts:
+    pipeline: 6h
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/bats/bats-push.yaml
+++ b/.tekton/bats/bats-push.yaml
@@ -31,6 +31,8 @@ spec:
     value: container-images/bats/Containerfile
   pipelineRef:
     name: push-pipeline
+  timeouts:
+    pipeline: 6h
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/cuda/cuda-pull-request.yaml
+++ b/.tekton/cuda/cuda-pull-request.yaml
@@ -33,6 +33,8 @@ spec:
     value: container-images/cuda/Containerfile
   pipelineRef:
     name: pull-request-pipeline
+  timeouts:
+    pipeline: 6h
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/cuda/cuda-push.yaml
+++ b/.tekton/cuda/cuda-push.yaml
@@ -30,6 +30,8 @@ spec:
     value: container-images/cuda/Containerfile
   pipelineRef:
     name: push-pipeline
+  timeouts:
+    pipeline: 6h
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/pipelines/pull-request-pipeline.yaml
+++ b/.tekton/pipelines/pull-request-pipeline.yaml
@@ -76,6 +76,18 @@ spec:
       set of values is determined by the configuration of the multi-platform-controller.
     name: build-platforms
     type: array
+  - default: ""
+    description: The image to use for running tests.
+    name: test-image
+  - default: []
+    description: List of environment variables (NAME=VALUE) to be set in the test environment.
+    name: test-envs
+    type: array
+  - default:
+    - echo "No tests defined"
+    description: List of test commands to run after the image is built.
+    name: test-commands
+    type: array
   results:
   - description: ""
     name: IMAGE_URL
@@ -241,6 +253,42 @@ spec:
       operator: in
       values:
       - "true"
+  - name: wait-for-test-image
+    params:
+    - name: ref
+      value: $(params.test-image)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: wait-for-image
+    when:
+    - input: $(params.test-image)
+      operator: notin
+      values:
+      - ""
+  - name: run-tests
+    matrix:
+      params:
+      - name: cmd
+        value:
+        - $(params.test-commands)
+    params:
+    - name: image
+      value: $(params.test-image)@$(tasks.wait-for-test-image.results.digest)
+    - name: source-artifact
+      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+    - name: envs
+      value:
+      - $(params.test-envs[*])
+    runAfter:
+    - wait-for-test-image
+    taskRef:
+      name: test-cmd
+    when:
+    - input: $(params.test-image)
+      operator: notin
+      values:
+      - ""
   - name: build-source-image
     params:
     - name: BINARY_IMAGE

--- a/.tekton/pipelines/pull-request-pipeline.yaml
+++ b/.tekton/pipelines/pull-request-pipeline.yaml
@@ -33,7 +33,7 @@ spec:
     description: Force rebuild image
     name: rebuild
     type: string
-  - default: "false"
+  - default: "true"
     description: Skip checks against built image
     name: skip-checks
     type: string

--- a/.tekton/pipelines/push-pipeline.yaml
+++ b/.tekton/pipelines/push-pipeline.yaml
@@ -76,6 +76,18 @@ spec:
       set of values is determined by the configuration of the multi-platform-controller.
     name: build-platforms
     type: array
+  - default: ""
+    description: The image to use for running tests.
+    name: test-image
+  - default: []
+    description: List of environment variables (NAME=VALUE) to be set in the test environment.
+    name: test-envs
+    type: array
+  - default:
+    - echo "No tests defined"
+    description: List of test commands to run after the image is built.
+    name: test-commands
+    type: array
   results:
   - description: ""
     name: IMAGE_URL
@@ -241,6 +253,42 @@ spec:
       operator: in
       values:
       - "true"
+  - name: wait-for-test-image
+    params:
+    - name: ref
+      value: $(params.test-image)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: wait-for-image
+    when:
+    - input: $(params.test-image)
+      operator: notin
+      values:
+      - ""
+  - name: run-tests
+    matrix:
+      params:
+      - name: cmd
+        value:
+        - $(params.test-commands)
+    params:
+    - name: image
+      value: $(params.test-image)@$(tasks.wait-for-test-image.results.digest)
+    - name: source-artifact
+      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+    - name: envs
+      value:
+      - $(params.test-envs[*])
+    runAfter:
+    - wait-for-test-image
+    taskRef:
+      name: test-cmd
+    when:
+    - input: $(params.test-image)
+      operator: notin
+      values:
+      - ""
   - name: build-source-image
     params:
     - name: BINARY_IMAGE

--- a/.tekton/ramalama/ramalama-pull-request.yaml
+++ b/.tekton/ramalama/ramalama-pull-request.yaml
@@ -32,6 +32,17 @@ spec:
     - linux/arm64
   - name: dockerfile
     value: container-images/ramalama/Containerfile
+  - name: test-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/bats:on-pr-{{revision}}
+  - name: test-envs
+    value:
+    - RAMALAMA_IMAGE=quay.io/redhat-user-workloads/ramalama-tenant/ramalama:on-pr-{{revision}}
+  - name: test-commands
+    value:
+    - make validate
+    - make bats-nocontainer
+    - make unit-tests
+    - make cov-tests
   pipelineRef:
     name: pull-request-pipeline
   workspaces:

--- a/.tekton/ramalama/ramalama-pull-request.yaml
+++ b/.tekton/ramalama/ramalama-pull-request.yaml
@@ -45,6 +45,8 @@ spec:
     - make cov-tests
   pipelineRef:
     name: pull-request-pipeline
+  timeouts:
+    pipeline: 6h
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/ramalama/ramalama-push.yaml
+++ b/.tekton/ramalama/ramalama-push.yaml
@@ -29,6 +29,17 @@ spec:
     - linux/arm64
   - name: dockerfile
     value: container-images/ramalama/Containerfile
+  - name: test-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/bats:{{revision}}
+  - name: test-envs
+    value:
+    - RAMALAMA_IMAGE=quay.io/redhat-user-workloads/ramalama-tenant/ramalama:{{revision}}
+  - name: test-commands
+    value:
+    - make validate
+    - make bats-nocontainer
+    - make unit-tests
+    - make cov-tests
   pipelineRef:
     name: push-pipeline
   workspaces:

--- a/.tekton/ramalama/ramalama-push.yaml
+++ b/.tekton/ramalama/ramalama-push.yaml
@@ -42,6 +42,8 @@ spec:
     - make cov-tests
   pipelineRef:
     name: push-pipeline
+  timeouts:
+    pipeline: 6h
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/rocm-ubi/rocm-ubi-pull-request.yaml
+++ b/.tekton/rocm-ubi/rocm-ubi-pull-request.yaml
@@ -33,6 +33,8 @@ spec:
     value: container-images/rocm-ubi/Containerfile
   pipelineRef:
     name: pull-request-pipeline
+  timeouts:
+    pipeline: 6h
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/rocm-ubi/rocm-ubi-push.yaml
+++ b/.tekton/rocm-ubi/rocm-ubi-push.yaml
@@ -30,6 +30,8 @@ spec:
     value: container-images/rocm-ubi/Containerfile
   pipelineRef:
     name: push-pipeline
+  timeouts:
+    pipeline: 6h
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/rocm/rocm-pull-request.yaml
+++ b/.tekton/rocm/rocm-pull-request.yaml
@@ -33,6 +33,8 @@ spec:
     value: container-images/rocm/Containerfile
   pipelineRef:
     name: pull-request-pipeline
+  timeouts:
+    pipeline: 6h
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/rocm/rocm-push.yaml
+++ b/.tekton/rocm/rocm-push.yaml
@@ -30,6 +30,8 @@ spec:
     value: container-images/rocm/Containerfile
   pipelineRef:
     name: push-pipeline
+  timeouts:
+    pipeline: 6h
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/tasks/test-cmd.yaml
+++ b/.tekton/tasks/test-cmd.yaml
@@ -1,0 +1,65 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: test-cmd
+spec:
+  description: Run a command in a test environment.
+  params:
+  - name: image
+    description: The image to use when setting up the test environment.
+  - name: source-artifact
+    description: The Trusted Artifact URI pointing to the artifact with the application source code.
+  - name: cmd
+    description: The command to run.
+  - name: envs
+    description: List of environment variables (NAME=VALUE) to be set in the test environment.
+    type: array
+    default: []
+  volumes:
+  - name: workdir
+    emptyDir: {}
+  stepTemplate:
+    volumeMounts:
+    - mountPath: /var/workdir
+      name: workdir
+    computeResources:
+      limits:
+        memory: 4Gi
+      requests:
+        cpu: "1"
+        memory: 1Gi
+  steps:
+  - name: use-trusted-artifact
+    image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:4689f88dd253bd1feebf57f1a76a5a751880f739000719cd662bbdc76990a7fd
+    args:
+    - use
+    - $(params.source-artifact)=/var/workdir/source
+  - name: set-env
+    image: $(params.image)
+    workingDir: /var/workdir/source
+    args:
+    - $(params.envs[*])
+    script: |
+      #!/bin/bash -e
+      rm -f .bashenv
+      while [ $# -ne 0 ]; do
+        echo "$1" >> .bashenv
+        shift
+      done
+  - name: run
+    image: $(params.image)
+    securityContext:
+      capabilities:
+        add:
+        - SETFCAP
+    workingDir: /var/workdir/source
+    env:
+    - name: BASH_ENV
+      value: .bashenv
+    command:
+    - /usr/bin/entrypoint.sh
+    args:
+    - /bin/bash
+    - -ex
+    - -c
+    - $(params.cmd)

--- a/.tekton/tasks/wait-for-image.yaml
+++ b/.tekton/tasks/wait-for-image.yaml
@@ -1,0 +1,31 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: wait-for-image
+spec:
+  description: Wait for an image to become available.
+  params:
+  - name: ref
+    description: Location of image to wait for.
+  results:
+  - name: digest
+    description: The digest that the image ref resolves to.
+  steps:
+  - name: check-and-wait
+    image: registry.redhat.io/rhel10/skopeo:latest
+    env:
+    - name: REF
+      value: $(params.ref)
+    - name: RESULTS_DIGEST_PATH
+      value: $(results.digest.path)
+    script: |
+      #!/bin/bash -e
+      while true; do
+        DIGEST="$(skopeo inspect -n -f {{.Digest}} "docker://$REF" || :)"
+        if [ "${#DIGEST}" -gt 0 ]; then
+          echo -n "$DIGEST" | tee "$RESULTS_DIGEST_PATH"
+          exit
+        fi
+        echo "$(date -uIseconds): $REF is not available, waiting..."
+        sleep 60
+      done

--- a/container-images/bats/entrypoint.sh
+++ b/container-images/bats/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-echo "$(id -u):10000:100000" > /etc/subuid
-echo "$(id -g):10000:100000" > /etc/subgid
+echo "$(id -un):10000:2000" > /etc/subuid
+echo "$(id -un):10000:2000" > /etc/subgid
 
 if [ $# -gt 0 ]; then
     exec "$@"


### PR DESCRIPTION
Use the bats container to run a set of Makefile targets to test the code and images in parallel.

## Summary by Sourcery

Integrate automated testing into Tekton build pipelines by adding new pipeline parameters and tasks to fetch built images, set up test environments, and execute Makefile-based test commands in parallel.

Enhancements:
- Add test-dependencies, test-envs, and test-commands parameters to pull-request and push pipelines to configure test execution
- Introduce new Tekton Task “wait-for-images” to block until required images are available
- Introduce new Tekton Task “test-cmd” to run configured commands against the built image and source artifacts

CI:
- Embed wait-for-test-images and run-tests steps into pull-request and push pipeline definitions

Tests:
- Provide Ramlama-specific pipeline configurations with bats and Makefile-based test commands