### PR TITLE
chore: bump ramalama-stack to 0.2.5

### DIFF
--- a/container-images/llama-stack/Containerfile
+++ b/container-images/llama-stack/Containerfile
@@ -1,6 +1,6 @@
 FROM quay.io/fedora/fedora:42
 
-ARG RAMALAMA_STACK_VERSION=0.2.4
+ARG RAMALAMA_STACK_VERSION=0.2.5
 
 # hack that should be removed when the following bug is addressed
 # https://github.com/containers/ramalama-stack/issues/53


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Update Containerfile ARG RAMALAMA_STACK_VERSION from 0.2.4 to 0.2.5