### PR TITLE
De-duplicate bash build scripts

### DIFF
--- a/container-images/scripts/build_llama_and_whisper.sh
+++ b/container-images/scripts/build_llama_and_whisper.sh
@@ -15,10 +15,6 @@ Python 3.10"
   echo "python3"
 }
 
-available() {
-  command -v "$1" >/dev/null
-}
-
 dnf_install_intel_gpu() {
   local intel_rpms=("intel-oneapi-mkl-sycl-devel" "intel-oneapi-dnnl-devel"
     "intel-oneapi-compiler-dpcpp-cpp" "intel-level-zero"
@@ -75,26 +71,6 @@ dnf_install_s390() {
   dnf install -y "openblas-devel"
 }
 
-add_stream_repo() {
-  local url="https://mirror.stream.centos.org/9-stream/$1/$uname_m/os/"
-  dnf config-manager --add-repo "$url"
-  url="http://mirror.centos.org/centos/RPM-GPG-KEY-CentOS-Official"
-  local file="/etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-Official"
-  if [ ! -e $file ]; then
-    curl --retry 8 --retry-all-errors -o $file "$url"
-    rpm --import $file
-  fi
-}
-
-rm_non_ubi_repos() {
-  local dir="/etc/yum.repos.d"
-  rm -rf $dir/mirror.stream.centos.org_9-stream_* $dir/epel*
-}
-
-is_rhel_based() { # doesn't include openEuler
-  [[ "${ID}" == "rhel" || "${ID}" == "redhat" || "${ID}" == "centos" ]]
-}
-
 dnf_install_mesa() {
   if [ "${ID}" = "fedora" ]; then
     dnf copr enable -y slp/mesa-libkrun-vulkan
@@ -108,13 +84,6 @@ dnf_install_mesa() {
   fi
 
   rm_non_ubi_repos
-}
-
-dnf_install_epel() {
-  local rpm_exclude_list="selinux-policy,container-selinux"
-  local url="https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm"
-  dnf reinstall -y "$url" || dnf install -y "$url" --exclude "${rpm_exclude_list}"
-  crb enable # this is in epel-release, can only install epel-release via url
 }
 
 # There is no ffmpeg-free package in the openEuler repository. openEuler can use ffmpeg,
@@ -132,6 +101,7 @@ dnf_install_ffmpeg() {
   else
     dnf install -y ffmpeg-free
   fi
+
   rm_non_ubi_repos
 }
 
@@ -258,10 +228,7 @@ clone_and_build_whisper_cpp() {
     whisper_flags+=("-DCMAKE_POSITION_INDEPENDENT_CODE=ON")
   fi
 
-  git clone https://github.com/ggerganov/whisper.cpp
-  cd whisper.cpp
-  git submodule update --init --recursive
-  git reset --hard "$whisper_cpp_sha"
+  git_clone_specific_commit "https://github.com/ggerganov/whisper.cpp" "$whisper_cpp_sha"
   cmake_steps "${whisper_flags[@]}"
   mkdir -p "$install_prefix/bin"
   cd ..
@@ -272,10 +239,7 @@ clone_and_build_llama_cpp() {
   local llama_cpp_sha="3f4fc97f1d745f1d5d3c853949503136d419e6de"
   local install_prefix
   install_prefix=$(set_install_prefix)
-  git clone https://github.com/ggml-org/llama.cpp
-  cd llama.cpp
-  git submodule update --init --recursive
-  git reset --hard "$llama_cpp_sha"
+  git_clone_specific_commit "https://github.com/ggml-org/llama.cpp" "$llama_cpp_sha"
   cmake_steps "${common_flags[@]}"
   install -m 755 build/bin/rpc-server "$install_prefix"/bin/rpc-server
   cd ..
@@ -301,6 +265,27 @@ install_entrypoints() {
   fi
 }
 
+cleanup() {
+  clone_and_build_llama_cpp
+  available dnf && dnf_remove
+  rm -rf /var/cache/*dnf* /opt/rocm-*/lib/*/library/*gfx9*
+  ldconfig # needed for libraries
+}
+
+add_common_flags() {
+  common_flags+=("-DLLAMA_CURL=ON" "-DGGML_RPC=ON")
+  case "$containerfile" in
+  ramalama)
+    if [ "$uname_m" = "x86_64" ] || [ "$uname_m" = "aarch64" ]; then
+      common_flags+=("-DGGML_VULKAN=ON")
+    elif [ "$uname_m" = "s390x" ]; then
+      common_flags+=("-DGGML_VXE=ON" "-DGGML_BLAS=ON")
+      common_flags+=("-DGGML_BLAS_VENDOR=OpenBLAS")
+    fi
+    ;;
+  esac
+}
+
 main() {
   # shellcheck disable=SC1091
   source /etc/os-release
@@ -308,6 +293,9 @@ main() {
   set -ex -o pipefail
   export PYTHON
   PYTHON=$(python_version)
+
+  # shellcheck disable=SC1091
+  source container-images/scripts/lib.sh
 
   local containerfile=${1-""}
   local install_prefix
@@ -321,27 +309,15 @@ main() {
   if [ -n "$containerfile" ]; then
     install_ramalama "${install_prefix}"
   fi
-  install_entrypoints
 
+  install_entrypoints
   setup_build_env
   if [ "$uname_m" != "s390x" ] && [ "$containerfile" != "rocm-ubi" ]; then
     clone_and_build_whisper_cpp
   fi
-  common_flags+=("-DLLAMA_CURL=ON" "-DGGML_RPC=ON")
-  case "$containerfile" in
-  ramalama)
-    if [ "$uname_m" = "x86_64" ] || [ "$uname_m" = "aarch64" ]; then
-      common_flags+=("-DGGML_VULKAN=ON")
-    elif [ "$uname_m" = "s390x" ]; then
-      common_flags+=("-DGGML_VXE=ON" "-DGGML_BLAS=ON" "-DGGML_BLAS_VENDOR=OpenBLAS")
-    fi
-    ;;
-  esac
 
-  clone_and_build_llama_cpp
-  available dnf && dnf_remove
-  rm -rf /var/cache/*dnf* /opt/rocm-*/lib/*/library/*gfx9*
-  ldconfig # needed for libraries
+  add_common_flags
+  cleanup
 }
 
 main "$@"

--- a/container-images/scripts/lib.sh
+++ b/container-images/scripts/lib.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+available() {
+  command -v "$1" >/dev/null
+}
+
+is_rhel_based() { # doesn't include openEuler
+  # shellcheck disable=SC1091
+  source /etc/os-release
+  [ "$ID" = "rhel" ] || [ "$ID" = "redhat" ] || [ "$ID" == "centos" ]
+}
+
+dnf_install_epel() {
+  local rpm_exclude_list="selinux-policy,container-selinux"
+  local url="https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm"
+  dnf reinstall -y "$url" || dnf install -y "$url" --exclude "$rpm_exclude_list"
+  crb enable # this is in epel-release, can only install epel-release via url
+}
+
+add_stream_repo() {
+  local uname_m
+  uname_m="$(uname -m)"
+  local url="https://mirror.stream.centos.org/9-stream/$1/$uname_m/os/"
+  dnf config-manager --add-repo "$url"
+  url="http://mirror.centos.org/centos/RPM-GPG-KEY-CentOS-Official"
+  local file="/etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-Official"
+  if [ ! -e $file ]; then
+    curl --retry 8 --retry-all-errors -o $file "$url"
+    rpm --import $file
+  fi
+}
+
+rm_non_ubi_repos() {
+  local dir="/etc/yum.repos.d"
+  rm -rf $dir/mirror.stream.centos.org_9-stream_* $dir/epel*
+}
+
+git_clone_specific_commit() {
+  local repo="${1##*/}"
+  git init "$repo"
+  cd "$repo" || return 1
+  git remote add origin "$1"
+  git fetch --depth 1 origin "$2"
+  git reset --hard "$2"
+  git submodule update --init --recursive
+}
+


### PR DESCRIPTION
Create a common lib.sh

## Summary by Sourcery

Deduplicate container image build scripts by extracting shared bash functions into a common lib.sh and updating the scripts to source and use those utilities

Enhancements:
- Extract common utility functions into container-images/scripts/lib.sh
- Remove duplicate function definitions from build-vllm.sh and build_llama_and_whisper.sh
- Update build scripts to source lib.sh and use git_clone_specific_commit with parameters