### PR TITLE
build_rag.sh: install cmake

### DIFF
--- a/container-images/scripts/build_rag.sh
+++ b/container-images/scripts/build_rag.sh
@@ -83,9 +83,9 @@ main() {
     python=$(python_version)
     local pkgs
     if available dnf; then
-        pkgs=("git-core" "gcc" "gcc-c++")
+        pkgs=("git-core" "gcc" "gcc-c++" "cmake")
     else
-        pkgs=("git" "gcc" "g++")
+        pkgs=("git" "gcc" "g++" "cmake")
     fi
     if [ "${gpu}" = "cuda" ]; then
         pkgs+=("libcudnn9-devel-cuda-12" "libcusparselt0" "cuda-cupti-12-*")


### PR DESCRIPTION
`cmake` is required to build `sentencepiece`.

## Summary by Sourcery

Build:
- Include cmake in the packages installed via dnf and apt in build_rag.sh