### PR TITLE
Make sure errors and progress messages go to STDERR

### DIFF
--- a/ramalama/chat.py
+++ b/ramalama/chat.py
@@ -11,6 +11,7 @@ import urllib.error
 import urllib.request
 from datetime import timedelta
 
+from ramalama.common import perror
 from ramalama.config import CONFIG
 from ramalama.console import EMOJI, should_colorize
 from ramalama.engine import dry_run, stop_container
@@ -68,7 +69,7 @@ def add_api_key(args, headers=None):
     if getattr(args, "api_key", None):
         api_key_min = 20
         if len(args.api_key) < api_key_min:
-            print("Warning: Provided API key is invalid.")
+            perror("Warning: Provided API key is invalid.")
 
         headers["Authorization"] = f"Bearer {args.api_key}"
 
@@ -161,7 +162,7 @@ class RamaLamaShell(cmd.Cmd):
                 break
             except Exception:
                 if sys.stdout.isatty():
-                    print(f"\r{c}", end="", flush=True)
+                    perror(f"\r{c}", end="", flush=True)
 
                 if total_time_slept > max_timeout:
                     break
@@ -176,7 +177,7 @@ class RamaLamaShell(cmd.Cmd):
 
         # Only show error and kill if not in initial connection phase
         if not getattr(self.args, "initial_connection", False):
-            print(f"\rError: could not connect to: {self.url}", file=sys.stderr)
+            perror(f"\rError: could not connect to: {self.url}")
             self.kills()
         else:
             logger.debug(f"Could not connect to: {self.url}")
@@ -251,7 +252,7 @@ def chat(args):
     except TimeoutException as e:
         logger.debug(f"Timeout Exception: {e}")
         # Handle the timeout, e.g., print a message and exit gracefully
-        print("")
+        perror("")
         pass
     finally:
         # Reset the alarm to 0 to cancel any pending alarms

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -382,7 +382,7 @@ def list_files_by_modification(args):
         if os.path.exists(path):
             models.append(path)
         else:
-            print(f"Broken symlink found in: {args.store}/models/{path} \nAttempting removal")
+            perror(f"Broken symlink found in: {args.store}/models/{path} \nAttempting removal")
             New(str(path).replace("/", "://", 1), args).remove(args)
 
     return sorted(models, key=lambda p: os.path.getmtime(p), reverse=True)

--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -580,7 +580,7 @@ def attempt_to_use_versioned(conman: str, image: str, vers: str, quiet: bool, sh
     try:
         # attempt to pull the versioned image
         if not quiet:
-            print(f"Attempting to pull {image}:{vers} ...")
+            perror(f"Attempting to pull {image}:{vers} ...")
         run_cmd([conman, "pull", f"{image}:{vers}"], ignore_stderr=True)
         return True
 

--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -13,14 +13,10 @@ import shutil
 import string
 import subprocess
 import sys
-import time
-import urllib.error
 from functools import lru_cache
 from typing import TYPE_CHECKING, Callable, List, Literal, Protocol, cast, get_args
 
 import ramalama.amdkfd as amdkfd
-import ramalama.console as console
-from ramalama.http_client import HttpClient
 from ramalama.logger import logger
 from ramalama.version import version
 
@@ -36,9 +32,6 @@ MNT_CHAT_TEMPLATE_FILE = f"{MNT_DIR}/chat_template.file"
 
 RAG_DIR = "/rag"
 RAG_CONTENT = f"{MNT_DIR}/vector.db"
-
-HTTP_NOT_FOUND = 404
-HTTP_RANGE_NOT_SATISFIABLE = 416  # "Range Not Satisfiable" error (file already downloaded)
 
 MIN_VRAM_BYTES = 1073741824  # 1GiB
 
@@ -214,99 +207,8 @@ def verify_checksum(filename: str) -> bool:
     return sha256_hash.hexdigest() == expected_checksum
 
 
-def download_and_verify(url: str, target_path: str, max_retries: int = 2):
-    """
-    Downloads a file from a given URL and verifies its checksum.
-    If the checksum does not match, it retries the download.
-    Args:
-        url (str): The URL to download from.
-        target_path (str): The path to save the downloaded file.
-        max_retries (int): Maximum number of retries for download.
-    Raises:
-        ValueError: If checksum verification fails after multiple attempts.
-    """
-
-    for attempt in range(max_retries):
-        download_file(url, target_path, headers={}, show_progress=True)
-        if verify_checksum(target_path):
-            break
-        console.warning(
-            f"Checksum mismatch for {target_path}, retrying download ... (Attempt {attempt + 1}/{max_retries})"
-        )
-        os.remove(target_path)
-    else:
-        raise ValueError(f"Checksum verification failed for {target_path} after multiple attempts")
-
-
 def genname():
     return "ramalama_" + "".join(random.choices(string.ascii_letters + string.digits, k=10))
-
-
-def download_file(url: str, dest_path: str, headers: dict[str, str] | None = None, show_progress: bool = True):
-    """
-    Downloads a file from a given URL to a specified destination path.
-
-    Args:
-        url (str): The URL to download from.
-        dest_path (str): The path to save the downloaded file.
-        headers (dict): Optional headers to include in the request.
-        show_progress (bool): Whether to show a progress bar during download.
-
-    Raises:
-        RuntimeError: If the download fails after multiple attempts.
-    """
-    headers = headers or {}
-
-    # If not running in a TTY, disable progress to prevent CI pollution
-    if not sys.stdout.isatty():
-        show_progress = False
-
-    http_client = HttpClient()
-    max_retries = 5  # Stop after 5 failures
-    retries = 0
-
-    while retries < max_retries:
-        try:
-            # Initialize HTTP client for the request
-            http_client.init(url=url, headers=headers, output_file=dest_path, show_progress=show_progress)
-            return  # Exit function if successful
-
-        except urllib.error.HTTPError as e:
-            if e.code in [HTTP_RANGE_NOT_SATISFIABLE, HTTP_NOT_FOUND]:
-                raise e
-            retries += 1
-
-        except urllib.error.URLError as e:
-            console.error(f"Network Error: {e.reason}")
-            retries += 1
-
-        except TimeoutError:
-            retries += 1
-            console.warning(f"TimeoutError: The server took too long to respond. Retrying {retries}/{max_retries} ...")
-
-        except RuntimeError as e:  # Catch network-related errors from HttpClient
-            retries += 1
-            console.warning(f"{e}. Retrying {retries}/{max_retries} ...")
-
-        except IOError as e:
-            retries += 1
-            console.warning(f"I/O Error: {e}. Retrying {retries}/{max_retries} ...")
-
-        except Exception as e:
-            console.error(f"Unexpected error: {str(e)}")
-            raise e
-
-        if retries >= max_retries:
-            error_message = (
-                "\nDownload failed after multiple attempts.\n"
-                "Possible causes:\n"
-                "- Internet connection issue\n"
-                "- Server is down or unresponsive\n"
-                "- Firewall or proxy blocking the request\n"
-            )
-            raise ConnectionError(error_message)
-
-        time.sleep(2**retries * 0.1)  # Exponential backoff (0.1s, 0.2s, 0.4s...)
 
 
 def engine_version(engine: SUPPORTED_ENGINES) -> str:

--- a/ramalama/engine.py
+++ b/ramalama/engine.py
@@ -47,7 +47,7 @@ class Engine:
         if not self.args.dryrun and self.use_docker and self.args.pull == "newer":
             try:
                 if not self.args.quiet:
-                    print(f"Checking for newer image {self.args.image}")
+                    perror(f"Checking for newer image {self.args.image}")
                 run_cmd([str(self.args.engine), "pull", "-q", self.args.image], ignore_all=True)
             except Exception:  # Ignore errors, the run command will handle it.
                 pass

--- a/ramalama/hf_style_repo_base.py
+++ b/ramalama/hf_style_repo_base.py
@@ -220,7 +220,7 @@ class HFStyleRepoModel(Model, ABC):
         hash, cached_files, all = self.model_store.get_cached_files(tag)
         if all:
             if not args.quiet:
-                print(f"Using cached {self.get_repo_type()}://{name}:{tag} ...")
+                perror(f"Using cached {self.get_repo_type()}://{name}:{tag} ...")
             return self.model_store.get_snapshot_file_path(hash, name)
 
         try:
@@ -252,4 +252,4 @@ class HFStyleRepoModel(Model, ABC):
         try:
             exec_cmd(cmd_args)
         except FileNotFoundError as e:
-            print(f"{str(e).strip()}\n{self.get_missing_message()}")
+            perror(f"{str(e).strip()}\n{self.get_missing_message()}")

--- a/ramalama/http_client.py
+++ b/ramalama/http_client.py
@@ -5,8 +5,13 @@ import shutil
 import time
 import urllib.request
 
+import ramalama.console as console
+from ramalama.common import perror, verify_checksum
 from ramalama.file import File
 from ramalama.logger import logger
+
+HTTP_NOT_FOUND = 404
+HTTP_RANGE_NOT_SATISFIABLE = 416  # "Range Not Satisfiable" error (file already downloaded)
 
 
 class HttpClient:
@@ -70,7 +75,7 @@ class HttpClient:
             self.update_progress(accumulated_size)
 
         if show_progress:
-            print("\033[K", end="\r")
+            perror("\033[K", end="\r")
 
     def human_readable_time(self, seconds):
         hrs = int(seconds) // 3600
@@ -125,7 +130,7 @@ class HttpClient:
         return 0
 
     def print_progress(self, progress_prefix, progress_bar, progress_suffix):
-        print(f"\r{progress_prefix}{progress_bar}| {progress_suffix}", end="")
+        perror(f"\r{progress_prefix}{progress_bar}| {progress_suffix}", end="")
 
     def update_progress(self, chunk_size):
         self.now_downloaded += chunk_size
@@ -143,3 +148,94 @@ class HttpClient:
         now = time.time()
         elapsed_seconds = now - start_time
         return now_downloaded / elapsed_seconds
+
+
+def download_file(url: str, dest_path: str, headers: dict[str, str] | None = None, show_progress: bool = True):
+    """
+    Downloads a file from a given URL to a specified destination path.
+
+    Args:
+        url (str): The URL to download from.
+        dest_path (str): The path to save the downloaded file.
+        headers (dict): Optional headers to include in the request.
+        show_progress (bool): Whether to show a progress bar during download.
+
+    Raises:
+        RuntimeError: If the download fails after multiple attempts.
+    """
+    headers = headers or {}
+
+    # If not running in a TTY, disable progress to prevent CI pollution
+    if not sys.stdout.isatty():
+        show_progress = False
+
+    http_client = HttpClient()
+    max_retries = 5  # Stop after 5 failures
+    retries = 0
+
+    while retries < max_retries:
+        try:
+            # Initialize HTTP client for the request
+            http_client.init(url=url, headers=headers, output_file=dest_path, show_progress=show_progress)
+            return  # Exit function if successful
+
+        except urllib.error.HTTPError as e:
+            if e.code in [HTTP_RANGE_NOT_SATISFIABLE, HTTP_NOT_FOUND]:
+                raise e
+            retries += 1
+
+        except urllib.error.URLError as e:
+            console.error(f"Network Error: {e.reason}")
+            retries += 1
+
+        except TimeoutError:
+            retries += 1
+            console.warning(f"TimeoutError: The server took too long to respond. Retrying {retries}/{max_retries} ...")
+
+        except RuntimeError as e:  # Catch network-related errors from HttpClient
+            retries += 1
+            console.warning(f"{e}. Retrying {retries}/{max_retries} ...")
+
+        except IOError as e:
+            retries += 1
+            console.warning(f"I/O Error: {e}. Retrying {retries}/{max_retries} ...")
+
+        except Exception as e:
+            console.error(f"Unexpected error: {str(e)}")
+            raise e
+
+        if retries >= max_retries:
+            error_message = (
+                "\nDownload failed after multiple attempts.\n"
+                "Possible causes:\n"
+                "- Internet connection issue\n"
+                "- Server is down or unresponsive\n"
+                "- Firewall or proxy blocking the request\n"
+            )
+            raise ConnectionError(error_message)
+
+        time.sleep(2**retries * 0.1)  # Exponential backoff (0.1s, 0.2s, 0.4s...)
+
+
+def download_and_verify(url: str, target_path: str, max_retries: int = 2):
+    """
+    Downloads a file from a given URL and verifies its checksum.
+    If the checksum does not match, it retries the download.
+    Args:
+        url (str): The URL to download from.
+        target_path (str): The path to save the downloaded file.
+        max_retries (int): Maximum number of retries for download.
+    Raises:
+        ValueError: If checksum verification fails after multiple attempts.
+    """
+
+    for attempt in range(max_retries):
+        download_file(url, target_path, headers={}, show_progress=True)
+        if verify_checksum(target_path):
+            break
+        console.warning(
+            f"Checksum mismatch for {target_path}, retrying download ... (Attempt {attempt + 1}/{max_retries})"
+        )
+        os.remove(target_path)
+    else:
+        raise ValueError(f"Checksum verification failed for {target_path} after multiple attempts")

--- a/ramalama/http_client.py
+++ b/ramalama/http_client.py
@@ -2,6 +2,7 @@
 
 import os
 import shutil
+import sys
 import time
 import urllib.request
 
@@ -178,6 +179,10 @@ def download_file(url: str, dest_path: str, headers: dict[str, str] | None = Non
             # Initialize HTTP client for the request
             http_client.init(url=url, headers=headers, output_file=dest_path, show_progress=show_progress)
             return  # Exit function if successful
+
+        except KeyboardInterrupt:
+            perror("\nDownload interrupted by user. Exiting cleanly.")
+            raise
 
         except urllib.error.HTTPError as e:
             if e.code in [HTTP_RANGE_NOT_SATISFIABLE, HTTP_NOT_FOUND]:

--- a/ramalama/huggingface.py
+++ b/ramalama/huggingface.py
@@ -130,7 +130,7 @@ def get_repo_info(repo_name):
 
 def handle_repo_info(repo_name, repo_info, runtime):
     if "safetensors" in repo_info and runtime == "llama.cpp":
-        print(
+        perror(
             "\nllama.cpp does not support running safetensor models, "
             "please use a/convert to the GGUF format using:\n"
             f"- https://huggingface.co/models?other=base_model:quantized:{repo_name} \n"

--- a/ramalama/model_store/snapshot_file.py
+++ b/ramalama/model_store/snapshot_file.py
@@ -2,7 +2,8 @@ import os
 from enum import IntEnum
 from typing import Dict
 
-from ramalama.common import download_file, generate_sha256
+from ramalama.common import generate_sha256
+from ramalama.http_client import download_file
 from ramalama.logger import logger
 
 

--- a/ramalama/oci.py
+++ b/ramalama/oci.py
@@ -311,12 +311,12 @@ RUN rm -rf /{model_name}-f16.gguf /models/{model_name}
         run_cmd(cmd_args, stdout=None)
 
     def _convert(self, source_model, args):
-        print(f"Converting {source_model.model_store.base_path} to {self.model_store.base_path} ...")
+        perror(f"Converting {source_model.model_store.base_path} to {self.model_store.base_path} ...")
         try:
             run_cmd([self.conman, "manifest", "rm", self.model], ignore_stderr=True, stdout=None)
         except subprocess.CalledProcessError:
             pass
-        print(f"Building {self.model} ...")
+        perror(f"Building {self.model} ...")
         imageid = self.build(source_model, args)
         try:
             self._create_manifest(self.model, imageid, args)
@@ -335,7 +335,7 @@ Tagging build instead"""
         target = self.model
         source = source_model.model
 
-        print(f"Pushing {self.model} ...")
+        perror(f"Pushing {self.model} ...")
         conman_args = [self.conman, "push"]
         if args.authfile:
             conman_args.extend([f"--authfile={args.authfile}"])
@@ -351,14 +351,15 @@ Tagging build instead"""
             raise e
 
     def pull(self, args):
-        if not args.quiet:
-            print(f"Downloading {self.model} ...")
         if not args.engine:
             raise NotImplementedError("OCI images require a container engine like Podman or Docker")
 
         conman_args = [args.engine, "pull"]
         if args.quiet:
             conman_args.extend(['--quiet'])
+        else:
+            # Write message to stderr
+            perror(f"Downloading {self.model} ...")
         if str(args.tlsverify).lower() == "false":
             conman_args.extend([f"--tls-verify={args.tlsverify}"])
         if args.authfile:

--- a/ramalama/ollama.py
+++ b/ramalama/ollama.py
@@ -3,7 +3,7 @@ import os
 import urllib.error
 from typing import Optional
 
-from ramalama.common import available
+from ramalama.common import available, perror
 from ramalama.model import Model
 from ramalama.model_store.snapshot_file import SnapshotFile, SnapshotFileType
 from ramalama.ollama_repo_utils import fetch_manifest_data
@@ -147,7 +147,7 @@ class Ollama(Model):
         hash, cached_files, all = self.model_store.get_cached_files(tag)
         if all:
             if not args.quiet:
-                print(f"Using cached ollama://{name}:{tag} ...")
+                perror(f"Using cached ollama://{name}:{tag} ...")
             return self.model_store.get_snapshot_file_path(hash, name)
 
         ollama_repo = OllamaRepository(self.model_store.model_name)
@@ -165,7 +165,7 @@ class Ollama(Model):
         # If a model has been downloaded via ollama cli, only create symlink in the snapshots directory
         if is_model_in_ollama_cache:
             if not args.quiet:
-                print(f"Using cached ollama://{name}{tag} ...")
+                perror(f"Using cached ollama://{name}{tag} ...")
             snapshot_model_path = self.model_store.get_snapshot_file_path(model_hash, self.model_store.model_name)
             os.symlink(ollama_cache_path, snapshot_model_path)
 

--- a/ramalama/ollama_repo_utils.py
+++ b/ramalama/ollama_repo_utils.py
@@ -93,7 +93,7 @@ def pull_blob(
         download_file(url, layer_blob_path, headers=headers, show_progress=show_progress)
         # Verify checksum after downloading the blob
         if not verify_checksum(layer_blob_path):
-            print(f"Checksum mismatch for blob {layer_blob_path}, retrying download ...")
+            perror(f"Checksum mismatch for blob {layer_blob_path}, retrying download ...")
             os.remove(layer_blob_path)
             download_file(url, layer_blob_path, headers=headers, show_progress=True)
             if not verify_checksum(layer_blob_path):

--- a/ramalama/ollama_repo_utils.py
+++ b/ramalama/ollama_repo_utils.py
@@ -2,7 +2,8 @@ import json
 import os
 import urllib.request
 
-from ramalama.common import download_file, run_cmd, verify_checksum
+from ramalama.common import perror, run_cmd, verify_checksum
+from ramalama.http_client import download_file
 from ramalama.logger import logger
 
 

--- a/ramalama/rag.py
+++ b/ramalama/rag.py
@@ -4,7 +4,7 @@ import subprocess
 import tempfile
 from urllib.parse import urlparse
 
-from ramalama.common import get_accel_env_vars, run_cmd, set_accel_env_vars
+from ramalama.common import get_accel_env_vars, perror, run_cmd, set_accel_env_vars
 from ramalama.engine import Engine
 from ramalama.logger import logger
 
@@ -21,10 +21,10 @@ class Rag:
         set_accel_env_vars()
 
     def build(self, source, target, args):
-        print(f"\nBuilding {target} ...")
+        perror(f"\nBuilding {target} ...")
         contextdir = os.path.dirname(source)
         src = os.path.basename(source)
-        print(f"adding {src} ...")
+        perror(f"adding {src} ...")
         cfile = f"""\
 FROM scratch
 COPY {src} /vector.db

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -514,7 +514,7 @@ class TestConfigIntegration:
             assert cfg.image == "test/image:latest"
 
     def test_config_empty_layers(self):
-        """Test behavior with empty configuration layers."""
+        """Test behaviour with empty configuration layers."""
         with patch("ramalama.config.load_file_config", return_value={}):
             cfg = default_config({})
 

--- a/test/unit/test_layered_config.py
+++ b/test/unit/test_layered_config.py
@@ -594,7 +594,7 @@ class TestLayeredMixin:
         assert config.is_set("settings") is False
 
     def test_layered_mixin_empty_layers(self):
-        """Test behavior with empty layers."""
+        """Test behaviour with empty layers."""
         layer1 = {}
         layer2 = {"name": "layer2"}
         layer3 = {}


### PR DESCRIPTION
## Summary by Sourcery

Ensure all progress and error messages are written to stderr and centralize download logic with retries, checksum verification, and HTTP error handling in HttpClient

New Features:
- Introduce download_file with retry logic and exponential backoff
- Add download_and_verify wrapper to verify checksums and retry on mismatch

Enhancements:
- Replace print calls with perror to redirect progress and error messages to stderr
- Relocate download utilities from common to http_client and define HTTP_NOT_FOUND/HTTP_RANGE_NOT_SATISFIABLE constants
- Automatically disable progress output when stdout is not a TTY
- Fix spelling in test docstrings