### PR TITLE
WIP: konflux: run tests on multi-arch VMs

### DIFF
--- a/.tekton/bats/bats-pull-request.yaml
+++ b/.tekton/bats/bats-pull-request.yaml
@@ -28,8 +28,8 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
-    - linux/arm64
+    - linux-c4xlarge/amd64
+    - linux-c4xlarge/arm64
   - name: dockerfile
     value: container-images/bats/Containerfile
   pipelineRef:

--- a/.tekton/bats/bats-push.yaml
+++ b/.tekton/bats/bats-push.yaml
@@ -25,8 +25,8 @@ spec:
     value: quay.io/redhat-user-workloads/ramalama-tenant/bats:{{revision}}
   - name: build-platforms
     value:
-    - linux/x86_64
-    - linux/arm64
+    - linux-c4xlarge/amd64
+    - linux-c4xlarge/arm64
   - name: dockerfile
     value: container-images/bats/Containerfile
   pipelineRef:

--- a/.tekton/cuda-llama-server/cuda-llama-server-pull-request.yaml
+++ b/.tekton/cuda-llama-server/cuda-llama-server-pull-request.yaml
@@ -28,7 +28,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-c4xlarge/amd64
   - name: dockerfile
     value: container-images/common/Containerfile.entrypoint
   - name: parent-image

--- a/.tekton/cuda-llama-server/cuda-llama-server-push.yaml
+++ b/.tekton/cuda-llama-server/cuda-llama-server-push.yaml
@@ -25,7 +25,7 @@ spec:
     value: quay.io/redhat-user-workloads/ramalama-tenant/cuda-llama-server:{{revision}}
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-c4xlarge/amd64
   - name: dockerfile
     value: container-images/common/Containerfile.entrypoint
   - name: parent-image

--- a/.tekton/cuda-rag/cuda-rag-pull-request.yaml
+++ b/.tekton/cuda-rag/cuda-rag-pull-request.yaml
@@ -28,7 +28,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-c4xlarge/amd64
   - name: dockerfile
     value: container-images/common/Containerfile.rag
   - name: parent-image

--- a/.tekton/cuda-rag/cuda-rag-push.yaml
+++ b/.tekton/cuda-rag/cuda-rag-push.yaml
@@ -25,7 +25,7 @@ spec:
     value: quay.io/redhat-user-workloads/ramalama-tenant/cuda-rag:{{revision}}
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-c4xlarge/amd64
   - name: dockerfile
     value: container-images/common/Containerfile.rag
   - name: parent-image

--- a/.tekton/cuda-whisper-server/cuda-whisper-server-pull-request.yaml
+++ b/.tekton/cuda-whisper-server/cuda-whisper-server-pull-request.yaml
@@ -28,7 +28,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-c4xlarge/amd64
   - name: dockerfile
     value: container-images/common/Containerfile.entrypoint
   - name: parent-image

--- a/.tekton/cuda-whisper-server/cuda-whisper-server-push.yaml
+++ b/.tekton/cuda-whisper-server/cuda-whisper-server-push.yaml
@@ -25,7 +25,7 @@ spec:
     value: quay.io/redhat-user-workloads/ramalama-tenant/cuda-whisper-server:{{revision}}
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-c4xlarge/amd64
   - name: dockerfile
     value: container-images/common/Containerfile.entrypoint
   - name: parent-image

--- a/.tekton/cuda/cuda-pull-request.yaml
+++ b/.tekton/cuda/cuda-pull-request.yaml
@@ -28,7 +28,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-c4xlarge/amd64
   - name: dockerfile
     value: container-images/cuda/Containerfile
   pipelineRef:

--- a/.tekton/cuda/cuda-push.yaml
+++ b/.tekton/cuda/cuda-push.yaml
@@ -25,7 +25,7 @@ spec:
     value: quay.io/redhat-user-workloads/ramalama-tenant/cuda:{{revision}}
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-c4xlarge/amd64
   - name: dockerfile
     value: container-images/cuda/Containerfile
   pipelineRef:

--- a/.tekton/integration/pipelines/bats-integration.yaml
+++ b/.tekton/integration/pipelines/bats-integration.yaml
@@ -1,0 +1,78 @@
+kind: Pipeline
+apiVersion: tekton.dev/v1
+metadata:
+  name: bats-integration
+spec:
+  description: |
+    Test the newly-built ramalama image and layered images on all supported architectures.
+  params:
+  - name: SNAPSHOT
+    description: >-
+      Information about the components included in the current snapshot under test.
+  - name: git-url
+    description: URL of the Git repository containing pipeline and task definitions
+    default: https://github.com/containers/ramalama
+  - name: git-revision
+    description: Revision of the Git repository containing pipeline and task definitions
+    default: main
+  tasks:
+  - name: init
+    params:
+    - name: SNAPSHOT
+      value: $(params.SNAPSHOT)
+    taskSpec:
+      params:
+      - name: SNAPSHOT
+      results:
+      - name: TEST_OUTPUT
+        description: Task result in json format
+      - name: bats-image
+        description: URI of the bats image included in the snapshot
+      - name: ramalama-image
+        description: URI of the ramalama image included in the snapshot
+      steps:
+      - name: process
+        image: registry.access.redhat.com/ubi10/ubi:latest
+        env:
+        - name: SNAPSHOT
+          value: $(params.SNAPSHOT)
+        - name: RESULTS_TEST_OUTPUT_PATH
+          value: $(results.TEST_OUTPUT.path)
+        - name: RESULTS_BATS_IMAGE_PATH
+          value: $(results.bats-image.path)
+        - name: RESULTS_RAMALAMA_IMAGE_PATH
+          value: $(results.ramalama-image.path)
+        script: |
+          #!/bin/bash -ex
+          dnf -y install jq
+          jq -j '.components[] | select(.name == "bats") | .containerImage' <<< "$SNAPSHOT" | tee $RESULTS_BATS_IMAGE_PATH
+          jq -j '.components[] | select(.name == "ramalama") | .containerImage' <<< "$SNAPSHOT" | tee $RESULTS_RAMALAMA_IMAGE_PATH
+          jq -jnc '{result: "SUCCESS", timestamp: now | todateiso8601, failures: 0, successes: 2, warnings: 0}' | tee $RESULTS_TEST_OUTPUT_PATH
+  - name: test
+    matrix:
+      params:
+      - name: PLATFORM
+        value:
+        - linux-c4xlarge/amd64
+        - linux-c4xlarge/arm64
+    params:
+    - name: image
+      value: $(tasks.init.results.bats-image)
+    - name: git-url
+      value: $(params.git-url)
+    - name: git-revision
+      value: $(params.git-revision)
+    - name: cmd
+      value: make bats
+    - name: envs
+      value:
+      - RAMALAMA_IMAGE=$(task.init.results.ramalama-image)
+    taskRef:
+      resolver: git
+      params:
+      - name: url
+        value: $(params.git-url)
+      - name: revision
+        value: $(params.git-revision)
+      - name: pathInRepo
+        value: .tekton/integration/tasks/test-vm-cmd.yaml

--- a/.tekton/integration/tasks/test-vm-cmd.yaml
+++ b/.tekton/integration/tasks/test-vm-cmd.yaml
@@ -1,0 +1,120 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: test-vm-cmd
+spec:
+  description: Run a command in a test VM.
+  params:
+  - name: PLATFORM
+    description: The platform of the VM to provision.
+  - name: image
+    description: The image to use when setting up the test environment.
+  - name: git-url
+    description: The URL of the source code repository.
+  - name: git-revision
+    description: The revision of the source code to test.
+  - name: cmd
+    description: The command to run.
+  - name: envs
+    description: List of environment variables (NAME=VALUE) to be set in the test environment.
+    type: array
+    default: []
+  volumes:
+  - name: workdir
+    emptyDir: {}
+  - name: ssh
+    secret:
+      secretName: multi-platform-ssh-$(context.taskRun.name)
+  steps:
+  - name: run-in-vm
+    image: registry.access.redhat.com/ubi10/ubi:latest
+    volumeMounts:
+    - mountPath: /var/workdir
+      name: workdir
+    - mountPath: /ssh
+      name: ssh
+    workingDir: /var/workdir
+    env:
+    - name: GIT_URL
+      value: $(params.git-url)
+    - name: GIT_REVISION
+      value: $(params.git-revision)
+    - name: TEST_IMAGE
+      value: $(params.image)
+    - name: TEST_CMD
+      value: $(params.cmd)
+    args:
+    - $(params.envs[*])
+    script: |
+      #!/bin/bash -ex
+      echo "[$(date -uIns)] Install packages"
+      dnf -y install openssh-clients rsync git-core
+
+      echo "[$(date -uIns)] Clone source"
+      git clone -n "$GIT_URL" source
+      pushd source
+      git checkout "$GIT_REVISION"
+      popd
+
+      echo "[$(date -uIns)] Prepare connection"
+
+      if [ -e "/ssh/error" ]; then
+        echo "Error provisioning VM"
+        cat /ssh/error
+        exit 1
+      fi
+      export SSH_HOST=$(cat /ssh/host)
+
+      mkdir -p ~/.ssh
+      if [ "$SSH_HOST" == "localhost" ] ; then
+        IS_LOCALHOST=true
+        echo "Localhost detected; running build in cluster"
+      elif [ -s "/ssh/otp" ]; then
+        echo "Fetching OTP token"
+        curl --cacert /ssh/otp-ca -d @/ssh/otp $(cat /ssh/otp-server) > ~/.ssh/id_rsa
+        echo "" >> ~/.ssh/id_rsa
+        chmod 0400 ~/.ssh/id_rsa
+      elif [ -s "/ssh/id_rsa" ]; then
+        echo "Copying ssh key"
+        cp /ssh/id_rsa ~/.ssh
+        chmod 0400 ~/.ssh/id_rsa
+      else
+        echo "No authentication mechanism found"
+        exit 1
+      fi
+
+      mkdir -p scripts
+
+      PODMAN_ENV=()
+      while [ $# -ne 0 ]; do
+        PODMAN_ENV+=("-e" "$1")
+        shift
+      done
+
+      cat > scripts/test.sh <<SCRIPTEOF
+      #!/bin/bash -ex
+      podman run \
+      --userns=keep-id \
+      --security-opt label=disable \
+      --security-opt unmask=/proc/* \
+      --device /dev/net/tun \
+      -v \$PWD/source:/src \
+      ${PODMAN_ENV[*]} \
+      $TEST_IMAGE $TEST_CMD
+      SCRIPTEOF
+      chmod +x scripts/test.sh
+
+      if ! [[ $IS_LOCALHOST ]]; then
+        echo "[$(date -uIns)] VM exec"
+        export BUILD_DIR=$(cat /ssh/user-dir)
+        export SSH_ARGS="-o StrictHostKeyChecking=no -o ServerAliveInterval=60 -o ServerAliveCountMax=10"
+        # ssh once before rsync to retrieve the host key
+        ssh $SSH_ARGS "$SSH_HOST" "cat /proc/cpuinfo /proc/meminfo"
+        rsync -ra scripts source "$SSH_HOST:$BUILD_DIR"
+        ssh $SSH_ARGS "$SSH_HOST" "$BUILD_DIR/scripts/test.sh"
+        echo "[$(date -uIns)] End VM exec"
+      else
+        echo "[$(date -uIns)] Local exec"
+        scripts/test.sh
+        echo "[$(date -uIns)] End local exec"
+      fi

--- a/.tekton/pipelines/pull-request-pipeline.yaml
+++ b/.tekton/pipelines/pull-request-pipeline.yaml
@@ -71,7 +71,7 @@ spec:
     name: privileged-nested
     type: string
   - default:
-    - linux/x86_64
+    - linux-c4xlarge/amd64
     description: List of platforms to build the container images on. The available
       set of values is determined by the configuration of the multi-platform-controller.
     name: build-platforms

--- a/.tekton/pipelines/push-pipeline.yaml
+++ b/.tekton/pipelines/push-pipeline.yaml
@@ -71,7 +71,7 @@ spec:
     name: privileged-nested
     type: string
   - default:
-    - linux/x86_64
+    - linux-c4xlarge/amd64
     description: List of platforms to build the container images on. The available
       set of values is determined by the configuration of the multi-platform-controller.
     name: build-platforms

--- a/.tekton/ramalama-llama-server/ramalama-llama-server-pull-request.yaml
+++ b/.tekton/ramalama-llama-server/ramalama-llama-server-pull-request.yaml
@@ -28,7 +28,8 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-c4xlarge/amd64
+    - linux-c4xlarge/arm64
   - name: dockerfile
     value: container-images/common/Containerfile.entrypoint
   - name: parent-image

--- a/.tekton/ramalama-llama-server/ramalama-llama-server-push.yaml
+++ b/.tekton/ramalama-llama-server/ramalama-llama-server-push.yaml
@@ -25,7 +25,8 @@ spec:
     value: quay.io/redhat-user-workloads/ramalama-tenant/ramalama-llama-server:{{revision}}
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-c4xlarge/amd64
+    - linux-c4xlarge/arm64
   - name: dockerfile
     value: container-images/common/Containerfile.entrypoint
   - name: parent-image

--- a/.tekton/ramalama-rag/ramalama-rag-pull-request.yaml
+++ b/.tekton/ramalama-rag/ramalama-rag-pull-request.yaml
@@ -28,7 +28,8 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-c4xlarge/amd64
+    - linux-c4xlarge/arm64
   - name: dockerfile
     value: container-images/common/Containerfile.rag
   - name: parent-image

--- a/.tekton/ramalama-rag/ramalama-rag-push.yaml
+++ b/.tekton/ramalama-rag/ramalama-rag-push.yaml
@@ -25,7 +25,8 @@ spec:
     value: quay.io/redhat-user-workloads/ramalama-tenant/ramalama-rag:{{revision}}
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-c4xlarge/amd64
+    - linux-c4xlarge/arm64
   - name: dockerfile
     value: container-images/common/Containerfile.rag
   - name: parent-image

--- a/.tekton/ramalama-whisper-server/ramalama-whisper-server-pull-request.yaml
+++ b/.tekton/ramalama-whisper-server/ramalama-whisper-server-pull-request.yaml
@@ -28,7 +28,8 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-c4xlarge/amd64
+    - linux-c4xlarge/arm64
   - name: dockerfile
     value: container-images/common/Containerfile.entrypoint
   - name: parent-image

--- a/.tekton/ramalama-whisper-server/ramalama-whisper-server-push.yaml
+++ b/.tekton/ramalama-whisper-server/ramalama-whisper-server-push.yaml
@@ -25,7 +25,8 @@ spec:
     value: quay.io/redhat-user-workloads/ramalama-tenant/ramalama-whisper-server:{{revision}}
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-c4xlarge/amd64
+    - linux-c4xlarge/arm64
   - name: dockerfile
     value: container-images/common/Containerfile.entrypoint
   - name: parent-image

--- a/.tekton/ramalama/ramalama-pull-request.yaml
+++ b/.tekton/ramalama/ramalama-pull-request.yaml
@@ -28,8 +28,8 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
-    - linux/arm64
+    - linux-c4xlarge/amd64
+    - linux-c4xlarge/arm64
   - name: dockerfile
     value: container-images/ramalama/Containerfile
   - name: test-image

--- a/.tekton/ramalama/ramalama-push.yaml
+++ b/.tekton/ramalama/ramalama-push.yaml
@@ -25,8 +25,8 @@ spec:
     value: quay.io/redhat-user-workloads/ramalama-tenant/ramalama:{{revision}}
   - name: build-platforms
     value:
-    - linux/x86_64
-    - linux/arm64
+    - linux-c4xlarge/amd64
+    - linux-c4xlarge/arm64
   - name: dockerfile
     value: container-images/ramalama/Containerfile
   - name: test-image

--- a/.tekton/rocm-llama-server/rocm-llama-server-pull-request.yaml
+++ b/.tekton/rocm-llama-server/rocm-llama-server-pull-request.yaml
@@ -28,7 +28,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-c4xlarge/amd64
   - name: dockerfile
     value: container-images/common/Containerfile.entrypoint
   - name: parent-image

--- a/.tekton/rocm-llama-server/rocm-llama-server-push.yaml
+++ b/.tekton/rocm-llama-server/rocm-llama-server-push.yaml
@@ -25,7 +25,7 @@ spec:
     value: quay.io/redhat-user-workloads/ramalama-tenant/rocm-llama-server:{{revision}}
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-c4xlarge/amd64
   - name: dockerfile
     value: container-images/common/Containerfile.entrypoint
   - name: parent-image

--- a/.tekton/rocm-rag/rocm-rag-pull-request.yaml
+++ b/.tekton/rocm-rag/rocm-rag-pull-request.yaml
@@ -28,7 +28,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-c4xlarge/amd64
   - name: dockerfile
     value: container-images/common/Containerfile.rag
   - name: parent-image

--- a/.tekton/rocm-rag/rocm-rag-push.yaml
+++ b/.tekton/rocm-rag/rocm-rag-push.yaml
@@ -25,7 +25,7 @@ spec:
     value: quay.io/redhat-user-workloads/ramalama-tenant/rocm-rag:{{revision}}
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-c4xlarge/amd64
   - name: dockerfile
     value: container-images/common/Containerfile.rag
   - name: parent-image

--- a/.tekton/rocm-ubi-llama-server/rocm-ubi-llama-server-pull-request.yaml
+++ b/.tekton/rocm-ubi-llama-server/rocm-ubi-llama-server-pull-request.yaml
@@ -28,7 +28,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-c4xlarge/amd64
   - name: dockerfile
     value: container-images/common/Containerfile.entrypoint
   - name: parent-image

--- a/.tekton/rocm-ubi-llama-server/rocm-ubi-llama-server-push.yaml
+++ b/.tekton/rocm-ubi-llama-server/rocm-ubi-llama-server-push.yaml
@@ -25,7 +25,7 @@ spec:
     value: quay.io/redhat-user-workloads/ramalama-tenant/rocm-ubi-llama-server:{{revision}}
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-c4xlarge/amd64
   - name: dockerfile
     value: container-images/common/Containerfile.entrypoint
   - name: parent-image

--- a/.tekton/rocm-ubi-rag/rocm-ubi-rag-pull-request.yaml
+++ b/.tekton/rocm-ubi-rag/rocm-ubi-rag-pull-request.yaml
@@ -28,7 +28,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-c4xlarge/amd64
   - name: dockerfile
     value: container-images/common/Containerfile.rag
   - name: parent-image

--- a/.tekton/rocm-ubi-rag/rocm-ubi-rag-push.yaml
+++ b/.tekton/rocm-ubi-rag/rocm-ubi-rag-push.yaml
@@ -25,7 +25,7 @@ spec:
     value: quay.io/redhat-user-workloads/ramalama-tenant/rocm-ubi-rag:{{revision}}
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-c4xlarge/amd64
   - name: dockerfile
     value: container-images/common/Containerfile.rag
   - name: parent-image

--- a/.tekton/rocm-ubi-whisper-server/rocm-ubi-whisper-server-pull-request.yaml
+++ b/.tekton/rocm-ubi-whisper-server/rocm-ubi-whisper-server-pull-request.yaml
@@ -28,7 +28,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-c4xlarge/amd64
   - name: dockerfile
     value: container-images/common/Containerfile.entrypoint
   - name: parent-image

--- a/.tekton/rocm-ubi-whisper-server/rocm-ubi-whisper-server-push.yaml
+++ b/.tekton/rocm-ubi-whisper-server/rocm-ubi-whisper-server-push.yaml
@@ -25,7 +25,7 @@ spec:
     value: quay.io/redhat-user-workloads/ramalama-tenant/rocm-ubi-whisper-server:{{revision}}
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-c4xlarge/amd64
   - name: dockerfile
     value: container-images/common/Containerfile.entrypoint
   - name: parent-image

--- a/.tekton/rocm-ubi/rocm-ubi-pull-request.yaml
+++ b/.tekton/rocm-ubi/rocm-ubi-pull-request.yaml
@@ -28,7 +28,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-c4xlarge/amd64
   - name: dockerfile
     value: container-images/rocm-ubi/Containerfile
   pipelineRef:

--- a/.tekton/rocm-ubi/rocm-ubi-push.yaml
+++ b/.tekton/rocm-ubi/rocm-ubi-push.yaml
@@ -25,7 +25,7 @@ spec:
     value: quay.io/redhat-user-workloads/ramalama-tenant/rocm-ubi:{{revision}}
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-c4xlarge/amd64
   - name: dockerfile
     value: container-images/rocm-ubi/Containerfile
   pipelineRef:

--- a/.tekton/rocm-whisper-server/rocm-whisper-server-pull-request.yaml
+++ b/.tekton/rocm-whisper-server/rocm-whisper-server-pull-request.yaml
@@ -28,7 +28,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-c4xlarge/amd64
   - name: dockerfile
     value: container-images/common/Containerfile.entrypoint
   - name: parent-image

--- a/.tekton/rocm-whisper-server/rocm-whisper-server-push.yaml
+++ b/.tekton/rocm-whisper-server/rocm-whisper-server-push.yaml
@@ -25,7 +25,7 @@ spec:
     value: quay.io/redhat-user-workloads/ramalama-tenant/rocm-whisper-server:{{revision}}
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-c4xlarge/amd64
   - name: dockerfile
     value: container-images/common/Containerfile.entrypoint
   - name: parent-image

--- a/.tekton/rocm/rocm-pull-request.yaml
+++ b/.tekton/rocm/rocm-pull-request.yaml
@@ -28,7 +28,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-c4xlarge/amd64
   - name: dockerfile
     value: container-images/rocm/Containerfile
   pipelineRef:

--- a/.tekton/rocm/rocm-push.yaml
+++ b/.tekton/rocm/rocm-push.yaml
@@ -25,7 +25,7 @@ spec:
     value: quay.io/redhat-user-workloads/ramalama-tenant/rocm:{{revision}}
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-c4xlarge/amd64
   - name: dockerfile
     value: container-images/rocm/Containerfile
   pipelineRef:

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ DESTDIR ?= /
 PATH := $(PATH):$(HOME)/.local/bin
 IMAGE ?= ramalama
 PROJECT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
-PYTHON_SCRIPTS := $(shell grep -lEr "^\#\!\s*/usr/bin/(env +)?python(3)?(\s|$$)" --exclude-dir={.venv,venv} $(PROJECT_DIR) || true)
+PYTHON_SCRIPTS := $(shell grep -lEr "^#!\s*/usr/bin/(env +)?python(3)?(\s|$$)" --exclude-dir={.venv,venv} $(PROJECT_DIR) || true)
 PYTEST_COMMON_CMD ?= PYTHONPATH=. pytest test/unit/ -vv
 BATS_IMAGE ?= localhost/bats:latest
 

--- a/test/system/015-help.bats
+++ b/test/system/015-help.bats
@@ -109,6 +109,7 @@ function check_help() {
 
 @test "ramalama verify default image" {
 
+    unset RAMALAMA_IMAGE
     run_ramalama run --help
     is "$output" ".*image IMAGE.*OCI container image to run with the specified AI model"  "Verify default image"
     is "$output" ".*default: quay.io/ramalama/.*"  "Verify default image"

--- a/test/system/060-info.bats
+++ b/test/system/060-info.bats
@@ -18,6 +18,7 @@ load helpers
     run_ramalama -q version
     is "$output" "$version"
 
+    unset RAMALAMA_IMAGE
     run_ramalama info
 
     # FIXME Engine  (podman|docker|'')


### PR DESCRIPTION
All Tekton tasks in Konflux are run on the host cluster, which is x86_64 by default. To run tests on other arches you need to request a VM from the [multi-platform controller](https://github.com/konflux-ci/multi-platform-controller), connect to that VM from your Tekton task, and execute your code on the VM.

Root access is not available (by default) on the VMs, so the tests are run in podman, passing appropriate command-line args so that code running in podman has the access it needs (including running additional containers using rootless podman-in-podman).

## Summary by Sourcery

Enable multi-architecture VM-based testing in Tekton pipelines by provisioning remote VMs and executing tests in podman.

New Features:
- Add vm-test-platforms and vm-test-commands parameters to pull-request and push pipelines to drive a VM test matrix.
- Introduce a new run-vm-tests pipeline step that iterates over platforms and commands to invoke the test-vm-cmd task.
- Provide a test-vm-cmd Tekton Task that provisions a VM via SSH, syncs sources, and runs tests inside podman on the VM.
- Configure the ramalama pipelines with default VM platforms (amd64, arm64) and test command for bats.