### PR TITLE
Minor fixes to rpm builds by packit and spec file.

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -79,7 +79,7 @@ jobs:
     dist_git_branches: &fedora_targets
       - fedora-all
       - epel10
-      - epel9
+      - epel10.0
 
   - job: koji_build
     trigger: commit
@@ -92,4 +92,4 @@ jobs:
     dist_git_branches:
       - fedora-branched # rawhide updates are created automatically
       - epel10
-      - epel9
+      - epel10.0

--- a/rpm/ramalama.spec
+++ b/rpm/ramalama.spec
@@ -31,9 +31,10 @@ BuildRequires:    make
 BuildRequires:    python3-devel
 BuildRequires:    podman
 BuildRequires:    python3-pytest
+BuildRequires:    mailcap
 
 Provides: python3-ramalama = %{version}-%{release}
-Obsoletes: python3-ramalama < 0.10.1-2
+Obsoletes: python3-ramalama < 0.11.0-1
 
 Requires: podman
 


### PR DESCRIPTION
* This removes epel9 from packit rules as epel9 does not currently build without many additional packages added to the distro.
* This fixes a breakage in epel10 by adding mailcap as a buildrequires.