### PR TITLE
Always use absolute path for --store option

### DIFF
--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -148,6 +148,10 @@ with software on the local system.
 """
 
 
+def abspath(astring) -> str:
+    return os.path.abspath(astring)
+
+
 def create_argument_parser(description: str):
     """Create and configure the argument parser for the CLI."""
     parser = ArgumentParserWithDefaults(
@@ -222,6 +226,7 @@ The RAMALAMA_IN_CONTAINER environment variable modifies default behaviour.""",
     parser.add_argument(
         "--store",
         default=CONFIG.store,
+        type=abspath,
         help="store AI Models in the specified directory",
     )
     parser.add_argument(

--- a/test/system/060-info.bats
+++ b/test/system/060-info.bats
@@ -46,7 +46,7 @@ Store   | \\\("${HOME}/.local/share/ramalama"\\\|"/var/lib/ramalama"\\\)
 Engine.Name | $engine
 Image   | $image
 Runtime | $runtime
-Store   | $store
+Store   | $(pwd)/$store
 "
 
     defer-assertion-failures
@@ -57,6 +57,14 @@ Store   | $store
 	is "$actual" "$expect" "jq .$field"
     done < <(parse_table "$tests")
 
+}
+
+@test "ramalama info --store" {
+      randdir=$(random_string 20)
+      store=$(pwd)/${randdir}
+      run_ramalama --store ./${randdir} info
+      actual=$(echo "$output" | jq -r ".Store")
+      is "$actual" "$store" "Verify relative paths translated to absolute path"
 }
 
 # vim: filetype=sh


### PR DESCRIPTION
Fixes: https://github.com/containers/ramalama/issues/1634

## Summary by Sourcery

Use absolute paths for the --store option to ensure consistent store directory resolution

Bug Fixes:
- Normalize relative paths supplied to --store by converting them to absolute paths

Enhancements:
- Introduce an abspath function and set it as the type converter for the --store argument in the CLI

Tests:
- Add a system test for ramalama info --store to verify relative paths are translated to their absolute equivalents