### PR TITLE
Fix handling of configured_has_all

### DIFF
--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -352,7 +352,8 @@ def check_nvidia() -> Literal["cuda"] | None:
 
     configured, unconfigured = find_in_cdi(visible_devices + ["all"])
 
-    if unconfigured and not (configured_has_all := "all" in configured):
+    configured_has_all = "all" in configured
+    if unconfigured and not configured_has_all:
         perror(f"No CDI configuration found for {','.join(unconfigured)}")
         perror("You can use the \"nvidia-ctk cdi generate\" command from the ")
         perror("nvidia-container-toolkit to generate a CDI configuration.")


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Define configured_has_all outside the if statement to prevent it from being undefined when checking for the “all” device.