### PR TITLE
Re-enable passing chat template to model

### DIFF
--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -593,10 +593,9 @@ class Model(ModelBase):
         else:
             exec_args += ["--jinja"]
 
-            # TODO: see https://github.com/containers/ramalama/issues/1202
-            # chat_template_path = self._get_chat_template_path(args.container, args.generate, args.dryrun)
-            # if chat_template_path is not None:
-            #     exec_args += ["--chat-template-file", chat_template_path]
+            chat_template_path = self._get_chat_template_path(args.container, args.generate, args.dryrun)
+            if chat_template_path is not None:
+                exec_args += ["--chat-template-file", chat_template_path]
 
         if should_colorize():
             exec_args += ["--log-colors"]


### PR DESCRIPTION
Fixes: https://github.com/containers/ramalama/issues/1202

Re-enable passing the chat template to running/serving the model as the issue where using the template lowers the quality of the output seems to be solved.

## Summary by Sourcery

Enhancements:
- Restore chat template retrieval and injection in the llama_serve execution arguments