### PR TITLE
Include mmproj mount in quadlet

### DIFF
--- a/ramalama/kube.py
+++ b/ramalama/kube.py
@@ -52,7 +52,7 @@ class Kube:
             mounts += m
             volumes += v
 
-        if os.path.exists(self.src_chat_template_path):
+        if self.src_chat_template_path and os.path.exists(self.src_chat_template_path):
             volumes += self._gen_chat_template_volume()
 
         m, v = self._gen_devices()

--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -689,13 +689,16 @@ class Model(ModelBase):
         # Get the blob paths (src) and mounted paths (dest)
         model_src_path = self._get_entry_model_path(False, False, args.dryrun)
         chat_template_src_path = self._get_chat_template_path(False, False, args.dryrun)
+        mmproj_src_path = self._get_mmproj_path(False, False, args.dryrun)
         model_dest_path = self._get_entry_model_path(True, True, args.dryrun)
         chat_template_dest_path = self._get_chat_template_path(True, True, args.dryrun)
+        mmproj_dest_path = self._get_mmproj_path(True, True, args.dryrun)
 
         if args.generate.gen_type == "quadlet":
             self.quadlet(
                 (model_src_path, model_dest_path),
                 (chat_template_src_path, chat_template_dest_path),
+                (mmproj_src_path, mmproj_dest_path),
                 args,
                 exec_args,
                 args.generate.output_dir,
@@ -712,6 +715,7 @@ class Model(ModelBase):
             self.quadlet_kube(
                 (model_src_path, model_dest_path),
                 (chat_template_src_path, chat_template_dest_path),
+                (mmproj_src_path, mmproj_dest_path),
                 args,
                 exec_args,
                 args.generate.output_dir,
@@ -755,16 +759,16 @@ class Model(ModelBase):
 
         self.execute_command(exec_args, args)
 
-    def quadlet(self, model_paths, chat_template_paths, args, exec_args, output_dir):
-        quadlet = Quadlet(self.model_name, model_paths, chat_template_paths, args, exec_args)
+    def quadlet(self, model_paths, chat_template_paths, mmproj_paths, args, exec_args, output_dir):
+        quadlet = Quadlet(self.model_name, model_paths, chat_template_paths, mmproj_paths, args, exec_args)
         for generated_file in quadlet.generate():
             generated_file.write(output_dir)
 
-    def quadlet_kube(self, model_paths, chat_template_paths, args, exec_args, output_dir):
+    def quadlet_kube(self, model_paths, chat_template_paths, mmproj_paths, args, exec_args, output_dir):
         kube = Kube(self.model_name, model_paths, chat_template_paths, args, exec_args)
         kube.generate().write(output_dir)
 
-        quadlet = Quadlet(self.model_name, model_paths, chat_template_paths, args, exec_args)
+        quadlet = Quadlet(self.model_name, model_paths, chat_template_paths, mmproj_paths, args, exec_args)
         quadlet.kube().write(output_dir)
 
     def kube(self, model_paths, chat_template_paths, args, exec_args, output_dir):

--- a/ramalama/quadlet.py
+++ b/ramalama/quadlet.py
@@ -12,6 +12,7 @@ class Quadlet:
         model_name: str,
         model_paths: Tuple[str, str],
         chat_template_paths: Optional[Tuple[str, str]],
+        mmproj_path: Optional[Tuple[str, str]],
         args,
         exec_args,
     ):
@@ -19,6 +20,7 @@ class Quadlet:
         self.src_chat_template_path, self.dest_chat_template_path = (
             chat_template_paths if chat_template_paths is not None else ("", "")
         )
+        self.src_mmproj_path, self.dest_mmproj_path = mmproj_path if mmproj_path is not None else ("", "")
 
         self.ai_image = model_name
         self.src_model_path = self.src_model_path.removeprefix("oci://")
@@ -67,6 +69,7 @@ class Quadlet:
                 quadlet_file.add("Container", "NoNewPrivileges", "true")
 
         self._gen_chat_template_volume(quadlet_file)
+        self._gen_mmproj_volume(quadlet_file)
         self._gen_env(quadlet_file)
         self._gen_name(quadlet_file)
         self._gen_port(quadlet_file)
@@ -83,11 +86,19 @@ class Quadlet:
         return files
 
     def _gen_chat_template_volume(self, quadlet_file: UnitFile):
-        if os.path.exists(self.src_chat_template_path):
+        if self.src_chat_template_path and os.path.exists(self.src_chat_template_path):
             quadlet_file.add(
                 "Container",
                 "Mount",
                 f"type=bind,src={self.src_chat_template_path},target={self.dest_chat_template_path},ro,Z",
+            )
+
+    def _gen_mmproj_volume(self, quadlet_file: UnitFile):
+        if self.src_mmproj_path and os.path.exists(self.src_mmproj_path):
+            quadlet_file.add(
+                "Container",
+                "Mount",
+                f"type=bind,src={self.src_mmproj_path},target={self.dest_mmproj_path},ro,Z",
             )
 
     def _gen_env(self, quadlet_file: UnitFile):

--- a/test/unit/data/test_quadlet/modelfromstore_mmproj/modelfromstore_mmproj.container
+++ b/test/unit/data/test_quadlet/modelfromstore_mmproj/modelfromstore_mmproj.container
@@ -1,0 +1,21 @@
+[Unit]
+Description=RamaLama modelfromstore_mmproj AI Model Service
+After=local-fs.target
+
+[Container]
+AddDevice=-/dev/accel
+AddDevice=-/dev/dri
+AddDevice=-/dev/kfd
+Image=testimage
+RunInit=true
+Environment=HOME=/tmp
+Exec=
+SecurityLabelDisable=true
+DropCapability=all
+NoNewPrivileges=true
+Mount=type=bind,src=sha256-c21bc76d14f19f6552bfd8bbf4e5f57494169b902c73aa12ce3ce855466477fa,target=model.mmproj,ro,Z
+Mount=type=bind,src=sha256-2af3b81862c6be03c769683af18efdadb2c33f60ff32ab6f83e42c043d6c7816,target=longpathtoablobsha,ro,Z
+
+[Install]
+WantedBy=multi-user.target default.target
+

--- a/test/unit/test_quadlet.py
+++ b/test/unit/test_quadlet.py
@@ -30,6 +30,9 @@ class Input:
         chat_template_src_blob: str = "",
         chat_template_dest_name: str = "",
         chat_template_file_exists: bool = False,
+        mmproj_src_blob: str = "",
+        mmproj_dest_name: str = "",
+        mmproj_file_exists: bool = False,
         image: str = "",
         args: Args = Args(),
         exec_args: list = [],
@@ -41,6 +44,9 @@ class Input:
         self.chat_template_src_blob = chat_template_src_blob
         self.chat_template_dest_name = chat_template_dest_name
         self.chat_template_file_exists = chat_template_file_exists
+        self.mmproj_src_blob = mmproj_src_blob
+        self.mmproj_dest_name = mmproj_dest_name
+        self.mmproj_file_exists = mmproj_file_exists
         self.image = image
         self.args = args
         self.exec_args = exec_args
@@ -104,6 +110,20 @@ DATA_PATH = Path(__file__).parent / "data" / "test_quadlet"
             ),
             DATA_PATH / "modelfromstore_ct",
         ),
+        (
+            Input(
+                model_name="modelfromstore_mmproj",
+                model_src_blob="sha256-2af3b81862c6be03c769683af18efdadb2c33f60ff32ab6f83e42c043d6c7816",
+                model_dest_name="longpathtoablobsha",
+                image="testimage",
+                args=Args(MODEL="modelfromstore_mmproj"),
+                model_file_exists=True,
+                mmproj_src_blob="sha256-c21bc76d14f19f6552bfd8bbf4e5f57494169b902c73aa12ce3ce855466477fa",
+                mmproj_dest_name="model.mmproj",
+                mmproj_file_exists=True,
+            ),
+            DATA_PATH / "modelfromstore_mmproj",
+        ),
     ],
 )
 def test_quadlet_generate(input: Input, expected_files_path: Path, monkeypatch):
@@ -115,6 +135,7 @@ def test_quadlet_generate(input: Input, expected_files_path: Path, monkeypatch):
     existence = {
         input.model_src_blob: input.model_file_exists,
         input.chat_template_src_blob: input.chat_template_file_exists,
+        input.mmproj_src_blob: input.mmproj_file_exists,
     }
 
     monkeypatch.setattr("os.path.exists", lambda path: existence.get(path, False))
@@ -124,6 +145,7 @@ def test_quadlet_generate(input: Input, expected_files_path: Path, monkeypatch):
         input.model_name,
         (input.model_src_blob, input.model_dest_name),
         (input.chat_template_src_blob, input.chat_template_dest_name),
+        (input.mmproj_src_blob, input.mmproj_dest_name),
         input.args,
         input.exec_args,
     ).generate():


### PR DESCRIPTION
Fixes: #1440

## Summary by Sourcery

Add mmproj mount support by propagating its source and destination paths through model, Quadlet, and Kube; update generation logic and tests accordingly

New Features:
- Add support for mounting an mmproj file as a bind volume in quadlet and kube outputs

Enhancements:
- Extend Quadlet and Kube classes to accept src/dest paths for mmproj
- Update model.generate_container_config to propagate mmproj paths through quadlet and kube generation

Tests:
- Enhance test_quadlet unit tests to include scenarios with mmproj src and destination paths