### PR TITLE
Improve NVIDIA GPU detection.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ requires-python = ">=3.10"
 keywords = ["ramalama", "llama", "AI"]
 dependencies = [
   "argcomplete",
-  "pyYAML",
 ]
 maintainers = [
    { name="Dan Walsh", email = "dwalsh@redhat.com" },


### PR DESCRIPTION
Allow GPUs to be specified by UUID as well as index since the index is not guaranteed to persist across reboots.

Crosscheck requested GPUs with nvidia-smi and CDI configuration. If any requested GPUs lack corresponding CDI configuration, print a message with a pointer to documentation.

If the only GPU specified in the CDI configuration is "all", as appears to be the case on WSL2, use "all" as the default.

Add an optional encoding argument to run_cmd() to facilitate checking the output of the command.

Add pyYAML as a dependency for parsing the CDI configuration.

## Summary by Sourcery

Improve NVIDIA GPU detection by supporting UUID-based selection, validating CUDA_VISIBLE_DEVICES against CDI configurations, adding an encoding option to command execution, and providing user guidance when CDI entries are missing.

New Features:
- Allow GPUs to be specified by UUID as well as by index

Enhancements:
- Introduce an optional encoding parameter in run_cmd for direct text decoding
- Implement load_cdi_config and find_in_cdi to parse YAML/JSON CDI specs and verify device configurations
- Enhance check_nvidia to query both GPU indices and UUIDs and validate requested devices against CDI
- Fallback to "all" or index 0 when CDI configuration only specifies "all" and guide users if devices lack CDI entries

Build:
- Add pyYAML dependency for CDI configuration parsing