### PR TITLE
konflux: build cuda on arm64, and simplify testing

### DIFF
--- a/.tekton/cuda-llama-server/cuda-llama-server-pull-request.yaml
+++ b/.tekton/cuda-llama-server/cuda-llama-server-pull-request.yaml
@@ -29,6 +29,7 @@ spec:
   - name: build-platforms
     value:
     - linux-m2xlarge/amd64
+    - linux-m2xlarge/arm64
   - name: dockerfile
     value: container-images/common/Containerfile.entrypoint
   - name: parent-image

--- a/.tekton/cuda-llama-server/cuda-llama-server-push.yaml
+++ b/.tekton/cuda-llama-server/cuda-llama-server-push.yaml
@@ -26,6 +26,7 @@ spec:
   - name: build-platforms
     value:
     - linux-m2xlarge/amd64
+    - linux-m2xlarge/arm64
   - name: dockerfile
     value: container-images/common/Containerfile.entrypoint
   - name: parent-image

--- a/.tekton/cuda-rag/cuda-rag-pull-request.yaml
+++ b/.tekton/cuda-rag/cuda-rag-pull-request.yaml
@@ -29,6 +29,7 @@ spec:
   - name: build-platforms
     value:
     - linux-d160-m2xlarge/amd64
+    - linux-d160-m2xlarge/arm64
   - name: dockerfile
     value: container-images/common/Containerfile.rag
   - name: parent-image

--- a/.tekton/cuda-rag/cuda-rag-push.yaml
+++ b/.tekton/cuda-rag/cuda-rag-push.yaml
@@ -26,6 +26,7 @@ spec:
   - name: build-platforms
     value:
     - linux-d160-m2xlarge/amd64
+    - linux-d160-m2xlarge/arm64
   - name: dockerfile
     value: container-images/common/Containerfile.rag
   - name: parent-image

--- a/.tekton/cuda-whisper-server/cuda-whisper-server-pull-request.yaml
+++ b/.tekton/cuda-whisper-server/cuda-whisper-server-pull-request.yaml
@@ -29,6 +29,7 @@ spec:
   - name: build-platforms
     value:
     - linux-m2xlarge/amd64
+    - linux-m2xlarge/arm64
   - name: dockerfile
     value: container-images/common/Containerfile.entrypoint
   - name: parent-image

--- a/.tekton/cuda-whisper-server/cuda-whisper-server-push.yaml
+++ b/.tekton/cuda-whisper-server/cuda-whisper-server-push.yaml
@@ -26,6 +26,7 @@ spec:
   - name: build-platforms
     value:
     - linux-m2xlarge/amd64
+    - linux-m2xlarge/arm64
   - name: dockerfile
     value: container-images/common/Containerfile.entrypoint
   - name: parent-image

--- a/.tekton/cuda/cuda-pull-request.yaml
+++ b/.tekton/cuda/cuda-pull-request.yaml
@@ -29,6 +29,7 @@ spec:
   - name: build-platforms
     value:
     - linux-c4xlarge/amd64
+    - linux-c4xlarge/arm64
   - name: dockerfile
     value: container-images/cuda/Containerfile
   pipelineRef:

--- a/.tekton/cuda/cuda-push.yaml
+++ b/.tekton/cuda/cuda-push.yaml
@@ -26,6 +26,7 @@ spec:
   - name: build-platforms
     value:
     - linux-c4xlarge/amd64
+    - linux-c4xlarge/arm64
   - name: dockerfile
     value: container-images/cuda/Containerfile
   pipelineRef:

--- a/.tekton/integration/pipelines/bats-integration.yaml
+++ b/.tekton/integration/pipelines/bats-integration.yaml
@@ -52,10 +52,6 @@ spec:
     params:
     - name: image
       value: $(tasks.init.results.bats-image)
-    - name: git-url
-      value: $(params.git-url)
-    - name: git-revision
-      value: $(params.git-revision)
     - name: envs
       value:
       - RAMALAMA_IMAGE=$(tasks.init.results.ramalama-image)

--- a/.tekton/integration/tasks/test-vm-cmd.yaml
+++ b/.tekton/integration/tasks/test-vm-cmd.yaml
@@ -9,10 +9,6 @@ spec:
     description: The platform of the VM to provision
   - name: image
     description: The image to use when setting up the test environment
-  - name: git-url
-    description: The URL of the source code repository
-  - name: git-revision
-    description: The revision of the source code to test
   - name: cmd
     description: The command to run
   - name: envs
@@ -38,10 +34,6 @@ spec:
       name: ssh
     workingDir: /var/workdir
     env:
-    - name: GIT_URL
-      value: $(params.git-url)
-    - name: GIT_REVISION
-      value: $(params.git-revision)
     - name: TEST_IMAGE
       value: $(params.image)
     - name: TEST_CMD
@@ -57,13 +49,7 @@ spec:
       }
 
       log Install packages
-      dnf -y install openssh-clients rsync git-core jq
-
-      log Clone source
-      git clone -n "$GIT_URL" source
-      pushd source
-      git checkout "$GIT_REVISION"
-      popd
+      dnf -y install openssh-clients rsync jq
 
       log Prepare connection
 
@@ -107,7 +93,7 @@ spec:
       --security-opt label=disable \
       --security-opt unmask=/proc/* \
       --device /dev/net/tun \
-      -v \$PWD/source:/src \
+      --device /dev/fuse \
       ${PODMAN_ENV[*]} \
       $TEST_IMAGE $TEST_CMD
       SCRIPTEOF
@@ -119,7 +105,7 @@ spec:
         export SSH_ARGS="-o StrictHostKeyChecking=no -o ServerAliveInterval=60 -o ServerAliveCountMax=10"
         # ssh once before rsync to retrieve the host key
         ssh $SSH_ARGS "$SSH_HOST" "uname -a"
-        rsync -ra scripts source "$SSH_HOST:$BUILD_DIR"
+        rsync -ra scripts "$SSH_HOST:$BUILD_DIR"
         ssh $SSH_ARGS "$SSH_HOST" "$BUILD_DIR/scripts/test.sh"
         log End VM exec
       else

--- a/.tekton/pipelines/pull-request-pipeline.yaml
+++ b/.tekton/pipelines/pull-request-pipeline.yaml
@@ -285,8 +285,6 @@ spec:
     params:
     - name: image
       value: $(params.test-image)@$(tasks.wait-for-test-image.results.digest)
-    - name: source-artifact
-      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
     - name: envs
       value:
       - $(params.test-envs[*])

--- a/.tekton/pipelines/push-pipeline.yaml
+++ b/.tekton/pipelines/push-pipeline.yaml
@@ -285,8 +285,6 @@ spec:
     params:
     - name: image
       value: $(params.test-image)@$(tasks.wait-for-test-image.results.digest)
-    - name: source-artifact
-      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
     - name: envs
       value:
       - $(params.test-envs[*])

--- a/.tekton/tasks/test-cmd.yaml
+++ b/.tekton/tasks/test-cmd.yaml
@@ -7,58 +7,29 @@ spec:
   params:
   - name: image
     description: The image to use when setting up the test environment.
-  - name: source-artifact
-    description: The Trusted Artifact URI pointing to the artifact with the application source code.
   - name: cmd
     description: The command to run.
   - name: envs
     description: List of environment variables (NAME=VALUE) to be set in the test environment.
     type: array
     default: []
-  volumes:
-  - name: workdir
-    emptyDir: {}
-  stepTemplate:
-    volumeMounts:
-    - mountPath: /var/workdir
-      name: workdir
+  steps:
+  - name: run
+    image: $(params.image)
     computeResources:
       limits:
         memory: 4Gi
       requests:
         cpu: "1"
         memory: 1Gi
-  steps:
-  - name: use-trusted-artifact
-    image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:f7d0c515f85aebf926b86d6298f9e2d42d905104506389dc9c3e5878c5c0d38f
-    args:
-    - use
-    - $(params.source-artifact)=/var/workdir/source
-  - name: set-env
-    image: $(params.image)
-    workingDir: /var/workdir/source
-    args:
-    - $(params.envs[*])
-    script: |
-      #!/bin/bash -e
-      rm -f .bashenv
-      while [ $# -ne 0 ]; do
-        echo "$1" >> .bashenv
-        shift
-      done
-  - name: run
-    image: $(params.image)
     securityContext:
       capabilities:
         add:
         - SETFCAP
-    workingDir: /var/workdir/source
-    env:
-    - name: BASH_ENV
-      value: .bashenv
     command:
     - /usr/bin/entrypoint.sh
     args:
+    - $(params.envs[*])
     - /bin/bash
     - -ex
     - -c

--- a/container-images/bats/Containerfile
+++ b/container-images/bats/Containerfile
@@ -25,4 +25,6 @@ RUN git clone --depth=1 https://github.com/ggml-org/llama.cpp && \
 
 COPY container-images/bats/entrypoint.sh /usr/bin
 COPY container-images/bats/containers.conf /etc/containers
+COPY . /src
+RUN chmod -R a+rw /src
 RUN chmod a+rw /etc/subuid /etc/subgid

--- a/container-images/bats/entrypoint.sh
+++ b/container-images/bats/entrypoint.sh
@@ -3,6 +3,16 @@
 echo "$(id -un):10000:2000" > /etc/subuid
 echo "$(id -un):10000:2000" > /etc/subgid
 
+while [ $# -gt 0 ]; do
+    if [[ "$1" =~ = ]]; then
+        # shellcheck disable=SC2163
+        export "$1"
+        shift
+    else
+        break
+    fi
+done
+
 if [ $# -gt 0 ]; then
     exec "$@"
 else

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -6,7 +6,8 @@ import pytest
 from ramalama.config import DEFAULT_PORT, default_config, get_default_engine, get_default_store, load_env_config
 
 
-def test_correct_config_defaults():
+def test_correct_config_defaults(monkeypatch):
+    monkeypatch.delenv("RAMALAMA_IMAGE", raising=False)
     cfg = default_config()
 
     assert cfg.carimage == "registry.access.redhat.com/ubi10-micro:latest"
@@ -30,7 +31,8 @@ def test_correct_config_defaults():
     assert cfg.ocr is False
 
 
-def test_config_defaults_not_set():
+def test_config_defaults_not_set(monkeypatch):
+    monkeypatch.delenv("RAMALAMA_IMAGE", raising=False)
     cfg = default_config()
 
     assert cfg.is_set("carimage") is False


### PR DESCRIPTION
Build `cuda` and layered images on `arm64`.

Include the source code in the `bats` image and use that code for unit and integration testing. It ensures consistency between the code and images being tested, and simplifies test execution.

## Summary by Sourcery

Enable ARM64 builds for CUDA and related images, and simplify testing by bundling source code in the bats image and streamlining Tekton test tasks.

New Features:
- Add ARM64 build platforms for CUDA, CUDA RAG, CUDA Whisper, and CUDA Llama Server images

Enhancements:
- Include project source code in the bats container image and grant read/write permissions
- Simplify Tekton test-cmd and VM test tasks by removing external source fetch and git clone steps
- Enhance bats entrypoint to parse and export environment variable assignments from arguments

CI:
- Remove source-artifact, git-url, and git-revision parameters from pull-request and push pipelines

Tests:
- Update unit tests to use monkeypatch for clearing environment variables before testing defaults