### PR TITLE
bump the version of mesa-vulkan-drivers to match the copr repo

### DIFF
--- a/container-images/scripts/build_llama_and_whisper.sh
+++ b/container-images/scripts/build_llama_and_whisper.sh
@@ -74,9 +74,9 @@ dnf_install_s390() {
 dnf_install_mesa() {
   if [ "${ID}" = "fedora" ]; then
     dnf copr enable -y slp/mesa-libkrun-vulkan
-    dnf install -y mesa-vulkan-drivers-25.0.7-100.fc42 virglrenderer \
+    dnf install -y mesa-vulkan-drivers-25.0.7-101.fc42 virglrenderer \
       "${vulkan_rpms[@]}"
-    dnf versionlock add mesa-vulkan-drivers-25.0.7-100.fc42
+    dnf versionlock add mesa-vulkan-drivers-25.0.7-101.fc42
   elif [ "${ID}" = "openEuler" ]; then
     dnf install -y mesa-vulkan-drivers virglrenderer "${vulkan_rpms[@]}"
   else # virglrenderer not available on RHEL or EPEL


### PR DESCRIPTION
See 385a992e for an explanation of why this specific version of `mesa-vulkan-drivers` is required.

## Summary by Sourcery

Build:
- Update mesa-vulkan-drivers version to 25.0.7-101.fc42 in the Fedora install script and versionlock