### PR TITLE
Fixes docsite page linking

### DIFF
--- a/docs/ramalama-cann.7.md
+++ b/docs/ramalama-cann.7.md
@@ -7,7 +7,7 @@ This guide walks through the steps required to set up RamaLama with Ascend NPU s
  - [Hardware](#hardware)
  - [Model](#model)
  - [Docker](#docker)
- - [HISTORY](#todo)
+ - [HISTORY](#history)
 
 ## Background
 

--- a/docsite/Makefile
+++ b/docsite/Makefile
@@ -3,7 +3,7 @@
 # This Makefile provides commands for building and managing the RamaLama
 # documentation site powered by Docusaurus.
 
-.PHONY: help convert dev build serve clean install
+.PHONY: help convert dev build serve clean install clean-generated
 
 # Default target - show help
 help: ## Show this help message
@@ -42,6 +42,14 @@ clean: ## Clean build artifacts and node_modules
 	@echo "Cleaning build artifacts..."
 	@rm -rf build .docusaurus node_modules
 	@echo "✅ Clean complete!"
+
+clean-generated: ## Clean auto-generated MDX files
+	@echo "Cleaning auto-generated MDX files..."
+	@find docs -name "*.mdx" -exec grep -l "# This file is auto-generated from manpages. Do not edit manually." {} \; | while read file; do \
+		echo "  Removing: $$file"; \
+		rm "$$file"; \
+	done
+	@echo "✅ Auto-generated files cleaned!"
 
 all: install convert build ## Install deps, convert manpages, and build site
 

--- a/docsite/convert_manpages.py
+++ b/docsite/convert_manpages.py
@@ -43,8 +43,14 @@ def extract_title_and_description(content, filename):
 
         title = f"{platform} Setup"
     if base_name.endswith('.5.md'):
-        # Config: ramalama.conf.5.md -> ramalama.conf
-        title = base_name.replace('.5.md', '')
+        # Config files with custom titles
+        if base_name == 'ramalama.conf.5.md':
+            title = 'Configuration File'
+        elif base_name == 'ramalama-oci.5.md':
+            title = 'OCI Spec'
+        else:
+            # Fallback for other .5.md files
+            title = base_name.replace('.5.md', '')
     else:
         # Fallback
         title = base_name.replace('.md', '').replace('-', ' ')
@@ -136,6 +142,8 @@ def convert_markdown_to_mdx(content, filename):
     if history_match:
         history_text = history_match.group(1).strip()
         content = re.sub(history_pattern, '', content, flags=re.DOTALL)
+        # Remove TOC links to HISTORY since it becomes a footer
+        content = re.sub(r'\s*- \[HISTORY\]\(#history\)\n?', '', content)
         # Add history as footer
         content += f"\n\n---\n\n*{history_text}*"
 
@@ -171,7 +179,7 @@ def convert_markdown_to_mdx(content, filename):
                 if filename == 'ramalama.1.md':
                     return f'[{text}](#)'  # Self-reference
                 else:
-                    return f'[{text}]({base_path}commands/ramalama/ramalama)'
+                    return f'[{text}](/docs/commands/ramalama/)'  # Link to ramalama category index
             return f'[{text}]({base_path}commands/ramalama/{command_name})'
         if link.endswith('.5.md'):
             # Configuration file

--- a/docsite/docs/commands/ramalama/bench.mdx
+++ b/docsite/docs/commands/ramalama/bench.mdx
@@ -156,7 +156,7 @@ ramalama bench granite3-moe
 ```
 
 ## See Also
-[ramalama(1)](../../commands/ramalama/ramalama)
+[ramalama(1)](/docs/commands/ramalama/)
 
 ---
 

--- a/docsite/docs/commands/ramalama/chat.mdx
+++ b/docsite/docs/commands/ramalama/chat.mdx
@@ -59,7 +59,7 @@ $ ramalama chat --url http://localhost:1234
 ```
 
 ## See Also
-[ramalama(1)](../../commands/ramalama/ramalama)
+[ramalama(1)](/docs/commands/ramalama/)
 
 ---
 

--- a/docsite/docs/commands/ramalama/containers.mdx
+++ b/docsite/docs/commands/ramalama/containers.mdx
@@ -74,7 +74,7 @@ granite-server
 ```
 
 ## See Also
-[ramalama(1)](../../commands/ramalama/ramalama)
+[ramalama(1)](/docs/commands/ramalama/)
 
 ---
 

--- a/docsite/docs/commands/ramalama/convert.mdx
+++ b/docsite/docs/commands/ramalama/convert.mdx
@@ -65,7 +65,7 @@ $ ramalama run oci://quay.io/kugupta/granite-3.2-q4-k-m:latest
 ```
 
 ## See Also
-[ramalama(1)](../../commands/ramalama/ramalama), [ramalama-push(1)](../../commands/ramalama/push)
+[ramalama(1)](/docs/commands/ramalama/), [ramalama-push(1)](../../commands/ramalama/push)
 
 ---
 

--- a/docsite/docs/commands/ramalama/info.mdx
+++ b/docsite/docs/commands/ramalama/info.mdx
@@ -352,7 +352,7 @@ $ ramalama info |  jq .Shortnames.Names.mixtao
 ```
 
 ## See Also
-[ramalama(1)](../../commands/ramalama/ramalama)
+[ramalama(1)](/docs/commands/ramalama/)
 
 ---
 

--- a/docsite/docs/commands/ramalama/inspect.mdx
+++ b/docsite/docs/commands/ramalama/inspect.mdx
@@ -75,7 +75,7 @@ $ ramalama inspect smollm:135m --all --json
 ```
 
 ## See Also
-[ramalama(1)](../../commands/ramalama/ramalama)
+[ramalama(1)](/docs/commands/ramalama/)
 
 ---
 

--- a/docsite/docs/commands/ramalama/list.mdx
+++ b/docsite/docs/commands/ramalama/list.mdx
@@ -49,7 +49,7 @@ $ ramalama list --json
 ```
 
 ## See Also
-[ramalama(1)](../../commands/ramalama/ramalama)
+[ramalama(1)](/docs/commands/ramalama/)
 
 ---
 

--- a/docsite/docs/commands/ramalama/login.mdx
+++ b/docsite/docs/commands/ramalama/login.mdx
@@ -69,7 +69,7 @@ $ ramalama login --token=XYZ
 Logging in to ModelScope requires the `modelscope` tool. For installation and usage instructions, see the documentation of the ModelScope command line interface: [*https://www.modelscope.cn/docs/Beginner-s-Guide/Environment-Setup*](https://www.modelscope.cn/docs/Beginner-s-Guide/Environment-Setup).
 
 ## See Also
-[ramalama(1)](../../commands/ramalama/ramalama)
+[ramalama(1)](/docs/commands/ramalama/)
 
 ---
 

--- a/docsite/docs/commands/ramalama/logout.mdx
+++ b/docsite/docs/commands/ramalama/logout.mdx
@@ -41,7 +41,7 @@ Logout from huggingface
 $ ramalama logout huggingface
 ```
 ## See Also
-[ramalama(1)](../../commands/ramalama/ramalama)
+[ramalama(1)](/docs/commands/ramalama/)
 
 ---
 

--- a/docsite/docs/commands/ramalama/perplexity.mdx
+++ b/docsite/docs/commands/ramalama/perplexity.mdx
@@ -164,7 +164,7 @@ ramalama perplexity granite3-moe
 ```
 
 ## See Also
-[ramalama(1)](../../commands/ramalama/ramalama)
+[ramalama(1)](/docs/commands/ramalama/)
 
 ---
 

--- a/docsite/docs/commands/ramalama/pull.mdx
+++ b/docsite/docs/commands/ramalama/pull.mdx
@@ -25,7 +25,7 @@ Print usage message
 require HTTPS and verify certificates when contacting OCI registries
 
 ## See Also
-[ramalama(1)](../../commands/ramalama/ramalama)
+[ramalama(1)](/docs/commands/ramalama/)
 
 ---
 

--- a/docsite/docs/commands/ramalama/push.mdx
+++ b/docsite/docs/commands/ramalama/push.mdx
@@ -74,7 +74,7 @@ Writing manifest to image destination
 ```
 
 ## See Also
-[ramalama(1)](../../commands/ramalama/ramalama), [ramalama-convert(1)](../../commands/ramalama/convert)
+[ramalama(1)](/docs/commands/ramalama/), [ramalama-convert(1)](../../commands/ramalama/convert)
 
 ---
 

--- a/docsite/docs/commands/ramalama/rag.mdx
+++ b/docsite/docs/commands/ramalama/rag.mdx
@@ -120,7 +120,7 @@ $ ls /tmp/output/docs/tmp/
 ```
 
 ## See Also
-[ramalama(1)](../../commands/ramalama/ramalama)
+[ramalama(1)](/docs/commands/ramalama/)
 
 ---
 

--- a/docsite/docs/commands/ramalama/rm.mdx
+++ b/docsite/docs/commands/ramalama/rm.mdx
@@ -35,7 +35,7 @@ $ ramalama rm --ignore bogusmodel
 ```
 
 ## See Also
-[ramalama(1)](../../commands/ramalama/ramalama)
+[ramalama(1)](/docs/commands/ramalama/)
 
 ---
 

--- a/docsite/docs/commands/ramalama/run.mdx
+++ b/docsite/docs/commands/ramalama/run.mdx
@@ -215,7 +215,7 @@ This program is a Python script that allows the user to interact with a terminal
 See [ramalama-cuda(7)](../../platform-guides/cuda) for setting up the host Linux system for CUDA support.
 
 ## See Also
-[ramalama(1)](../../commands/ramalama/ramalama), [ramalama-cuda(7)](../../platform-guides/cuda)
+[ramalama(1)](/docs/commands/ramalama/), [ramalama-cuda(7)](../../platform-guides/cuda)
 
 ---
 

--- a/docsite/docs/commands/ramalama/serve.mdx
+++ b/docsite/docs/commands/ramalama/serve.mdx
@@ -522,7 +522,7 @@ ramalama --runtime=mlx serve hf://mlx-community/Unsloth-Phi-4-4bit
 ```
 
 ## See Also
-[ramalama(1)](../../commands/ramalama/ramalama), [ramalama-stop(1)](../../commands/ramalama/stop), **quadlet(1)**, **systemctl(1)**, **podman(1)**, **podman-ps(1)**, [ramalama-cuda(7)](../../platform-guides/cuda)
+[ramalama(1)](/docs/commands/ramalama/), [ramalama-stop(1)](../../commands/ramalama/stop), **quadlet(1)**, **systemctl(1)**, **podman(1)**, **podman-ps(1)**, [ramalama-cuda(7)](../../platform-guides/cuda)
 
 ---
 

--- a/docsite/docs/commands/ramalama/stop.mdx
+++ b/docsite/docs/commands/ramalama/stop.mdx
@@ -38,7 +38,7 @@ $ ramalama stop --all
 ```
 
 ## See Also
-[ramalama(1)](../../commands/ramalama/ramalama), [ramalama-run(1)](../../commands/ramalama/run), [ramalama-serve(1)](../../commands/ramalama/serve)
+[ramalama(1)](/docs/commands/ramalama/), [ramalama-run(1)](../../commands/ramalama/run), [ramalama-serve(1)](../../commands/ramalama/serve)
 
 ---
 

--- a/docsite/docs/commands/ramalama/version.mdx
+++ b/docsite/docs/commands/ramalama/version.mdx
@@ -28,7 +28,7 @@ $ ramalama -q version
 >
 ```
 ## See Also
-[ramalama(1)](../../commands/ramalama/ramalama)
+[ramalama(1)](/docs/commands/ramalama/)
 
 ---
 

--- a/docsite/docs/configuration/conf.mdx
+++ b/docsite/docs/configuration/conf.mdx
@@ -1,11 +1,11 @@
 ---
-title: ramalama.conf
+title: Configuration File
 description: Configuration file reference
 # This file is auto-generated from manpages. Do not edit manually.
 # Source: ramalama.conf.5.md
 ---
 
-# ramalama.conf
+# Configuration File
 
 # NAME
 ramalama.conf - These configuration files specifies default

--- a/docsite/docs/configuration/ramalama-oci.mdx
+++ b/docsite/docs/configuration/ramalama-oci.mdx
@@ -1,11 +1,11 @@
 ---
-title: ramalama-oci
+title: OCI Spec
 description: Configuration file reference
 # This file is auto-generated from manpages. Do not edit manually.
 # Source: ramalama-oci.5.md
 ---
 
-# ramalama-oci
+# OCI Spec
 
 # NAME
 ramalama-oci - RamaLama oci:// Image Format

--- a/docsite/docs/getting-started/installation.mdx
+++ b/docsite/docs/getting-started/installation.mdx
@@ -77,7 +77,7 @@ Once RamaLama is installed, you can:
 2. **Run a model**: `ramalama run ollama://tinyllama`
 3. **Explore available commands**: `ramalama --help`
 
-For detailed usage instructions, see the [Commands](../commands/ramalama/ramalama) section.
+For detailed usage instructions, see the [Commands](../commands/ramalama/) section.
 
 ## Platform-Specific Setup
 

--- a/docsite/docs/platform-guides/cann.mdx
+++ b/docsite/docs/platform-guides/cann.mdx
@@ -14,8 +14,6 @@ This guide walks through the steps required to set up RamaLama with Ascend NPU s
  - [Hardware](#hardware)
  - [Model](#model)
  - [Docker](#docker)
- - [HISTORY](#todo)
-
 ## Background
 
 **Ascend NPU** is a range of AI processors using Neural Processing Unit. It will efficiently handle matrix-matrix multiplication, dot-product and scalars.

--- a/docsite/docs/platform-guides/cuda.mdx
+++ b/docsite/docs/platform-guides/cuda.mdx
@@ -186,7 +186,7 @@ sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
 
 ## See Also
 
-[ramalama(1)](../commands/ramalama/ramalama), [podman(1)](https://github.com/containers/podman/blob/main/docs/source/markdown/podman.1.md)
+[ramalama(1)](/docs/commands/ramalama/), [podman(1)](https://github.com/containers/podman/blob/main/docs/source/markdown/podman.1.md)
 
 ---
 

--- a/docsite/docs/platform-guides/macos.mdx
+++ b/docsite/docs/platform-guides/macos.mdx
@@ -60,7 +60,7 @@ Refer to the [Podman Desktop documentation](https://podman-desktop.io/docs/podma
 
 ## See Also
 
-[ramalama(1)](../commands/ramalama/ramalama), [podman-machine(1)](https://github.com/containers/podman/blob/main/docs/source/markdown/podman-machine.1.md)
+[ramalama(1)](/docs/commands/ramalama/), [podman-machine(1)](https://github.com/containers/podman/blob/main/docs/source/markdown/podman-machine.1.md)
 
 ---
 

--- a/docsite/docusaurus.config.ts
+++ b/docsite/docusaurus.config.ts
@@ -97,7 +97,7 @@ const config: Config = {
           items: [
             {
               label: 'Getting Started',
-              to: '/docs/getting-started',
+              to: '/docs/getting-started/installation',
             },
             {
               label: 'API References',


### PR DESCRIPTION
## Summary by Sourcery

Fix docsite linking issues and improve manpage-to-mdx conversion

Bug Fixes:
- Correct internal See Also links to point to /docs/commands/ramalama/ instead of relative paths
- Fix HISTORY anchor references and remove obsolete TOC entries in converted markdown

Enhancements:
- Map specific .5.md config manpages to custom titles
- Add a clean-generated Makefile target to remove auto-generated MDX files
- Strip HISTORY TOC links during markdown-to-MDX conversion

Documentation:
- Update frontmatter titles for Configuration File and OCI Spec pages