### PR TITLE
Fixup release of stable-diffusion images

### DIFF
--- a/container-images/stable-diffusion/Containerfile
+++ b/container-images/stable-diffusion/Containerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:42
+FROM quay.io/fedora/fedora:42
 
 COPY container-images/stable-diffusion/entrypoint.sh /usr/bin/entrypoint.sh
 COPY container-images/scripts/build_stable_diffusion.sh /tmp/

--- a/scripts/release-image.sh
+++ b/scripts/release-image.sh
@@ -20,7 +20,7 @@ release-arm() {
     podman push "${REPO}/$1" "${ARMREPO}/$1"
 
     case ${1} in
-	openvino | ramalama-cli | llama-stack)
+	stable-diffusion | openvino | ramalama-cli | llama-stack)
 	;;
 	*)
 	    podman push "${REPO}"/"$1"-whisper-server "${ARMREPO}"/"$1"-whisper-server
@@ -43,7 +43,7 @@ release-ramalama() {
 release() {
     release-ramalama "$1"
     case ${1} in
-	openvino | ramalama-cli | llama-stack)
+	stable-diffusion | openvino | ramalama-cli | llama-stack)
 	;;
 	*)
 	    release-ramalama "$1"-whisper-server
@@ -62,6 +62,9 @@ case ${1} in
 	;;
     llama-stack)
 	podman run --pull=never --rm "${REPO}/$1" llama -h
+	;;
+    stable-diffusion)
+	podman run --pull=never --rm "${REPO}/$1" sd -h
 	;;
     *)
 	podman run --pull=never --rm "${REPO}/$1" ls -l /usr/bin/llama-server

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -49,6 +49,10 @@ case ${1} in
 	podman run --pull=never --rm "${REPO}/$1" llama -h
 	release "$1"
 	;;
+    stable-diffusion)
+	podman run --pull=never --rm "${REPO}/$1" sd -h
+	release "$1"
+	;;
     *)
 	podman run --pull=never --rm "${REPO}/$1" ls -l /usr/bin/llama-server
 	podman run --pull=never --rm "${REPO}/$1" ls -l /usr/bin/llama-run


### PR DESCRIPTION
## Summary by Sourcery

Extend the release pipeline to properly handle stable-diffusion images by skipping unnecessary whisper-server artifacts, adding a smoke test, and pointing the Containerfile at the quay.io Fedora registry.

Enhancements:
- Include stable-diffusion in the skip list for whisper-server pushes in the release-image.sh and release.sh scripts
- Add smoke-test invocations of `sd -h` for stable-diffusion in both release-image.sh and release.sh
- Update the stable-diffusion Containerfile to use the quay.io/fedora registry instead of registry.fedoraproject.org