### PR TITLE
konflux: add pipelines for ramalama-vllm and layered images

### DIFF
--- a/.tekton/ramalama-vllm-llama-server/ramalama-vllm-llama-server-pull-request.yaml
+++ b/.tekton/ramalama-vllm-llama-server/ramalama-vllm-llama-server-pull-request.yaml
@@ -1,0 +1,47 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: ramalama-vllm-llama-server
+    pipelines.appstudio.openshift.io/type: build
+  name: ramalama-vllm-llama-server-on-pull-request
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/ramalama-vllm-llama-server:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: build-platforms
+    value:
+    - linux-m2xlarge/amd64
+  - name: dockerfile
+    value: container-images/common/Containerfile.entrypoint
+  - name: parent-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/ramalama-vllm:on-pr-{{revision}}
+  - name: build-args
+    value:
+    - PARENT=quay.io/redhat-user-workloads/ramalama-tenant/ramalama-vllm:on-pr-{{revision}}
+    - ENTRYPOINT=/usr/bin/llama-server.sh
+  pipelineRef:
+    name: pull-request-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/ramalama-vllm-llama-server/ramalama-vllm-llama-server-push.yaml
+++ b/.tekton/ramalama-vllm-llama-server/ramalama-vllm-llama-server-push.yaml
@@ -1,0 +1,44 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "push" && target_branch == "main"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: ramalama-vllm-llama-server
+    pipelines.appstudio.openshift.io/type: build
+  name: ramalama-vllm-llama-server-on-push
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/ramalama-vllm-llama-server:{{revision}}
+  - name: build-platforms
+    value:
+    - linux-m2xlarge/amd64
+  - name: dockerfile
+    value: container-images/common/Containerfile.entrypoint
+  - name: parent-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/ramalama-vllm:{{revision}}
+  - name: build-args
+    value:
+    - PARENT=quay.io/redhat-user-workloads/ramalama-tenant/ramalama-vllm:{{revision}}
+    - ENTRYPOINT=/usr/bin/llama-server.sh
+  pipelineRef:
+    name: push-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/ramalama-vllm-rag/ramalama-vllm-rag-pull-request.yaml
+++ b/.tekton/ramalama-vllm-rag/ramalama-vllm-rag-pull-request.yaml
@@ -1,0 +1,47 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: ramalama-vllm-rag
+    pipelines.appstudio.openshift.io/type: build
+  name: ramalama-vllm-rag-on-pull-request
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/ramalama-vllm-rag:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: build-platforms
+    value:
+    - linux-d160-m2xlarge/amd64
+  - name: dockerfile
+    value: container-images/common/Containerfile.rag
+  - name: parent-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/ramalama-vllm:on-pr-{{revision}}
+  - name: build-args
+    value:
+    - PARENT=quay.io/redhat-user-workloads/ramalama-tenant/ramalama-vllm:on-pr-{{revision}}
+    - GPU=cpu
+  pipelineRef:
+    name: pull-request-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/ramalama-vllm-rag/ramalama-vllm-rag-push.yaml
+++ b/.tekton/ramalama-vllm-rag/ramalama-vllm-rag-push.yaml
@@ -1,0 +1,44 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "push" && target_branch == "main"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: ramalama-vllm-rag
+    pipelines.appstudio.openshift.io/type: build
+  name: ramalama-vllm-rag-on-push
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/ramalama-vllm-rag:{{revision}}
+  - name: build-platforms
+    value:
+    - linux-d160-m2xlarge/amd64
+  - name: dockerfile
+    value: container-images/common/Containerfile.rag
+  - name: parent-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/ramalama-vllm:{{revision}}
+  - name: build-args
+    value:
+    - PARENT=quay.io/redhat-user-workloads/ramalama-tenant/ramalama-vllm:{{revision}}
+    - GPU=cpu
+  pipelineRef:
+    name: push-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/ramalama-vllm-whisper-server/ramalama-vllm-whisper-server-pull-request.yaml
+++ b/.tekton/ramalama-vllm-whisper-server/ramalama-vllm-whisper-server-pull-request.yaml
@@ -1,0 +1,47 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: ramalama-vllm-whisper-server
+    pipelines.appstudio.openshift.io/type: build
+  name: ramalama-vllm-whisper-server-on-pull-request
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/ramalama-vllm-whisper-server:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: build-platforms
+    value:
+    - linux-m2xlarge/amd64
+  - name: dockerfile
+    value: container-images/common/Containerfile.entrypoint
+  - name: parent-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/ramalama-vllm:on-pr-{{revision}}
+  - name: build-args
+    value:
+    - PARENT=quay.io/redhat-user-workloads/ramalama-tenant/ramalama-vllm:on-pr-{{revision}}
+    - ENTRYPOINT=/usr/bin/whisper-server.sh
+  pipelineRef:
+    name: pull-request-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/ramalama-vllm-whisper-server/ramalama-vllm-whisper-server-push.yaml
+++ b/.tekton/ramalama-vllm-whisper-server/ramalama-vllm-whisper-server-push.yaml
@@ -1,0 +1,44 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "push" && target_branch == "main"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: ramalama-vllm-whisper-server
+    pipelines.appstudio.openshift.io/type: build
+  name: ramalama-vllm-whisper-server-on-push
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/ramalama-vllm-whisper-server:{{revision}}
+  - name: build-platforms
+    value:
+    - linux-m2xlarge/amd64
+  - name: dockerfile
+    value: container-images/common/Containerfile.entrypoint
+  - name: parent-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/ramalama-vllm:{{revision}}
+  - name: build-args
+    value:
+    - PARENT=quay.io/redhat-user-workloads/ramalama-tenant/ramalama-vllm:{{revision}}
+    - ENTRYPOINT=/usr/bin/whisper-server.sh
+  pipelineRef:
+    name: push-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/ramalama-vllm/ramalama-vllm-pull-request.yaml
+++ b/.tekton/ramalama-vllm/ramalama-vllm-pull-request.yaml
@@ -1,0 +1,41 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: ramalama-vllm
+    pipelines.appstudio.openshift.io/type: build
+  name: ramalama-vllm-on-pull-request
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/ramalama-vllm:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: build-platforms
+    value:
+    - linux-c4xlarge/amd64
+  - name: dockerfile
+    value: container-images/ramalama-vllm/Containerfile
+  pipelineRef:
+    name: pull-request-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/ramalama-vllm/ramalama-vllm-pull-request.yaml
+++ b/.tekton/ramalama-vllm/ramalama-vllm-pull-request.yaml
@@ -31,6 +31,11 @@ spec:
     - linux-c4xlarge/amd64
   - name: dockerfile
     value: container-images/ramalama-vllm/Containerfile
+  - name: parent-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/ramalama:on-pr-{{revision}}
+  - name: build-args
+    value:
+    - PARENT=quay.io/redhat-user-workloads/ramalama-tenant/ramalama:on-pr-{{revision}}
   pipelineRef:
     name: pull-request-pipeline
   timeouts:

--- a/.tekton/ramalama-vllm/ramalama-vllm-push.yaml
+++ b/.tekton/ramalama-vllm/ramalama-vllm-push.yaml
@@ -28,6 +28,11 @@ spec:
     - linux-c4xlarge/amd64
   - name: dockerfile
     value: container-images/ramalama-vllm/Containerfile
+  - name: parent-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/ramalama:{{revision}}
+  - name: build-args
+    value:
+    - PARENT=quay.io/redhat-user-workloads/ramalama-tenant/ramalama:{{revision}}
   pipelineRef:
     name: push-pipeline
   timeouts:

--- a/.tekton/ramalama-vllm/ramalama-vllm-push.yaml
+++ b/.tekton/ramalama-vllm/ramalama-vllm-push.yaml
@@ -1,0 +1,38 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/containers/ramalama?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "push" && target_branch == "main"
+  labels:
+    appstudio.openshift.io/application: ramalama
+    appstudio.openshift.io/component: ramalama-vllm
+    pipelines.appstudio.openshift.io/type: build
+  name: ramalama-vllm-on-push
+  namespace: ramalama-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/ramalama-tenant/ramalama-vllm:{{revision}}
+  - name: build-platforms
+    value:
+    - linux-c4xlarge/amd64
+  - name: dockerfile
+    value: container-images/ramalama-vllm/Containerfile
+  pipelineRef:
+    name: push-pipeline
+  timeouts:
+    pipeline: 6h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/container-images/ramalama-vllm/Containerfile
+++ b/container-images/ramalama-vllm/Containerfile
@@ -1,10 +1,9 @@
 ARG PARENT=quay.io/ramalama/ramalama:latest
 FROM $PARENT
 
-ENV PATH="/root/.local/bin:$PATH"
-ENV VIRTUAL_ENV="/opt/venv"
 ENV UV_PYTHON_INSTALL_DIR="/opt/uv/python"
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+ENV VIRTUAL_ENV="/opt/venv"
+ENV PATH="$VIRTUAL_ENV/bin:/root/.local/bin:$PATH"
 
 ENV UV_HTTP_TIMEOUT=500
 

--- a/container-images/ramalama-vllm/Containerfile
+++ b/container-images/ramalama-vllm/Containerfile
@@ -1,4 +1,5 @@
-FROM quay.io/ramalama/ramalama
+ARG PARENT=quay.io/ramalama/ramalama:latest
+FROM $PARENT
 
 ENV PATH="/root/.local/bin:$PATH"
 ENV VIRTUAL_ENV="/opt/venv"

--- a/container-images/scripts/build_rag.sh
+++ b/container-images/scripts/build_rag.sh
@@ -51,20 +51,20 @@ docling() {
             PYTORCH_DIR="cpu"
             ;;
     esac
-    ${python} -m pip install --prefix=/usr docling docling-core accelerate --extra-index-url "https://download.pytorch.org/whl/$PYTORCH_DIR"
+    ${python} -m pip install docling docling-core accelerate --extra-index-url "https://download.pytorch.org/whl/$PYTORCH_DIR"
     # Preloads models (assumes its installed from container_build.sh)
     doc2rag load
 }
 
 rag() {
-    ${python} -m pip install --prefix=/usr wheel qdrant_client pymilvus fastembed openai fastapi uvicorn
+    ${python} -m pip install wheel qdrant_client pymilvus fastembed openai fastapi uvicorn
     rag_framework load
 }
 
 to_gguf() {
     # required to build under GCC 15 until a new release is available, see https://github.com/google/sentencepiece/issues/1108 for details
     export CXXFLAGS="-include cstdint"
-    ${python} -m pip install --prefix=/usr "numpy~=1.26.4" "sentencepiece~=0.2.0" "transformers>=4.45.1,<5.0.0" git+https://github.com/ggml-org/llama.cpp#subdirectory=gguf-py "protobuf>=4.21.0,<5.0.0"
+    ${python} -m pip install "numpy~=1.26.4" "sentencepiece~=0.2.0" "transformers>=4.45.1,<5.0.0" git+https://github.com/ggml-org/llama.cpp#subdirectory=gguf-py "protobuf>=4.21.0,<5.0.0"
 }
 
 main() {


### PR DESCRIPTION
## Summary by Sourcery

Add Tekton PipelineRun configurations to automate building and pushing ramalama-vllm and its llama-server, rag, and whisper-server variants on pull request and main branch push events.

New Features:
- Introduce pull-request PipelineRun YAMLs for ramalama-vllm, llama-server, rag, and whisper-server components with multi-arch image builds and expiration settings
- Introduce push PipelineRun YAMLs for the same components to build and publish images upon main branch updates