### PR TITLE
container-images: add virglrenderer to vulkan

### DIFF
--- a/container-images/scripts/build_llama_and_whisper.sh
+++ b/container-images/scripts/build_llama_and_whisper.sh
@@ -99,10 +99,10 @@ is_rhel_based() { # doesn't include openEuler
 dnf_install_mesa() {
   if [ "${ID}" = "fedora" ]; then
     dnf copr enable -y slp/mesa-libkrun-vulkan
-    dnf install -y mesa-vulkan-drivers-25.0.7-100.fc42 "${vulkan_rpms[@]}"
+    dnf install -y mesa-vulkan-drivers-25.0.7-100.fc42 virglrenderer "${vulkan_rpms[@]}"
     dnf versionlock add mesa-vulkan-drivers-25.0.7-100.fc42
   else
-    dnf install -y mesa-vulkan-drivers "${vulkan_rpms[@]}"
+    dnf install -y mesa-vulkan-drivers virglrenderer "${vulkan_rpms[@]}"
   fi
 
   rm_non_ubi_repos


### PR DESCRIPTION
When running in a krun-isolated container, we need "/usr/libexec/virgl_render_server" to be present in the container image to launch it before entering the microVM.

Install the virglrenderer package in addition to mesa-vulkan-drivers.

## Summary by Sourcery

Enhancements:
- Include virglrenderer package in container image builds to ensure virgl_render_server availability for Vulkan