### PR TITLE
No virglrenderer in RHEL

### DIFF
--- a/container-images/scripts/build_llama_and_whisper.sh
+++ b/container-images/scripts/build_llama_and_whisper.sh
@@ -99,10 +99,13 @@ is_rhel_based() { # doesn't include openEuler
 dnf_install_mesa() {
   if [ "${ID}" = "fedora" ]; then
     dnf copr enable -y slp/mesa-libkrun-vulkan
-    dnf install -y mesa-vulkan-drivers-25.0.7-100.fc42 virglrenderer "${vulkan_rpms[@]}"
+    dnf install -y mesa-vulkan-drivers-25.0.7-100.fc42 virglrenderer \
+      "${vulkan_rpms[@]}"
     dnf versionlock add mesa-vulkan-drivers-25.0.7-100.fc42
-  else
+  elif [ "${ID}" = "openEuler" ]; then
     dnf install -y mesa-vulkan-drivers virglrenderer "${vulkan_rpms[@]}"
+  else # virglrenderer not available on RHEL or EPEL
+    dnf install -y mesa-vulkan-drivers "${vulkan_rpms[@]}"
   fi
 
   rm_non_ubi_repos


### PR DESCRIPTION
In this build script we basically assume if it's a dnf based OS that is not Fedora. It's some RHEL-based OS. virglrenderer is required for a microVM feature in RamaLama. krun and virglrenderer are not in RHEL.

## Summary by Sourcery

Bug Fixes:
- Remove virglrenderer from the dnf install command on non-Fedora dnf-based OS