### PR TITLE
musa: re-enable whisper.cpp build and update its commit SHA

### DIFF
--- a/container-images/scripts/build_llama_and_whisper.sh
+++ b/container-images/scripts/build_llama_and_whisper.sh
@@ -253,8 +253,7 @@ configure_common_flags() {
 
 clone_and_build_whisper_cpp() {
   local whisper_flags=("${common_flags[@]}")
-  # last time we tried to upgrade the whisper sha, rocm build broke
-  local whisper_cpp_sha="d682e150908e10caa4c15883c633d7902d385237"
+  local whisper_cpp_sha="d0a9d8c7f8f7b91c51d77bbaa394b915f79cde6b"
   whisper_flags+=("-DBUILD_SHARED_LIBS=OFF")
   # See: https://github.com/ggml-org/llama.cpp/blob/master/docs/build.md#compilation-options
   if [ "$containerfile" = "musa" ]; then
@@ -327,7 +326,7 @@ main() {
   install_entrypoints
 
   setup_build_env
-  if [ "$uname_m" != "s390x" ] && [ "$containerfile" != "musa" ]; then
+  if [ "$uname_m" != "s390x" ]; then
     clone_and_build_whisper_cpp
   fi
   common_flags+=("-DLLAMA_CURL=ON" "-DGGML_RPC=ON")


### PR DESCRIPTION
### Testing Done

#### ROCm

```bash
root@0-4-9-gpu-mi300x1-192gb-devcloud-atl1:~/ramalama# IMAGE=rocm make build
./container_build.sh  build rocm -v ""
docker build --no-cache --platform linux/amd64 -t quay.io/ramalama/rocm -f container-images/rocm/Containerfile .
[+] Building 1375.0s (9/9) FINISHED                                                                                                                                  docker:default 
 => [internal] load build definition from Containerfile                                                                                                                        0.0s
 => => transferring dockerfile: 262B                                                                                                                                           0.0s 
 => [internal] load metadata for quay.io/fedora/fedora:42                                                                                                                      0.3s
 => [internal] load .dockerignore                                                                                                                                              0.0s 
 => => transferring context: 2B                                                                                                                                                0.0s
 => [internal] load build context                                                                                                                                              0.0s 
 => => transferring context: 96.82kB                                                                                                                                           0.0s
 => CACHED [1/5] FROM quay.io/fedora/fedora:42@sha256:91abbfb46efac2ca7268f74751752fe5f5c36943516ab45512381eddf833b9a7                                                         0.0sn
 => [2/5] COPY . /src/ramalama                                                                                                                                                 0.0s
 => [3/5] WORKDIR /src/ramalama                                                                                                                                                0.0s 
 => [4/5] RUN container-images/scripts/build_llama_and_whisper.sh rocm                                                                                                      1361.5s
 => exporting to image                                                                                                                                                        13.1s 
 => => exporting layers                                                                                                                                                       13.1s 
 => => writing image sha256:16ecae5dbb70574838f459e2dac5e341c98d78f6ca794284cc15aad2f537a007                                                                                   0.0s 
 => => naming to quay.io/ramalama/rocm  
```

#### MUSA

```bash
❯ IMAGE=musa make build
./container_build.sh  build musa -v ""
docker build --no-cache --platform linux/x86_64 -t quay.io/ramalama/musa -f container-images/musa/Containerfile .
[+] Building 984.3s (12/12) FINISHED                                                                                                                                        docker:default
 => [internal] load build definition from Containerfile                                                                                                                               0.0s
 => => transferring dockerfile: 35B                                                                                                                                                   0.0s
 => [internal] load .dockerignore                                                                                                                                                     0.0s
 => => transferring context: 2B                                                                                                                                                       0.0s
 => [internal] load metadata for docker.io/mthreads/musa:rc4.2.0-runtime-ubuntu22.04-amd64                                                                                            0.0s
 => [internal] load metadata for docker.io/mthreads/musa:rc4.2.0-devel-ubuntu22.04-amd64                                                                                              0.0s
 => [internal] load build context                                                                                                                                                     0.0s
 => => transferring context: 234.02kB                                                                                                                                                 0.0s
 => CACHED [builder 1/4] FROM docker.io/mthreads/musa:rc4.2.0-devel-ubuntu22.04-amd64                                                                                                 0.0s
 => CACHED [stage-1 1/3] FROM docker.io/mthreads/musa:rc4.2.0-runtime-ubuntu22.04-amd64                                                                                               0.0s
 => [builder 2/4] COPY . /src/ramalama                                                                                                                                                0.1s
 => [builder 3/4] WORKDIR /src/ramalama                                                                                                                                               0.0s
 => [builder 4/4] RUN container-images/scripts/build_llama_and_whisper.sh musa   
```

## Summary by Sourcery

Re-enable building whisper.cpp in the MUSA container and update its pinned commit SHA

Enhancements:
- Allow whisper.cpp to be built on MUSA by removing the previous exclusion
- Bump the locked whisper.cpp commit SHA to d0a9d8c7f8f7b91c51d77bbaa394b915f79cde6b in the build script

Build:
- Adjust build_llama_and_whisper.sh script to incorporate the new SHA and build logic