### PR TITLE
Splitting pypi build and upload into dedicated make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,11 +144,14 @@ ifeq ($(OS),Linux)
 	hack/xref-helpmsgs-manpages
 endif
 
-.PHONY: pypi
-pypi:   clean
+.PHONY: pypi-build
+pypi-build:   clean
 	make docs
 	python3 -m build --sdist
 	python3 -m build --wheel
+
+.PHONY: pypi
+pypi: pypi-build
 	python3 -m twine upload dist/*
 
 .PHONY: bats


### PR DESCRIPTION
By splitting pypi build and upload into dedicated make targets it enables to build a custom python wheel package, e.g. for development.

## Summary by Sourcery

Split the existing pypi make target into separate pypi-build and pypi-upload targets to allow building wheels independently from uploading them

Build:
- Rename the pypi target to pypi-build with clean, docs, sdist, and wheel steps
- Introduce a pypi-upload target that depends on pypi-build to handle distribution uploads