### PR TITLE
Improve error message when huggingface-cli is needed and missing

### DIFF
--- a/ramalama/huggingface.py
+++ b/ramalama/huggingface.py
@@ -13,11 +13,15 @@ from ramalama.hf_style_repo_base import (
 from ramalama.logger import logger
 from ramalama.model_store.snapshot_file import SnapshotFileType
 
-missing_huggingface = """
-Optional: Huggingface models require the huggingface-cli module.
-This module can be installed via PyPI tools like uv, pip, pip3, pipx, or via
-distribution package managers like dnf or apt. Example:
-uv pip install huggingface_hub
+missing_huggingface = """This operation requires huggingface-cli which is not available.
+
+This tool can be installed via PyPI tools like uv, pip, pip3 or pipx. Example:
+
+pip install -U "huggingface_hub[cli]"
+
+Or via distribution package managers like dnf or apt. Example:
+
+sudo dnf install python3-huggingface-hub
 """
 
 

--- a/ramalama/modelscope.py
+++ b/ramalama/modelscope.py
@@ -10,11 +10,11 @@ from ramalama.hf_style_repo_base import (
 )
 from ramalama.model_store.snapshot_file import SnapshotFileType
 
-missing_modelscope = """
-Optional: ModelScope models require the modelscope module.
-This module can be installed via PyPI tools like uv, pip, pip3, pipx, or via
-distribution package managers like dnf or apt. Example:
-uv pip install modelscope
+missing_modelscope = """This operation requires modelscope which is not available.
+
+This tool can be installed via PyPI tools like uv, pip, pip3 or pipx. Example:
+
+pip install modelscope
 """
 
 


### PR DESCRIPTION
Before:

    Error:
    Optional: Huggingface models require the huggingface-cli module.
    This module can be installed via PyPI tools like uv, pip, pip3, pipx, or via
    distribution package managers like dnf or apt. Example:
    uv pip install huggingface_hub

After:

    Error: Huggingface models require the huggingface-cli tool.

    This tool can be installed via PyPI tools like uv, pip, pip3, pipx. Example:

    pip install -U "huggingface_hub[cli]"

    Or via distribution package managers like dnf or apt. Example:

    sudo install python3-huggingface-hub

In particular:

    - separate error from the explanation and guidance by new line,

    - provide `pip` as first example how to solve the issue (that's also the tool mention in the README)

    - use same package extra as official documentation to install the CLI tool: https://huggingface.co/docs/huggingface_hub/en/guides/cli

    - provide example with dnf command to install the package (dnf is also mentioned in the README file)

    - `huggingface-cli` is a command line tool, not a module as it was referred before

Fixes: #1766

## Summary by Sourcery

Enhance the missing huggingface-cli error message to provide clearer guidance and up-to-date install instructions

Enhancements:
- Separate the error header from the explanatory guidance with a blank line
- Prioritize pip install example using `pip install -U "huggingface_hub[cli]"` to match official documentation
- Include distribution package install command (`sudo install python3-huggingface-hub`) alongside pip instructions
- Correct terminology from module to tool in the error message