### PR TITLE
README: move "install" section up and simplify description

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,11 @@
 <img src="https://github.com/user-attachments/assets/1a338ecf-dc84-4495-8c70-16882955da47" width=50%>
 </p>
 
-[RamaLama](https://ramalama.ai) is an open-source tool that simplifies the local use and serving of AI models for inference from any source through the familiar approach of containers.
+[RamaLama](https://ramalama.ai) strives to make working with AI simple, straightforward, and familiar by using OCI containers.
 <br>
 <br>
 
 ## Description
-RamaLama strives to make working with AI simple, straightforward, and familiar by using OCI containers.
 
 RamaLama is an open-source tool that simplifies the local use and serving of AI models for inference from any source through the familiar approach of containers. Using a container engine like Podman, engineers can use container-centric development patterns and benefits to extend to AI use cases.
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,25 @@ RamaLama eliminates the need to configure the host system by instead pulling a c
 - Interact with models via REST API or as a chatbot.
 <br>
 
+## Install
+### Install on Fedora
+RamaLama is available in [Fedora 40](https://fedoraproject.org/) and later. To install it, run:
+```
+sudo dnf install python3-ramalama
+```
+
+### Install via PyPi
+RamaLama is available via PyPi at [https://pypi.org/project/ramalama](https://pypi.org/project/ramalama)
+```
+pip install ramalama
+```
+
+### Install script (Linux and macOS)
+Install RamaLama by running:
+```
+curl -fsSL https://ramalama.ai/install.sh | bash
+```
+
 ## Accelerated images
 
 | Accelerator                       | Image                      |
@@ -102,24 +121,6 @@ pip install mlx-lm
 ramalama --runtime=mlx serve hf://mlx-community/Unsloth-Phi-4-4bit
 ```
 
-## Install
-### Install on Fedora
-RamaLama is available in [Fedora 40](https://fedoraproject.org/) and later. To install it, run:
-```
-sudo dnf install python3-ramalama
-```
-
-### Install via PyPi
-RamaLama is available via PyPi at [https://pypi.org/project/ramalama](https://pypi.org/project/ramalama)
-```
-pip install ramalama
-```
-
-### Install script (Linux and macOS)
-Install RamaLama by running:
-```
-curl -fsSL https://ramalama.ai/install.sh | bash
-```
 
 #### Default Container Engine
 When both Podman and Docker are installed, RamaLama defaults to Podman. The `RAMALAMA_CONTAINER_ENGINE=docker` environment variable can override this behaviour. When neither are installed, RamaLama will attempt to run the model with software on the local system.


### PR DESCRIPTION
1. Remove some duplicate text from the description.

2. Most README users want to know how to install so they can get running quickly. Move this to the top of the README.
