### PR TITLE
Fix excess error output in run command

### DIFF
--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -983,17 +983,19 @@ def run_cli(args):
 
     try:
         model = New(args.MODEL, args)
+        model.ensure_model_exists(args)
         model.serve(args, quiet=True) if args.rag else model.run(args)
 
     except KeyError as e:
         logger.debug(e)
         try:
             args.quiet = True
-            model = ModelFactory(args.MODEL, args, ignore_stderr=True).create_oci()
-            model.serve(args) if args.rag else model.run(args)
-        except Exception:
-            raise e
+            oci_model = ModelFactory(args.MODEL, args, ignore_stderr=True).create_oci()
+            oci_model.ensure_model_exists(args)
 
+            oci_model.serve(args, quiet=True) if args.rag else oci_model.run(args)
+        except Exception as exc:
+            raise e from exc
 
 def serve_parser(subparsers):
     parser = subparsers.add_parser("serve", help="serve REST API on specified AI Model")


### PR DESCRIPTION
Fixes: #1644

Originally, `ramalama run bogus` would output three separate errors due to the chain of failure in the try catch statement allowing for run or serve to be ran twice for non-existent models . Now, by ensuring that the model exists before being ran, the program fails faster by not attempting to run a model that doesn't exist. This also provides a more direct answer as to why the model failed to run since there is only one error as opposed to 3 outputted errors.

**Example Output (Current Implementation)**
```
python bin/ramalama run bogus
Error: Manifest for bogus:latest was not found in the Ollama registry
Error: Manifest for bogus:latest was not found in the Ollama registry
Error: Failed to serve model bogus, for ramalama run command
```

**Example Output (With My Fix)**
```
python bin/ramalama run bogus
Error: Manifest for bogus:latest was not found in the Ollama registry
```

## Summary by Sourcery

Fail fast on non-existent models by validating existence before attempting run or serve to eliminate redundant error messages.

Bug Fixes:
- Prevent multiple identical errors when running a missing model by checking existence earlier.

Enhancements:
- Add ensure_model_exists check for both primary and OCI model instantiations to unify error handling and reduce output noise.