### PR TITLE
Set TMPDIR to /var/tmp if not set

### DIFF
--- a/bin/ramalama
+++ b/bin/ramalama
@@ -1,11 +1,16 @@
 #!/usr/bin/env python3
 
+import os
 import sys
 
 
 def main():
     if not sys.stdout.isatty():
         sys.stdout.reconfigure(line_buffering=True)
+
+    if sys.platform != 'win32':
+        # default TMPDIR environment to /var/tmp on non Windows platforms
+        os.environ["TMPDIR"] = os.getenv("TMPDIR", "/var/tmp")
 
     sys.path.insert(0, './')
     try:

--- a/docs/ramalama.1.md
+++ b/docs/ramalama.1.md
@@ -178,6 +178,7 @@ although the recommended way is to use the ramalama.conf file.
 | RAMALAMA_IN_CONTAINER     | Run RamaLama in the default container      |
 | RAMALAMA_STORE            | location to store AI Models                |
 | RAMALAMA_TRANSPORT        | default AI Model transport (ollama, huggingface, OCI) |
+| TMPDIR                    | directory for temporary files. Defaults to /var/tmp if unset.|
 
 ## SEE ALSO
 **[podman(1)](https://github.com/containers/podman/blob/main/docs/source/markdown/podman.1.md)**, **docker(1)**, **[ramalama.conf(5)](ramalama.conf.5.md)**, **[ramalama-cuda(7)](ramalama-cuda.7.md)**, **[ramalama-macos(7)](ramalama-macos.7.md)**


### PR DESCRIPTION
Currently we are defaulting to /tmp and in some cases this means pulling huge models to the /tmp directory which on a lot of linux platforms is a tmpfs. /var/tmp tends to have much more space, so setting this as a default is better.

Fixes: https://github.com/containers/ramalama/issues/1778

## Summary by Sourcery

Use /var/tmp as the default temporary directory if TMPDIR is unset and update documentation accordingly

Enhancements:
- Default TMPDIR to /var/tmp when not set to avoid tmpfs size constraints

Documentation:
- Document the new TMPDIR environment variable in the man page