### PR TITLE
Define image within container with full name

### DIFF
--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -260,6 +260,9 @@ class Model(ModelBase):
         # so that accel_image will add -rag to the image specification.
         if getattr(args, "rag", None) and not getattr(args, "image_override", False):
             args.image = rag_image(args.image)
+        if self.type == "Ollama":
+            args.UNRESOLVED_MODEL = args.MODEL
+            args.MODEL = self.resolve_model()
         self.engine = Engine(args)
         if args.subcommand == "run" and not getattr(args, "ARGS", None) and sys.stdin.isatty():
             self.engine.add(["-i"])

--- a/ramalama/ollama.py
+++ b/ramalama/ollama.py
@@ -152,6 +152,10 @@ class Ollama(Model):
             model_organization = "library"
         return model_name, model_tag, model_organization
 
+    def resolve_model(self):
+        name, tag, organization = self.extract_model_identifiers()
+        return f"ollama://{organization}/{name}:{tag}"
+
     def pull(self, args):
         name, tag, organization = self.extract_model_identifiers()
         _, cached_files, all = self.model_store.get_cached_files(tag)

--- a/test/system/040-serve.bats
+++ b/test/system/040-serve.bats
@@ -117,6 +117,9 @@ verify_begin=".*run --rm"
 @test "ramalama serve and stop" {
     skip_if_nocontainer
 
+    run_ramalama -q --dryrun serve smollm
+    is "$output" ".*ai.ramalama.model=ollama://library/smollm:latest" "smollm should be expanded to fullname"
+
     model=ollama://smollm:135m
     container1=c_$(safename)
     container2=c_$(safename)


### PR DESCRIPTION
Fixes: https://github.com/containers/ramalama/issues/1268

## Summary by Sourcery

Expand Ollama model references inside containers to their full URI by implementing a resolve_model method and updating the model initialization logic, and add a system test to validate the expansion.

Enhancements:
- Add resolve_model method to generate fully qualified Ollama model URIs
- Use resolved model URI to override args.MODEL for Ollama engine initialization

Tests:
- Add system test to verify that shorthand model names are expanded to full image names on serve