### PR TITLE
konflux: add pipelines for the layered images of ramalama, cuda, rocm, and rocm-ubi

### DIFF
--- a/.tekton/cuda-llama-server/cuda-llama-server-pull-request.yaml
+++ b/.tekton/cuda-llama-server/cuda-llama-server-pull-request.yaml
@@ -1,0 +1,47 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "main"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: cuda-llama-server
+    pipelines.appstudio.openshift.io/type: build
+  name: cuda-llama-server-on-pull-request
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/cuda-llama-server:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: build-platforms
+    value:
+    - linux/x86_64
+  - name: dockerfile
+    value: container-images/common/Containerfile.entrypoint
+  - name: parent-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/cuda:on-pr-{{revision}}
+  - name: build-args
+    value:
+    - PARENT=quay.io/redhat-user-workloads/ramalama-tenant/cuda:on-pr-{{revision}}
+    - ENTRYPOINT=/usr/bin/llama-server.sh
+  pipelineRef:
+    name: pull-request-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/cuda-llama-server/cuda-llama-server-push.yaml
+++ b/.tekton/cuda-llama-server/cuda-llama-server-push.yaml
@@ -1,0 +1,44 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "main"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: cuda-llama-server
+    pipelines.appstudio.openshift.io/type: build
+  name: cuda-llama-server-on-push
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/cuda-llama-server:{{revision}}
+  - name: build-platforms
+    value:
+    - linux/x86_64
+  - name: dockerfile
+    value: container-images/common/Containerfile.entrypoint
+  - name: parent-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/cuda:{{revision}}
+  - name: build-args
+    value:
+    - PARENT=quay.io/redhat-user-workloads/ramalama-tenant/cuda:{{revision}}
+    - ENTRYPOINT=/usr/bin/llama-server.sh
+  pipelineRef:
+    name: push-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/cuda-rag/cuda-rag-pull-request.yaml
+++ b/.tekton/cuda-rag/cuda-rag-pull-request.yaml
@@ -1,0 +1,47 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "main"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: cuda-rag
+    pipelines.appstudio.openshift.io/type: build
+  name: cuda-rag-on-pull-request
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/cuda-rag:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: build-platforms
+    value:
+    - linux/x86_64
+  - name: dockerfile
+    value: container-images/common/Containerfile.rag
+  - name: parent-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/cuda:on-pr-{{revision}}
+  - name: build-args
+    value:
+    - PARENT=quay.io/redhat-user-workloads/ramalama-tenant/cuda:on-pr-{{revision}}
+    - GPU=cuda
+  pipelineRef:
+    name: pull-request-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/cuda-rag/cuda-rag-push.yaml
+++ b/.tekton/cuda-rag/cuda-rag-push.yaml
@@ -1,0 +1,44 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "main"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: cuda-rag
+    pipelines.appstudio.openshift.io/type: build
+  name: cuda-rag-on-push
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/cuda-rag:{{revision}}
+  - name: build-platforms
+    value:
+    - linux/x86_64
+  - name: dockerfile
+    value: container-images/common/Containerfile.rag
+  - name: parent-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/cuda:{{revision}}
+  - name: build-args
+    value:
+    - PARENT=quay.io/redhat-user-workloads/ramalama-tenant/cuda:{{revision}}
+    - GPU=cuda
+  pipelineRef:
+    name: push-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/cuda-whisper-server/cuda-whisper-server-pull-request.yaml
+++ b/.tekton/cuda-whisper-server/cuda-whisper-server-pull-request.yaml
@@ -1,0 +1,47 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "main"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: cuda-whisper-server
+    pipelines.appstudio.openshift.io/type: build
+  name: cuda-whisper-server-on-pull-request
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/cuda-whisper-server:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: build-platforms
+    value:
+    - linux/x86_64
+  - name: dockerfile
+    value: container-images/common/Containerfile.entrypoint
+  - name: parent-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/cuda:on-pr-{{revision}}
+  - name: build-args
+    value:
+    - PARENT=quay.io/redhat-user-workloads/ramalama-tenant/cuda:on-pr-{{revision}}
+    - ENTRYPOINT=/usr/bin/whisper-server.sh
+  pipelineRef:
+    name: pull-request-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/cuda-whisper-server/cuda-whisper-server-push.yaml
+++ b/.tekton/cuda-whisper-server/cuda-whisper-server-push.yaml
@@ -1,0 +1,44 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "main"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: cuda-whisper-server
+    pipelines.appstudio.openshift.io/type: build
+  name: cuda-whisper-server-on-push
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/cuda-whisper-server:{{revision}}
+  - name: build-platforms
+    value:
+    - linux/x86_64
+  - name: dockerfile
+    value: container-images/common/Containerfile.entrypoint
+  - name: parent-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/cuda:{{revision}}
+  - name: build-args
+    value:
+    - PARENT=quay.io/redhat-user-workloads/ramalama-tenant/cuda:{{revision}}
+    - ENTRYPOINT=/usr/bin/whisper-server.sh
+  pipelineRef:
+    name: push-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/pipelines/pull-request-pipeline.yaml
+++ b/.tekton/pipelines/pull-request-pipeline.yaml
@@ -77,6 +77,9 @@ spec:
     name: build-platforms
     type: array
   - default: ""
+    description: The parent image of the image being built.
+    name: parent-image
+  - default: ""
     description: The image to use for running tests.
     name: test-image
   - default: []
@@ -174,6 +177,17 @@ spec:
       workspace: git-auth
     - name: netrc
       workspace: netrc
+  - name: wait-for-parent-image
+    params:
+    - name: ref
+      value: $(params.parent-image)
+    taskRef:
+      name: wait-for-image
+    when:
+    - input: $(params.parent-image)
+      operator: notin
+      values:
+      - ""
   - matrix:
       params:
       - name: PLATFORM
@@ -209,6 +223,7 @@ spec:
     - name: IMAGE_APPEND_PLATFORM
       value: "true"
     runAfter:
+    - wait-for-parent-image
     - prefetch-dependencies
     taskRef:
       params:

--- a/.tekton/pipelines/push-pipeline.yaml
+++ b/.tekton/pipelines/push-pipeline.yaml
@@ -77,6 +77,9 @@ spec:
     name: build-platforms
     type: array
   - default: ""
+    description: The parent image of the image being built.
+    name: parent-image
+  - default: ""
     description: The image to use for running tests.
     name: test-image
   - default: []
@@ -174,6 +177,17 @@ spec:
       workspace: git-auth
     - name: netrc
       workspace: netrc
+  - name: wait-for-parent-image
+    params:
+    - name: ref
+      value: $(params.parent-image)
+    taskRef:
+      name: wait-for-image
+    when:
+    - input: $(params.parent-image)
+      operator: notin
+      values:
+      - ""
   - matrix:
       params:
       - name: PLATFORM
@@ -209,6 +223,7 @@ spec:
     - name: IMAGE_APPEND_PLATFORM
       value: "true"
     runAfter:
+    - wait-for-parent-image
     - prefetch-dependencies
     taskRef:
       params:

--- a/.tekton/ramalama-llama-server/ramalama-llama-server-pull-request.yaml
+++ b/.tekton/ramalama-llama-server/ramalama-llama-server-pull-request.yaml
@@ -1,0 +1,47 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "main"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: ramalama-llama-server
+    pipelines.appstudio.openshift.io/type: build
+  name: ramalama-llama-server-on-pull-request
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/ramalama-llama-server:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: build-platforms
+    value:
+    - linux/x86_64
+  - name: dockerfile
+    value: container-images/common/Containerfile.entrypoint
+  - name: parent-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/ramalama:on-pr-{{revision}}
+  - name: build-args
+    value:
+    - PARENT=quay.io/redhat-user-workloads/ramalama-tenant/ramalama:on-pr-{{revision}}
+    - ENTRYPOINT=/usr/bin/llama-server.sh
+  pipelineRef:
+    name: pull-request-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/ramalama-llama-server/ramalama-llama-server-push.yaml
+++ b/.tekton/ramalama-llama-server/ramalama-llama-server-push.yaml
@@ -1,0 +1,44 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "main"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: ramalama-llama-server
+    pipelines.appstudio.openshift.io/type: build
+  name: ramalama-llama-server-on-push
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/ramalama-llama-server:{{revision}}
+  - name: build-platforms
+    value:
+    - linux/x86_64
+  - name: dockerfile
+    value: container-images/common/Containerfile.entrypoint
+  - name: parent-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/ramalama:{{revision}}
+  - name: build-args
+    value:
+    - PARENT=quay.io/redhat-user-workloads/ramalama-tenant/ramalama:{{revision}}
+    - ENTRYPOINT=/usr/bin/llama-server.sh
+  pipelineRef:
+    name: push-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/ramalama-rag/ramalama-rag-pull-request.yaml
+++ b/.tekton/ramalama-rag/ramalama-rag-pull-request.yaml
@@ -1,0 +1,47 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "main"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: ramalama-rag
+    pipelines.appstudio.openshift.io/type: build
+  name: ramalama-rag-on-pull-request
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/ramalama-rag:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: build-platforms
+    value:
+    - linux/x86_64
+  - name: dockerfile
+    value: container-images/common/Containerfile.rag
+  - name: parent-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/ramalama:on-pr-{{revision}}
+  - name: build-args
+    value:
+    - PARENT=quay.io/redhat-user-workloads/ramalama-tenant/ramalama:on-pr-{{revision}}
+    - GPU=cpu
+  pipelineRef:
+    name: pull-request-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/ramalama-rag/ramalama-rag-push.yaml
+++ b/.tekton/ramalama-rag/ramalama-rag-push.yaml
@@ -1,0 +1,44 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "main"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: ramalama-rag
+    pipelines.appstudio.openshift.io/type: build
+  name: ramalama-rag-on-push
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/ramalama-rag:{{revision}}
+  - name: build-platforms
+    value:
+    - linux/x86_64
+  - name: dockerfile
+    value: container-images/common/Containerfile.rag
+  - name: parent-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/ramalama:{{revision}}
+  - name: build-args
+    value:
+    - PARENT=quay.io/redhat-user-workloads/ramalama-tenant/ramalama:{{revision}}
+    - GPU=cpu
+  pipelineRef:
+    name: push-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/ramalama-whisper-server/ramalama-whisper-server-pull-request.yaml
+++ b/.tekton/ramalama-whisper-server/ramalama-whisper-server-pull-request.yaml
@@ -1,0 +1,47 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "main"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: ramalama-whisper-server
+    pipelines.appstudio.openshift.io/type: build
+  name: ramalama-whisper-server-on-pull-request
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/ramalama-whisper-server:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: build-platforms
+    value:
+    - linux/x86_64
+  - name: dockerfile
+    value: container-images/common/Containerfile.entrypoint
+  - name: parent-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/ramalama:on-pr-{{revision}}
+  - name: build-args
+    value:
+    - PARENT=quay.io/redhat-user-workloads/ramalama-tenant/ramalama:on-pr-{{revision}}
+    - ENTRYPOINT=/usr/bin/whisper-server.sh
+  pipelineRef:
+    name: pull-request-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/ramalama-whisper-server/ramalama-whisper-server-push.yaml
+++ b/.tekton/ramalama-whisper-server/ramalama-whisper-server-push.yaml
@@ -1,0 +1,44 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "main"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: ramalama-whisper-server
+    pipelines.appstudio.openshift.io/type: build
+  name: ramalama-whisper-server-on-push
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/ramalama-whisper-server:{{revision}}
+  - name: build-platforms
+    value:
+    - linux/x86_64
+  - name: dockerfile
+    value: container-images/common/Containerfile.entrypoint
+  - name: parent-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/ramalama:{{revision}}
+  - name: build-args
+    value:
+    - PARENT=quay.io/redhat-user-workloads/ramalama-tenant/ramalama:{{revision}}
+    - ENTRYPOINT=/usr/bin/whisper-server.sh
+  pipelineRef:
+    name: push-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/rocm-llama-server/rocm-llama-server-pull-request.yaml
+++ b/.tekton/rocm-llama-server/rocm-llama-server-pull-request.yaml
@@ -1,0 +1,47 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "main"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: rocm-llama-server
+    pipelines.appstudio.openshift.io/type: build
+  name: rocm-llama-server-on-pull-request
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/rocm-llama-server:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: build-platforms
+    value:
+    - linux/x86_64
+  - name: dockerfile
+    value: container-images/common/Containerfile.entrypoint
+  - name: parent-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/rocm:on-pr-{{revision}}
+  - name: build-args
+    value:
+    - PARENT=quay.io/redhat-user-workloads/ramalama-tenant/rocm:on-pr-{{revision}}
+    - ENTRYPOINT=/usr/bin/llama-server.sh
+  pipelineRef:
+    name: pull-request-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/rocm-llama-server/rocm-llama-server-push.yaml
+++ b/.tekton/rocm-llama-server/rocm-llama-server-push.yaml
@@ -1,0 +1,44 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "main"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: rocm-llama-server
+    pipelines.appstudio.openshift.io/type: build
+  name: rocm-llama-server-on-push
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/rocm-llama-server:{{revision}}
+  - name: build-platforms
+    value:
+    - linux/x86_64
+  - name: dockerfile
+    value: container-images/common/Containerfile.entrypoint
+  - name: parent-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/rocm:{{revision}}
+  - name: build-args
+    value:
+    - PARENT=quay.io/redhat-user-workloads/ramalama-tenant/rocm:{{revision}}
+    - ENTRYPOINT=/usr/bin/llama-server.sh
+  pipelineRef:
+    name: push-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/rocm-rag/rocm-rag-pull-request.yaml
+++ b/.tekton/rocm-rag/rocm-rag-pull-request.yaml
@@ -1,0 +1,47 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "main"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: rocm-rag
+    pipelines.appstudio.openshift.io/type: build
+  name: rocm-rag-on-pull-request
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/rocm-rag:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: build-platforms
+    value:
+    - linux/x86_64
+  - name: dockerfile
+    value: container-images/common/Containerfile.rag
+  - name: parent-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/rocm:on-pr-{{revision}}
+  - name: build-args
+    value:
+    - PARENT=quay.io/redhat-user-workloads/ramalama-tenant/rocm:on-pr-{{revision}}
+    - GPU=rocm
+  pipelineRef:
+    name: pull-request-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/rocm-rag/rocm-rag-push.yaml
+++ b/.tekton/rocm-rag/rocm-rag-push.yaml
@@ -1,0 +1,44 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "main"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: rocm-rag
+    pipelines.appstudio.openshift.io/type: build
+  name: rocm-rag-on-push
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/rocm-rag:{{revision}}
+  - name: build-platforms
+    value:
+    - linux/x86_64
+  - name: dockerfile
+    value: container-images/common/Containerfile.rag
+  - name: parent-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/rocm:{{revision}}
+  - name: build-args
+    value:
+    - PARENT=quay.io/redhat-user-workloads/ramalama-tenant/rocm:{{revision}}
+    - GPU=rocm
+  pipelineRef:
+    name: push-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/rocm-ubi-llama-server/rocm-ubi-llama-server-pull-request.yaml
+++ b/.tekton/rocm-ubi-llama-server/rocm-ubi-llama-server-pull-request.yaml
@@ -1,0 +1,47 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "main"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: rocm-ubi-llama-server
+    pipelines.appstudio.openshift.io/type: build
+  name: rocm-ubi-llama-server-on-pull-request
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/rocm-ubi-llama-server:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: build-platforms
+    value:
+    - linux/x86_64
+  - name: dockerfile
+    value: container-images/common/Containerfile.entrypoint
+  - name: parent-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/rocm-ubi:on-pr-{{revision}}
+  - name: build-args
+    value:
+    - PARENT=quay.io/redhat-user-workloads/ramalama-tenant/rocm-ubi:on-pr-{{revision}}
+    - ENTRYPOINT=/usr/bin/llama-server.sh
+  pipelineRef:
+    name: pull-request-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/rocm-ubi-llama-server/rocm-ubi-llama-server-push.yaml
+++ b/.tekton/rocm-ubi-llama-server/rocm-ubi-llama-server-push.yaml
@@ -1,0 +1,44 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "main"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: rocm-ubi-llama-server
+    pipelines.appstudio.openshift.io/type: build
+  name: rocm-ubi-llama-server-on-push
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/rocm-ubi-llama-server:{{revision}}
+  - name: build-platforms
+    value:
+    - linux/x86_64
+  - name: dockerfile
+    value: container-images/common/Containerfile.entrypoint
+  - name: parent-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/rocm-ubi:{{revision}}
+  - name: build-args
+    value:
+    - PARENT=quay.io/redhat-user-workloads/ramalama-tenant/rocm-ubi:{{revision}}
+    - ENTRYPOINT=/usr/bin/llama-server.sh
+  pipelineRef:
+    name: push-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/rocm-ubi-rag/rocm-ubi-rag-pull-request.yaml
+++ b/.tekton/rocm-ubi-rag/rocm-ubi-rag-pull-request.yaml
@@ -1,0 +1,47 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "main"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: rocm-ubi-rag
+    pipelines.appstudio.openshift.io/type: build
+  name: rocm-ubi-rag-on-pull-request
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/rocm-ubi-rag:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: build-platforms
+    value:
+    - linux/x86_64
+  - name: dockerfile
+    value: container-images/common/Containerfile.rag
+  - name: parent-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/rocm-ubi:on-pr-{{revision}}
+  - name: build-args
+    value:
+    - PARENT=quay.io/redhat-user-workloads/ramalama-tenant/rocm-ubi:on-pr-{{revision}}
+    - GPU=rocm
+  pipelineRef:
+    name: pull-request-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/rocm-ubi-rag/rocm-ubi-rag-push.yaml
+++ b/.tekton/rocm-ubi-rag/rocm-ubi-rag-push.yaml
@@ -1,0 +1,44 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "main"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: rocm-ubi-rag
+    pipelines.appstudio.openshift.io/type: build
+  name: rocm-ubi-rag-on-push
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/rocm-ubi-rag:{{revision}}
+  - name: build-platforms
+    value:
+    - linux/x86_64
+  - name: dockerfile
+    value: container-images/common/Containerfile.rag
+  - name: parent-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/rocm-ubi:{{revision}}
+  - name: build-args
+    value:
+    - PARENT=quay.io/redhat-user-workloads/ramalama-tenant/rocm-ubi:{{revision}}
+    - GPU=rocm
+  pipelineRef:
+    name: push-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/rocm-ubi-whisper-server/rocm-ubi-whisper-server-pull-request.yaml
+++ b/.tekton/rocm-ubi-whisper-server/rocm-ubi-whisper-server-pull-request.yaml
@@ -1,0 +1,47 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "main"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: rocm-ubi-whisper-server
+    pipelines.appstudio.openshift.io/type: build
+  name: rocm-ubi-whisper-server-on-pull-request
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/rocm-ubi-whisper-server:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: build-platforms
+    value:
+    - linux/x86_64
+  - name: dockerfile
+    value: container-images/common/Containerfile.entrypoint
+  - name: parent-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/rocm-ubi:on-pr-{{revision}}
+  - name: build-args
+    value:
+    - PARENT=quay.io/redhat-user-workloads/ramalama-tenant/rocm-ubi:on-pr-{{revision}}
+    - ENTRYPOINT=/usr/bin/whisper-server.sh
+  pipelineRef:
+    name: pull-request-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/rocm-ubi-whisper-server/rocm-ubi-whisper-server-push.yaml
+++ b/.tekton/rocm-ubi-whisper-server/rocm-ubi-whisper-server-push.yaml
@@ -1,0 +1,44 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "main"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: rocm-ubi-whisper-server
+    pipelines.appstudio.openshift.io/type: build
+  name: rocm-ubi-whisper-server-on-push
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/rocm-ubi-whisper-server:{{revision}}
+  - name: build-platforms
+    value:
+    - linux/x86_64
+  - name: dockerfile
+    value: container-images/common/Containerfile.entrypoint
+  - name: parent-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/rocm-ubi:{{revision}}
+  - name: build-args
+    value:
+    - PARENT=quay.io/redhat-user-workloads/ramalama-tenant/rocm-ubi:{{revision}}
+    - ENTRYPOINT=/usr/bin/whisper-server.sh
+  pipelineRef:
+    name: push-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/rocm-whisper-server/rocm-whisper-server-pull-request.yaml
+++ b/.tekton/rocm-whisper-server/rocm-whisper-server-pull-request.yaml
@@ -1,0 +1,47 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "main"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: rocm-whisper-server
+    pipelines.appstudio.openshift.io/type: build
+  name: rocm-whisper-server-on-pull-request
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/rocm-whisper-server:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: build-platforms
+    value:
+    - linux/x86_64
+  - name: dockerfile
+    value: container-images/common/Containerfile.entrypoint
+  - name: parent-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/rocm:on-pr-{{revision}}
+  - name: build-args
+    value:
+    - PARENT=quay.io/redhat-user-workloads/ramalama-tenant/rocm:on-pr-{{revision}}
+    - ENTRYPOINT=/usr/bin/whisper-server.sh
+  pipelineRef:
+    name: pull-request-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/rocm-whisper-server/rocm-whisper-server-push.yaml
+++ b/.tekton/rocm-whisper-server/rocm-whisper-server-push.yaml
@@ -1,0 +1,44 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "main"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: rocm-whisper-server
+    pipelines.appstudio.openshift.io/type: build
+  name: rocm-whisper-server-on-push
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/rocm-whisper-server:{{revision}}
+  - name: build-platforms
+    value:
+    - linux/x86_64
+  - name: dockerfile
+    value: container-images/common/Containerfile.entrypoint
+  - name: parent-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/rocm:{{revision}}
+  - name: build-args
+    value:
+    - PARENT=quay.io/redhat-user-workloads/ramalama-tenant/rocm:{{revision}}
+    - ENTRYPOINT=/usr/bin/whisper-server.sh
+  pipelineRef:
+    name: push-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/tasks/wait-for-image.yaml
+++ b/.tekton/tasks/wait-for-image.yaml
@@ -20,12 +20,13 @@ spec:
       value: $(results.digest.path)
     script: |
       #!/bin/bash -e
+      echo "Fetching digest of $REF"
       while true; do
         DIGEST="$(skopeo inspect -n -f {{.Digest}} "docker://$REF" || :)"
         if [ "${#DIGEST}" -gt 0 ]; then
           echo -n "$DIGEST" | tee "$RESULTS_DIGEST_PATH"
           exit
         fi
-        echo "$(date -uIseconds): $REF is not available, waiting..."
+        echo "$(date -uIseconds): digest unavailable, waiting..."
         sleep 60
       done


### PR DESCRIPTION
Build the `-llama-server`, `-whisper-server`, and `-rag` layered images, which inherit from the existing `ramalama`, `cuda`, `rocm`, and `rocm-ubi` images.

Layered images use shared `Containerfiles`, and customize their builds using `--build-arg`.

## Summary by Sourcery

Enable building layered server and RAG images by extending Tekton pipelines with parent-image support and adding dedicated PipelineRun manifests for each layered variant across ramalama, cuda, rocm, and rocm-ubi bases.

Enhancements:
- Update wait-for-image task to log the parent image reference when fetching digest

CI:
- Add ‘parent-image’ parameter and conditional wait-for-parent-image step to pull-request and push pipelines to ensure base images are ready before build
- Create pull-request and push PipelineRun manifests for llama-server, whisper-server, and rag layered images inheriting from ramalama, cuda, rocm, and rocm-ubi bases across all variants