### PR TITLE
Don't override image when using rag if user specified it

### DIFF
--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -258,7 +258,7 @@ class Model(ModelBase):
     def base(self, args, name):
         # force accel_image to use -rag version. Drop TAG if it exists
         # so that accel_image will add -rag to the image specification.
-        if args.image == self.default_image and getattr(args, "rag", None):
+        if getattr(args, "rag", None) and not getattr(args, "image_override", False):
             args.image = rag_image(args.image)
         self.engine = Engine(args)
         if args.subcommand == "run" and not getattr(args, "ARGS", None) and sys.stdin.isatty():

--- a/ramalama/rag.py
+++ b/ramalama/rag.py
@@ -114,7 +114,8 @@ COPY {src} /vector.db
 
             self.engine.add(["-e", f"{k}={v}"])
 
-        self.engine.add([rag_image(args.image)])
+        image = args.image if getattr(args, "image_override", False) else rag_image(args.image)
+        self.engine.add([image])
         self.engine.add(["doc2rag", "--format", args.format, "/output", INPUT_DIR])
         if args.ocr:
             self.engine.add(["--ocr"])

--- a/test/system/070-rag.bats
+++ b/test/system/070-rag.bats
@@ -51,6 +51,8 @@ load helpers
        RAMALAMA_CONFIG=/dev/null run_ramalama --dryrun run --rag quay.io/ramalama/myrag:1.2 ollama://smollm:135m
        is "$output" ".*--pull newer.*" "Expected to use --pull newer"
     fi
+    run_ramalama --image quay.io/ramalama/bogus --dryrun run --rag quay.io/ramalama/myrag:1.2 ollama://smollm:135m
+    assert "$output" !~ ".*quay.io/ramalama/bogus-rag.*" "Expected to not use -rag image"
 
     run_ramalama info
     engine=$(echo "$output" | jq --raw-output '.Engine.Name')


### PR DESCRIPTION
Fixes: https://github.com/containers/ramalama/issues/1713

## Summary by Sourcery

Respect user-provided images by applying the RAG suffix only when the image_override flag is not set, and add a system test to validate this behavior

Bug Fixes:
- Prevent unintended overriding of a user-specified image when using RAG

Enhancements:
- Introduce the image_override flag to control whether the RAG suffix is applied to images

Tests:
- Add a system test to verify that custom images are not modified with the -rag suffix when image_override is enabled