### PR TITLE
vLLM v0.10.0 release

### DIFF
--- a/container-images/cuda-vllm/Containerfile
+++ b/container-images/cuda-vllm/Containerfile
@@ -15,5 +15,5 @@ WORKDIR /
 # Final runtime image
 FROM quay.io/ramalama/cuda:latest
 
-COPY --from=builder /opt/venv /opt/venv
+COPY --from=builder /opt /opt
 

--- a/container-images/scripts/build-vllm.sh
+++ b/container-images/scripts/build-vllm.sh
@@ -88,7 +88,7 @@ preload_and_ulimit() {
   fi
 
   echo 'ulimit -c 0' >> ~/.bashrc
-  export PATH="$virtual_env/bin:/root/.local/bin:$PATH"
+  export PATH="/opt/app-root/bin:$virtual_env/bin:/root/.local/bin:$PATH"
   add_to_environment "PATH" "$PATH"
 }
 
@@ -156,14 +156,14 @@ main() {
   uv pip install --upgrade pip
 
   local vllm_url="https://github.com/vllm-project/vllm"
-  local commit="ac9fb732a5c0b8e671f8c91be8b40148282bb14a"
+  local commit="6d8d0a24c02bfd84d46b3016b865a44f048ae84b"
   git_clone_specific_commit
   set_vllm_env_vars
   pip_install_all
 
   # Have had to set MAX_JOBS as low as 1 while building, even on machine
   # with 32GB RAM, kept running out of memory causing crashes.
-  MAX_JOBS=1 python3 setup.py install
+  MAX_JOBS=2 python3 setup.py install
 
   cd -
   rm -rf vllm /root/.cache


### PR DESCRIPTION
x86_64 build fix included here

## Summary by Sourcery

Update the vLLM build script to use the v0.10.0 commit and adjust build parallelism to improve reliability on x86_64 machines

Enhancements:
- Bump vLLM commit to v0.10.0 in the build script
- Increase MAX_JOBS from 1 to 2 during installation to prevent OOM on x86_64 builds