### PR TITLE
Fix the 050-pull test.

### DIFF
--- a/test/system/050-pull.bats
+++ b/test/system/050-pull.bats
@@ -22,7 +22,7 @@ load setup_suite
     run_ramalama pull ollama://smollm:360m
     run_ramalama list
     is "$output" ".*ollama://library/smollm:360m" "image was actually pulled locally"
-    run_ramalama rm ollama://smollm:135m ollama://smollm:360m
+    run_ramalama rm https://ollama.com/library/smollm:135m ollama://smollm:360m
 
     random_image_name=i_$(safename)
     run_ramalama 1 -q pull ${random_image_name}


### PR DESCRIPTION
Remove the smollm:135m model with the URL used to pull it, otherwise the test will fail with:
 in test file test/system/050-pull.bats, line 25)
 `run_ramalama rm ollama://smollm:135m ollama://smollm:360m' failed
 ...
 Error: Model 'smollm:135m' not found

## Summary by Sourcery

Tests:
- Update 050-pull.bats to remove the 135m model using its full ollama.com/library URL instead of the shorthand schema