### PR TITLE
fixes issue where format=markdown saves to dublicate absolute path

### DIFF
--- a/docs/ramalama-rag.1.md
+++ b/docs/ramalama-rag.1.md
@@ -19,7 +19,7 @@ positional arguments:
 	    AsciiDoc & Markdown formatted files to be processed.
 	    Can be specified multiple times.
 
-  *PATH|IMAGE*   Path or OCI Image name to contain processed rag data
+  *DESTINATION*   Path or OCI Image name to contain processed rag data
 
 ## OPTIONS
 

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -1126,7 +1126,9 @@ If GPU device on host is accessible to via group access, this option leaks the u
 Files/Directory containing PDF, DOCX, PPTX, XLSX, HTML, AsciiDoc & Markdown
 formatted files to be processed""",
     )
-    parser.add_argument("IMAGE", help="OCI Image name to contain processed rag data", completer=suppressCompleter)
+    parser.add_argument(
+        "DESTINATION", help="Path or OCI Image name to contain processed rag data", completer=suppressCompleter
+    )
     parser.add_argument(
         "--ocr",
         dest="ocr",
@@ -1138,7 +1140,7 @@ formatted files to be processed""",
 
 
 def rag_cli(args):
-    rag = ramalama.rag.Rag(args.IMAGE)
+    rag = ramalama.rag.Rag(args.DESTINATION)
     rag.generate(args)
 
 

--- a/ramalama/rag.py
+++ b/ramalama/rag.py
@@ -65,8 +65,9 @@ COPY {src} /vector.db
         parsed = urlparse(path)
         if parsed.scheme in ["file", ""] and parsed.netloc == "":
             if os.path.exists(parsed.path):
-                fpath = os.path.realpath(parsed.path)
-                self.engine.add(["-v", f"{fpath}:{INPUT_DIR}/{fpath}:ro,z"])
+                fpath = os.path.realpath(parsed.path.rstrip("/"))
+                input_name = os.path.basename(fpath)
+                self.engine.add(["-v", f"{fpath}:{INPUT_DIR}/{input_name}:ro,z"])
             else:
                 raise ValueError(f"{path} does not exist")
             return

--- a/test/system/070-rag.bats
+++ b/test/system/070-rag.bats
@@ -15,7 +15,7 @@ load helpers
 
     FILE=README.md
     run_ramalama --dryrun rag $FILE quay.io/ramalama/myrag:1.2
-    is "$output" ".*-v ${PWD}/$FILE:/docs/$PWD/$FILE" "Expected to see file volume mounted in"
+    is "$output" ".*-v ${PWD}/$FILE:/docs/$FILE" "Expected to see file volume mounted in"
     is "$output" ".*doc2rag --format qdrant /output /docs " "Expected to doc2rag command"
     is "$output" ".*--pull missing" "only pull if missing"
 
@@ -25,7 +25,7 @@ load helpers
 
     FILE_URL=file://${PWD}/README.md
     run_ramalama --dryrun rag $FILE_URL quay.io/ramalama/myrag:1.2
-    is "$output" ".*-v ${PWD}/$FILE:/docs/$PWD/$FILE" "Expected to see file volume mounted in"
+    is "$output" ".*-v ${PWD}/$FILE:/docs/$FILE" "Expected to see file volume mounted in"
 
     FILE=BOGUS
     run_ramalama 22 --dryrun rag $FILE quay.io/ramalama/myrag:1.2


### PR DESCRIPTION
## Summary by Sourcery

Fix path handling and CLI argument naming in rag command

Bug Fixes:
- Strip trailing slash and use basename for local path mounts to avoid duplicate absolute paths in container

Enhancements:
- Rename CLI positional argument from IMAGE to DESTINATION for clarity

Documentation:
- Update CLI usage docs to reflect DESTINATION argument rename