### PR TITLE
Fix handling of oci models when being served

### DIFF
--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -344,6 +344,9 @@ class Model(ModelBase):
             return
 
         if self.model_type == 'oci':
+            if not self.engine.use_podman:
+                raise NotImplementedError("Serving OCI models via image mount is only supported with Podman.")
+            self.engine.add([f"--mount=type=image,src={self.model},destination={MNT_DIR},subpath=/models,rw=false"])
             return None
 
         ref_file = self.model_store.get_ref_file(self.model_tag)

--- a/ramalama/oci.py
+++ b/ramalama/oci.py
@@ -205,7 +205,8 @@ RUN ln -s /models/{model_name}-{args.gguf}.gguf model.file
 RUN rm -rf /{model_name}-f16.gguf /models/{model_name}
 """
         else:
-            content += f"RUN mkdir -p /models; cd /models; ln -s {model_name} model.file\n"
+            name = ref_file.model_files[0].name if ref_file.model_files else model_name
+            content += f"""RUN mkdir -p /models; cd /models; ln -s {model_name}/{name} model.file\n"""
 
         if not is_car:
             content += "\nFROM scratch\n"

--- a/test/unit/data/test_oci/ollama-type-car
+++ b/test/unit/data/test_oci/ollama-type-car
@@ -1,5 +1,5 @@
 FROM quay.io/ramalama/ramalama-rag:latest
-RUN mkdir -p /models; cd /models; ln -s tinyllama model.file
+RUN mkdir -p /models; cd /models; ln -s tinyllama/tinyllama model.file
 COPY sha256-2af3b81862c6be03c769683af18efdadb2c33f60ff32ab6f83e42c043d6c7816 /models/tinyllama/tinyllama
 COPY sha256-6331358be52a6ebc2fd0755a51ad1175734fd17a628ab5ea6897109396245362 /models/tinyllama/config.json
 COPY sha256-af0ddbdaaa26f30d54d727f9dd944b76bdb926fdaf9a58f63f78c532f57c191f /models/tinyllama/chat_template

--- a/test/unit/data/test_oci/url-simple
+++ b/test/unit/data/test_oci/url-simple
@@ -1,5 +1,5 @@
 FROM quay.io/ramalama/ramalama-rag:latest AS builder
-RUN mkdir -p /models; cd /models; ln -s aimodel model.file
+RUN mkdir -p /models; cd /models; ln -s aimodel/aimodel model.file
 
 FROM scratch
 COPY --from=builder /models /models


### PR DESCRIPTION
## Summary by Sourcery

Fix handling of OCI models by correcting the symlink in the generated Containerfile and adding the proper image mount option when setting up model mounts

Bug Fixes:
- Update Containerfile generation for OCI models to symlink the nested model file path
- Add --mount=type=image with subpath=/models flag in setup_mounts for OCI models