### PR TITLE
Bugfix for chat

### DIFF
--- a/ramalama/chat.py
+++ b/ramalama/chat.py
@@ -132,8 +132,9 @@ class RamaLamaShell(cmd.Cmd):
             "stream": True,
             "messages": self.conversation_history,
         }
-        if not (hasattr(self.args, 'runtime') and self.args.runtime == "mlx"):
-            data["model"] = self.args.MODEL
+        if getattr(self.args, "model", False):
+            data["model"] = self.args.model
+
         json_data = json.dumps(data).encode("utf-8")
         headers = {
             "Content-Type": "application/json",


### PR DESCRIPTION
This was recently removed:

+            if getattr(self.args, "model", False):
+                data["model"] = self.args.model

it is required

## Summary by Sourcery

Restore conditional addition of the `model` field in chat request payloads based on the presence of the `--model` argument.

Bug Fixes:
- Reintroduce the model field in request data only when `self.args.model` is set instead of always using `self.args.MODEL`.

Enhancements:
- Switch to using `getattr(self.args, "model", False)` for safe attribute access.