### PR TITLE
Supports gpt-oss

### DIFF
--- a/container-images/scripts/build_llama_and_whisper.sh
+++ b/container-images/scripts/build_llama_and_whisper.sh
@@ -236,7 +236,7 @@ clone_and_build_whisper_cpp() {
 }
 
 clone_and_build_llama_cpp() {
-  local llama_cpp_sha="3f4fc97f1d745f1d5d3c853949503136d419e6de"
+  local llama_cpp_sha="1d72c841888b9450916bdd5a9b3274da380f5b36"
   local install_prefix
   install_prefix=$(set_install_prefix)
   git_clone_specific_commit "https://github.com/ggml-org/llama.cpp" "$llama_cpp_sha"

--- a/container-images/scripts/build_rag.sh
+++ b/container-images/scripts/build_rag.sh
@@ -64,7 +64,7 @@ rag() {
 to_gguf() {
     # required to build under GCC 15 until a new release is available, see https://github.com/google/sentencepiece/issues/1108 for details
     export CXXFLAGS="-include cstdint"
-    ${python} -m pip install "numpy~=1.26.4" "sentencepiece~=0.2.0" "transformers>=4.45.1,<5.0.0" git+https://github.com/ggml-org/llama.cpp#subdirectory=gguf-py "protobuf>=4.21.0,<5.0.0"
+    ${python} -m pip install "numpy~=1.26.4" "sentencepiece~=0.2.0" "transformers>=4.45.1,<5.0.0" git+https://github.com/ggml-org/llama.cpp#subdirectory=gguf-py "protobuf>=5.27.2,<6.0.0"
 }
 
 main() {

--- a/ramalama/model_inspect/gguf_parser.py
+++ b/ramalama/model_inspect/gguf_parser.py
@@ -42,6 +42,16 @@ class GGML_TYPE(IntEnum):
     GGML_TYPE_I64 = (27,)
     GGML_TYPE_F64 = (28,)
     GGML_TYPE_IQ1_M = (29,)
+    GGML_TYPE_BF16 = (30,)
+    # GGML_TYPE_Q4_0_4_4 = 31, support has been removed from gguf files
+    # GGML_TYPE_Q4_0_4_8 = 32,
+    # GGML_TYPE_Q4_0_8_8 = 33,
+    GGML_TYPE_TQ1_0 = (34,)
+    GGML_TYPE_TQ2_0 = (35,)
+    # GGML_TYPE_IQ4_NL_4_4 = 36,
+    # GGML_TYPE_IQ4_NL_4_8 = 37,
+    # GGML_TYPE_IQ4_NL_8_8 = 38,
+    GGML_TYPE_MXFP4 = (39,)  # MXFP4 (1 block)
 
 
 # Based on gguf_metadata_value_type in


### PR DESCRIPTION
This PR is to support gpt-oss.
- Use newer llama.cpp
- Update GGML_TYPE

Tested model: `hf://lmstudio-community/gpt-oss-20b-GGUF`
Tested images: ramalama, rocm

## Summary by Sourcery

Update the GGUF parser to recognize newly introduced GGML types and bump the llama.cpp dependency to a newer commit to enable GPT-OSS support.

New Features:
- Add support for new GGUF data types (BF16, TQ1_0, TQ2_0, MXFP4) in the parser

Build:
- Update llama.cpp commit SHA in the build_llama_and_whisper.sh script