### PR TITLE
Remove GGUF version check when parsing

### DIFF
--- a/ramalama/model_inspect/gguf_info.py
+++ b/ramalama/model_inspect/gguf_info.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict
+from typing import Any, Dict, Union
 
 from ramalama.endian import GGUFEndian
 from ramalama.model_inspect.base_info import ModelInfoBase, Tensor, adjust_new_line
@@ -14,6 +14,7 @@ class GGUFModelInfo(ModelInfoBase):
         Name: str,
         Registry: str,
         Path: str,
+        Version: Union[int, float],
         metadata: Dict[str, Any],
         tensors: list[Tensor],
         endianness: GGUFEndian,
@@ -21,7 +22,7 @@ class GGUFModelInfo(ModelInfoBase):
         super().__init__(Name, Registry, Path)
 
         self.Format = GGUFModelInfo.MAGIC_NUMBER
-        self.Version = GGUFModelInfo.VERSION
+        self.Version = Version
         self.Metadata: Dict[str, Any] = metadata
         self.Tensors: list[Tensor] = tensors
         self.Endianness: GGUFEndian = endianness

--- a/ramalama/model_inspect/gguf_parser.py
+++ b/ramalama/model_inspect/gguf_parser.py
@@ -192,8 +192,6 @@ class GGUFInfoParser:
                 raise ParseError(f"Invalid GGUF magic number '{magic_number}'")
 
             gguf_version = GGUFInfoParser.read_number(model, GGUFValueType.UINT32, model_endianness)
-            if gguf_version != GGUFModelInfo.VERSION:
-                raise ParseError(f"Expected GGUF version '{GGUFModelInfo.VERSION}', but got '{gguf_version}'")
 
             tensor_count = GGUFInfoParser.read_number(model, GGUFValueType.UINT64, model_endianness)
             metadata_kv_count = GGUFInfoParser.read_number(model, GGUFValueType.UINT64, model_endianness)
@@ -215,4 +213,6 @@ class GGUFInfoParser:
                 offset = GGUFInfoParser.read_number(model, GGUFValueType.UINT64, model_endianness)
                 tensors.append(Tensor(name, n_dimensions, dimensions, tensor_type, offset))
 
-            return GGUFModelInfo(model_name, model_registry, model_path, metadata, tensors, model_endianness)
+            return GGUFModelInfo(
+                model_name, model_registry, model_path, gguf_version, metadata, tensors, model_endianness
+            )


### PR DESCRIPTION
In the GGUFParser the version of the GGUF model is being checked against a hard-coded constant, currently v3. This prevents using older (or newer) GGUF models. This check should not be done in the parser, but rather in the used backend such as llama.cpp. If the backend supports it, its fine and if not, then an error is being thrown anyway.

## Summary by Sourcery

Drop the fixed GGUF version check in the parser and propagate the actual version into the model info

Enhancements:
- Remove hard-coded GGUF version validation in the parser to support any model version
- Add a version parameter to GGUFModelInfo and assign the parsed version instead of using a constant