### PR TITLE
Adding --add-to-unit option to --generate to allow creating or updati…

### DIFF
--- a/docs/ramalama-serve.1.md
+++ b/docs/ramalama-serve.1.md
@@ -38,6 +38,18 @@ For REST API endpoint documentation, see:
 
 ## OPTIONS
 
+#### **--add-to-unit**
+
+format: --add-to-unit section:key:value
+
+Adds to the generated unit file (quadlet) in the section *section* the key *key* with the value *value*.
+
+Useful, for instance, to add environment variables to the generated unit file, or to place the container in a specific pod/network (Container:Network:xxx.network).
+
+**Only valid with *--generate* parameter.**
+
+Section, key and value are required and must be separated by colons.
+
 #### **--api**=**llama-stack** | none**
 Unified API layer for Inference, RAG, Agents, Tools, Safety, Evals, and Telemetry.(default: none)
 The default can be overridden in the ramalama.conf file.
@@ -75,6 +87,7 @@ process to be launched inside of the container. If an environment variable is
 specified without a value, the container engine checks the host environment
 for a value and set the variable only if it is set on the host.
 
+
 #### **--generate**=type
 Generate specified configuration format for running the AI Model as a service
 
@@ -86,6 +99,7 @@ Generate specified configuration format for running the AI Model as a service
 
 Optionally, an output directory for the generated files can be specified by
 appending the path to the type, e.g. `--generate kube:/etc/containers/systemd`.
+
 
 #### **--help**, **-h**
 show this help message and exit

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -280,6 +280,15 @@ def post_parse_setup(args):
         if not hasattr(args, "model"):
             args.model = args.MODEL
 
+    # Validate that --add-to-unit is only used with --generate and its format is <section>:<key>:<value>
+    if hasattr(args, "add_to_unit") and (add_to_units := args.add_to_unit):
+        if getattr(args, "generate", None) is None:
+            parser = get_parser()
+            parser.error("--add-to-unit can only be used with --generate")
+        if not (all(len([value for value in unit_to_add.split(":", 2) if value]) == 3 for unit_to_add in add_to_units)):
+            parser = get_parser()
+            parser.error("--add-to-unit parameters must be of the form <section>:<key>:<value>")
+
     if hasattr(args, "runtime_args"):
         args.runtime_args = shlex.split(args.runtime_args)
 
@@ -783,6 +792,14 @@ def runtime_options(parser, command):
             type=parse_generate_option,
             choices=GENERATE_OPTIONS,
             help="generate specified configuration format for running the AI Model as a service",
+        )
+        parser.add_argument(
+            "--add-to-unit",
+            dest="add_to_unit",
+            action='append',
+            type=str,
+            help="add KEY VALUE pair to generated unit file in the section SECTION (only valid with --generate)",
+            metavar="SECTION:KEY:VALUE",
         )
         parser.add_argument(
             "--host",

--- a/ramalama/quadlet.py
+++ b/ramalama/quadlet.py
@@ -70,7 +70,10 @@ class Quadlet:
             if not getattr(self.args, "nocapdrop", False):
                 quadlet_file.add("Container", "DropCapability", "all")
                 quadlet_file.add("Container", "NoNewPrivileges", "true")
-
+        if add_to_units := getattr(self.args, "add_to_unit", None):
+            for unit in add_to_units:
+                section, key, value = unit.split(":", 2)
+                quadlet_file.add(section, key, value)
         self._gen_chat_template_volume(quadlet_file)
         self._gen_mmproj_volume(quadlet_file)
         self._gen_env(quadlet_file)

--- a/test/system/040-serve.bats
+++ b/test/system/040-serve.bats
@@ -219,6 +219,23 @@ verify_begin=".*run --rm"
     rm $quadlet
     run_ramalama 2 serve --name=${name} --port 1234 --generate=bogus $model
     is "$output" ".*error: argument --generate: invalid choice: .*bogus.* (choose from.*quadlet.*kube.*quadlet/kube.*)" "Should fail"
+
+        run_ramalama pull $model_quant
+    run_ramalama -q serve --port 1234 --generate=quadlet --add-to-unit "section1:key0:value0" $model
+    is "$output" "Generating quadlet file: $quadlet" "generate $quadlet"
+
+    run cat $quadlet
+    is "$output" ".*PublishPort=0.0.0.0:1234:1234" "PublishPort should match"
+    is "$output" ".*Exec=.*llama-server --port 1234 --model .*" "Exec line should be correct"
+    is "$output" ".*Mount=type=bind,.*$model" "Mount line should be correct"
+    is "$output" ".*key0=value0.*" "added unit should be correct"
+
+    run_ramalama 2 -q serve --port 1234 --generate=quadlet --add-to-unit "section1:key0:" $model
+    is "$output" ".*error: --add-to-unit parameters must be of the form <section>:<key>:<value>.*"
+
+    rm $quadlet
+    run_ramalama 2 serve --name=${name} --port 1234 --add-to-unit "section1:key0:value0"  $model
+    is "$output" ".*error: --add-to-unit can only be used with --generate.*"
 }
 
 @test "ramalama serve --generate=quadlet and --generate=kube with OCI" {
@@ -293,6 +310,82 @@ verify_begin=".*run --rm"
 
     rm $name.yaml
 }
+#
+# TODO: Enable this test again after the rework for building OCI images is done
+#       see: https://github.com/containers/ramalama/issues/1674
+#
+# @test "ramalama serve --generate=quadlet and --generate=kube with OCI" {
+#     skip_if_darwin
+#     skip_if_docker
+#     skip_if_nocontainer
+#     local registry=localhost:${PODMAN_LOGIN_REGISTRY_PORT}
+#     local authfile=$RAMALAMA_TMPDIR/authfile.json
+#
+#     start_registry
+#
+#     run_ramalama login --authfile=$authfile \
+# 	--tls-verify=false \
+# 	--username ${PODMAN_LOGIN_USER} \
+# 	--password ${PODMAN_LOGIN_PASS} \
+# 	oci://$registry
+#
+#     run_ramalama pull tiny
+#
+#     ociimage=$registry/tiny:latest
+#     for modeltype in "" "--type=car" "--type=raw"; do
+# 	name=c_$(safename)
+# 	run_ramalama push $modeltype --authfile=$authfile --tls-verify=false tiny oci://${ociimage}
+# 	run_ramalama serve --authfile=$authfile --tls-verify=false --name=${name} --port 1234 --generate=quadlet oci://${ociimage}
+# 	is "$output" ".*Generating quadlet file: ${name}.container" "generate .container file"
+# 	is "$output" ".*Generating quadlet file: ${name}.volume" "generate .volume file"
+# 	is "$output" ".*Generating quadlet file: ${name}.image" "generate .image file"
+#
+# 	run cat $name.container
+# 	is "$output" ".*PublishPort=1234:1234" "PublishPort should match"
+# 	is "$output" ".*ContainerName=${name}" "Quadlet should have ContainerName field"
+# 	is "$output" ".*Exec=.*llama-server --port 1234 --model .*" "Exec line should be correct"
+# 	is "$output" ".*Mount=type=image,source=${ociimage},destination=/mnt/models,subpath=/models,readwrite=false" "Volume line should be correct"
+#
+# 	if is_container; then
+# 	   run cat $name.volume
+# 	   is "$output" ".*Driver=image" "Driver Image"
+# 	   is "$output" ".*Image=$name.image" "Image should exist"
+#
+# 	   run cat $name.image
+# 	   is "$output" ".*Image=${ociimage}" "Image should match"
+# 	fi
+#
+# 	run_ramalama list
+# 	is "$output" ".*${ociimage}" "Image should match"
+#
+# 	rm $name.container
+# 	if is_container; then
+# 	   rm $name.volume
+# 	   rm $name.image
+# 	fi
+#
+# 	run_ramalama rm oci://${ociimage}
+#     done
+#     stop_registry
+#     skip "vLLM can't serve GGUFs, needs tiny safetensor"
+#
+# 	run_ramalama --runtime=vllm serve --authfile=$authfile --tls-verify=false --name=${name} --port 1234 --generate=kube oci://${ociimage}
+# 	is "$output" ".*Generating Kubernetes YAML file: ${name}.yaml" "generate .yaml file"
+#
+# 	run_ramalama --runtime=vllm serve --authfile=$authfile --tls-verify=false --name=${name} --port 1234 --generate=quadlet/kube oci://${ociimage}
+# 	is "$output" ".*Generating Kubernetes YAML file: ${name}.yaml" "generate .yaml file"
+# 	is "$output" ".*Generating quadlet file: ${name}.kube" "generate .kube file"
+#
+#
+# 	run cat $name.yaml
+# 	is "$output" ".*command: \[\"--port\"\]" "command is correct"
+# 	is "$output" ".*args: \['1234', '--model', '/mnt/models/model.file', '--max_model_len', '2048'\]" "args are correct"
+#
+# 	is "$output" ".*reference: ${ociimage}" "AI image should be created"
+# 	is "$output" ".*pullPolicy: IfNotPresent" "pullPolicy should exist"
+#
+#     rm $name.yaml
+# }
 
 @test "ramalama serve --generate=kube" {
     model="smollm"

--- a/test/unit/data/test_quadlet/modelfromstore_add_to_unit/modelfromstore_add_to_unit.container
+++ b/test/unit/data/test_quadlet/modelfromstore_add_to_unit/modelfromstore_add_to_unit.container
@@ -1,0 +1,27 @@
+[Unit]
+Description=RamaLama modelfromstore_add_to_unit AI Model Service
+After=local-fs.target
+
+[Container]
+AddDevice=-/dev/accel
+AddDevice=-/dev/dri
+AddDevice=-/dev/kfd
+Image=testimage
+RunInit=true
+Environment=HOME=/tmp
+Exec=
+SecurityLabelDisable=true
+DropCapability=all
+NoNewPrivileges=true
+test=dummy
+Mount=type=bind,src=sha256-c21bc76d14f19f6552bfd8bbf4e5f57494169b902c73aa12ce3ce855466477fa,target=model.mmproj,ro,Z
+Mount=type=bind,src=sha256-2af3b81862c6be03c769683af18efdadb2c33f60ff32ab6f83e42c043d6c7816,target=longpathtoablobsha,ro,Z
+
+[section1]
+key0=value0
+key1=valu:e:1
+key2=value1:
+
+[Install]
+WantedBy=multi-user.target default.target
+

--- a/test/unit/test_quadlet.py
+++ b/test/unit/test_quadlet.py
@@ -17,6 +17,7 @@ class Args:
         host: str = "0.0.0.0",
         env: list = [],
         MODEL: Optional[str] = None,
+        add_to_unit=None,
     ):
         self.name = name
         self.rag = rag
@@ -26,6 +27,7 @@ class Args:
         self.image = "testimage"
         if MODEL is not None:
             self.MODEL = MODEL
+        self.add_to_unit = add_to_unit
 
 
 class Input:
@@ -142,6 +144,28 @@ DATA_PATH = Path(__file__).parent / "data" / "test_quadlet"
                 mmproj_file_exists=True,
             ),
             DATA_PATH / "modelfromstore_mmproj",
+        ),
+        (
+            Input(
+                model_name="modelfromstore_add_to_unit",
+                model_src_blob="sha256-2af3b81862c6be03c769683af18efdadb2c33f60ff32ab6f83e42c043d6c7816",
+                model_dest_name="longpathtoablobsha",
+                image="testimage",
+                args=Args(
+                    MODEL="modelfromstore_add_to_unit",
+                    add_to_unit=[
+                        "section1:key0:value0",
+                        "section1:key1:valu:e:1",
+                        "section1:key2:value1:",
+                        "Container:test:dummy",
+                    ],
+                ),
+                model_file_exists=True,
+                mmproj_src_blob="sha256-c21bc76d14f19f6552bfd8bbf4e5f57494169b902c73aa12ce3ce855466477fa",
+                mmproj_dest_name="model.mmproj",
+                mmproj_file_exists=True,
+            ),
+            DATA_PATH / "modelfromstore_add_to_unit",
         ),
         (
             Input(


### PR DESCRIPTION
Adding --add-to-unit option to --generate to allow creating or updating section:key:value in the generated unit file (Quadlet).

    The goal is to be able to, for instance, associate the created container to a pod network or set any other configuration parameter.

There a basic tests, the only untested part is the parameter check in `post_parse_setup` in `cli.py` that validates the format `section:key:value` but this seems rather independent of other changes and tests for it would just be code to maintain.
I tried to update the documentation and pass make validate in full.

## Summary by Sourcery

Introduce a new --add-to-unit flag for the generate command to allow users to append custom section:key:value entries to the generated unit (Quadlet) file with proper validation and documentation.

New Features:
- Add --add-to-unit option to the --generate command

Enhancements:
- Validate that --add-to-unit is only used with --generate and enforces section:key:value format
- Apply specified section:key:value entries when generating the unit file

Documentation:
- Document the new --add-to-unit option in the manpage

Tests:
- Add unit test to verify --add-to-unit entries are correctly inserted into the generated unit file