### PR TITLE
Readme improvements: Update model's name and improve CUDA_VISIBLE_DEVICES section 

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ $ cat /usr/share/ramalama/shortnames.conf
 	<br>
 
 	```
-	$ ramalama bench granite-moe3
+	$ ramalama bench granite3-moe
 	```
 </details>
 
@@ -831,7 +831,7 @@ $ cat /usr/share/ramalama/shortnames.conf
 
 	Perplexity measures how well the model can predict the next token with lower values being better
 	```
-	$ ramalama perplexity granite-moe3
+	$ ramalama perplexity granite3-moe
 	```
 </details>
 

--- a/docs/ramalama-bench.1.md
+++ b/docs/ramalama-bench.1.md
@@ -148,7 +148,7 @@ Benchmark specified AI Model.
 ## EXAMPLES
 
 ```
-ramalama bench granite-moe3
+ramalama bench granite3-moe
 ```
 
 ## SEE ALSO

--- a/docs/ramalama-cuda.7.md
+++ b/docs/ramalama-cuda.7.md
@@ -137,6 +137,19 @@ ramalama run granite
 
 This is particularly useful in multi-GPU systems where you want to dedicate specific GPUs to different workloads.
 
+If the `CUDA_VISIBLE_DEVICES` environment variable is set to an empty string, RamaLama will default to using the CPU.
+
+```bash
+export CUDA_VISIBLE_DEVICES=""  # Defaults to CPU
+ramalama run granite
+```
+
+To revert to using all available GPUs, unset the environment variable:
+
+```bash
+unset CUDA_VISIBLE_DEVICES
+```
+
 ## Troubleshooting
 
 ### CUDA Updates

--- a/docs/ramalama-perplexity.1.md
+++ b/docs/ramalama-perplexity.1.md
@@ -156,7 +156,7 @@ Calculate the perplexity of an AI Model. Perplexity measures how well the model 
 ## EXAMPLES
 
 ```
-ramalama perplexity granite-moe3
+ramalama perplexity granite3-moe
 ```
 
 ## SEE ALSO


### PR DESCRIPTION
1. `granite-moe3` is not found on Ollama, the name probably changed in the repository.
2. It wasn't clear on how to use CPU instead of GPUs and what happened if CUDA_VISIBLE_DEVICES was set to empty.

### Reproducing 1:
On bash: `ramalama bench granite-moe3`

Should show:

`Error: Manifest for granite-moe3:latest was not found in the Ollama registry`

### Reproducing 2:
```bash
export CUDA_VISIBLE_DEVICES="" # or export CUDA_VISIBLE_DEVICES= 
ramalama bench granite3-moe
```
Will show:
`ggml_cuda_init: failed to initialize CUDA: no CUDA-capable device is detected`

And when executing `unset CUDA_VISIBLE_DEVICES` it returns to the standard behavior, using all GPUs.

## Summary by Sourcery

Correct the model shortname in documentation and clarify CUDA_VISIBLE_DEVICES behavior.

Documentation:
- Update all references of the model from granite-moe3 to granite3-moe in README and manpages
- Add guidance that setting CUDA_VISIBLE_DEVICES to empty defaults to CPU and unsetting it restores GPU usage