### PR TITLE
konflux: push images to the quay.io/ramalama org after integration testing

### DIFF
--- a/.tekton/integration/pipelines/bats-integration.yaml
+++ b/.tekton/integration/pipelines/bats-integration.yaml
@@ -26,6 +26,16 @@ spec:
   - name: git-revision
     description: Revision of the Git repository containing pipeline and task definitions
     default: main
+  - name: repo-prefix
+    description: The prefix (usually hostname/orgname) of the destination repo where the Snapshot components will be pushed
+    default: quay.io/ramalama
+  - name: skip-components
+    description: A space-separated list of components that should not be pushed
+    default: bats
+  results:
+  - name: TEST_OUTPUT
+    description: Test results in JSON format
+    value: $(tasks.push.results.TEST_OUTPUT)
   tasks:
   - name: init
     params:
@@ -64,3 +74,30 @@ spec:
         value: $(params.git-revision)
       - name: pathInRepo
         value: .tekton/integration/tasks/test-vm-cmd.yaml
+    when:
+    - input: $(tasks.init.results.sync)
+      operator: in
+      values: ["true"]
+  - name: push
+    params:
+    - name: SNAPSHOT
+      value: $(params.SNAPSHOT)
+    - name: event-type
+      value: $(tasks.init.results.event-type)
+    - name: sync
+      value: $(tasks.init.results.sync)
+    - name: repo-prefix
+      value: $(params.repo-prefix)
+    - name: skip-components
+      value: $(params.skip-components)
+    taskRef:
+      resolver: git
+      params:
+      - name: url
+        value: $(params.git-url)
+      - name: revision
+        value: $(params.git-revision)
+      - name: pathInRepo
+        value: .tekton/integration/tasks/push-snapshot.yaml
+    runAfter:
+    - test

--- a/.tekton/integration/tasks/init-snapshot.yaml
+++ b/.tekton/integration/tasks/init-snapshot.yaml
@@ -11,6 +11,12 @@ spec:
   results:
   - name: event-type
     description: The type of event that triggered the pipeline
+  - name: snapshot-type
+    description: The type of Snapshot that is being tested.
+  - name: sync
+    description: >-
+      True if all components are built from the same git commit. False if components
+      are built from different commits.
   - name: bats-image
     description: URI of the bats image included in the snapshot
   - name: ramalama-image
@@ -27,8 +33,16 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.labels['pac.test.appstudio.openshift.io/event-type']
+    - name: SNAPSHOT_TYPE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.labels['test.appstudio.openshift.io/type']
     - name: RESULTS_EVENT_TYPE_PATH
       value: $(results.event-type.path)
+    - name: RESULTS_SNAPSHOT_TYPE_PATH
+      value: $(results.snapshot-type.path)
+    - name: RESULTS_SYNC_PATH
+      value: $(results.sync.path)
     - name: RESULTS_BATS_IMAGE_PATH
       value: $(results.bats-image.path)
     - name: RESULTS_RAMALAMA_IMAGE_PATH
@@ -39,6 +53,10 @@ spec:
       #!/bin/bash -ex
       dnf -y install jq
       echo -n "$EVENT_TYPE" | tee "$RESULTS_EVENT_TYPE_PATH"
+      echo
+      echo -n "$SNAPSHOT_TYPE" | tee "$RESULTS_SNAPSHOT_TYPE_PATH"
+      echo
+      jq -j '[.components[] | .source.git.revision] | unique | length == 1' <<< "$SNAPSHOT" | tee "$RESULTS_SYNC_PATH"
       echo
       component_image() {
         TAGSEP=":"

--- a/.tekton/integration/tasks/push-snapshot.yaml
+++ b/.tekton/integration/tasks/push-snapshot.yaml
@@ -1,0 +1,132 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: push-snapshot
+spec:
+  description: Push images referenced by the provided Snapshot to another registry
+  params:
+  - name: SNAPSHOT
+    description: Information about the Snapshot to be pushed
+  - name: event-type
+    description: The type of event that triggered the pipeline
+  - name: sync
+    description: >-
+      True if all components are built from the same git commit. False if components
+      are built from different commits.
+  - name: repo-prefix
+    description: >-
+      The prefix (usually hostname/orgname) of the destination repo to push the Snapshot components to.
+      The name of the component will be appended to this prefix and the result will be used as the
+      destination repo to push the component to.
+  - name: skip-components
+    description: >-
+      A space-separated list of components that should not be pushed
+    default: ""
+  results:
+  - name: TEST_OUTPUT
+    description: Test results in JSON format
+  steps:
+  - name: push-to-registry
+    image: registry.access.redhat.com/ubi10/skopeo:latest
+    env:
+    - name: SNAPSHOT
+      value: $(params.SNAPSHOT)
+    - name: EVENT_TYPE
+      value: $(params.event-type)
+    - name: SYNC
+      value: $(params.sync)
+    - name: REPO_PREFIX
+      value: $(params.repo-prefix)
+    - name: SKIP_COMPONENTS
+      value: $(params.skip-components)
+    - name: RESULTS_TEST_OUTPUT_PATH
+      value: $(results.TEST_OUTPUT.path)
+    - name: NAMESPACE
+      value: $(context.taskRun.namespace)
+    script: |
+      #!/bin/bash -x
+      dnf -y install jq
+
+      log() {
+        echo "[$(date -uIns)]" $*
+      }
+
+      in_args() {
+        local item="$1"
+        shift
+        while [ "$#" -gt 0 ]; do
+          if [ "$item" == "$1" ]; then
+            return 0
+          fi
+          shift
+        done
+        return 1
+      }
+
+      test_output() {
+        local RESULT="$1"
+        local SUCCESSES="$2"
+        local FAILURES="$3"
+        local WARNINGS="$4"
+        local NOTE="$5"
+
+        jq -jnc \
+          --arg result "$RESULT" \
+          --arg note "$NOTE" \
+          --arg namespace "$NAMESPACE" \
+          --arg successes "$SUCCESSES" \
+          --arg failures "$FAILURES" \
+          --arg warnings "$WARNINGS" \
+          '{
+             result: $result,
+             timestamp: now | todateiso8601[:-1] | "\(.)+00:00",
+             note: $note,
+             namespace: $namespace,
+             successes: $successes | tonumber,
+             failures: $failures | tonumber,
+             warnings: $warnings | tonumber
+          }' | tee "$RESULTS_TEST_OUTPUT_PATH"
+      }
+
+      COMPONENTS="$(jq -r '.components | length' <<< "$SNAPSHOT")"
+      SKIP=($SKIP_COMPONENTS)
+
+      if [ "$EVENT_TYPE" != "push" ]; then
+        NOTE="Skipped push of $COMPONENTS components from \"$EVENT_TYPE\" event"
+        test_output SKIPPED 0 0 0 "$NOTE"
+        exit
+      elif [ "$SYNC" != "true" ]; then
+        NOTE="Skipped push of $COMPONENTS components due to out-of-sync components"
+        test_output SKIPPED 0 0 0 "$NOTE"
+        exit
+      fi
+
+      SUCCESSES=0
+      SKIPS=0
+      FAILED_COMPONENTS=()
+      while read NAME SRC DEST; do
+        if in_args "$NAME" "${SKIP[@]}"; then
+          log Skipping push of "$NAME"
+          (( SKIPS+=1 ))
+          continue
+        fi
+        log Copying "$NAME" from "$SRC" to "$DEST"
+        if skopeo copy --all --multi-arch all --retry-times 5 "docker://$SRC" "docker://$DEST"; then
+          (( SUCCESSES+=1 ))
+        else
+          FAILED_COMPONENTS+=("$NAME")
+        fi
+      done < <(
+        jq -r --arg prefix "$REPO_PREFIX" \
+          '.components[] | "\(.name) \(.containerImage) \($prefix)/\(.name):\(.source.git.revision)"' \
+          <<< "$SNAPSHOT"
+      )
+
+      if [ "${#FAILED_COMPONENTS[*]}" -gt 0 ]; then
+        NOTE="$SUCCESSES components successfully pushed, $SKIPS components skipped, ${#FAILED_COMPONENTS[*]} failed to push: ${FAILED_COMPONENTS[*]}"
+        test_output FAILURE "$SUCCESSES" "${#FAILED_COMPONENTS[*]}" 0 "$NOTE"
+        exit 1
+      else
+        NOTE="$SUCCESSES components successfully pushed, $SKIPS components skipped"
+        test_output SUCCESS "$SUCCESSES" 0 0 "$NOTE"
+      fi


### PR DESCRIPTION
The `bats-integration` pipeline is now run on every pull request and push to the main branch. In the case of pushes, if the integration tests run successfully, the images are pushed to a repo matching their component name in the `quay.io/ramalama` org. Images will be tagged with the sha of the commit from which they were built.

## Summary by Sourcery

Extend the Tekton integration pipeline to push built component images to quay.io/ramalama after successful integration tests on push events

New Features:
- Add a push-snapshot task that copies snapshot component images to a target registry tagged by commit SHA
- Introduce repo-prefix and skip-components parameters to configure the destination registry and exclude specific components from pushing
- Add sync detection to only push when all components originate from the same Git commit

Enhancements:
- Refactor init and test steps to reference named Tekton tasks instead of using the Git resolver
- Configure the push step to run only after tests pass and only on push events with in-sync components