### PR TITLE
Fix assembling URLs for big models

### DIFF
--- a/test/unit/test_url.py
+++ b/test/unit/test_url.py
@@ -1,0 +1,58 @@
+from dataclasses import dataclass, field
+
+import pytest
+
+from ramalama.model_store.snapshot_file import SnapshotFile
+from ramalama.url import URL
+
+
+@dataclass
+class Input:
+    Model: str
+
+
+@dataclass
+class Expected:
+    URLList: list[str] = field(default_factory=lambda: [])
+    Names: list[str] = field(default_factory=lambda: [])
+
+
+@pytest.mark.parametrize(
+    "input,expected",
+    [
+        (Input(""), Expected()),
+        (Input("file:///tmp/models/granite-3b-code-base.Q4_K_M.gguf"), Expected()),
+        (
+            Input(
+                "huggingface.co/unsloth/Qwen3-Coder-480B-A35B-Instruct-GGUF/resolve/main/Q3_K_M/Qwen3-Coder-480B-A35B-Instruct-Q3_K_M-00001-of-00005.gguf"  # noqa: E501
+            ),
+            Expected(
+                URLList=[
+                    "https://huggingface.co/unsloth/Qwen3-Coder-480B-A35B-Instruct-GGUF/resolve/main/Q3_K_M/Qwen3-Coder-480B-A35B-Instruct-Q3_K_M-00001-of-00005.gguf",  # noqa: E501
+                    "https://huggingface.co/unsloth/Qwen3-Coder-480B-A35B-Instruct-GGUF/resolve/main/Q3_K_M/Qwen3-Coder-480B-A35B-Instruct-Q3_K_M-00002-of-00005.gguf",  # noqa: E501
+                    "https://huggingface.co/unsloth/Qwen3-Coder-480B-A35B-Instruct-GGUF/resolve/main/Q3_K_M/Qwen3-Coder-480B-A35B-Instruct-Q3_K_M-00003-of-00005.gguf",  # noqa: E501
+                    "https://huggingface.co/unsloth/Qwen3-Coder-480B-A35B-Instruct-GGUF/resolve/main/Q3_K_M/Qwen3-Coder-480B-A35B-Instruct-Q3_K_M-00004-of-00005.gguf",  # noqa: E501
+                    "https://huggingface.co/unsloth/Qwen3-Coder-480B-A35B-Instruct-GGUF/resolve/main/Q3_K_M/Qwen3-Coder-480B-A35B-Instruct-Q3_K_M-00005-of-00005.gguf",  # noqa: E501
+                ],
+                Names=[
+                    "Qwen3-Coder-480B-A35B-Instruct-Q3_K_M-00001-of-00005.gguf",
+                    "Qwen3-Coder-480B-A35B-Instruct-Q3_K_M-00002-of-00005.gguf",
+                    "Qwen3-Coder-480B-A35B-Instruct-Q3_K_M-00003-of-00005.gguf",
+                    "Qwen3-Coder-480B-A35B-Instruct-Q3_K_M-00004-of-00005.gguf",
+                    "Qwen3-Coder-480B-A35B-Instruct-Q3_K_M-00005-of-00005.gguf",
+                ],
+            ),
+        ),
+    ],
+)
+def test__assemble_split_file_list(input: Input, expected: Expected):
+    # store path and scheme irrelevant here
+    model = URL(input.Model, "/store", "https")
+    files: list[SnapshotFile] = model._assemble_split_file_list("doesnotmatterhere")
+    file_count = len(files)
+    assert file_count == len(expected.Names)
+    assert file_count == len(expected.URLList)
+
+    for i in range(file_count):
+        assert files[i].url == expected.URLList[i]
+        assert files[i].name == expected.Names[i]


### PR DESCRIPTION
Previously, the loop was missing the first file of a big model and using the same name for all models. This has been fixed in this PR.

For example, previously running 
```
ramalama pull https://huggingface.co/unsloth/Qwen3-Coder-480B-A35B-Instruct-GGUF/resolve/main/Q3_K_M/Qwen3-Coder-480B-A35B-Instruct-Q3_K_M-00001-of-00005.gguf`
```
would result in the following files to be downloaded (missing the 00001):
```
https://huggingface.co/unsloth/Qwen3-Coder-480B-A35B-Instruct-GGUF/resolve/main/Q3_K_M/Qwen3-Coder-480B-A35B-Instruct-Q3_K_M-00002-of-00005.gguf
https://huggingface.co/unsloth/Qwen3-Coder-480B-A35B-Instruct-GGUF/resolve/main/Q3_K_M/Qwen3-Coder-480B-A35B-Instruct-Q3_K_M-00003-of-00005.gguf
https://huggingface.co/unsloth/Qwen3-Coder-480B-A35B-Instruct-GGUF/resolve/main/Q3_K_M/Qwen3-Coder-480B-A35B-Instruct-Q3_K_M-00004-of-00005.gguf
https://huggingface.co/unsloth/Qwen3-Coder-480B-A35B-Instruct-GGUF/resolve/main/Q3_K_M/Qwen3-Coder-480B-A35B-Instruct-Q3_K_M-00005-of-00005.gguf
```
And each file would have the same name of `Qwen3-Coder-480B-A35B-Instruct-Q3_K_M-00001-of-00005.gguf`, causing previously downloaded files to be overwritten. 

With this fix, it correctly downloads the following files with their respective names:
```
Qwen3-Coder-480B-A35B-Instruct-Q3_K_M-00001-of-00005.gguf
Qwen3-Coder-480B-A35B-Instruct-Q3_K_M-00002-of-00005.gguf
Qwen3-Coder-480B-A35B-Instruct-Q3_K_M-00003-of-00005.gguf
Qwen3-Coder-480B-A35B-Instruct-Q3_K_M-00004-of-00005.gguf
Qwen3-Coder-480B-A35B-Instruct-Q3_K_M-00005-of-00005.gguf
```

## Summary by Sourcery

Correctly assemble URLs and filenames for split model files to include the first part and prevent overwriting by generating unique names for each part

Bug Fixes:
- Include the first part when assembling URLs for split models and prevent filename collisions by generating unique filenames for each part

Enhancements:
- Extract split model file list generation into a dedicated private `_assemble_split_file_list` method