### PR TITLE
Hide --container option, having --container/--nocontainer is confusing

### DIFF
--- a/docs/ramalama.1.md
+++ b/docs/ramalama.1.md
@@ -108,10 +108,6 @@ $ cat /usr/share/ramalama/shortnames.conf
 
 ## GLOBAL OPTIONS
 
-#### **--container**
-run RamaLama in the default container. Default is `true` unless overridden in the ramalama.conf file.
-The environment variable "RAMALAMA_IN_CONTAINER=false" can also change the default.
-
 #### **--debug**
 print debug messages
 
@@ -126,10 +122,10 @@ The default can be overridden in the ramalama.conf file or via the RAMALAMA_CONT
 show this help message and exit
 
 #### **--nocontainer**
-Do not run RamaLama in the default container (default: False)
+Do not run RamaLama workloads in containers (default: False)
 The default can be overridden in the ramalama.conf file.
 
-Note: OCI images cannot be used with the --nocontainer option. This option disables the following features: GPU acceleration, containerized environment isolation, and dynamic resource allocation. For a complete list of affected features, please see the RamaLama documentation at [link-to-feature-list].
+Note: OCI images cannot be used with the --nocontainer option. This option disables the following features: Automatic GPU acceleration, containerized environment isolation, and dynamic resource allocation. For a complete list of affected features, please see the RamaLama documentation at [link-to-feature-list].
 
 #### **--quiet**
 Decrease output verbosity.

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -171,8 +171,7 @@ def configure_arguments(parser):
         dest="container",
         default=CONFIG.container,
         action="store_true",
-        help="""run RamaLama in the default container.
-The RAMALAMA_IN_CONTAINER environment variable modifies default behaviour.""",
+        help=argparse.SUPPRESS,
     )
     verbosity_group.add_argument(
         "--debug",
@@ -196,7 +195,7 @@ The RAMALAMA_CONTAINER_ENGINE environment variable modifies default behaviour.""
     parser.add_argument(
         "--nocontainer",
         dest="container",
-        default=CONFIG.nocontainer,
+        default=not CONFIG.container,
         action="store_false",
         help="""do not run RamaLama in the default container.
 The RAMALAMA_IN_CONTAINER environment variable modifies default behaviour.""",

--- a/ramalama/config.py
+++ b/ramalama/config.py
@@ -84,7 +84,6 @@ class BaseConfig:
     keep_groups: bool = False
     ngl: int = -1
     threads: int = -1
-    nocontainer: bool = False
     port: str = str(DEFAULT_PORT)
     pull: str = "newer"
     runtime: str = "llama.cpp"
@@ -179,7 +178,7 @@ def load_env_config(env: Mapping[str, str] | None = None) -> dict[str, Any]:
     if 'images' in config:
         config['images'] = json.loads(config['images'])
 
-    for key in ['ocr', 'nocontainer', 'keep_groups', 'container']:
+    for key in ['ocr', 'keep_groups', 'container']:
         if key in config:
             config[key] = coerce_to_bool(config[key])
 

--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -568,7 +568,7 @@ class Model(ModelBase):
             if not is_apple_silicon:
                 raise ValueError("MLX runtime is only supported on macOS with Apple Silicon.")
 
-        # If --container was specified return valid
+        # If --nocontainer=False was specified return valid
         if args.container:
             return
         if args.privileged:

--- a/test/system/015-help.bats
+++ b/test/system/015-help.bats
@@ -101,7 +101,7 @@ function check_help() {
     # Test for regression of #7273 (spurious "--remote" help on output)
     for helpopt in help --help -h; do
         run_ramalama $helpopt
-        is "${lines[0]}" "usage: ramalama [-h] [--container] [--debug] [--dryrun] [--engine ENGINE]" \
+        is "${lines[0]}" "usage: ramalama [-h] [--debug] [--dryrun] [--engine ENGINE] [--nocontainer]" \
            "ramalama $helpopt: first line of output"
     done
 
@@ -195,10 +195,10 @@ EOF
     skip_if_nocontainer
 
     run_ramalama --help
-    is "$output" ".*The RAMALAMA_IN_CONTAINER environment variable modifies default behaviour. (default: True)"  "Verify default container"
+    is "$output" ".*The RAMALAMA_IN_CONTAINER environment variable modifies default behaviour. (default: False)"  "Verify default container"
 
     RAMALAMA_IN_CONTAINER=false run_ramalama --help
-    is "$output" ".*The RAMALAMA_IN_CONTAINER environment variable modifies default behaviour. (default: False)"  "Verify default container with environment"
+    is "$output" ".*The RAMALAMA_IN_CONTAINER environment variable modifies default behaviour. (default: True)"  "Verify default container with environment"
 
     conf=$RAMALAMA_TMPDIR/ramalama.conf
     cat >$conf <<EOF
@@ -207,7 +207,7 @@ container=false
 EOF
 
     RAMALAMA_CONFIG=${conf} run_ramalama --help
-    is "$output" ".*The RAMALAMA_IN_CONTAINER environment variable modifies default behaviour. (default: False)"  "Verify default container override in ramalama.conf"
+    is "$output" ".*The RAMALAMA_IN_CONTAINER environment variable modifies default behaviour. (default: True)"  "Verify default container override in ramalama.conf"
 }
 
 @test "ramalama verify transport" {

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -21,7 +21,6 @@ def test_correct_config_defaults():
     assert cfg.keep_groups is False
     assert cfg.ngl == -1
     assert cfg.threads == -1
-    assert cfg.nocontainer is False
     assert cfg.port == str(DEFAULT_PORT)
     assert cfg.pull == "newer"
     assert cfg.runtime == "llama.cpp"
@@ -46,7 +45,6 @@ def test_config_defaults_not_set():
     assert cfg.is_set("keep_groups") is False
     assert cfg.is_set("ngl") is False
     assert cfg.is_set("threads") is False
-    assert cfg.is_set("nocontainer") is False
     assert cfg.is_set("port") is False
     assert cfg.is_set("pull") is False
     assert cfg.is_set("runtime") is False
@@ -531,7 +529,6 @@ class TestConfigIntegration:
             "RAMALAMA_NGL": "2",
             "RAMALAMA_CONTAINER": "true",
             "RAMALAMA_KEEP_GROUPS": "true",
-            "RAMALAMA_NOCONTAINER": "false",
             "RAMALAMA_OCR": "true",
             "RAMALAMA_USER__NO_MISSING_GPU_PROMPT": "true",
         }
@@ -544,7 +541,6 @@ class TestConfigIntegration:
             assert cfg.ngl == 2
             assert cfg.container is True
             assert cfg.keep_groups is True
-            assert cfg.nocontainer is False
             assert cfg.ocr is True
             assert cfg.user.no_missing_gpu_prompt is True
 


### PR DESCRIPTION
## Summary by Sourcery

Hide the --container flag from help and make --nocontainer the sole visible switch for container control, updating defaults and related references accordingly

Enhancements:
- Suppress the --container option in the CLI and expose only --nocontainer to avoid confusion
- Combine --container and --nocontainer into a mutually exclusive argument group

Documentation:
- Remove the --container entry from the manpage documentation

Tests:
- Update system tests to expect --nocontainer in usage and to verify toggled default behavior
- Adjust help output tests to reflect inverted default values based on RAMALAMA_IN_CONTAINER

Chores:
- Revise argument parsing comments and usage text in model validation to reference --nocontainer