### PR TITLE
Use modelstore as tmpdir for hfcli

### DIFF
--- a/ramalama/hf_style_repo_base.py
+++ b/ramalama/hf_style_repo_base.py
@@ -238,7 +238,7 @@ class HFStyleRepoModel(Model, ABC):
                 raise KeyError(f"Failed to pull model: {str(e)}")
 
             # Create temporary directory for downloading via CLI
-            with tempfile.TemporaryDirectory() as tempdir:
+            with tempfile.TemporaryDirectory(prefix="tmp_hfcli_", dir=self.model_store.base_path) as tempdir:
                 model = f"{organization}/{name}"
                 conman_args = self.get_cli_download_args(tempdir, model)
                 run_cmd(conman_args)


### PR DESCRIPTION
Relates to: https://github.com/containers/ramalama/issues/1778

Instead of creating a temporary directory in the default location, lets use the modelstore directory for the hfcli files until these are moved to a snapshot. 
The created temporary directory will always been cleaned up.

## Summary by Sourcery

Enhancements:
- Create hfcli temp directories under model_store.base_path with prefix "tmp_hfcli_" instead of using the system default temp location