### PR TITLE
fix "skopeo copy" command"

### DIFF
--- a/.tekton/integration/tasks/push-snapshot.yaml
+++ b/.tekton/integration/tasks/push-snapshot.yaml
@@ -111,7 +111,7 @@ spec:
           continue
         fi
         log Copying "$NAME" from "$SRC" to "$DEST"
-        if skopeo copy --all --multi-arch all --retry-times 5 "docker://$SRC" "docker://$DEST"; then
+        if skopeo copy --all --retry-times 5 "docker://$SRC" "docker://$DEST"; then
           (( SUCCESSES+=1 ))
         else
           FAILED_COMPONENTS+=("$NAME")


### PR DESCRIPTION
`--multi-arch all` conflicts with `--all`.

## Summary by Sourcery

Bug Fixes:
- Remove --multi-arch all flag from skopeo copy command to avoid conflict with --all.