### PR TITLE
Included ramalama.conf in wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,7 @@ log_cli_date_format = "%Y-%m-%d %H:%M:%S"
 include = ["ramalama", "ramalama.*"]
 
 [tool.setuptools.data-files]
-"share/ramalama" = ["shortnames/shortnames.conf"]
+"share/ramalama" = ["shortnames/shortnames.conf", "docs/ramalama.conf"]
 "share/man/man1" = ["docs/*.1"]
 "share/man/man5" = ["docs/*.5"]
 "share/man/man7" = ["docs/*.7"]

--- a/rpm/ramalama.spec
+++ b/rpm/ramalama.spec
@@ -56,14 +56,12 @@ will run the AI Models within a container based on the OCI image.
 %forgeautosetup -p1
 
 %build
+make docs
 %pyproject_wheel
-%{__make} docs
 
 %install
 %pyproject_install
 %pyproject_save_files -l %{pypi_name}
-%{__make} DESTDIR=%{buildroot} PREFIX=%{_prefix} install-docs install-shortnames
-%{__make} DESTDIR=%{buildroot} PREFIX=%{_prefix} install-completions
 
 %check
 %pytest -v test/unit


### PR DESCRIPTION
Currently other data files such as shortnames.conf, man pages, and shell completions are included in the Python wheel.  Including ramalama.conf as well means we can avoid several calls to make in the RPM spec file, instead relying on the wheel mechanisms to put these files in place.  As long as `make docs` is run before the wheel generation, all the necessary files are included.

## Summary by Sourcery

Include ramalama.conf in the Python wheel and simplify the RPM spec to rely on wheel installation for documentation and auxiliary files.

Enhancements:
- Add docs/ramalama.conf to setuptools data-files in pyproject.toml
- Run `make docs` during the RPM build phase instead of after wheel installation
- Remove manual install steps for docs, shortnames, and completions from the RPM spec