### PR TITLE
Include fix that allows us to build on older ARM SoC's

### DIFF
--- a/container-images/scripts/build-vllm.sh
+++ b/container-images/scripts/build-vllm.sh
@@ -117,7 +117,7 @@ main() {
   uv pip install --upgrade pip
 
   local vllm_url="https://github.com/vllm-project/vllm"
-  local commit="6d8d0a24c02bfd84d46b3016b865a44f048ae84b"
+  local commit="fcfd1eb9c556e295eb5708eb0f5e6ae775807775"
   git_clone_specific_commit "$vllm_url" "$commit"
   set_vllm_env_vars
   pip_install_all


### PR DESCRIPTION
Like M1, etc.

http://github.com/vllm-project/vllm/commit/b876860c6214d03279e79e0babb7eb4e3e286cbd

## Summary by Sourcery

Bug Fixes:
- Bump pinned vllm commit in the container build script to include fix for building on older ARM SoCs like Apple M1.