### PR TITLE
Only install if pyproject.toml exists

### DIFF
--- a/container-images/scripts/build_llama_and_whisper.sh
+++ b/container-images/scripts/build_llama_and_whisper.sh
@@ -282,18 +282,22 @@ clone_and_build_llama_cpp() {
 }
 
 install_ramalama() {
-  $PYTHON -m pip install . --prefix="$1"
+  if [ -e "pyproject.toml" ]; then
+    $PYTHON -m pip install . --prefix="$1"
+  fi
 }
 
 install_entrypoints() {
-  install -d "$install_prefix"/bin
-  install -m 755 \
-    container-images/scripts/llama-server.sh \
-    container-images/scripts/whisper-server.sh \
-    container-images/scripts/build_rag.sh \
-    container-images/scripts/doc2rag \
-    container-images/scripts/rag_framework \
-    "$install_prefix"/bin
+  if [ -e "container-images" ]; then
+    install -d "$install_prefix"/bin
+    install -m 755 \
+      container-images/scripts/llama-server.sh \
+      container-images/scripts/whisper-server.sh \
+      container-images/scripts/build_rag.sh \
+      container-images/scripts/doc2rag \
+      container-images/scripts/rag_framework \
+      "$install_prefix"/bin
+  fi
 }
 
 main() {


### PR DESCRIPTION
Otherwise skip

## Summary by Sourcery

Add a guard to skip the pip installation if the project definition file is missing

Enhancements:
- Wrap the pip install command in install_ramalama with a check for pyproject.toml
- Skip installation when pyproject.toml does not exist