### PR TITLE
konflux: add pipelines for asahi, cann, intel-gpu, llama-stack, musa, openvino, and ramalama-cli

### DIFF
--- a/.tekton/asahi-llama-server/asahi-llama-server-pull-request.yaml
+++ b/.tekton/asahi-llama-server/asahi-llama-server-pull-request.yaml
@@ -1,0 +1,48 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: asahi-llama-server
+    pipelines.appstudio.openshift.io/type: build
+  name: asahi-llama-server-on-pull-request
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/asahi-llama-server:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: build-platforms
+    value:
+    - linux-m2xlarge/amd64
+    - linux-m2xlarge/arm64
+  - name: dockerfile
+    value: container-images/common/Containerfile.entrypoint
+  - name: parent-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/asahi:on-pr-{{revision}}
+  - name: build-args
+    value:
+    - PARENT=quay.io/redhat-user-workloads/ramalama-tenant/asahi:on-pr-{{revision}}
+    - ENTRYPOINT=/usr/bin/llama-server.sh
+  pipelineRef:
+    name: pull-request-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/asahi-llama-server/asahi-llama-server-push.yaml
+++ b/.tekton/asahi-llama-server/asahi-llama-server-push.yaml
@@ -1,0 +1,45 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "push" && target_branch == "main"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: asahi-llama-server
+    pipelines.appstudio.openshift.io/type: build
+  name: asahi-llama-server-on-push
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/asahi-llama-server:{{revision}}
+  - name: build-platforms
+    value:
+    - linux-m2xlarge/amd64
+    - linux-m2xlarge/arm64
+  - name: dockerfile
+    value: container-images/common/Containerfile.entrypoint
+  - name: parent-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/asahi:{{revision}}
+  - name: build-args
+    value:
+    - PARENT=quay.io/redhat-user-workloads/ramalama-tenant/asahi:{{revision}}
+    - ENTRYPOINT=/usr/bin/llama-server.sh
+  pipelineRef:
+    name: push-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/asahi-rag/asahi-rag-pull-request.yaml
+++ b/.tekton/asahi-rag/asahi-rag-pull-request.yaml
@@ -1,0 +1,48 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: asahi-rag
+    pipelines.appstudio.openshift.io/type: build
+  name: asahi-rag-on-pull-request
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/asahi-rag:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: build-platforms
+    value:
+    - linux-d160-m2xlarge/amd64
+    - linux-d160-m2xlarge/arm64
+  - name: dockerfile
+    value: container-images/common/Containerfile.rag
+  - name: parent-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/asahi:on-pr-{{revision}}
+  - name: build-args
+    value:
+    - PARENT=quay.io/redhat-user-workloads/ramalama-tenant/asahi:on-pr-{{revision}}
+    - GPU=cpu
+  pipelineRef:
+    name: pull-request-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/asahi-rag/asahi-rag-push.yaml
+++ b/.tekton/asahi-rag/asahi-rag-push.yaml
@@ -1,0 +1,45 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "push" && target_branch == "main"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: asahi-rag
+    pipelines.appstudio.openshift.io/type: build
+  name: asahi-rag-on-push
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/asahi-rag:{{revision}}
+  - name: build-platforms
+    value:
+    - linux-d160-m2xlarge/amd64
+    - linux-d160-m2xlarge/arm64
+  - name: dockerfile
+    value: container-images/common/Containerfile.rag
+  - name: parent-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/asahi:{{revision}}
+  - name: build-args
+    value:
+    - PARENT=quay.io/redhat-user-workloads/ramalama-tenant/asahi:{{revision}}
+    - GPU=cpu
+  pipelineRef:
+    name: push-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/asahi-whisper-server/asahi-whisper-server-pull-request.yaml
+++ b/.tekton/asahi-whisper-server/asahi-whisper-server-pull-request.yaml
@@ -1,0 +1,48 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: asahi-whisper-server
+    pipelines.appstudio.openshift.io/type: build
+  name: asahi-whisper-server-on-pull-request
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/asahi-whisper-server:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: build-platforms
+    value:
+    - linux-m2xlarge/amd64
+    - linux-m2xlarge/arm64
+  - name: dockerfile
+    value: container-images/common/Containerfile.entrypoint
+  - name: parent-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/asahi:on-pr-{{revision}}
+  - name: build-args
+    value:
+    - PARENT=quay.io/redhat-user-workloads/ramalama-tenant/asahi:on-pr-{{revision}}
+    - ENTRYPOINT=/usr/bin/whisper-server.sh
+  pipelineRef:
+    name: pull-request-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/asahi-whisper-server/asahi-whisper-server-push.yaml
+++ b/.tekton/asahi-whisper-server/asahi-whisper-server-push.yaml
@@ -1,0 +1,45 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "push" && target_branch == "main"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: asahi-whisper-server
+    pipelines.appstudio.openshift.io/type: build
+  name: asahi-whisper-server-on-push
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/asahi-whisper-server:{{revision}}
+  - name: build-platforms
+    value:
+    - linux-m2xlarge/amd64
+    - linux-m2xlarge/arm64
+  - name: dockerfile
+    value: container-images/common/Containerfile.entrypoint
+  - name: parent-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/asahi:{{revision}}
+  - name: build-args
+    value:
+    - PARENT=quay.io/redhat-user-workloads/ramalama-tenant/asahi:{{revision}}
+    - ENTRYPOINT=/usr/bin/whisper-server.sh
+  pipelineRef:
+    name: push-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/asahi/asahi-pull-request.yaml
+++ b/.tekton/asahi/asahi-pull-request.yaml
@@ -1,0 +1,42 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: asahi
+    pipelines.appstudio.openshift.io/type: build
+  name: asahi-on-pull-request
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/asahi:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: build-platforms
+    value:
+    - linux-c4xlarge/amd64
+    - linux-c4xlarge/arm64
+  - name: dockerfile
+    value: container-images/asahi/Containerfile
+  pipelineRef:
+    name: pull-request-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/asahi/asahi-push.yaml
+++ b/.tekton/asahi/asahi-push.yaml
@@ -1,0 +1,39 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "push" && target_branch == "main"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: asahi
+    pipelines.appstudio.openshift.io/type: build
+  name: asahi-on-push
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/asahi:{{revision}}
+  - name: build-platforms
+    value:
+    - linux-c4xlarge/amd64
+    - linux-c4xlarge/arm64
+  - name: dockerfile
+    value: container-images/asahi/Containerfile
+  pipelineRef:
+    name: push-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/bats/bats-pull-request.yaml
+++ b/.tekton/bats/bats-pull-request.yaml
@@ -8,8 +8,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review"
   labels:
     appstudio.openshift.io/application: ramalama
     appstudio.openshift.io/component: bats

--- a/.tekton/bats/bats-push.yaml
+++ b/.tekton/bats/bats-push.yaml
@@ -7,8 +7,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "push" && target_branch == "main"
   labels:
     appstudio.openshift.io/application: ramalama
     appstudio.openshift.io/component: bats

--- a/.tekton/cann-llama-server/cann-llama-server-pull-request.yaml
+++ b/.tekton/cann-llama-server/cann-llama-server-pull-request.yaml
@@ -1,0 +1,48 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: cann-llama-server
+    pipelines.appstudio.openshift.io/type: build
+  name: cann-llama-server-on-pull-request
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/cann-llama-server:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: build-platforms
+    value:
+    - linux-m2xlarge/amd64
+    - linux-m2xlarge/arm64
+  - name: dockerfile
+    value: container-images/common/Containerfile.entrypoint
+  - name: parent-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/cann:on-pr-{{revision}}
+  - name: build-args
+    value:
+    - PARENT=quay.io/redhat-user-workloads/ramalama-tenant/cann:on-pr-{{revision}}
+    - ENTRYPOINT=/usr/bin/llama-server.sh
+  pipelineRef:
+    name: pull-request-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/cann-llama-server/cann-llama-server-push.yaml
+++ b/.tekton/cann-llama-server/cann-llama-server-push.yaml
@@ -1,0 +1,45 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "push" && target_branch == "main"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: cann-llama-server
+    pipelines.appstudio.openshift.io/type: build
+  name: cann-llama-server-on-push
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/cann-llama-server:{{revision}}
+  - name: build-platforms
+    value:
+    - linux-m2xlarge/amd64
+    - linux-m2xlarge/arm64
+  - name: dockerfile
+    value: container-images/common/Containerfile.entrypoint
+  - name: parent-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/cann:{{revision}}
+  - name: build-args
+    value:
+    - PARENT=quay.io/redhat-user-workloads/ramalama-tenant/cann:{{revision}}
+    - ENTRYPOINT=/usr/bin/llama-server.sh
+  pipelineRef:
+    name: push-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/cann-rag/cann-rag-pull-request.yaml
+++ b/.tekton/cann-rag/cann-rag-pull-request.yaml
@@ -1,0 +1,48 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: cann-rag
+    pipelines.appstudio.openshift.io/type: build
+  name: cann-rag-on-pull-request
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/cann-rag:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: build-platforms
+    value:
+    - linux-d160-m2xlarge/amd64
+    - linux-d160-m2xlarge/arm64
+  - name: dockerfile
+    value: container-images/common/Containerfile.rag
+  - name: parent-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/cann:on-pr-{{revision}}
+  - name: build-args
+    value:
+    - PARENT=quay.io/redhat-user-workloads/ramalama-tenant/cann:on-pr-{{revision}}
+    - GPU=cpu
+  pipelineRef:
+    name: pull-request-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/cann-rag/cann-rag-push.yaml
+++ b/.tekton/cann-rag/cann-rag-push.yaml
@@ -1,0 +1,45 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "push" && target_branch == "main"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: cann-rag
+    pipelines.appstudio.openshift.io/type: build
+  name: cann-rag-on-push
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/cann-rag:{{revision}}
+  - name: build-platforms
+    value:
+    - linux-d160-m2xlarge/amd64
+    - linux-d160-m2xlarge/arm64
+  - name: dockerfile
+    value: container-images/common/Containerfile.rag
+  - name: parent-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/cann:{{revision}}
+  - name: build-args
+    value:
+    - PARENT=quay.io/redhat-user-workloads/ramalama-tenant/cann:{{revision}}
+    - GPU=cpu
+  pipelineRef:
+    name: push-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/cann-whisper-server/cann-whisper-server-pull-request.yaml
+++ b/.tekton/cann-whisper-server/cann-whisper-server-pull-request.yaml
@@ -1,0 +1,48 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: cann-whisper-server
+    pipelines.appstudio.openshift.io/type: build
+  name: cann-whisper-server-on-pull-request
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/cann-whisper-server:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: build-platforms
+    value:
+    - linux-m2xlarge/amd64
+    - linux-m2xlarge/arm64
+  - name: dockerfile
+    value: container-images/common/Containerfile.entrypoint
+  - name: parent-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/cann:on-pr-{{revision}}
+  - name: build-args
+    value:
+    - PARENT=quay.io/redhat-user-workloads/ramalama-tenant/cann:on-pr-{{revision}}
+    - ENTRYPOINT=/usr/bin/whisper-server.sh
+  pipelineRef:
+    name: pull-request-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/cann-whisper-server/cann-whisper-server-push.yaml
+++ b/.tekton/cann-whisper-server/cann-whisper-server-push.yaml
@@ -1,0 +1,45 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "push" && target_branch == "main"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: cann-whisper-server
+    pipelines.appstudio.openshift.io/type: build
+  name: cann-whisper-server-on-push
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/cann-whisper-server:{{revision}}
+  - name: build-platforms
+    value:
+    - linux-m2xlarge/amd64
+    - linux-m2xlarge/arm64
+  - name: dockerfile
+    value: container-images/common/Containerfile.entrypoint
+  - name: parent-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/cann:{{revision}}
+  - name: build-args
+    value:
+    - PARENT=quay.io/redhat-user-workloads/ramalama-tenant/cann:{{revision}}
+    - ENTRYPOINT=/usr/bin/whisper-server.sh
+  pipelineRef:
+    name: push-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/cann/cann-pull-request.yaml
+++ b/.tekton/cann/cann-pull-request.yaml
@@ -1,0 +1,42 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: cann
+    pipelines.appstudio.openshift.io/type: build
+  name: cann-on-pull-request
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/cann:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: build-platforms
+    value:
+    - linux-c4xlarge/amd64
+    - linux-c4xlarge/arm64
+  - name: dockerfile
+    value: container-images/cann/Containerfile
+  pipelineRef:
+    name: pull-request-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/cann/cann-push.yaml
+++ b/.tekton/cann/cann-push.yaml
@@ -1,0 +1,39 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "push" && target_branch == "main"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: cann
+    pipelines.appstudio.openshift.io/type: build
+  name: cann-on-push
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/cann:{{revision}}
+  - name: build-platforms
+    value:
+    - linux-c4xlarge/amd64
+    - linux-c4xlarge/arm64
+  - name: dockerfile
+    value: container-images/cann/Containerfile
+  pipelineRef:
+    name: push-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/cuda-llama-server/cuda-llama-server-pull-request.yaml
+++ b/.tekton/cuda-llama-server/cuda-llama-server-pull-request.yaml
@@ -8,8 +8,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review"
   labels:
     appstudio.openshift.io/application: ramalama
     appstudio.openshift.io/component: cuda-llama-server

--- a/.tekton/cuda-llama-server/cuda-llama-server-push.yaml
+++ b/.tekton/cuda-llama-server/cuda-llama-server-push.yaml
@@ -7,8 +7,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "push" && target_branch == "main"
   labels:
     appstudio.openshift.io/application: ramalama
     appstudio.openshift.io/component: cuda-llama-server

--- a/.tekton/cuda-rag/cuda-rag-pull-request.yaml
+++ b/.tekton/cuda-rag/cuda-rag-pull-request.yaml
@@ -8,8 +8,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review"
   labels:
     appstudio.openshift.io/application: ramalama
     appstudio.openshift.io/component: cuda-rag

--- a/.tekton/cuda-rag/cuda-rag-push.yaml
+++ b/.tekton/cuda-rag/cuda-rag-push.yaml
@@ -7,8 +7,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "push" && target_branch == "main"
   labels:
     appstudio.openshift.io/application: ramalama
     appstudio.openshift.io/component: cuda-rag

--- a/.tekton/cuda-whisper-server/cuda-whisper-server-pull-request.yaml
+++ b/.tekton/cuda-whisper-server/cuda-whisper-server-pull-request.yaml
@@ -8,8 +8,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review"
   labels:
     appstudio.openshift.io/application: ramalama
     appstudio.openshift.io/component: cuda-whisper-server

--- a/.tekton/cuda-whisper-server/cuda-whisper-server-push.yaml
+++ b/.tekton/cuda-whisper-server/cuda-whisper-server-push.yaml
@@ -7,8 +7,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "push" && target_branch == "main"
   labels:
     appstudio.openshift.io/application: ramalama
     appstudio.openshift.io/component: cuda-whisper-server

--- a/.tekton/cuda/cuda-pull-request.yaml
+++ b/.tekton/cuda/cuda-pull-request.yaml
@@ -8,8 +8,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review"
   labels:
     appstudio.openshift.io/application: ramalama
     appstudio.openshift.io/component: cuda

--- a/.tekton/cuda/cuda-push.yaml
+++ b/.tekton/cuda/cuda-push.yaml
@@ -7,8 +7,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "push" && target_branch == "main"
   labels:
     appstudio.openshift.io/application: ramalama
     appstudio.openshift.io/component: cuda

--- a/.tekton/intel-gpu-llama-server/intel-gpu-llama-server-pull-request.yaml
+++ b/.tekton/intel-gpu-llama-server/intel-gpu-llama-server-pull-request.yaml
@@ -1,0 +1,47 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: intel-gpu-llama-server
+    pipelines.appstudio.openshift.io/type: build
+  name: intel-gpu-llama-server-on-pull-request
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/intel-gpu-llama-server:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: build-platforms
+    value:
+    - linux-m2xlarge/amd64
+  - name: dockerfile
+    value: container-images/common/Containerfile.entrypoint
+  - name: parent-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/intel-gpu:on-pr-{{revision}}
+  - name: build-args
+    value:
+    - PARENT=quay.io/redhat-user-workloads/ramalama-tenant/intel-gpu:on-pr-{{revision}}
+    - ENTRYPOINT=/usr/bin/llama-server.sh
+  pipelineRef:
+    name: pull-request-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/intel-gpu-llama-server/intel-gpu-llama-server-push.yaml
+++ b/.tekton/intel-gpu-llama-server/intel-gpu-llama-server-push.yaml
@@ -1,0 +1,44 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "push" && target_branch == "main"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: intel-gpu-llama-server
+    pipelines.appstudio.openshift.io/type: build
+  name: intel-gpu-llama-server-on-push
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/intel-gpu-llama-server:{{revision}}
+  - name: build-platforms
+    value:
+    - linux-m2xlarge/amd64
+  - name: dockerfile
+    value: container-images/common/Containerfile.entrypoint
+  - name: parent-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/intel-gpu:{{revision}}
+  - name: build-args
+    value:
+    - PARENT=quay.io/redhat-user-workloads/ramalama-tenant/intel-gpu:{{revision}}
+    - ENTRYPOINT=/usr/bin/llama-server.sh
+  pipelineRef:
+    name: push-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/intel-gpu-rag/intel-gpu-rag-pull-request.yaml
+++ b/.tekton/intel-gpu-rag/intel-gpu-rag-pull-request.yaml
@@ -1,0 +1,47 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: intel-gpu-rag
+    pipelines.appstudio.openshift.io/type: build
+  name: intel-gpu-rag-on-pull-request
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/intel-gpu-rag:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: build-platforms
+    value:
+    - linux-d160-m2xlarge/amd64
+  - name: dockerfile
+    value: container-images/common/Containerfile.rag
+  - name: parent-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/intel-gpu:on-pr-{{revision}}
+  - name: build-args
+    value:
+    - PARENT=quay.io/redhat-user-workloads/ramalama-tenant/intel-gpu:on-pr-{{revision}}
+    - GPU=cpu
+  pipelineRef:
+    name: pull-request-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/intel-gpu-rag/intel-gpu-rag-push.yaml
+++ b/.tekton/intel-gpu-rag/intel-gpu-rag-push.yaml
@@ -1,0 +1,44 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "push" && target_branch == "main"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: intel-gpu-rag
+    pipelines.appstudio.openshift.io/type: build
+  name: intel-gpu-rag-on-push
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/intel-gpu-rag:{{revision}}
+  - name: build-platforms
+    value:
+    - linux-d160-m2xlarge/amd64
+  - name: dockerfile
+    value: container-images/common/Containerfile.rag
+  - name: parent-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/intel-gpu:{{revision}}
+  - name: build-args
+    value:
+    - PARENT=quay.io/redhat-user-workloads/ramalama-tenant/intel-gpu:{{revision}}
+    - GPU=cpu
+  pipelineRef:
+    name: push-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/intel-gpu-whisper-server/intel-gpu-whisper-server-pull-request.yaml
+++ b/.tekton/intel-gpu-whisper-server/intel-gpu-whisper-server-pull-request.yaml
@@ -1,0 +1,47 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: intel-gpu-whisper-server
+    pipelines.appstudio.openshift.io/type: build
+  name: intel-gpu-whisper-server-on-pull-request
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/intel-gpu-whisper-server:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: build-platforms
+    value:
+    - linux-m2xlarge/amd64
+  - name: dockerfile
+    value: container-images/common/Containerfile.entrypoint
+  - name: parent-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/intel-gpu:on-pr-{{revision}}
+  - name: build-args
+    value:
+    - PARENT=quay.io/redhat-user-workloads/ramalama-tenant/intel-gpu:on-pr-{{revision}}
+    - ENTRYPOINT=/usr/bin/whisper-server.sh
+  pipelineRef:
+    name: pull-request-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/intel-gpu-whisper-server/intel-gpu-whisper-server-push.yaml
+++ b/.tekton/intel-gpu-whisper-server/intel-gpu-whisper-server-push.yaml
@@ -1,0 +1,44 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "push" && target_branch == "main"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: intel-gpu-whisper-server
+    pipelines.appstudio.openshift.io/type: build
+  name: intel-gpu-whisper-server-on-push
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/intel-gpu-whisper-server:{{revision}}
+  - name: build-platforms
+    value:
+    - linux-m2xlarge/amd64
+  - name: dockerfile
+    value: container-images/common/Containerfile.entrypoint
+  - name: parent-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/intel-gpu:{{revision}}
+  - name: build-args
+    value:
+    - PARENT=quay.io/redhat-user-workloads/ramalama-tenant/intel-gpu:{{revision}}
+    - ENTRYPOINT=/usr/bin/whisper-server.sh
+  pipelineRef:
+    name: push-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/intel-gpu/intel-gpu-pull-request.yaml
+++ b/.tekton/intel-gpu/intel-gpu-pull-request.yaml
@@ -1,0 +1,41 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: intel-gpu
+    pipelines.appstudio.openshift.io/type: build
+  name: intel-gpu-on-pull-request
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/intel-gpu:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: build-platforms
+    value:
+    - linux-c4xlarge/amd64
+  - name: dockerfile
+    value: container-images/intel-gpu/Containerfile
+  pipelineRef:
+    name: pull-request-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/intel-gpu/intel-gpu-push.yaml
+++ b/.tekton/intel-gpu/intel-gpu-push.yaml
@@ -1,0 +1,38 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "push" && target_branch == "main"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: intel-gpu
+    pipelines.appstudio.openshift.io/type: build
+  name: intel-gpu-on-push
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/intel-gpu:{{revision}}
+  - name: build-platforms
+    value:
+    - linux-c4xlarge/amd64
+  - name: dockerfile
+    value: container-images/intel-gpu/Containerfile
+  pipelineRef:
+    name: push-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/llama-stack/llama-stack-pull-request.yaml
+++ b/.tekton/llama-stack/llama-stack-pull-request.yaml
@@ -1,0 +1,42 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: llama-stack
+    pipelines.appstudio.openshift.io/type: build
+  name: llama-stack-on-pull-request
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/llama-stack:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: build-platforms
+    value:
+    - linux-c4xlarge/amd64
+    - linux-c4xlarge/arm64
+  - name: dockerfile
+    value: container-images/llama-stack/Containerfile
+  pipelineRef:
+    name: pull-request-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/llama-stack/llama-stack-push.yaml
+++ b/.tekton/llama-stack/llama-stack-push.yaml
@@ -1,0 +1,39 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "push" && target_branch == "main"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: llama-stack
+    pipelines.appstudio.openshift.io/type: build
+  name: llama-stack-on-push
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/llama-stack:{{revision}}
+  - name: build-platforms
+    value:
+    - linux-c4xlarge/amd64
+    - linux-c4xlarge/arm64
+  - name: dockerfile
+    value: container-images/llama-stack/Containerfile
+  pipelineRef:
+    name: push-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/musa-llama-server/musa-llama-server-pull-request.yaml
+++ b/.tekton/musa-llama-server/musa-llama-server-pull-request.yaml
@@ -1,0 +1,47 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: musa-llama-server
+    pipelines.appstudio.openshift.io/type: build
+  name: musa-llama-server-on-pull-request
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/musa-llama-server:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: build-platforms
+    value:
+    - linux-m2xlarge/amd64
+  - name: dockerfile
+    value: container-images/common/Containerfile.entrypoint
+  - name: parent-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/musa:on-pr-{{revision}}
+  - name: build-args
+    value:
+    - PARENT=quay.io/redhat-user-workloads/ramalama-tenant/musa:on-pr-{{revision}}
+    - ENTRYPOINT=/usr/bin/llama-server.sh
+  pipelineRef:
+    name: pull-request-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/musa-llama-server/musa-llama-server-push.yaml
+++ b/.tekton/musa-llama-server/musa-llama-server-push.yaml
@@ -1,0 +1,44 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "push" && target_branch == "main"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: musa-llama-server
+    pipelines.appstudio.openshift.io/type: build
+  name: musa-llama-server-on-push
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/musa-llama-server:{{revision}}
+  - name: build-platforms
+    value:
+    - linux-m2xlarge/amd64
+  - name: dockerfile
+    value: container-images/common/Containerfile.entrypoint
+  - name: parent-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/musa:{{revision}}
+  - name: build-args
+    value:
+    - PARENT=quay.io/redhat-user-workloads/ramalama-tenant/musa:{{revision}}
+    - ENTRYPOINT=/usr/bin/llama-server.sh
+  pipelineRef:
+    name: push-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/musa-rag/musa-rag-pull-request.yaml
+++ b/.tekton/musa-rag/musa-rag-pull-request.yaml
@@ -1,0 +1,47 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: musa-rag
+    pipelines.appstudio.openshift.io/type: build
+  name: musa-rag-on-pull-request
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/musa-rag:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: build-platforms
+    value:
+    - linux-d160-m2xlarge/amd64
+  - name: dockerfile
+    value: container-images/common/Containerfile.rag
+  - name: parent-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/musa:on-pr-{{revision}}
+  - name: build-args
+    value:
+    - PARENT=quay.io/redhat-user-workloads/ramalama-tenant/musa:on-pr-{{revision}}
+    - GPU=musa
+  pipelineRef:
+    name: pull-request-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/musa-rag/musa-rag-push.yaml
+++ b/.tekton/musa-rag/musa-rag-push.yaml
@@ -1,0 +1,44 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "push" && target_branch == "main"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: musa-rag
+    pipelines.appstudio.openshift.io/type: build
+  name: musa-rag-on-push
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/musa-rag:{{revision}}
+  - name: build-platforms
+    value:
+    - linux-d160-m2xlarge/amd64
+  - name: dockerfile
+    value: container-images/common/Containerfile.rag
+  - name: parent-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/musa:{{revision}}
+  - name: build-args
+    value:
+    - PARENT=quay.io/redhat-user-workloads/ramalama-tenant/musa:{{revision}}
+    - GPU=musa
+  pipelineRef:
+    name: push-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/musa-whisper-server/musa-whisper-server-pull-request.yaml
+++ b/.tekton/musa-whisper-server/musa-whisper-server-pull-request.yaml
@@ -1,0 +1,47 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: musa-whisper-server
+    pipelines.appstudio.openshift.io/type: build
+  name: musa-whisper-server-on-pull-request
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/musa-whisper-server:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: build-platforms
+    value:
+    - linux-m2xlarge/amd64
+  - name: dockerfile
+    value: container-images/common/Containerfile.entrypoint
+  - name: parent-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/musa:on-pr-{{revision}}
+  - name: build-args
+    value:
+    - PARENT=quay.io/redhat-user-workloads/ramalama-tenant/musa:on-pr-{{revision}}
+    - ENTRYPOINT=/usr/bin/whisper-server.sh
+  pipelineRef:
+    name: pull-request-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/musa-whisper-server/musa-whisper-server-push.yaml
+++ b/.tekton/musa-whisper-server/musa-whisper-server-push.yaml
@@ -1,0 +1,44 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "push" && target_branch == "main"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: musa-whisper-server
+    pipelines.appstudio.openshift.io/type: build
+  name: musa-whisper-server-on-push
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/musa-whisper-server:{{revision}}
+  - name: build-platforms
+    value:
+    - linux-m2xlarge/amd64
+  - name: dockerfile
+    value: container-images/common/Containerfile.entrypoint
+  - name: parent-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/musa:{{revision}}
+  - name: build-args
+    value:
+    - PARENT=quay.io/redhat-user-workloads/ramalama-tenant/musa:{{revision}}
+    - ENTRYPOINT=/usr/bin/whisper-server.sh
+  pipelineRef:
+    name: push-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/musa/musa-pull-request.yaml
+++ b/.tekton/musa/musa-pull-request.yaml
@@ -1,0 +1,41 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: musa
+    pipelines.appstudio.openshift.io/type: build
+  name: musa-on-pull-request
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/musa:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: build-platforms
+    value:
+    - linux-c4xlarge/amd64
+  - name: dockerfile
+    value: container-images/musa/Containerfile
+  pipelineRef:
+    name: pull-request-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/musa/musa-push.yaml
+++ b/.tekton/musa/musa-push.yaml
@@ -1,0 +1,38 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "push" && target_branch == "main"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: musa
+    pipelines.appstudio.openshift.io/type: build
+  name: musa-on-push
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/musa:{{revision}}
+  - name: build-platforms
+    value:
+    - linux-c4xlarge/amd64
+  - name: dockerfile
+    value: container-images/musa/Containerfile
+  pipelineRef:
+    name: push-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/openvino/openvino-pull-request.yaml
+++ b/.tekton/openvino/openvino-pull-request.yaml
@@ -1,0 +1,41 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: openvino
+    pipelines.appstudio.openshift.io/type: build
+  name: openvino-on-pull-request
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/openvino:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: build-platforms
+    value:
+    - linux-c4xlarge/amd64
+  - name: dockerfile
+    value: container-images/openvino/Containerfile
+  pipelineRef:
+    name: pull-request-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/openvino/openvino-push.yaml
+++ b/.tekton/openvino/openvino-push.yaml
@@ -1,0 +1,38 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "push" && target_branch == "main"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: openvino
+    pipelines.appstudio.openshift.io/type: build
+  name: openvino-on-push
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/openvino:{{revision}}
+  - name: build-platforms
+    value:
+    - linux-c4xlarge/amd64
+  - name: dockerfile
+    value: container-images/openvino/Containerfile
+  pipelineRef:
+    name: push-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/ramalama-cli/ramalama-cli-pull-request.yaml
+++ b/.tekton/ramalama-cli/ramalama-cli-pull-request.yaml
@@ -1,0 +1,42 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: ramalama-cli
+    pipelines.appstudio.openshift.io/type: build
+  name: ramalama-cli-on-pull-request
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/ramalama-cli:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: build-platforms
+    value:
+    - linux-c4xlarge/amd64
+    - linux-c4xlarge/arm64
+  - name: dockerfile
+    value: container-images/ramalama-cli/Containerfile
+  pipelineRef:
+    name: pull-request-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/ramalama-cli/ramalama-cli-push.yaml
+++ b/.tekton/ramalama-cli/ramalama-cli-push.yaml
@@ -1,0 +1,39 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "push" && target_branch == "main"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: ramalama-cli
+    pipelines.appstudio.openshift.io/type: build
+  name: ramalama-cli-on-push
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/ramalama-cli:{{revision}}
+  - name: build-platforms
+    value:
+    - linux-c4xlarge/amd64
+    - linux-c4xlarge/arm64
+  - name: dockerfile
+    value: container-images/ramalama-cli/Containerfile
+  pipelineRef:
+    name: push-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/ramalama-llama-server/ramalama-llama-server-pull-request.yaml
+++ b/.tekton/ramalama-llama-server/ramalama-llama-server-pull-request.yaml
@@ -8,8 +8,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review"
   labels:
     appstudio.openshift.io/application: ramalama
     appstudio.openshift.io/component: ramalama-llama-server

--- a/.tekton/ramalama-llama-server/ramalama-llama-server-push.yaml
+++ b/.tekton/ramalama-llama-server/ramalama-llama-server-push.yaml
@@ -7,8 +7,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "push" && target_branch == "main"
   labels:
     appstudio.openshift.io/application: ramalama
     appstudio.openshift.io/component: ramalama-llama-server

--- a/.tekton/ramalama-rag/ramalama-rag-pull-request.yaml
+++ b/.tekton/ramalama-rag/ramalama-rag-pull-request.yaml
@@ -8,8 +8,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review"
   labels:
     appstudio.openshift.io/application: ramalama
     appstudio.openshift.io/component: ramalama-rag

--- a/.tekton/ramalama-rag/ramalama-rag-push.yaml
+++ b/.tekton/ramalama-rag/ramalama-rag-push.yaml
@@ -7,8 +7,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "push" && target_branch == "main"
   labels:
     appstudio.openshift.io/application: ramalama
     appstudio.openshift.io/component: ramalama-rag

--- a/.tekton/ramalama-whisper-server/ramalama-whisper-server-pull-request.yaml
+++ b/.tekton/ramalama-whisper-server/ramalama-whisper-server-pull-request.yaml
@@ -8,8 +8,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review"
   labels:
     appstudio.openshift.io/application: ramalama
     appstudio.openshift.io/component: ramalama-whisper-server

--- a/.tekton/ramalama-whisper-server/ramalama-whisper-server-push.yaml
+++ b/.tekton/ramalama-whisper-server/ramalama-whisper-server-push.yaml
@@ -7,8 +7,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "push" && target_branch == "main"
   labels:
     appstudio.openshift.io/application: ramalama
     appstudio.openshift.io/component: ramalama-whisper-server

--- a/.tekton/ramalama/ramalama-pull-request.yaml
+++ b/.tekton/ramalama/ramalama-pull-request.yaml
@@ -8,8 +8,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review"
   labels:
     appstudio.openshift.io/application: ramalama
     appstudio.openshift.io/component: ramalama

--- a/.tekton/ramalama/ramalama-push.yaml
+++ b/.tekton/ramalama/ramalama-push.yaml
@@ -7,8 +7,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "push" && target_branch == "main"
   labels:
     appstudio.openshift.io/application: ramalama
     appstudio.openshift.io/component: ramalama

--- a/.tekton/rocm-llama-server/rocm-llama-server-pull-request.yaml
+++ b/.tekton/rocm-llama-server/rocm-llama-server-pull-request.yaml
@@ -8,8 +8,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review"
   labels:
     appstudio.openshift.io/application: ramalama
     appstudio.openshift.io/component: rocm-llama-server

--- a/.tekton/rocm-llama-server/rocm-llama-server-push.yaml
+++ b/.tekton/rocm-llama-server/rocm-llama-server-push.yaml
@@ -7,8 +7,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "push" && target_branch == "main"
   labels:
     appstudio.openshift.io/application: ramalama
     appstudio.openshift.io/component: rocm-llama-server

--- a/.tekton/rocm-rag/rocm-rag-pull-request.yaml
+++ b/.tekton/rocm-rag/rocm-rag-pull-request.yaml
@@ -8,8 +8,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review"
   labels:
     appstudio.openshift.io/application: ramalama
     appstudio.openshift.io/component: rocm-rag

--- a/.tekton/rocm-rag/rocm-rag-push.yaml
+++ b/.tekton/rocm-rag/rocm-rag-push.yaml
@@ -7,8 +7,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "push" && target_branch == "main"
   labels:
     appstudio.openshift.io/application: ramalama
     appstudio.openshift.io/component: rocm-rag

--- a/.tekton/rocm-ubi-llama-server/rocm-ubi-llama-server-pull-request.yaml
+++ b/.tekton/rocm-ubi-llama-server/rocm-ubi-llama-server-pull-request.yaml
@@ -8,8 +8,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review"
   labels:
     appstudio.openshift.io/application: ramalama
     appstudio.openshift.io/component: rocm-ubi-llama-server

--- a/.tekton/rocm-ubi-llama-server/rocm-ubi-llama-server-push.yaml
+++ b/.tekton/rocm-ubi-llama-server/rocm-ubi-llama-server-push.yaml
@@ -7,8 +7,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "push" && target_branch == "main"
   labels:
     appstudio.openshift.io/application: ramalama
     appstudio.openshift.io/component: rocm-ubi-llama-server

--- a/.tekton/rocm-ubi-rag/rocm-ubi-rag-pull-request.yaml
+++ b/.tekton/rocm-ubi-rag/rocm-ubi-rag-pull-request.yaml
@@ -8,8 +8,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review"
   labels:
     appstudio.openshift.io/application: ramalama
     appstudio.openshift.io/component: rocm-ubi-rag

--- a/.tekton/rocm-ubi-rag/rocm-ubi-rag-push.yaml
+++ b/.tekton/rocm-ubi-rag/rocm-ubi-rag-push.yaml
@@ -7,8 +7,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "push" && target_branch == "main"
   labels:
     appstudio.openshift.io/application: ramalama
     appstudio.openshift.io/component: rocm-ubi-rag

--- a/.tekton/rocm-ubi-whisper-server/rocm-ubi-whisper-server-pull-request.yaml
+++ b/.tekton/rocm-ubi-whisper-server/rocm-ubi-whisper-server-pull-request.yaml
@@ -8,8 +8,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review"
   labels:
     appstudio.openshift.io/application: ramalama
     appstudio.openshift.io/component: rocm-ubi-whisper-server

--- a/.tekton/rocm-ubi-whisper-server/rocm-ubi-whisper-server-push.yaml
+++ b/.tekton/rocm-ubi-whisper-server/rocm-ubi-whisper-server-push.yaml
@@ -7,8 +7,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "push" && target_branch == "main"
   labels:
     appstudio.openshift.io/application: ramalama
     appstudio.openshift.io/component: rocm-ubi-whisper-server

--- a/.tekton/rocm-ubi/rocm-ubi-pull-request.yaml
+++ b/.tekton/rocm-ubi/rocm-ubi-pull-request.yaml
@@ -8,8 +8,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review"
   labels:
     appstudio.openshift.io/application: ramalama
     appstudio.openshift.io/component: rocm-ubi

--- a/.tekton/rocm-ubi/rocm-ubi-push.yaml
+++ b/.tekton/rocm-ubi/rocm-ubi-push.yaml
@@ -7,8 +7,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "push" && target_branch == "main"
   labels:
     appstudio.openshift.io/application: ramalama
     appstudio.openshift.io/component: rocm-ubi

--- a/.tekton/rocm-whisper-server/rocm-whisper-server-pull-request.yaml
+++ b/.tekton/rocm-whisper-server/rocm-whisper-server-pull-request.yaml
@@ -8,8 +8,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review"
   labels:
     appstudio.openshift.io/application: ramalama
     appstudio.openshift.io/component: rocm-whisper-server

--- a/.tekton/rocm-whisper-server/rocm-whisper-server-push.yaml
+++ b/.tekton/rocm-whisper-server/rocm-whisper-server-push.yaml
@@ -7,8 +7,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "push" && target_branch == "main"
   labels:
     appstudio.openshift.io/application: ramalama
     appstudio.openshift.io/component: rocm-whisper-server

--- a/.tekton/rocm/rocm-pull-request.yaml
+++ b/.tekton/rocm/rocm-pull-request.yaml
@@ -8,8 +8,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review"
   labels:
     appstudio.openshift.io/application: ramalama
     appstudio.openshift.io/component: rocm

--- a/.tekton/rocm/rocm-push.yaml
+++ b/.tekton/rocm/rocm-push.yaml
@@ -7,8 +7,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "push" && target_branch == "main"
   labels:
     appstudio.openshift.io/application: ramalama
     appstudio.openshift.io/component: rocm


### PR DESCRIPTION
On-board 7 new images and their layered images.

Update `on-cel-expression` in the `PipelineRuns` to avoid unnecessary pipelines, and to improve readability.

## Summary by Sourcery

Introduce pipeline configurations for seven new container images and improve trigger expressions across all Tekton PipelineRuns

New Features:
- Add pull_request and push Tekton PipelineRuns for asahi, cann, intel-gpu, llama-stack, musa, openvino, and ramalama-cli images

Enhancements:
- Refine on-cel-expression in existing pipelines to exclude "ready_for_review" pull_request events and standardize formatting for readability