### PR TITLE
Free up disk space for building all images

### DIFF
--- a/.github/workflows/ci-images.yml
+++ b/.github/workflows/ci-images.yml
@@ -18,6 +18,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -48,7 +49,10 @@ jobs:
       - name: Free Disk Space Linux
         shell: bash
         run: |
-          sudo docker rmi "$(docker image ls -aq)" >/dev/null 2>&1 || true
+          sudo mkdir -m a=rwx -p /mnt/tmp /mnt/runner
+          sudo mkdir -m o=rwx -p /home/runner/.local
+          sudo chown runner:runner /mnt/runner /home/runner/.local
+          sudo mount --bind /mnt/runner /home/runner/.local
           sudo rm -rf \
             /usr/share/dotnet /usr/local/lib/android /opt/ghc \
             /usr/local/share/powershell /usr/share/swift /usr/local/.ghcup \
@@ -57,16 +61,6 @@ jobs:
           sudo swapoff -a
           sudo rm -f /mnt/Swapfile
 
-      # /mnt has ~ 65 GB free disk space. / is too small.
-      - name: Reconfigure Docker data-root
-        run: |
-          sudo mkdir -p /mnt/docker /etc/docker
-          echo '{"data-root": "/mnt/docker"}' > /tmp/daemon.json
-          sudo mv /tmp/daemon.json /etc/docker/daemon.json
-          cat /etc/docker/daemon.json
-          sudo systemctl restart docker.service
-          df -h
-
       - name: Print disk space after cleanup
         shell: bash
         run: |
@@ -74,4 +68,4 @@ jobs:
 
       - name: Build Images
         run: |
-          ./container_build.sh -r -c build
+          ./container_build.sh -r -c -s build


### PR DESCRIPTION
Were using Podman to build images, so don't futz with Docker.

only build base images, not as necessary to build RAG Images.

## Summary by Sourcery

Update the CI image-building workflow to free disk space by bind-mounting the runner’s local directory onto a larger volume, remove obsolete Docker data-root reconfiguration, and adjust the build script to only produce base images.

Enhancements:
- Add the -s flag to container_build.sh to skip building RAG images and only build base images

CI:
- Replace Docker image removal with creation and bind-mounting of /home/runner/.local onto /mnt/runner for disk cleanup
- Remove the Docker data-root reconfiguration step to simplify setup