### PR TITLE
Use model organization as namespace when pulling Ollama models

### DIFF
--- a/ramalama/ollama.py
+++ b/ramalama/ollama.py
@@ -33,15 +33,16 @@ def in_existing_cache(model_name, model_tag):
 
 
 class OllamaRepository:
-    REGISTRY_URL = "https://registry.ollama.ai/v2/library"
+    REGISTRY_URL = "https://registry.ollama.ai/v2"
     ACCEPT = "Accept: application/vnd.docker.distribution.manifest.v2+json"
 
     FILE_NAME_CONFIG = "config.json"
     FILE_NAME_CHAT_TEMPLATE = "chat_template"
 
-    def __init__(self, name):
+    def __init__(self, name: str, namespace: str = "library"):
         self.name = name
-        self.registry_head = f"{OllamaRepository.REGISTRY_URL}/{name}"
+        self.namespace = namespace
+        self.registry_head = f"{OllamaRepository.REGISTRY_URL}/{namespace}/{name}"
         self.blob_url = f"{self.registry_head}/blobs"
         self.headers = {"Accept": OllamaRepository.ACCEPT}
 
@@ -142,22 +143,30 @@ class Ollama(Model):
 
         self.type = "Ollama"
 
+    def extract_model_identifiers(self):
+        model_name, model_tag, model_organization = super().extract_model_identifiers()
+
+        # use the ollama default namespace if no model organization has been identified
+        if not model_organization:
+            model_organization = "library"
+        return model_name, model_tag, model_organization
+
     def pull(self, args):
-        name, tag, _ = self.extract_model_identifiers()
+        name, tag, organization = self.extract_model_identifiers()
         _, cached_files, all = self.model_store.get_cached_files(tag)
         if all:
             if not args.quiet:
-                perror(f"Using cached ollama://{name}:{tag} ...")
+                perror(f"Using cached ollama://{organization}/{name}:{tag} ...")
             return
 
-        ollama_repo = OllamaRepository(self.model_store.model_name)
+        ollama_repo = OllamaRepository(name, organization)
         manifest = ollama_repo.fetch_manifest(tag)
         ollama_cache_path = in_existing_cache(self.model_name, tag)
         is_model_in_ollama_cache = ollama_cache_path is not None
         files: list[SnapshotFile] = ollama_repo.get_file_list(tag, cached_files, is_model_in_ollama_cache)
 
         if not args.quiet:
-            self.print_pull_message(f"ollama://{name}:{tag}")
+            self.print_pull_message(f"ollama://{organization}/{name}:{tag}")
 
         model_hash = ollama_repo.get_model_hash(manifest)
         self.model_store.new_snapshot(tag, model_hash, files)

--- a/test/system/050-pull.bats
+++ b/test/system/050-pull.bats
@@ -21,7 +21,7 @@ load setup_suite
     RAMALAMA_TRANSPORT=ollama run_ramalama pull smollm:360m
     run_ramalama pull ollama://smollm:360m
     run_ramalama list
-    is "$output" ".*ollama://smollm/smollm:360m" "image was actually pulled locally"
+    is "$output" ".*ollama://library/smollm:360m" "image was actually pulled locally"
     run_ramalama rm ollama://smollm:135m ollama://smollm:360m
 
     random_image_name=i_$(safename)
@@ -49,7 +49,7 @@ load setup_suite
     RAMALAMA_TRANSPORT=ollama run_ramalama pull smollm:360m
     run_ramalama pull ollama://smollm:360m
     run_ramalama list
-    is "$output" ".*ollama://smollm/smollm:360m" "image was actually pulled locally from ollama cache"
+    is "$output" ".*ollama://library/smollm:360m" "image was actually pulled locally from ollama cache"
     run_ramalama rm https://ollama.com/library/smollm:135m ollama://smollm:360m
     ollama rm smollm:135m smollm:360m
 

--- a/test/system/100-inspect.bats
+++ b/test/system/100-inspect.bats
@@ -14,7 +14,7 @@ load setup_suite
     run_ramalama inspect tiny
 
     is "${lines[0]}" "tinyllama" "model name"
-    is "${lines[1]}" "   Path: .*store/ollama/tinyllama/.*" "model path"
+    is "${lines[1]}" "   Path: .*store/ollama/library/tinyllama/.*" "model path"
     is "${lines[2]}" "   Registry: ollama" "model registry"
     is "${lines[3]}" "   Format: GGUF" "model format"
     is "${lines[4]}" "   Version: 3" "model format version"
@@ -28,7 +28,7 @@ load setup_suite
     run_ramalama inspect --all tiny
 
     is "${lines[0]}" "tinyllama" "model name"
-    is "${lines[1]}" "   Path: .*store/ollama/tinyllama/.*" "model path"
+    is "${lines[1]}" "   Path: .*store/ollama/library/tinyllama/.*" "model path"
     is "${lines[2]}" "   Registry: ollama" "model registry"
     is "${lines[3]}" "   Format: GGUF" "model format"
     is "${lines[4]}" "   Version: 3" "model format version"

--- a/test/unit/test_model.py
+++ b/test/unit/test_model.py
@@ -49,14 +49,14 @@ ms_granite_blob = "https://modelscope.cn/models/ibm-granite/granite-3b-code-base
             "f823b84ec4b84f9a6742c8a1f6a893deeca75f06",
             "modelscope.cn/models/ibm-granite/granite-3b-code-base-2k-GGUF",
         ),
-        ("ollama://granite-code", "granite-code", "latest", ""),
+        ("ollama://granite-code", "granite-code", "latest", "library"),
         (
             "https://ollama.com/huihui_ai/granite3.1-dense-abliterated:2b-instruct-fp16",
             "granite3.1-dense-abliterated",
             "2b-instruct-fp16",
             "ollama.com/huihui_ai",
         ),
-        ("ollama.com/library/granite-code", "granite-code", "latest", ""),
+        ("ollama.com/library/granite-code", "granite-code", "latest", "library"),
         (
             "huihui_ai/granite3.1-dense-abliterated:2b-instruct-fp16",
             "granite3.1-dense-abliterated",


### PR DESCRIPTION
Relates to: https://github.com/containers/ramalama/issues/1278

Previously, the /library namespace was hard-coded into the Ollama API registry head which caused pulling namespaced Ollama models to fail with a 404 error. By mapping the model organization to the API calls namespace, this has been resolved. In addition, the organization for Ollama models falls back to "library" if no organization can be found in the model input.

PTAL @jcajka

## Summary by Sourcery

Enable pulling Ollama models from named organizations by using the model’s organization as the API namespace instead of hard‐coded “library.”

Enhancements:
- Use dynamic namespace in Ollama registry URL by removing the static “library” segment from REGISTRY_URL and including the model organization.
- Add extract_model_identifiers override to default to “library” when no organization is provided.
- Pass the resolved model organization into OllamaRepository during model pull operations.