### PR TITLE
musa: disable build of whisper.cpp, and update llama.cpp

### DIFF
--- a/container-images/scripts/build_llama_and_whisper.sh
+++ b/container-images/scripts/build_llama_and_whisper.sh
@@ -271,7 +271,7 @@ clone_and_build_whisper_cpp() {
 }
 
 clone_and_build_llama_cpp() {
-  local llama_cpp_sha="f667f1e6244e1f420512fa66692b7096ff17f366"
+  local llama_cpp_sha="3f4fc97f1d745f1d5d3c853949503136d419e6de"
   local install_prefix
   install_prefix=$(set_install_prefix)
   git clone https://github.com/ggml-org/llama.cpp
@@ -326,7 +326,7 @@ main() {
   install_entrypoints
 
   setup_build_env
-  if [ "$uname_m" != "s390x" ]; then
+  if [ "$uname_m" != "s390x" ] && [ "$containerfile" != "musa" ]; then
     clone_and_build_whisper_cpp
   fi
   common_flags+=("-DLLAMA_CURL=ON" "-DGGML_RPC=ON")


### PR DESCRIPTION
Updating the musa images to `rc4.2.0` requires a newer version of `llama.cpp`, and broke the `whisper.cpp` build. For more info see:

https://github.com/containers/ramalama/pull/1697

## Summary by Sourcery

Update llama.cpp to a newer commit and disable whisper.cpp build for the Musa container

Enhancements:
- Bump llama.cpp checkout to commit 3f4fc97f1d745f1d5d3c853949503136d419e6de
- Skip building whisper.cpp when running the Musa container image