### PR TITLE
fix parsing of CDI yaml

### DIFF
--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -251,7 +251,7 @@ def load_cdi_yaml(stream: Iterable[str]) -> CDI_RETURN_TYPE:
     for line in stream:
         if ':' in line:
             key, value = line.split(':', 1)
-            if key.strip() == "name":
+            if key.strip() == "- name":
                 data['devices'].append({'name': value.strip().strip('"')})
     return data
 


### PR DESCRIPTION
A previous commit removed pyyaml as a dependency and replaced it with code which parses the yaml line-by-line looking for "name" and using the following token as the device name. However, the code did not handle the hyphen prefix used in yaml lists, so it was ignoring all entries in the yaml, preventing use of "cuda" acceleration. Fix the parser to correctly handle hyphens.

## Summary by Sourcery

Fix load_cdi_yaml to correctly handle hyphen-prefixed list entries and expand coverage with unit tests for YAML parsing, configuration loading, and device lookup

Bug Fixes:
- Handle "- name" keys when parsing CDI YAML lists to include all device entries

Tests:
- Add parameterized tests for load_cdi_yaml covering empty lists, numeric, "all", and UUID names
- Add tests for load_cdi_config to verify configuration file discovery and parsing
- Add tests for find_in_cdi to validate visibility filtering and no-config fallback