### PR TITLE
konflux: build -rag images on bigger instances with large disks

### DIFF
--- a/.tekton/asahi-rag/asahi-rag-pull-request.yaml
+++ b/.tekton/asahi-rag/asahi-rag-pull-request.yaml
@@ -28,8 +28,8 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux-d160-m2xlarge/amd64
-    - linux-d160-m2xlarge/arm64
+    - linux-d160-c8xlarge/amd64
+    - linux-d160-c8xlarge/arm64
   - name: dockerfile
     value: container-images/common/Containerfile.rag
   - name: parent-image

--- a/.tekton/asahi-rag/asahi-rag-push.yaml
+++ b/.tekton/asahi-rag/asahi-rag-push.yaml
@@ -25,8 +25,8 @@ spec:
     value: quay.io/redhat-user-workloads/ramalama-tenant/asahi-rag:{{revision}}
   - name: build-platforms
     value:
-    - linux-d160-m2xlarge/amd64
-    - linux-d160-m2xlarge/arm64
+    - linux-d160-c8xlarge/amd64
+    - linux-d160-c8xlarge/arm64
   - name: dockerfile
     value: container-images/common/Containerfile.rag
   - name: parent-image

--- a/.tekton/cann-rag/cann-rag-pull-request.yaml
+++ b/.tekton/cann-rag/cann-rag-pull-request.yaml
@@ -28,8 +28,8 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux-d160-m2xlarge/amd64
-    - linux-d160-m2xlarge/arm64
+    - linux-d160-c8xlarge/amd64
+    - linux-d160-c8xlarge/arm64
   - name: dockerfile
     value: container-images/common/Containerfile.rag
   - name: parent-image

--- a/.tekton/cann-rag/cann-rag-push.yaml
+++ b/.tekton/cann-rag/cann-rag-push.yaml
@@ -25,8 +25,8 @@ spec:
     value: quay.io/redhat-user-workloads/ramalama-tenant/cann-rag:{{revision}}
   - name: build-platforms
     value:
-    - linux-d160-m2xlarge/amd64
-    - linux-d160-m2xlarge/arm64
+    - linux-d160-c8xlarge/amd64
+    - linux-d160-c8xlarge/arm64
   - name: dockerfile
     value: container-images/common/Containerfile.rag
   - name: parent-image

--- a/.tekton/cuda-rag/cuda-rag-pull-request.yaml
+++ b/.tekton/cuda-rag/cuda-rag-pull-request.yaml
@@ -28,8 +28,8 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux-d160-m2xlarge/amd64
-    - linux-d160-m2xlarge/arm64
+    - linux-d160-c8xlarge/amd64
+    - linux-d160-c8xlarge/arm64
   - name: dockerfile
     value: container-images/common/Containerfile.rag
   - name: parent-image

--- a/.tekton/cuda-rag/cuda-rag-push.yaml
+++ b/.tekton/cuda-rag/cuda-rag-push.yaml
@@ -25,8 +25,8 @@ spec:
     value: quay.io/redhat-user-workloads/ramalama-tenant/cuda-rag:{{revision}}
   - name: build-platforms
     value:
-    - linux-d160-m2xlarge/amd64
-    - linux-d160-m2xlarge/arm64
+    - linux-d160-c8xlarge/amd64
+    - linux-d160-c8xlarge/arm64
   - name: dockerfile
     value: container-images/common/Containerfile.rag
   - name: parent-image

--- a/.tekton/intel-gpu-rag/intel-gpu-rag-pull-request.yaml
+++ b/.tekton/intel-gpu-rag/intel-gpu-rag-pull-request.yaml
@@ -28,7 +28,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux-d160-m2xlarge/amd64
+    - linux-d160-c8xlarge/amd64
   - name: dockerfile
     value: container-images/common/Containerfile.rag
   - name: parent-image

--- a/.tekton/intel-gpu-rag/intel-gpu-rag-push.yaml
+++ b/.tekton/intel-gpu-rag/intel-gpu-rag-push.yaml
@@ -25,7 +25,7 @@ spec:
     value: quay.io/redhat-user-workloads/ramalama-tenant/intel-gpu-rag:{{revision}}
   - name: build-platforms
     value:
-    - linux-d160-m2xlarge/amd64
+    - linux-d160-c8xlarge/amd64
   - name: dockerfile
     value: container-images/common/Containerfile.rag
   - name: parent-image

--- a/.tekton/musa-rag/musa-rag-pull-request.yaml
+++ b/.tekton/musa-rag/musa-rag-pull-request.yaml
@@ -28,7 +28,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux-d160-m2xlarge/amd64
+    - linux-d160-c8xlarge/amd64
   - name: dockerfile
     value: container-images/common/Containerfile.rag
   - name: parent-image

--- a/.tekton/musa-rag/musa-rag-push.yaml
+++ b/.tekton/musa-rag/musa-rag-push.yaml
@@ -25,7 +25,7 @@ spec:
     value: quay.io/redhat-user-workloads/ramalama-tenant/musa-rag:{{revision}}
   - name: build-platforms
     value:
-    - linux-d160-m2xlarge/amd64
+    - linux-d160-c8xlarge/amd64
   - name: dockerfile
     value: container-images/common/Containerfile.rag
   - name: parent-image

--- a/.tekton/ramalama-rag/ramalama-rag-pull-request.yaml
+++ b/.tekton/ramalama-rag/ramalama-rag-pull-request.yaml
@@ -28,8 +28,8 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux-d160-m2xlarge/amd64
-    - linux-d160-m2xlarge/arm64
+    - linux-d160-c8xlarge/amd64
+    - linux-d160-c8xlarge/arm64
   - name: dockerfile
     value: container-images/common/Containerfile.rag
   - name: parent-image

--- a/.tekton/ramalama-rag/ramalama-rag-push.yaml
+++ b/.tekton/ramalama-rag/ramalama-rag-push.yaml
@@ -25,8 +25,8 @@ spec:
     value: quay.io/redhat-user-workloads/ramalama-tenant/ramalama-rag:{{revision}}
   - name: build-platforms
     value:
-    - linux-d160-m2xlarge/amd64
-    - linux-d160-m2xlarge/arm64
+    - linux-d160-c8xlarge/amd64
+    - linux-d160-c8xlarge/arm64
   - name: dockerfile
     value: container-images/common/Containerfile.rag
   - name: parent-image

--- a/.tekton/ramalama-vllm-rag/ramalama-vllm-rag-pull-request.yaml
+++ b/.tekton/ramalama-vllm-rag/ramalama-vllm-rag-pull-request.yaml
@@ -28,7 +28,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux-d160-m2xlarge/amd64
+    - linux-d160-c8xlarge/amd64
   - name: dockerfile
     value: container-images/common/Containerfile.rag
   - name: parent-image

--- a/.tekton/ramalama-vllm-rag/ramalama-vllm-rag-push.yaml
+++ b/.tekton/ramalama-vllm-rag/ramalama-vllm-rag-push.yaml
@@ -25,7 +25,7 @@ spec:
     value: quay.io/redhat-user-workloads/ramalama-tenant/ramalama-vllm-rag:{{revision}}
   - name: build-platforms
     value:
-    - linux-d160-m2xlarge/amd64
+    - linux-d160-c8xlarge/amd64
   - name: dockerfile
     value: container-images/common/Containerfile.rag
   - name: parent-image

--- a/.tekton/rocm-rag/rocm-rag-pull-request.yaml
+++ b/.tekton/rocm-rag/rocm-rag-pull-request.yaml
@@ -28,7 +28,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux-d160-m2xlarge/amd64
+    - linux-d160-c8xlarge/amd64
   - name: dockerfile
     value: container-images/common/Containerfile.rag
   - name: parent-image

--- a/.tekton/rocm-rag/rocm-rag-push.yaml
+++ b/.tekton/rocm-rag/rocm-rag-push.yaml
@@ -25,7 +25,7 @@ spec:
     value: quay.io/redhat-user-workloads/ramalama-tenant/rocm-rag:{{revision}}
   - name: build-platforms
     value:
-    - linux-d160-m2xlarge/amd64
+    - linux-d160-c8xlarge/amd64
   - name: dockerfile
     value: container-images/common/Containerfile.rag
   - name: parent-image

--- a/.tekton/rocm-ubi-rag/rocm-ubi-rag-pull-request.yaml
+++ b/.tekton/rocm-ubi-rag/rocm-ubi-rag-pull-request.yaml
@@ -28,7 +28,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux-d160-m2xlarge/amd64
+    - linux-d160-c8xlarge/amd64
   - name: dockerfile
     value: container-images/common/Containerfile.rag
   - name: parent-image

--- a/.tekton/rocm-ubi-rag/rocm-ubi-rag-push.yaml
+++ b/.tekton/rocm-ubi-rag/rocm-ubi-rag-push.yaml
@@ -25,7 +25,7 @@ spec:
     value: quay.io/redhat-user-workloads/ramalama-tenant/rocm-ubi-rag:{{revision}}
   - name: build-platforms
     value:
-    - linux-d160-m2xlarge/amd64
+    - linux-d160-c8xlarge/amd64
   - name: dockerfile
     value: container-images/common/Containerfile.rag
   - name: parent-image


### PR DESCRIPTION
The `-rag` images take a long time to build, delaying developer feedback and slowing down the development and testing cycle. Build the images on the largest instance types available, which also have the larger (160G) disk sizes necessary to handle `-rag` images.

## Summary by Sourcery

CI:
- Switch build-platforms to linux-d160-c8xlarge for both amd64 and arm64 in all -rag pull-request and push pipelines