### PR TITLE
We should use all config files paths found

### DIFF
--- a/docs/ramalama.1.md
+++ b/docs/ramalama.1.md
@@ -29,7 +29,9 @@ When both Podman and Docker are installed, RamaLama defaults to Podman, The `RAM
 
 Note: On MacOS systems that use Podman for containers, configure the Podman machine to use the `libkrun` machine provider. The `libkrun` provider enables containers within the Podman Machine access to the Mac's GPU. See **[ramalama-macos(7)](ramalama-macos.7.md)** for further information.
 
-Note: On systems with NVIDIA GPUs, see **[ramalama-cuda(7)](ramalama-cuda.7.md)** to correctly configure the host system. Default settings for flags are defined in **[ramalama.conf(5)](ramalama.conf.5.md)**.
+Note: On systems with NVIDIA GPUs, see **[ramalama-cuda(7)](ramalama-cuda.7.md)** to correctly configure the host system.
+
+RamaLama CLI defaults can be modified via ramalama.conf files. Default settings for flags are defined in **[ramalama.conf(5)](ramalama.conf.5.md)**.
 
 ## SECURITY
 
@@ -154,7 +156,7 @@ The default can be overridden in the ramalama.conf file.
 
 ## CONFIGURATION FILES
 
-**ramalama.conf** (`/usr/share/ramalama/ramalama.conf`, `/etc/ramalama/ramalama.conf`, `$HOME/.config/ramalama/ramalama.conf`)
+**ramalama.conf** (`/usr/share/ramalama/ramalama.conf`, `/etc/ramalama/ramalama.conf`, `/etc/ramalama/ramalama.conf.d/*.conf`, `$HOME/.config/ramalama/ramalama.conf`, `$HOME/.config/ramalama/ramalama.conf.d/*.conf`)
 
 RamaLama has builtin defaults for command line options. These defaults can be overridden using the ramalama.conf configuration files.
 

--- a/docs/ramalama.conf.5.md
+++ b/docs/ramalama.conf.5.md
@@ -5,7 +5,7 @@ ramalama.conf - These configuration files specifies default
 configuration options and command-line flags for RamaLama.
 
 # DESCRIPTION
-RamaLama reads the ramalama.conf file, if it exists
+RamaLama reads all ramalama.conf files, if they exists
 and modify the defaults for running RamaLama on the host. ramalama.conf uses
 a TOML format that can be easily modified and versioned.
 
@@ -29,8 +29,8 @@ For user specific configuration it reads
 | __$HOME/.config/ramalama/ramalama.conf__ | `$XDG_CONFIG_HOME` not set |
 | __$HOME/.config/ramalama/ramalama.conf.d/\*.conf__ | `$XDG_CONFIG_HOME` not set |
 
-Fields specified in ramalama conf override the default options, as well as
-options in previously read ramalama.conf files.
+Fields specified in ramalama conf files override the default options, as well as
+options in previously read ramalama conf files.
 
 Config files in the `.d` directories, are added in alpha numeric sorted order and must end in `.conf`.
 

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -26,7 +26,7 @@ import ramalama.oci
 from ramalama import engine
 from ramalama.chat import default_prefix
 from ramalama.common import accel_image, get_accel, perror
-from ramalama.config import CONFIG, coerce_to_bool
+from ramalama.config import CONFIG, coerce_to_bool, load_file_config
 from ramalama.logger import configure_logger, logger
 from ramalama.model import MODEL_TYPES, trim_model_name
 from ramalama.model_factory import ModelFactory, New
@@ -528,6 +528,7 @@ def _list_models(args):
 
 def info_cli(args):
     info = {
+        "Config": load_file_config(),
         "Engine": {
             "Name": args.engine,
         },

--- a/ramalama/config.py
+++ b/ramalama/config.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any, Literal, Mapping, TypeAlias
 
 from ramalama.common import available
-from ramalama.layered_config import LayeredMixin, deep_merge
+from ramalama.layered_config import LayeredMixin
 from ramalama.toml_parser import TOMLParser
 
 PathStr: TypeAlias = str
@@ -60,7 +60,7 @@ class UserConfig:
 class RamalamaSettings:
     """These settings are not managed directly by the user"""
 
-    config_file: str | None = None
+    config_files: list[str] | None = None
 
 
 @dataclass
@@ -125,33 +125,32 @@ def load_file_config() -> dict[str, Any]:
     if config_path and os.path.exists(config_path):
         config = parser.parse_file(config_path)
         config = config.get("ramalama", {})
-        config['settings'] = {'config_file': config_path}
+        config['settings'] = {'config_files': [config_path]}
         return config
 
     config = {}
-    config_paths = [
+    default_config_paths = [
         "/usr/share/ramalama/ramalama.conf",
         "/usr/local/share/ramalama/ramalama.conf",
         "/etc/ramalama/ramalama.conf",
         os.path.expanduser(os.path.join(os.getenv("XDG_CONFIG_HOME", "~/.config"), "ramalama", "ramalama.conf")),
     ]
 
-    config_path = None
-    for path in config_paths:
+    config_paths = []
+    for path in default_config_paths:
         if os.path.exists(path):
-            config = parser.parse_file(path)
-
+            config_paths.append(str(path))
+            parser.parse_file(path)
         path_str = f"{path}.d"
         if os.path.isdir(path_str):
             for conf_file in sorted(Path(path_str).glob("*.conf")):
-                deep_merge(config, parser.parse_file(conf_file))
-
-        if config:
-            config = config.get('ramalama', {})
-            config['settings'] = {'config_file': config_path}
-            return config
-
-    return {}
+                config_paths.append(str(conf_file))
+                parser.parse_file(conf_file)
+    config = parser.data
+    if config:
+        config = config.get('ramalama', {})
+        config['settings'] = {'config_files': config_paths}
+    return config
 
 
 def load_env_config(env: Mapping[str, str] | None = None) -> dict[str, Any]:

--- a/ramalama/toml_parser.py
+++ b/ramalama/toml_parser.py
@@ -1,5 +1,7 @@
 import re
 
+from ramalama.logger import logger
+
 
 class TOMLParser:
     def __init__(self):
@@ -19,8 +21,10 @@ class TOMLParser:
                 key, value = line.split("=", 1)
                 key = key.strip()
                 value = self._parse_value(value.strip())
+                # We are parsing multiple TOML files,
+                # if there are duplicate keys from previous files, we just overwrite them
                 if key in current_section:
-                    raise ValueError(f"Duplicate key found: {key}")
+                    logger.debug(f"Duplicate key found: {key}")
                 current_section[key] = value
             else:
                 raise ValueError(f"Invalid TOML line: {line}")

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -198,7 +198,7 @@ class TestLoadEnvConfig:
         """Test loading nested configuration via double underscores."""
         env = {
             "RAMALAMA_USER__NO_MISSING_GPU_PROMPT": "true",
-            "RAMALAMA_SETTINGS__CONFIG_FILE": "/path/to/config",
+            "RAMALAMA_SETTINGS__CONFIG_FILES": ["/path/to/config"],
             "RAMALAMA_IMAGES": '{"CUDA_VISIBLE_DEVICES": "custom/cuda:latest"}',
         }
 
@@ -206,7 +206,7 @@ class TestLoadEnvConfig:
 
         expected = {
             "user": {"no_missing_gpu_prompt": "true"},
-            "settings": {"config_file": "/path/to/config"},
+            "settings": {"config_files": ["/path/to/config"]},
             "images": {"CUDA_VISIBLE_DEVICES": "custom/cuda:latest"},
         }
 
@@ -431,7 +431,7 @@ class TestConfigIntegration:
         """Test that nested environment variables are properly loaded and merged."""
         env = {
             "RAMALAMA_USER__NO_MISSING_GPU_PROMPT": "true",
-            "RAMALAMA_SETTINGS__CONFIG_FILE": "/custom/config.toml",
+            "RAMALAMA_SETTINGS__CONFIG_FILES": ["/custom/config.toml"],
             "RAMALAMA_IMAGES": (
                 '{"CUDA_VISIBLE_DEVICES": "custom/cuda:latest", "HIP_VISIBLE_DEVICES": "custom/rocm:latest"}'
             ),
@@ -441,7 +441,7 @@ class TestConfigIntegration:
             cfg = default_config(env)
 
             assert cfg.user.no_missing_gpu_prompt is True
-            assert cfg.settings.config_file == "/custom/config.toml"
+            assert cfg.settings.config_files == ["/custom/config.toml"]
             assert cfg.images["CUDA_VISIBLE_DEVICES"] == "custom/cuda:latest"
             assert cfg.images["HIP_VISIBLE_DEVICES"] == "custom/rocm:latest"
 

--- a/test/unit/test_toml_parser.py
+++ b/test/unit/test_toml_parser.py
@@ -183,13 +183,6 @@ def test_get_method_without_extra(toml, expected):
     [
         ("This is not a valid TOML file.", "Invalid TOML line: This is not a valid TOML file."),
         ('key = "value', "Unsupported value type: \"value"),
-        (
-            """
-            key = 123
-            key = 456
-            """,
-            "Duplicate key found: key",
-        ),
         ("key = unquoted string", "Unsupported value type: unquoted string"),
     ],
 )


### PR DESCRIPTION
If user overrides one field in a config file, we should use it along with other overrides in other config files, when their is duplicates we use the new value.

ramalama info should show the config file paths used along with the specified files found in the config files.

Fixes: https://github.com/containers/ramalama/issues/1797

## Summary by Sourcery

Load and merge all matching config files, track their paths, and surface them in the info command while allowing duplicate keys to be overwritten instead of erroring out.

New Features:
- Aggregate and merge settings from multiple configuration files and .d directories
- Expose the list of used config file paths in the ramalama info output

Enhancements:
- Rename the single config_file setting to config_files to hold multiple paths
- Log and overwrite duplicate TOML keys instead of throwing errors