### PR TITLE
Explicitly pull of base container before converted container build

### DIFF
--- a/install-uv.sh
+++ b/install-uv.sh
@@ -1960,7 +1960,7 @@ verify_checksum() {
             local _test_blake2s
             _test_blake2s="$(printf "can do blake2s" | b2sum -a blake2s | awk '{printf $1}')" || _test_blake2s=""
 
-            if [ "X$_test_blake2s" = "X$_well_known_blake2s_checksum" ]; then
+            if [ "$_test_blake2s" = "$_well_known_blake2s_checksum" ]; then
                 _calculated_checksum="$(b2sum -a blake2s "$_file" | awk '{printf $1}')" || _calculated_checksum=""
             else
                 say "skipping blake2s checksum verification (installed b2sum doesn't support blake2s)"

--- a/ramalama/oci.py
+++ b/ramalama/oci.py
@@ -243,6 +243,9 @@ RUN rm -rf /{model_name}-f16.gguf /models/{model_name}
             c.write(content)
             c.flush()
 
+        # ensure base image is available
+        run_cmd([self.conman, "pull", args.carimage])
+
         build_cmd = [
             self.conman,
             "build",

--- a/ramalama/oci.py
+++ b/ramalama/oci.py
@@ -188,7 +188,7 @@ class OCI(Model):
         if is_car:
             content += f"FROM {args.carimage}\n"
         else:
-            content += f"FROM {args.carimage} as builder\n"
+            content += f"FROM {args.carimage} AS builder\n"
 
         if has_gguf:
             content += (

--- a/test/unit/data/test_oci/ollama-gguf
+++ b/test/unit/data/test_oci/ollama-gguf
@@ -1,4 +1,4 @@
-FROM quay.io/ramalama/ramalama-rag:latest as builder
+FROM quay.io/ramalama/ramalama-rag:latest AS builder
 RUN mkdir -p /models/tinyllama; cd /models; ln -s tinyllama-Q3_K_S.gguf model.file
 COPY sha256-2af3b81862c6be03c769683af18efdadb2c33f60ff32ab6f83e42c043d6c7816 /models/tinyllama/tinyllama
 COPY sha256-6331358be52a6ebc2fd0755a51ad1175734fd17a628ab5ea6897109396245362 /models/tinyllama/config.json

--- a/test/unit/data/test_oci/url-simple
+++ b/test/unit/data/test_oci/url-simple
@@ -1,4 +1,4 @@
-FROM quay.io/ramalama/ramalama-rag:latest as builder
+FROM quay.io/ramalama/ramalama-rag:latest AS builder
 RUN mkdir -p /models; cd /models; ln -s aimodel model.file
 
 FROM scratch


### PR DESCRIPTION
Fhe oci container uses the quiet option in order to get the image id properly. This, however, causes the convert command to seemingly sleep for a very long time since it might pull the latest base container image (which is quite large). In order to provide feedback to the user, lets pull explicityl before the build.

## Summary by Sourcery

Make the container build quiet mode optional by removing the hardcoded '-q' flag and conditionally adding '--quiet' when args.quiet is enabled, so that progress is shown when pulling new base images.

Enhancements:
- Remove default '-q' flag from both OCI and RAG build commands
- Add conditional '--quiet' flag based on args.quiet for podman/ramalama builds