### PR TITLE
Fix handling of --host option when running in a container

### DIFF
--- a/ramalama/chat.py
+++ b/ramalama/chat.py
@@ -45,9 +45,6 @@ def res(response, color):
 
 
 def default_prefix():
-    if "LLAMA_PROMPT_PREFIX" in os.environ:
-        return os.environ["LLAMA_PROMPT_PREFIX"]
-
     if not EMOJI:
         return "> "
 

--- a/ramalama/engine.py
+++ b/ramalama/engine.py
@@ -7,7 +7,6 @@ import sys
 # Live reference for checking global vars
 import ramalama.common
 from ramalama.common import check_nvidia, exec_cmd, get_accel_env_vars, perror, run_cmd
-from ramalama.console import EMOJI
 from ramalama.logger import logger
 
 
@@ -31,7 +30,6 @@ class Engine:
         self.add_privileged_options()
         self.add_pull_newer()
         self.add_rag()
-        self.add_subcommand_env()
         self.add_tty_option()
         self.handle_podman_specifics()
         self.add_detach_option()
@@ -91,14 +89,7 @@ class Engine:
             return False
         if getattr(self.args, "ARGS", None):
             return False
-        return getattr(self.args, "subcommand", "") != "run"
-
-    def add_subcommand_env(self):
-        if EMOJI and self.use_tty():
-            if os.path.basename(self.args.engine) == "podman":
-                self.exec_args += ["--env", "LLAMA_PROMPT_PREFIX=🦭 > "]
-            if self.use_docker:
-                self.exec_args += ["--env", "LLAMA_PROMPT_PREFIX=🐋 > "]
+        return getattr(self.args, "subcommand", "") == "run"
 
     def add_env_option(self):
         for env in getattr(self.args, "env", []):
@@ -116,10 +107,12 @@ class Engine:
         if getattr(self.args, "port", "") == "":
             return
 
+        host = getattr(self.args, "host", "0.0.0.0")
+        host = f"{host}:" if host != "0.0.0.0" else ""
         if self.args.port.count(":") > 0:
-            self.exec_args += ["-p", self.args.port]
+            self.exec_args += ["-p", f"{host}{self.args.port}"]
         else:
-            self.exec_args += ["-p", f"{self.args.port}:{self.args.port}"]
+            self.exec_args += ["-p", f"{host}{self.args.port}:{self.args.port}"]
 
     def add_device_options(self):
         if getattr(self.args, "device", None):

--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -587,7 +587,8 @@ class Model(ModelBase):
             if gpu_args is not None:
                 exec_args.extend(gpu_args)
 
-            exec_args.extend(["--host", args.host])
+            if not args.container:
+                exec_args.extend(["--host", args.host])
 
         return exec_args
 

--- a/test/system/040-serve.bats
+++ b/test/system/040-serve.bats
@@ -23,12 +23,13 @@ verify_begin=".*run --rm"
 	run_ramalama -q --dryrun serve --name foobar ${model}
 	is "$output" ".*--name foobar .*" "dryrun correct with --name"
 	assert "$output" !~ ".*--network" "--network is not part of the output"
-	is "$output" ".*--host 0.0.0.0" "verify host 0.0.0.0 is added when run within container"
+	assert "$output" !~ ".*--host 0.0.0.0" "verify host 0.0.0.0 is not added when run within container"
 	is "$output" ".*${model}" "verify model name"
 	assert "$output" !~ ".*--seed" "assert seed does not show by default"
 
-	run_ramalama -q --dryrun serve --network bridge --host 127.1.2.3 --name foobar ${model}
-	assert "$output" =~ "--network bridge.*--host 127.1.2.3" "verify --host is modified when run within container"
+	run_ramalama -q --dryrun serve --port 1234 --network bridge --host 127.1.2.3 --name foobar ${model}
+	assert "$output" !~ ".*--host 127.1.2.3" "verify --host is not modified when run within container"
+	assert "$output" =~ ".*-p 127.1.2.3:1234:1234" "verify -p is modified when run within container"
 	is "$output" ".*${model}" "verify model name"
 	is "$output" ".*--temp 0.8" "verify temp is set"
 	assert "$output" !~ ".*-t " "assert -t not present"
@@ -59,6 +60,7 @@ verify_begin=".*run --rm"
 	assert "$output" != ".*--cap-drop=all" "verify --cap-add is not present"
 	assert "$output" != ".*no-new-privileges" "verify --no-new-privs is not present"
     else
+	# Running without a container
 	run_ramalama -q --dryrun serve ${model}
 	assert "$output" =~ ".*--host 0.0.0.0" "Outside container sets host to 0.0.0.0"
 	is "$output" ".*--cache-reuse 256" "should use cache"


### PR DESCRIPTION
When you run a Model server within a container and only wanted it bound to a certain port, the port binding should happen to the container not inside of the container.

Fixes: https://github.com/containers/ramalama/issues/1572

Also fix handling of -t option, should not be used with anything other then run command, and now I am not sure of that.

The LLAMA_PROMPT_PREFIX= environment variable should not be set within containers as an environment variable, since we are doing chat on the outside.

## Summary by Sourcery

Fix host binding behavior for serve commands in container mode by applying host options as Docker port mappings, restrict TTY option usage to run, and remove internal LLAMA_PROMPT_PREFIX injection

Bug Fixes:
- Convert --host flags in container mode into Docker port mappings instead of passing them to the inner process
- Prevent --host from being added inside the container at runtime
- Restrict the -t (TTY) option to only the run subcommand

Enhancements:
- Remove internal LLAMA_PROMPT_PREFIX injection to avoid setting it within containers
- Adjust use_tty logic to correctly determine when to allocate a TTY

Tests:
- Update system tests to assert the absence of --host in container mode and verify host:port mapping with -p