### PR TITLE
Fix listing models

### DIFF
--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -43,6 +43,10 @@ def is_split_file_model(model_path):
     return bool(re.match(SPLIT_MODEL_PATH_RE, model_path))
 
 
+def sanitize_filename(filename: str) -> str:
+    return filename.replace(":", "-")
+
+
 podman_machine_accel = False
 
 


### PR DESCRIPTION
Fixes: https://github.com/containers/ramalama/issues/1735

The migration for RefFile to RefJSONFile needs to be checked, and optionally triggered, when listing models. Otherwise no files are being found and the model is listed with 0 Bytes. It also moves the migrating of RefFile to RefJSONFile into a dedicated function so that it can be removed more easily in later releases (when this is no longer needed).

## Summary by Sourcery

Fix model listing by migrating legacy RefFile to the new RefJSONFile format during listing, refactor migration logic into dedicated utilities, and clean up duplicate mapping code.

Bug Fixes:
- Trigger migration of old RefFile records when listing models so files are found and sizes calculated correctly.

Enhancements:
- Extract migration routines into map_to_refjsonfile and migrate_reffile_to_refjsonfile in the reffile module and apply them in ModelStore.get_ref_file and global_store.list_models.

Chores:
- Remove duplicate map_ref_file and sanitize_filename definitions from store.py and centralize filename sanitization in common.py.