### PR TITLE
MLX runtime support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,6 +264,11 @@ jobs:
         uses: astral-sh/setup-uv@v6
         with:
           activate-environment: true
+
+      - name: install mlx-lm
+        shell: bash
+        run: |
+          uv pip install mlx-lm
           
       - name: install golang
         shell: bash

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ RamaLama then pulls AI Models from model registries, starting a chatbot or REST 
 | :--------------------------------- | :-------------------------: |
 | CPU                                | &check;                     |
 | Apple Silicon GPU (Linux / Asahi)  | &check;                     |
-| Apple Silicon GPU (macOS)          | &check;                     |
+| Apple Silicon GPU (macOS)          | &check; llama.cpp or MLX    |
 | Apple Silicon GPU (podman-machine) | &check;                     |
 | Nvidia GPU (cuda)                  | &check; See note below      |
 | AMD GPU (rocm, vulkan)             | &check;                     |
@@ -86,6 +86,22 @@ See the [Intel hardware table](https://dgpu-docs.intel.com/devices/hardware-tabl
 
 ### Moore Threads GPUs
 On systems with Moore Threads GPUs, see [ramalama-musa](docs/ramalama-musa.7.md) documentation for the correct host system configuration.
+
+### MLX Runtime (macOS only)
+The MLX runtime provides optimized inference for Apple Silicon Macs. MLX requires:
+- macOS operating system
+- Apple Silicon hardware (M1, M2, M3, or later)
+- Usage with `--nocontainer` option (containers are not supported)
+- The `mlx-lm` Python package installed on the host system
+
+To install and run Phi-4 on MLX, use either `uv` or `pip`:
+```bash
+uv pip install mlx-lm
+# or pip:
+pip install mlx-lm
+
+ramalama --runtime=mlx serve hf://mlx-community/Unsloth-Phi-4-4bit
+```
 
 ## Install
 ### Install on Fedora
@@ -1125,6 +1141,7 @@ This project wouldn't be possible without the help of other projects like:
 - [llama.cpp](https://github.com/ggml-org/llama.cpp)
 - [whisper.cpp](https://github.com/ggml-org/whisper.cpp)
 - [vllm](https://github.com/vllm-project/vllm)
+- [mlx-lm](https://github.com/ml-explore/mlx-examples)
 - [podman](https://github.com/containers/podman)
 - [huggingface](https://github.com/huggingface)
 

--- a/docs/ramalama-serve.1.md
+++ b/docs/ramalama-serve.1.md
@@ -29,9 +29,12 @@ Modify individual model transports by specifying the `huggingface://`, `oci://`,
 URL support means if a model is on a web site or even on your local system, you can run it directly.
 
 ## REST API ENDPOINTS
-Under the hood, `ramalama-serve` uses the `LLaMA.cpp` HTTP server by default.
+Under the hood, `ramalama-serve` uses the `llama.cpp` HTTP server by default. When using `--runtime=vllm`, it uses the vLLM server. When using `--runtime=mlx`, it uses the MLX LM server.
 
-For REST API endpoint documentation, see: [https://github.com/ggml-org/llama.cpp/blob/master/tools/server/README.md#api-endpoints](https://github.com/ggml-org/llama.cpp/blob/master/tools/server/README.md#api-endpoints)
+For REST API endpoint documentation, see:
+- llama.cpp: [https://github.com/ggml-org/llama.cpp/blob/master/tools/server/README.md#api-endpoints](https://github.com/ggml-org/llama.cpp/blob/master/tools/server/README.md#api-endpoints)
+- vLLM: [https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html](https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html)
+- MLX LM: [https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/SERVER.md](https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/SERVER.md)
 
 ## OPTIONS
 
@@ -461,6 +464,27 @@ WantedBy=multi-user.target default.target
 ## NVIDIA CUDA Support
 
 See **[ramalama-cuda(7)](ramalama-cuda.7.md)** for setting up the host Linux system for CUDA support.
+
+## MLX Support
+
+The MLX runtime is designed for Apple Silicon Macs and provides optimized performance on these systems. MLX support has the following requirements:
+
+- **Operating System**: macOS only
+- **Hardware**: Apple Silicon (M1, M2, M3, or later)
+- **Container Mode**: MLX requires `--nocontainer` as it cannot run inside containers
+- **Dependencies**: Requires `mlx-lm` package to be installed on the host system
+
+To install MLX dependencies, use either `uv` or `pip`:
+```bash
+uv pip install mlx-lm
+# or pip:
+pip install mlx-lm
+```
+
+Example usage:
+```bash
+ramalama --runtime=mlx serve hf://mlx-community/Unsloth-Phi-4-4bit
+```
 
 ## SEE ALSO
 **[ramalama(1)](ramalama.1.md)**, **[ramalama-stop(1)](ramalama-stop.1.md)**, **quadlet(1)**, **systemctl(1)**, **podman(1)**, **podman-ps(1)**, **[ramalama-cuda(7)](ramalama-cuda.7.md)**

--- a/docs/ramalama.conf
+++ b/docs/ramalama.conf
@@ -86,8 +86,8 @@
 #
 #pull = "newer"
 
-# Specify the AI runtime to use; valid options are 'llama.cpp' and 'vllm' (default: llama.cpp)
-# Options: llama.cpp, vllm
+# Specify the AI runtime to use; valid options are 'llama.cpp', 'vllm', and 'mlx' (default: llama.cpp)
+# Options: llama.cpp, vllm, mlx
 #
 #runtime = "llama.cpp"
 

--- a/docs/ramalama.conf.5.md
+++ b/docs/ramalama.conf.5.md
@@ -132,8 +132,8 @@ Specify default port for services to listen on
 
 **runtime**="llama.cpp"
 
-Specify the AI runtime to use; valid options are 'llama.cpp' and 'vllm' (default: llama.cpp)
-Options: llama.cpp, vllm
+Specify the AI runtime to use; valid options are 'llama.cpp', 'vllm', and 'mlx' (default: llama.cpp)
+Options: llama.cpp, vllm, mlx
 
 **store**="$HOME/.local/share/ramalama"
 

--- a/ramalama/chat.py
+++ b/ramalama/chat.py
@@ -131,10 +131,9 @@ class RamaLamaShell(cmd.Cmd):
         data = {
             "stream": True,
             "messages": self.conversation_history,
-            "model": self.args.MODEL,
         }
         if not (hasattr(self.args, 'runtime') and self.args.runtime == "mlx"):
-            data["model"] = self.args.model
+            data["model"] = self.args.MODEL
         json_data = json.dumps(data).encode("utf-8")
         headers = {
             "Content-Type": "application/json",

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -216,8 +216,8 @@ The RAMALAMA_IN_CONTAINER environment variable modifies default behaviour.""",
     parser.add_argument(
         "--runtime",
         default=CONFIG.runtime,
-        choices=["llama.cpp", "vllm"],
-        help="specify the runtime to use; valid options are 'llama.cpp' and 'vllm'",
+        choices=["llama.cpp", "vllm", "mlx"],
+        help="specify the runtime to use; valid options are 'llama.cpp', 'vllm', and 'mlx'",
     )
     parser.add_argument(
         "--store",
@@ -269,6 +269,12 @@ def post_parse_setup(args):
             args.MODEL = resolved_model
     if hasattr(args, "runtime_args"):
         args.runtime_args = shlex.split(args.runtime_args)
+
+    # MLX runtime automatically requires --nocontainer
+    if getattr(args, "runtime", None) == "mlx":
+        if getattr(args, "container", None) is True:
+            logger.info("MLX runtime automatically uses --nocontainer mode")
+        args.container = False
 
     configure_logger("DEBUG" if args.debug else "WARNING")
 

--- a/test/system/040-serve.bats
+++ b/test/system/040-serve.bats
@@ -23,7 +23,9 @@ verify_begin=".*run --rm"
 	run_ramalama -q --dryrun serve --name foobar ${model}
 	is "$output" ".*--name foobar .*" "dryrun correct with --name"
 	assert "$output" !~ ".*--network" "--network is not part of the output"
-	assert "$output" !~ ".*--host 0.0.0.0" "verify host 0.0.0.0 is not added when run within container"
+	# Extract container args (everything before the image name) and verify --host is not there
+	container_args=$(echo "$output" | sed 's/quay\.io\/ramalama\/ramalama.*//')
+	assert "$container_args" !~ ".*--host" "verify --host is not added to container arguments"
 	is "$output" ".*${model}" "verify model name"
 	assert "$output" !~ ".*--seed" "assert seed does not show by default"
 

--- a/test/system/080-mlx.bats
+++ b/test/system/080-mlx.bats
@@ -1,0 +1,177 @@
+#!/usr/bin/env bats
+
+load helpers
+
+MODEL=hf://mlx-community/SmolLM-135M-4bit
+
+function skip_if_not_apple_silicon() {
+    if ! is_apple_silicon; then
+        skip "MLX runtime requires macOS with Apple Silicon"
+    fi
+}
+
+function skip_if_no_mlx() {
+    if ! python3 -c "import mlx_lm" 2>/dev/null; then
+        skip "MLX runtime requires mlx-lm package to be installed"
+    fi
+}
+
+@test "ramalama --runtime=mlx help shows MLX option" {
+    run_ramalama --help
+    is "$output" ".*mlx.*" "MLX should be listed as runtime option"
+}
+
+@test "ramalama --runtime=mlx info shows MLX runtime" {
+    skip_if_not_apple_silicon
+    skip_if_no_mlx
+    
+    run_ramalama --runtime=mlx info
+    is "$output" ".*Runtime.*mlx.*" "info should show MLX runtime"
+}
+
+@test "ramalama --runtime=mlx automatically enables --nocontainer" {
+    skip_if_not_apple_silicon
+    skip_if_no_mlx
+    
+    # MLX should automatically set --nocontainer even when not specified
+    run_ramalama --runtime=mlx --dryrun run ${MODEL}
+    # Should succeed without error about container requirements
+    is "$status" "0" "MLX should auto-enable --nocontainer"
+    # Should not contain container runtime commands
+    assert "$output" !~ "podman\|docker" "should not use container runtime"
+}
+
+@test "ramalama --runtime=mlx --container shows warning but works" {
+    skip_if_not_apple_silicon
+    skip_if_no_mlx
+    
+    # When user explicitly specifies --container with MLX, should warn but auto-switch to --nocontainer
+    run_ramalama --runtime=mlx --container --dryrun run ${MODEL}
+    is "$status" "0" "should work despite --container flag"
+    assert "$output" !~ "podman\|docker" "should not use container runtime even with --container flag"
+}
+
+@test "ramalama --runtime=mlx --dryrun run shows server-client model" {
+    skip_if_not_apple_silicon
+    skip_if_no_mlx
+    
+    run_ramalama --runtime=mlx --dryrun run ${MODEL}
+    is "$status" "0" "MLX run should work"
+    # Should use python -m mlx_lm server for the server process
+    is "$output" ".*python.*-m.*mlx_lm server.*" "should use MLX server command"
+    is "$output" ".*--port.*" "should include port specification"
+}
+
+@test "ramalama --runtime=mlx --dryrun run with prompt shows server-client model" {
+    skip_if_not_apple_silicon
+    skip_if_no_mlx
+    
+    prompt="Hello, how are you?"
+    run_ramalama --runtime=mlx --dryrun run ${MODEL} "$prompt"
+    is "$status" "0" "MLX run with prompt should work"
+    is "$output" ".*python.*-m.*mlx_lm server.*" "should use MLX server command"
+    is "$output" ".*--port.*" "should include port specification"
+}
+
+@test "ramalama --runtime=mlx --dryrun run with temperature" {
+    skip_if_not_apple_silicon
+    skip_if_no_mlx
+    
+    run_ramalama --runtime=mlx --dryrun run --temp 0.5 ${MODEL} "test"
+    is "$status" "0" "MLX run with temperature should work"
+    is "$output" ".*--temp.*0.5.*" "should include temperature setting"
+}
+
+@test "ramalama --runtime=mlx --dryrun run with max tokens" {
+    skip_if_not_apple_silicon
+    skip_if_no_mlx
+    
+    run_ramalama --runtime=mlx --dryrun run --ctx-size 1024 ${MODEL} "test"
+    is "$status" "0" "MLX run with ctx-size should work"
+    is "$output" ".*--max-tokens.*1024.*" "should include max tokens setting"
+}
+
+@test "ramalama --runtime=mlx --dryrun serve shows MLX server command" {
+    skip_if_not_apple_silicon
+    skip_if_no_mlx
+    
+    run_ramalama --runtime=mlx --dryrun serve ${MODEL}
+    is "$status" "0" "MLX serve should work"
+    # Should use python -m mlx_lm.server
+    is "$output" ".*python.*-m.*mlx_lm server.*" "should use MLX server command"
+    is "$output" ".*--port.*8080.*" "should include default port"
+}
+
+@test "ramalama --runtime=mlx --dryrun serve with custom port" {
+    skip_if_not_apple_silicon
+    skip_if_no_mlx
+    
+    run_ramalama --runtime=mlx --dryrun serve --port 9090 ${MODEL}
+    is "$status" "0" "MLX serve with custom port should work"
+    is "$output" ".*--port.*9090.*" "should include custom port"
+}
+
+@test "ramalama --runtime=mlx --dryrun serve with host" {
+    skip_if_not_apple_silicon
+    skip_if_no_mlx
+    
+    run_ramalama --runtime=mlx --dryrun serve --host 127.0.0.1 ${MODEL}
+    is "$status" "0" "MLX serve with custom host should work"
+    is "$output" ".*--host.*127.0.0.1.*" "should include custom host"
+}
+
+@test "ramalama --runtime=mlx run fails on non-Apple Silicon" {
+    if is_apple_silicon; then
+        skip "This test only runs on non-Apple Silicon systems"
+    fi
+    
+    run_ramalama 22 --runtime=mlx run ${MODEL}
+    is "$output" ".*MLX.*Apple Silicon.*" "should show Apple Silicon requirement error"
+}
+
+@test "ramalama --runtime=mlx serve fails on non-Apple Silicon" {
+    if is_apple_silicon; then
+        skip "This test only runs on non-Apple Silicon systems"
+    fi
+    
+    run_ramalama 22 --runtime=mlx serve ${MODEL}
+    is "$output" ".*MLX.*Apple Silicon.*" "should show Apple Silicon requirement error"
+}
+
+@test "ramalama --runtime=mlx works with ollama model format" {
+    skip_if_not_apple_silicon
+    skip_if_no_mlx
+    
+    model="ollama://smollm:135m"
+    run_ramalama --runtime=mlx --dryrun run "$model"
+    is "$status" "0" "MLX should work with ollama model format"
+    is "$output" ".*python.*-m.*mlx_lm server.*" "should use MLX server command"
+}
+
+@test "ramalama --runtime=mlx works with huggingface model format" {
+    skip_if_not_apple_silicon
+    skip_if_no_mlx
+    
+    model="huggingface://microsoft/DialoGPT-small"
+    run_ramalama --runtime=mlx --dryrun run "$model"
+    is "$status" "0" "MLX should work with huggingface model format"
+    is "$output" ".*python.*-m.*mlx_lm server.*" "should use MLX server command"
+}
+
+@test "ramalama --runtime=mlx rejects --name option" {
+    skip_if_not_apple_silicon
+    skip_if_no_mlx
+    
+    # --name requires container mode, which MLX doesn't support
+    run_ramalama 1 --runtime=mlx run --name test ${MODEL}
+    is "$output" ".*--nocontainer.*--name.*conflict.*" "should show conflict error"
+}
+
+@test "ramalama --runtime=mlx rejects --privileged option" {
+    skip_if_not_apple_silicon
+    skip_if_no_mlx
+    
+    # --privileged requires container mode, which MLX doesn't support
+    run_ramalama 1 --runtime=mlx run --privileged ${MODEL}
+    is "$output" ".*--nocontainer.*--privileged.*conflict.*" "should show conflict error"
+}

--- a/test/system/helpers.bash
+++ b/test/system/helpers.bash
@@ -258,6 +258,16 @@ function skip_if_darwin() {
     fi
 }
 
+function is_apple_silicon() {
+    # Check if we're on macOS and have Apple Silicon (arm64)
+    if is_darwin; then
+        arch=$(uname -m)
+        [[ "$arch" == "arm64" ]]
+    else
+        return 1
+    fi
+}
+
 function skip_if_no_hf-cli(){
     if ! command -v huggingface-cli 2>&1 >/dev/null
     then


### PR DESCRIPTION
Assisted by: Cursor (Claude 4 sonnet)

Enables a new ‘mlx’ runtime option that integrates the `mlx_lm` Python package for optimized Apple Silicon inference, wiring it into the CLI, model execution paths (run, serve), enforcing platform constraints, updating documentation, and covering it with unit and system tests.

New Features:
- Add MLX runtime support for interactive chat, one-shot generation, serving, and benchmarking via the `mlx_lm` CLI

Enhancements:
- Enforce MLX runtime only on Apple Silicon macOS with automatic `--nocontainer` mode and validation
- Refactor model store type hint to `ModelStore | None` and add helper methods for building MLX subprocess arguments

CI:
- Install `mlx-lm` package in CI workflows

Documentation:
- Document MLX runtime requirements and usage in README, man pages, and configuration files

Tests:
- Add unit tests for MLX runtime argument building, validation, and behavior
- Add system BATS tests covering MLX CLI commands and runtime constraints

Examples:
```
❯ ramalama --debug --runtime mlx run hf://mlx-community/Unsloth-Phi-4-4bit 'What is the answer to life?'
2025-07-01 20:55:09 - DEBUG - run_cmd: npu-smi info
2025-07-01 20:55:09 - DEBUG - Working directory: None
2025-07-01 20:55:09 - DEBUG - Ignore stderr: False
2025-07-01 20:55:09 - DEBUG - Ignore all: False
2025-07-01 20:55:09 - DEBUG - run_cmd: mthreads-gmi
2025-07-01 20:55:09 - DEBUG - Working directory: None
2025-07-01 20:55:09 - DEBUG - Ignore stderr: False
2025-07-01 20:55:09 - DEBUG - Ignore all: False
2025-07-01 20:55:09 - DEBUG - exec_cmd: python -m mlx_lm generate --model /Users/kugupta/.local/share/ramalama/store/huggingface/mlx-community/Unsloth-Phi-4-4bit/snapshots/sha256-d1f444c20e6479cbf8cf6bc057ee3248fa10cd42 --temp 0.8 --max-tokens 2048 --prompt "What is the answer to life?"
==========
The question "What is the answer to life?" is famously explored in Douglas Adams' "The Hitchhiker's Guide to the Galaxy" series, where the ultimate answer to life, the universe, and everything is humorously given as "42." However, this is a fictional and whimsical answer.

In a more philosophical or existential context, the "answer" to life can vary greatly depending on individual beliefs, values, and perspectives. Many people find meaning in relationships, personal growth, contributing to society, or spiritual beliefs. Ultimately, the answer to what makes life meaningful is deeply personal and subjective.
==========
Prompt: 14 tokens, 55.354 tokens-per-sec
Generation: 122 tokens, 16.332 tokens-per-sec
Peak memory: 8.330 GB
```

```
❯ ramalama --debug --runtime mlx run hf://mlx-community/Unsloth-Phi-4-4bit
2025-07-01 20:33:35 - DEBUG - run_cmd: npu-smi info
2025-07-01 20:33:35 - DEBUG - Working directory: None
2025-07-01 20:33:35 - DEBUG - Ignore stderr: False
2025-07-01 20:33:35 - DEBUG - Ignore all: False
2025-07-01 20:33:35 - DEBUG - run_cmd: mthreads-gmi
2025-07-01 20:33:35 - DEBUG - Working directory: None
2025-07-01 20:33:35 - DEBUG - Ignore stderr: False
2025-07-01 20:33:35 - DEBUG - Ignore all: False
2025-07-01 20:33:35 - DEBUG - exec_cmd: python -m mlx_lm chat --model /Users/kugupta/.local/share/ramalama/store/huggingface/mlx-community/Unsloth-Phi-4-4bit/snapshots/sha256-d1f444c20e6479cbf8cf6bc057ee3248fa10cd42 --temp 0.8 --max-tokens 2048
[INFO] Starting chat session with /Users/kugupta/.local/share/ramalama/store/huggingface/mlx-community/Unsloth-Phi-4-4bit/snapshots/sha256-d1f444c20e6479cbf8cf6bc057ee3248fa10cd42.
The command list:
- 'q' to exit
- 'r' to reset the chat
- 'h' to display these commands
>> What is the answer to life?
The question "What is the answer to life?" is famously left open in Douglas Adams's science fiction series "The Hitchhiker's Guide to the Galaxy." In the story, a supercomputer named Deep Thought is asked to find the meaning of life, the universe, and everything. After seven and a half million years of calculation, it reveals that the answer is simply "42." This has since become a popular cultural reference to the idea that the answers to profound questions may be ultimately unattainable or absurdly simple.

Philosophically, different traditions and thinkers propose various answers to what the meaning or purpose of life might be. Some suggest it is to seek happiness, love, or the pursuit of knowledge. Others propose that life has no inherent meaning beyond what each individual ascribes to it. Essentially, the question of life's meaning varies greatly depending on cultural, religious, and personal perspectives.
>> q
```

```
❯ ramalama --debug --runtime mlx serve hf://mlx-community/Unsloth-Phi-4-4bit
2025-07-01 20:34:11 - DEBUG - run_cmd: npu-smi info
2025-07-01 20:34:11 - DEBUG - Working directory: None
2025-07-01 20:34:11 - DEBUG - Ignore stderr: False
2025-07-01 20:34:11 - DEBUG - Ignore all: False
2025-07-01 20:34:11 - DEBUG - run_cmd: mthreads-gmi
2025-07-01 20:34:11 - DEBUG - Working directory: None
2025-07-01 20:34:11 - DEBUG - Ignore stderr: False
2025-07-01 20:34:11 - DEBUG - Ignore all: False
2025-07-01 20:34:11 - DEBUG - Checking if 8080 is available
2025-07-01 20:34:11 - DEBUG - run_cmd: npu-smi info
2025-07-01 20:34:11 - DEBUG - Working directory: None
2025-07-01 20:34:11 - DEBUG - Ignore stderr: False
2025-07-01 20:34:11 - DEBUG - Ignore all: False
2025-07-01 20:34:11 - DEBUG - run_cmd: mthreads-gmi
2025-07-01 20:34:11 - DEBUG - Working directory: None
2025-07-01 20:34:11 - DEBUG - Ignore stderr: False
2025-07-01 20:34:11 - DEBUG - Ignore all: False
2025-07-01 20:34:11 - DEBUG - exec_cmd: python -m mlx_lm server --model /Users/kugupta/.local/share/ramalama/store/huggingface/mlx-community/Unsloth-Phi-4-4bit/snapshots/sha256-d1f444c20e6479cbf8cf6bc057ee3248fa10cd42 --temp 0.8 --max-tokens 2048 --port 8080 --host 0.0.0.0
/Users/kugupta/Documents/work/ramalama/.venv/lib/python3.12/site-packages/mlx_lm/server.py:924: UserWarning: mlx_lm.server is not recommended for production as it only implements basic security checks.
  warnings.warn(
2025-07-01 20:34:14,048 - INFO - Starting httpd at 0.0.0.0 on port 8080...

❯ curl localhost:8080/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
     "messages": [{"role": "user", "content": "What is the answer to life?"}],
     "temperature": 0.8
   }'
{"id": "chatcmpl-7aff951b-0c46-49e6-ba36-4299fd859990", "system_fingerprint": "0.25.3-0.26.1-macOS-15.5-arm64-arm-64bit-applegpu_g15s", "object": "chat.completion", "model": "default_model", "created": 1751416485, "choices": [{"index": 0, "logprobs": {"token_logprobs": [0.0, -0.03125, -0.15625, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, -0.125, -0.03125, -1.0, -0.5625, -0.046875, 0.0, -0.03125, -0.78125, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, -0.421875, -0.03125, -0.09375, -0.109375, -0.046875, -0.390625, -0.328125, 0.0, 0.0, -0.03125, 0.0, -0.265625, 0.0, -0.03125, -1.421875, 0.0, -0.875, -0.1875, -0.703125, -0.75, -1.75, -2.125, -1.859375, -2.25, -0.15625, -0.21875, -0.390625, -0.296875, -0.28125, -0.59375, -0.03125, -0.1875, -0.015625, -0.421875, 0.0, -0.109375, -0.609375, -0.1875, -0.15625, 0.0, 0.0, -0.609375, -0.140625, -0.28125, -0.015625, 0.0, -0.484375, -0.03125, -0.140625, -0.828125, -0.25, 0.0, -0.046875, -0.125, -0.609375, 0.0, -0.21875, -1.109375, -0.0625, -0.53125, -0.328125, -0.765625, -0.0625, -0.96875, -0.015625, -0.875, -0.3125, -1.9375, 0.0, -0.46875, -1.046875, -0.03125, -0.890625, -1.96875, 0.0, -0.40625, -0.09375, -0.9375, 0.0, -0.484375, -2.015625, -0.015625, -1.21875, 0.0, 0.0, -0.03125, -1.15625, -0.0625, 0.0, -0.96875, -0.890625, -0.234375, -0.40625, -0.953125, -0.4375, -1.90625, -0.0625, -0.078125, -0.71875, 0.0, -0.015625, -0.03125], "top_logprobs": [], "tokens": [791, 3488, 330, 3923, 374, 279, 4320, 311, 2324, 7673, 374, 51287, 37260, 304, 31164, 27329, 6, 330, 791, 71464, 71, 25840, 596, 13002, 311, 279, 20238, 1, 4101, 11, 1405, 279, 4320, 374, 28485, 7162, 2728, 439, 330, 2983, 1210, 4452, 11, 420, 374, 264, 44682, 2077, 323, 8967, 369, 95471, 2515, 382, 644, 264, 810, 41903, 477, 67739, 2317, 11, 279, 330, 9399, 311, 2324, 1, 649, 13592, 19407, 11911, 389, 3927, 21463, 11, 13042, 36576, 11, 323, 4443, 11704, 13, 4427, 1253, 1505, 7438, 1555, 13901, 11, 3885, 1555, 12135, 11, 28697, 11, 477, 29820, 311, 279, 23460, 315, 3885, 13, 55106, 11, 279, 330, 9399, 311, 2324, 1, 374, 264, 17693, 4443, 3488, 430, 1855, 1732, 1253, 14532, 304, 872, 1866, 5016, 1648, 13, 100265]}, "finish_reason": "stop", "message": {"role": "assistant", "content": "The question \"What is the answer to life?\" is famously posed in Douglas Adams' \"The Hitchhiker's Guide to the Galaxy\" series, where the answer is humorously given as \"42.\" However, this is a fictional response and meant for comedic effect.\n\nIn a more philosophical or existential context, the \"answer to life\" can vary greatly depending on individual beliefs, cultural backgrounds, and personal experiences. Some may find meaning through religion, others through relationships, creativity, or contributing to the welfare of others. Ultimately, the \"answer to life\" is a deeply personal question that each person may interpret in their own unique way.", "tool_calls": []}}], "usage": {"prompt_tokens": 14, "completion_tokens": 129, "total_tokens": 143}}%
```

## Summary by Sourcery

Enable the new MLX runtime option using the mlx_lm package for optimized Apple Silicon inference, integrate it into run/serve/benchmark commands, enforce platform and container constraints, update CI and documentation, and add comprehensive tests.

New Features:
- Support MLX runtime for interactive chat and one-shot text generation
- Support MLX runtime for model serving via the CLI
- Support MLX runtime for model benchmarking workflows

Enhancements:
- Automatically enforce MLX runtime only on macOS Apple Silicon with automatic no-container mode
- Refactor MLX subprocess argument builder and integrate server-client model in the run command
- Refactor model store type hint to Optional and add helper methods for MLX argument construction

CI:
- Install mlx-lm package in CI workflows

Documentation:
- Document MLX runtime requirements and usage in README, man pages, and configuration files

Tests:
- Add unit tests for MLX runtime argument building, validation, exec args generation, and unsupported features
- Add system BATS tests covering MLX CLI commands, platform checks, and runtime behaviors