### PR TITLE
Bug/chat fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ __pycache__/
 coverage.*
 htmlcov/
 .idea/
+.hypothesis/
+uv.lock

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dev = [
     "codespell~=2.0",
     "flake8~=7.0",
     "huggingface_hub~=0.33.0",
+    "hypothesis>=6.135.26",
     "isort~=6.0",
     "pytest~=8.3",
     "wheel~=0.45.0",

--- a/ramalama/arg_types.py
+++ b/ramalama/arg_types.py
@@ -1,20 +1,27 @@
-from dataclasses import dataclass
-from typing import Protocol
+from dataclasses import make_dataclass
+from typing import List, Protocol, get_type_hints
 
-from ramalama.config import SUPPORTED_ENGINES
+from ramalama.config import COLOR_OPTIONS, SUPPORTED_ENGINES, SUPPORTED_RUNTIMES, PathStr
+
+
+def protocol_to_dataclass(proto_cls):
+    hints = get_type_hints(proto_cls)
+    fields = [(name, typ) for name, typ in hints.items()]
+    return make_dataclass(f"{proto_cls.__name__}DC", fields)
 
 
 class EngineArgType(Protocol):
     engine: SUPPORTED_ENGINES | None
 
 
-@dataclass
-class EngineArgs(EngineArgType):
-    engine: SUPPORTED_ENGINES | None
+EngineArgs = protocol_to_dataclass(EngineArgType)
 
 
 class ContainerArgType(Protocol):
     container: bool | None
+
+
+ContainerArgs = protocol_to_dataclass(ContainerArgType)
 
 
 class StoreArgType(Protocol):
@@ -23,8 +30,36 @@ class StoreArgType(Protocol):
     store: str
 
 
-@dataclass
-class StoreArgs(StoreArgType):
-    engine: SUPPORTED_ENGINES | None
+StoreArgs = protocol_to_dataclass(StoreArgType)
+
+
+class DefaultArgsType(Protocol):
     container: bool
-    store: str
+    runtime: SUPPORTED_RUNTIMES
+    store: PathStr
+    debug: bool
+    quiet: bool
+    dryrun: bool
+    engine: SUPPORTED_ENGINES
+    noout: bool | None
+
+
+DefaultArgs = protocol_to_dataclass(DefaultArgsType)
+
+
+class ChatSubArgsType(Protocol):
+    prefix: str
+    url: str
+    color: COLOR_OPTIONS
+    list: bool
+    model: str | None
+    rag: str | None
+    api_key: str | None
+    ARGS: List[str] | None
+
+
+ChatSubArgs = protocol_to_dataclass(ChatSubArgsType)
+
+
+class ChatArgsType(DefaultArgsType, ChatSubArgsType):
+    pass

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -8,6 +8,9 @@ import sys
 import urllib.error
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import get_args
+
+from ramalama.config import COLOR_OPTIONS, SUPPORTED_RUNTIMES
 
 # if autocomplete doesn't exist, just do nothing, don't break
 try:
@@ -121,11 +124,16 @@ class ArgumentParserWithDefaults(argparse.ArgumentParser):
         return action
 
 
-def init_cli():
-    """Initialize the RamaLama CLI and parse command line arguments."""
+def get_parser():
     description = get_description()
     parser = create_argument_parser(description)
     configure_subcommands(parser)
+    return parser
+
+
+def init_cli():
+    """Initialize the RamaLama CLI and parse command line arguments."""
+    parser = get_parser()
     args = parse_arguments(parser)
     post_parse_setup(args)
     return parser, args
@@ -209,7 +217,7 @@ The RAMALAMA_IN_CONTAINER environment variable modifies default behaviour.""",
     parser.add_argument(
         "--runtime",
         default=CONFIG.runtime,
-        choices=["llama.cpp", "vllm", "mlx"],
+        choices=get_args(SUPPORTED_RUNTIMES),
         help="specify the runtime to use; valid options are 'llama.cpp', 'vllm', and 'mlx'",
     )
     parser.add_argument(
@@ -256,11 +264,18 @@ def parse_arguments(parser):
 
 def post_parse_setup(args):
     """Perform additional setup after parsing arguments."""
-    if getattr(args, "MODEL", None) and args.subcommand != "rm":
-        resolved_model = shortnames.resolve(args.MODEL)
-        if resolved_model:
-            args.UNRESOLVED_MODEL = args.MODEL
-            args.MODEL = resolved_model
+    if getattr(args, "MODEL", None):
+        if args.subcommand != "rm":
+            resolved_model = shortnames.resolve(args.MODEL)
+            if resolved_model:
+                args.UNRESOLVED_MODEL = args.MODEL
+                args.MODEL = resolved_model
+
+        # TODO: This is a hack. Once we have more typing in place these special cases
+        # _should_ be removed.
+        if not hasattr(args, "model"):
+            args.model = args.MODEL
+
     if hasattr(args, "runtime_args"):
         args.runtime_args = shlex.split(args.runtime_args)
 
@@ -914,7 +929,7 @@ def chat_parser(subparsers):
         '--color',
         '--colour',
         default="auto",
-        choices=['never', 'always', 'auto'],
+        choices=get_args(COLOR_OPTIONS),
         help='possible values are "never", "always" and "auto".',
     )
     parser.add_argument(
@@ -940,7 +955,7 @@ def run_parser(subparsers):
         '--color',
         '--colour',
         default="auto",
-        choices=['never', 'always', 'auto'],
+        choices=get_args(COLOR_OPTIONS),
         help='possible values are "never", "always" and "auto".',
     )
     parser.add_argument("--prefix", type=str, help="prefix for the user prompt", default=default_prefix())

--- a/ramalama/config.py
+++ b/ramalama/config.py
@@ -9,10 +9,13 @@ from ramalama.common import available
 from ramalama.layered_config import LayeredMixin, deep_merge
 from ramalama.toml_parser import TOMLParser
 
+PathStr = str
 DEFAULT_PORT_RANGE: tuple[int, int] = (8080, 8090)
 DEFAULT_PORT: int = DEFAULT_PORT_RANGE[0]
 DEFAULT_IMAGE = "quay.io/ramalama/ramalama"
-SUPPORTED_ENGINES = Literal["podman", "docker"] | os.PathLike[str]
+SUPPORTED_ENGINES = Literal["podman", "docker"] | PathStr
+SUPPORTED_RUNTIMES = Literal["llama.cpp", "vllm", "mlx"]
+COLOR_OPTIONS = Literal["auto", "always", "never"]
 
 
 def get_default_engine() -> SUPPORTED_ENGINES | None:
@@ -87,7 +90,7 @@ class BaseConfig:
     port: str = str(DEFAULT_PORT)
     pull: str = "newer"
     rag_format: Literal["qdrant", "json", "markdown"] = "qdrant"
-    runtime: str = "llama.cpp"
+    runtime: SUPPORTED_RUNTIMES = "llama.cpp"
     store: str = field(default_factory=get_default_store)
     temp: str = "0.8"
     transport: str = "ollama"

--- a/test/unit/test_cli_args.py
+++ b/test/unit/test_cli_args.py
@@ -1,0 +1,124 @@
+import sys
+from dataclasses import fields
+from typing import get_args
+from unittest.mock import MagicMock
+
+import pytest
+
+from ramalama.arg_types import ChatSubArgs, DefaultArgs
+from ramalama.cli import get_parser
+from ramalama.config import SUPPORTED_ENGINES
+
+try:
+    from hypothesis import given
+    from hypothesis import strategies as st
+
+    HAS_HYPOTHESIS = True
+
+    def shell_quoted_string_with_escaping():
+        """
+        Cli arguments can't be empty so we set the min_size to 1.
+        Additionally we quote all string arguments to avoid special character issues.
+        """
+        base = st.text(min_size=1)
+
+        def quote(s):
+            if "'" not in s:
+                return f"'{s}'"
+            else:
+                return s.replace('"', '\\"')
+
+        return base.map(quote)
+
+    st.register_type_strategy(str, shell_quoted_string_with_escaping())
+except ImportError:
+    HAS_HYPOTHESIS = False
+    hypothesis = MagicMock()
+    sys.modules["hypothesis"] = hypothesis
+    hypothesis.given = lambda *x, **y: lambda *z: z
+    hypothesis.strategies = MagicMock()
+    hypothesis.strategies.sampled_from = lambda *x, **y: x
+    hypothesis.strategies.just = lambda *x, **y: x
+    hypothesis.strategies.text = lambda *x, **y: x
+    hypothesis.strategies.builds = lambda *x, **y: x
+    hypothesis.strategies.register_type_strategy = lambda *x, **y: x
+
+    from hypothesis import given
+    from hypothesis import strategies as st
+
+
+parser = get_parser()
+
+special_cases = {
+    "api_key": "api-key",
+}
+
+
+def args_to_cli_args(args_obj, subcommand: str | None, special_cases: dict | None = None) -> list:
+    """
+    Convert a dataclass instance to CLI arguments for argparse.
+    - subcommand: the CLI subcommand (e.g., 'chat')
+    - special_cases: dict mapping attribute names to CLI flag names (e.g., {'api_key': 'api-key'})
+    """
+    if special_cases is None:
+        special_cases = {}
+
+    cli_args = []
+    if subcommand is not None:
+        cli_args.append(subcommand)
+
+    for f in fields(args_obj):
+        if (value := getattr(args_obj, f.name)) is None:
+            continue
+
+        # Determine CLI flag name
+        flag = f"--{special_cases.get(f.name, f.name)}"
+
+        # Handle booleans as flags
+        if f.type is bool or (getattr(f.type, '__origin__', None) is type(None) and isinstance(value, bool)):
+            if value:
+                cli_args.append(flag)
+            continue
+
+        # TODO: Handle list as positional arguments. This is hacky, maybe introspect the parser for nargs?
+        if isinstance(value, list):
+            cli_args.extend(value)
+            continue
+
+        # Otherwise, add as --flag value
+        cli_args.extend([flag, str(value)])
+
+    return cli_args
+
+
+@pytest.mark.skipif(not HAS_HYPOTHESIS, reason="Hypothesis is not installed")
+@given(
+    st.builds(
+        DefaultArgs,
+        engine=st.sampled_from(get_args(get_args(SUPPORTED_ENGINES)[0])),
+        store=st.sampled_from(['/', '/tmp']),
+        debug=st.just(False),
+        quiet=st.just(False),
+    )
+)
+def test_default_endpoint(chatargs):
+    cli_args = args_to_cli_args(chatargs, None, special_cases)
+    args = parser.parse_args(cli_args)
+
+    for field in DefaultArgs.__dataclass_fields__:
+        assert hasattr(args, field), f"Missing attribute: {field}"
+
+
+@pytest.mark.skipif(not HAS_HYPOTHESIS, reason="Hypothesis is not installed")
+@given(
+    st.builds(
+        ChatSubArgs,
+        url=st.sampled_from(['https://test.com', 'test.com']),
+    )
+)
+def test_chat_endpoint(chatargs):
+    cli_args = args_to_cli_args(chatargs, 'chat', special_cases)
+    args = parser.parse_args(cli_args)
+
+    for field in ChatSubArgs.__dataclass_fields__:
+        assert hasattr(args, field), f"Missing attribute: {field}"


### PR DESCRIPTION
It looks like a basic chat fix #1679 was already merged but this PR was created in response to the same bug. I've additionally included formal typing on the chat path to prevent such issues in the future, added a mechanism to validate protocol definitions, and proposed a path forwards to obviate the need for on the fly modification of the initial user args.

## Summary by Sourcery

Enforce formal typing for CLI arguments by generating dataclasses from Protocols, strengthen chat commands with typed arguments and operational parameters, refactor the CLI parser to use dynamic enums for choices, validate protocol definitions, update configuration types, add property-based tests for CLI args, and clean up deprecated scripts.

New Features:
- Add protocol_to_dataclass helper to convert Protocol definitions into runtime dataclasses for CLI argument typing
- Introduce ChatOperationalArgs dataclass to encapsulate chat shell operational parameters
- Extend configuration with SUPPORTED_RUNTIMES and COLOR_OPTIONS enums and use them to validate CLI argument choices

Bug Fixes:
- Fix optional chat argument handling by replacing getattr checks with direct typed attribute access for rag and model

Enhancements:
- Extract get_parser in CLI and simplify init_cli while replacing static choice lists with dynamic get_args
- Remove on-the-fly mutation of initial user arguments in chat handlers

Build:
- Add Hypothesis to dev dependencies in pyproject.toml

Tests:
- Add Hypothesis-based property tests to verify CLI argument parsing for DefaultArgs and ChatSubArgs

Chores:
- Remove obsolete scripting files (newver.sh, release-image.sh, release.sh, replace-shas.sh)