### PR TITLE
Use config instance for defining pull behavior in accel_image

### DIFF
--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -191,7 +191,7 @@ The RAMALAMA_CONTAINER_ENGINE environment variable modifies default behaviour.""
     )
     parser.add_argument(
         "--image",
-        default=accel_image(CONFIG, pull=False),
+        default=accel_image(CONFIG),
         help="OCI container image to run with the specified AI model",
         action=OverrideDefaultAction,
         completer=local_images,


### PR DESCRIPTION
By using the pull field in the config instance for the flag to indicate pulling of the container image should be attempted in the accel_image function, the behavior is tied to the cli options. This also prevents a ramalama ls to seemingly block since the image is downloaded (with no output).

## Summary by Sourcery

Tie container image pull behavior in accel_image to the config instance’s pull setting and prevent unintended image downloads by respecting that configuration.

Enhancements:
- Remove explicit pull parameter from accel_image in favor of using config.pull to determine pull behavior
- Extend attempt_to_use_versioned to accept a should_pull flag and skip pulling when disabled in config
- Update default CLI --image argument to call accel_image without the pull parameter