### PR TITLE
Add command to list available models

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   lint:
     name: Lint Code
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       
@@ -77,7 +77,7 @@ jobs:
   unit-test:
     name: Unit Tests
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - name: Install the latest version of uv and activate the environment

--- a/.github/workflows/install_ramalama.yml
+++ b/.github/workflows/install_ramalama.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set Up Dependencies (Ubuntu)
-        timeout-minutes: 10
+        timeout-minutes: 20
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get install -y lshw curl

--- a/docs/ramalama-chat.1.md
+++ b/docs/ramalama-chat.1.md
@@ -26,6 +26,12 @@ Possible values are "never", "always" and "auto". (default: auto)
 #### **--help**, **-h**
 Show this help message and exit
 
+#### **--list**
+List the available models at an endpoint
+
+#### **--model**=MODEL
+Model for inferencing (may not be required for endpoints that only serve one model)
+
 #### **--prefix**
 Prefix for the user prompt (default: 🦭 > )
 

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -904,10 +904,16 @@ def chat_parser(subparsers):
         choices=['never', 'always', 'auto'],
         help='possible values are "never", "always" and "auto".',
     )
+    parser.add_argument(
+        "--list",
+        "--ls",
+        action="store_true",
+        help="list the available models at an endpoint",
+    )
     parser.add_argument("--prefix", type=str, help="prefix for the user prompt", default=default_prefix())
     parser.add_argument("--rag", type=str, help="a file or directory to use as context for the chat")
     parser.add_argument("--url", type=str, default="http://127.0.0.1:8080/v1", help="the url to send requests to")
-    parser.add_argument("MODEL", completer=local_models)  # positional argument
+    parser.add_argument("--model", "-m", type=str, completer=local_models, help="model for inferencing")
     parser.add_argument(
         "ARGS", nargs="*", help="overrides the default prompt, and the output is returned without entering the chatbot"
     )
@@ -1173,17 +1179,17 @@ def main():
         perror("Error: " + str(e).strip("'\""))
         sys.exit(exit_code)
 
+    if not args.subcommand:
+        parser.print_usage()
+        perror("ramalama: requires a subcommand")
+        return 0
+
     try:
         args.func(args)
     except urllib.error.HTTPError as e:
         eprint(f"pulling {e.geturl()} failed: {e}", errno.EINVAL)
     except HelpException:
         parser.print_help()
-    except AttributeError as e:
-        parser.print_usage()
-        perror("ramalama: requires a subcommand")
-        if getattr(args, "debug", False):
-            raise e
     except IndexError as e:
         eprint(e, errno.EINVAL)
     except KeyError as e:

--- a/test/system/040-serve.bats
+++ b/test/system/040-serve.bats
@@ -121,6 +121,9 @@ verify_begin=".*run --rm"
     run_ramalama ps
     is "$output" ".*${container1}" "list correct for container1"
 
+    run_ramalama chat --ls
+    is "$output" "ollama://smollm:135m" "list of models available correct"
+
     run_ramalama containers --noheading
     is "$output" ".*${container1}" "list correct for container1"
     run_ramalama stop ${container1}


### PR DESCRIPTION
With commands such as:

  ramalama chat --url https://generativelanguage.googleapis.com/v1beta/openai --ls

we can now list the various models available.

## Summary by Sourcery

Introduce a model listing command, streamline API key management, and refactor model selection flags in the chat interface

New Features:
- Add `--list`/`--ls` option to display available models from the API endpoint
- Support specifying the inference model via `--model`/`-m` flag instead of a positional argument

Enhancements:
- Consolidate API key header injection and validation into a new `add_api_key` helper
- Refactor chat request logic to use the lowercase `model` flag and centralized API key handling

Chores:
- Remove obsolete `AttributeError` exception handler in the CLI