### PR TITLE
Enable multiline chat

### DIFF
--- a/docs/ramalama-chat.1.md
+++ b/docs/ramalama-chat.1.md
@@ -53,6 +53,12 @@ $ ramalama chat
 Communicate with an alternative OpenAI REST API URL. With Docker containers.
 $ ramalama chat --url http://localhost:1234
 🐋 >
+
+Send multiple lines at once
+$ ramalama chat
+🦭 > Hi \
+🦭 > tell me a funny story \
+🦭 > please
 ```
 
 ## SEE ALSO

--- a/docs/ramalama-run.1.md
+++ b/docs/ramalama-run.1.md
@@ -204,6 +204,13 @@ This program is a Python script that allows the user to interact with a terminal
  [end of text]
 ```
 
+Run command and send multiple lines at once to the chatbot by adding a backslash `\`
+at the end of the line
+$ ramalama run granite
+🦭 > Hi \
+🦭 > tell me a funny story \
+🦭 > please
+
 ## Exit Codes:
 
 0   Success

--- a/ramalama/chat.py
+++ b/ramalama/chat.py
@@ -105,6 +105,8 @@ class RamaLamaShell(cmd.Cmd):
 
         self.operational_args = operational_args
 
+        self.content = []
+
     def prep_rag_message(self):
         if (context := self.args.rag) is None:
             return
@@ -134,10 +136,16 @@ class RamaLamaShell(cmd.Cmd):
         return True
 
     def default(self, user_content):
+        self.content.append(user_content.rstrip(" \\"))
+        if user_content.endswith(" \\"):
+            return False
+
         if user_content in ["/bye", "exit"]:
             return True
 
-        self.conversation_history.append({"role": "user", "content": user_content})
+        content = "\n".join(self.content)
+        self.content = []
+        self.conversation_history.append({"role": "user", "content": content})
         self.request_in_process = True
         response = self._req()
         if not response:


### PR DESCRIPTION
This PR enables multiline chat by using the backslack `\` symbol as control character. 
Users can either add `\` to the end of the line or paste a text block (with `\` at the end of each line) to the chat console:
```bash
🦭 > hi \
🦭 > tell me a funny story \
🦭 > please
sure, here's a funny story:
...
```

## Summary by Sourcery

Enable multiline user input in the chat console by treating a trailing backslash as a continuation marker and sending the accumulated lines as a single message once the backslash is omitted.

New Features:
- Allow users to enter multiline messages by ending lines with a backslash and pasting blocks with backslashes at line ends

Enhancements:
- Initialize and maintain a content buffer in the Chat class to accumulate and join input lines into one message