### PR TITLE
konflux: build on the fastest instance types available, and increase timeouts

### DIFF
--- a/.tekton/asahi-llama-server/asahi-llama-server-pull-request.yaml
+++ b/.tekton/asahi-llama-server/asahi-llama-server-pull-request.yaml
@@ -41,7 +41,8 @@ spec:
   pipelineRef:
     name: pull-request-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/asahi-llama-server/asahi-llama-server-pull-request.yaml
+++ b/.tekton/asahi-llama-server/asahi-llama-server-pull-request.yaml
@@ -26,10 +26,6 @@ spec:
     value: quay.io/redhat-user-workloads/ramalama-tenant/asahi-llama-server:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: build-platforms
-    value:
-    - linux-m2xlarge/amd64
-    - linux-m2xlarge/arm64
   - name: dockerfile
     value: container-images/common/Containerfile.entrypoint
   - name: parent-image

--- a/.tekton/asahi-llama-server/asahi-llama-server-push.yaml
+++ b/.tekton/asahi-llama-server/asahi-llama-server-push.yaml
@@ -23,10 +23,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/ramalama-tenant/asahi-llama-server:{{revision}}
-  - name: build-platforms
-    value:
-    - linux-m2xlarge/amd64
-    - linux-m2xlarge/arm64
   - name: dockerfile
     value: container-images/common/Containerfile.entrypoint
   - name: parent-image

--- a/.tekton/asahi-llama-server/asahi-llama-server-push.yaml
+++ b/.tekton/asahi-llama-server/asahi-llama-server-push.yaml
@@ -38,7 +38,8 @@ spec:
   pipelineRef:
     name: push-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/asahi-rag/asahi-rag-pull-request.yaml
+++ b/.tekton/asahi-rag/asahi-rag-pull-request.yaml
@@ -41,7 +41,8 @@ spec:
   pipelineRef:
     name: pull-request-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/asahi-rag/asahi-rag-pull-request.yaml
+++ b/.tekton/asahi-rag/asahi-rag-pull-request.yaml
@@ -26,10 +26,6 @@ spec:
     value: quay.io/redhat-user-workloads/ramalama-tenant/asahi-rag:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: build-platforms
-    value:
-    - linux-d160-c8xlarge/amd64
-    - linux-d160-c8xlarge/arm64
   - name: dockerfile
     value: container-images/common/Containerfile.rag
   - name: parent-image

--- a/.tekton/asahi-rag/asahi-rag-push.yaml
+++ b/.tekton/asahi-rag/asahi-rag-push.yaml
@@ -23,10 +23,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/ramalama-tenant/asahi-rag:{{revision}}
-  - name: build-platforms
-    value:
-    - linux-d160-c8xlarge/amd64
-    - linux-d160-c8xlarge/arm64
   - name: dockerfile
     value: container-images/common/Containerfile.rag
   - name: parent-image

--- a/.tekton/asahi-rag/asahi-rag-push.yaml
+++ b/.tekton/asahi-rag/asahi-rag-push.yaml
@@ -38,7 +38,8 @@ spec:
   pipelineRef:
     name: push-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/asahi-whisper-server/asahi-whisper-server-pull-request.yaml
+++ b/.tekton/asahi-whisper-server/asahi-whisper-server-pull-request.yaml
@@ -41,7 +41,8 @@ spec:
   pipelineRef:
     name: pull-request-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/asahi-whisper-server/asahi-whisper-server-pull-request.yaml
+++ b/.tekton/asahi-whisper-server/asahi-whisper-server-pull-request.yaml
@@ -26,10 +26,6 @@ spec:
     value: quay.io/redhat-user-workloads/ramalama-tenant/asahi-whisper-server:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: build-platforms
-    value:
-    - linux-m2xlarge/amd64
-    - linux-m2xlarge/arm64
   - name: dockerfile
     value: container-images/common/Containerfile.entrypoint
   - name: parent-image

--- a/.tekton/asahi-whisper-server/asahi-whisper-server-push.yaml
+++ b/.tekton/asahi-whisper-server/asahi-whisper-server-push.yaml
@@ -23,10 +23,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/ramalama-tenant/asahi-whisper-server:{{revision}}
-  - name: build-platforms
-    value:
-    - linux-m2xlarge/amd64
-    - linux-m2xlarge/arm64
   - name: dockerfile
     value: container-images/common/Containerfile.entrypoint
   - name: parent-image

--- a/.tekton/asahi-whisper-server/asahi-whisper-server-push.yaml
+++ b/.tekton/asahi-whisper-server/asahi-whisper-server-push.yaml
@@ -38,7 +38,8 @@ spec:
   pipelineRef:
     name: push-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/asahi/asahi-pull-request.yaml
+++ b/.tekton/asahi/asahi-pull-request.yaml
@@ -26,10 +26,6 @@ spec:
     value: quay.io/redhat-user-workloads/ramalama-tenant/asahi:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: build-platforms
-    value:
-    - linux-c4xlarge/amd64
-    - linux-c4xlarge/arm64
   - name: dockerfile
     value: container-images/asahi/Containerfile
   pipelineRef:

--- a/.tekton/asahi/asahi-pull-request.yaml
+++ b/.tekton/asahi/asahi-pull-request.yaml
@@ -35,7 +35,8 @@ spec:
   pipelineRef:
     name: pull-request-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/asahi/asahi-push.yaml
+++ b/.tekton/asahi/asahi-push.yaml
@@ -23,10 +23,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/ramalama-tenant/asahi:{{revision}}
-  - name: build-platforms
-    value:
-    - linux-c4xlarge/amd64
-    - linux-c4xlarge/arm64
   - name: dockerfile
     value: container-images/asahi/Containerfile
   pipelineRef:

--- a/.tekton/asahi/asahi-push.yaml
+++ b/.tekton/asahi/asahi-push.yaml
@@ -32,7 +32,8 @@ spec:
   pipelineRef:
     name: push-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/bats/bats-pull-request.yaml
+++ b/.tekton/bats/bats-pull-request.yaml
@@ -26,10 +26,6 @@ spec:
     value: quay.io/redhat-user-workloads/ramalama-tenant/bats:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: build-platforms
-    value:
-    - linux-c4xlarge/amd64
-    - linux-c4xlarge/arm64
   - name: dockerfile
     value: container-images/bats/Containerfile
   pipelineRef:

--- a/.tekton/bats/bats-pull-request.yaml
+++ b/.tekton/bats/bats-pull-request.yaml
@@ -35,7 +35,8 @@ spec:
   pipelineRef:
     name: pull-request-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/bats/bats-push.yaml
+++ b/.tekton/bats/bats-push.yaml
@@ -23,10 +23,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/ramalama-tenant/bats:{{revision}}
-  - name: build-platforms
-    value:
-    - linux-c4xlarge/amd64
-    - linux-c4xlarge/arm64
   - name: dockerfile
     value: container-images/bats/Containerfile
   pipelineRef:

--- a/.tekton/bats/bats-push.yaml
+++ b/.tekton/bats/bats-push.yaml
@@ -32,7 +32,8 @@ spec:
   pipelineRef:
     name: push-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/cann-llama-server/cann-llama-server-pull-request.yaml
+++ b/.tekton/cann-llama-server/cann-llama-server-pull-request.yaml
@@ -41,7 +41,8 @@ spec:
   pipelineRef:
     name: pull-request-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/cann-llama-server/cann-llama-server-pull-request.yaml
+++ b/.tekton/cann-llama-server/cann-llama-server-pull-request.yaml
@@ -26,10 +26,6 @@ spec:
     value: quay.io/redhat-user-workloads/ramalama-tenant/cann-llama-server:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: build-platforms
-    value:
-    - linux-m2xlarge/amd64
-    - linux-m2xlarge/arm64
   - name: dockerfile
     value: container-images/common/Containerfile.entrypoint
   - name: parent-image

--- a/.tekton/cann-llama-server/cann-llama-server-push.yaml
+++ b/.tekton/cann-llama-server/cann-llama-server-push.yaml
@@ -23,10 +23,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/ramalama-tenant/cann-llama-server:{{revision}}
-  - name: build-platforms
-    value:
-    - linux-m2xlarge/amd64
-    - linux-m2xlarge/arm64
   - name: dockerfile
     value: container-images/common/Containerfile.entrypoint
   - name: parent-image

--- a/.tekton/cann-llama-server/cann-llama-server-push.yaml
+++ b/.tekton/cann-llama-server/cann-llama-server-push.yaml
@@ -38,7 +38,8 @@ spec:
   pipelineRef:
     name: push-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/cann-rag/cann-rag-pull-request.yaml
+++ b/.tekton/cann-rag/cann-rag-pull-request.yaml
@@ -41,7 +41,8 @@ spec:
   pipelineRef:
     name: pull-request-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/cann-rag/cann-rag-pull-request.yaml
+++ b/.tekton/cann-rag/cann-rag-pull-request.yaml
@@ -26,10 +26,6 @@ spec:
     value: quay.io/redhat-user-workloads/ramalama-tenant/cann-rag:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: build-platforms
-    value:
-    - linux-d160-c8xlarge/amd64
-    - linux-d160-c8xlarge/arm64
   - name: dockerfile
     value: container-images/common/Containerfile.rag
   - name: parent-image

--- a/.tekton/cann-rag/cann-rag-push.yaml
+++ b/.tekton/cann-rag/cann-rag-push.yaml
@@ -23,10 +23,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/ramalama-tenant/cann-rag:{{revision}}
-  - name: build-platforms
-    value:
-    - linux-d160-c8xlarge/amd64
-    - linux-d160-c8xlarge/arm64
   - name: dockerfile
     value: container-images/common/Containerfile.rag
   - name: parent-image

--- a/.tekton/cann-rag/cann-rag-push.yaml
+++ b/.tekton/cann-rag/cann-rag-push.yaml
@@ -38,7 +38,8 @@ spec:
   pipelineRef:
     name: push-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/cann-whisper-server/cann-whisper-server-pull-request.yaml
+++ b/.tekton/cann-whisper-server/cann-whisper-server-pull-request.yaml
@@ -41,7 +41,8 @@ spec:
   pipelineRef:
     name: pull-request-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/cann-whisper-server/cann-whisper-server-pull-request.yaml
+++ b/.tekton/cann-whisper-server/cann-whisper-server-pull-request.yaml
@@ -26,10 +26,6 @@ spec:
     value: quay.io/redhat-user-workloads/ramalama-tenant/cann-whisper-server:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: build-platforms
-    value:
-    - linux-m2xlarge/amd64
-    - linux-m2xlarge/arm64
   - name: dockerfile
     value: container-images/common/Containerfile.entrypoint
   - name: parent-image

--- a/.tekton/cann-whisper-server/cann-whisper-server-push.yaml
+++ b/.tekton/cann-whisper-server/cann-whisper-server-push.yaml
@@ -23,10 +23,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/ramalama-tenant/cann-whisper-server:{{revision}}
-  - name: build-platforms
-    value:
-    - linux-m2xlarge/amd64
-    - linux-m2xlarge/arm64
   - name: dockerfile
     value: container-images/common/Containerfile.entrypoint
   - name: parent-image

--- a/.tekton/cann-whisper-server/cann-whisper-server-push.yaml
+++ b/.tekton/cann-whisper-server/cann-whisper-server-push.yaml
@@ -38,7 +38,8 @@ spec:
   pipelineRef:
     name: push-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/cann/cann-pull-request.yaml
+++ b/.tekton/cann/cann-pull-request.yaml
@@ -35,7 +35,8 @@ spec:
   pipelineRef:
     name: pull-request-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/cann/cann-pull-request.yaml
+++ b/.tekton/cann/cann-pull-request.yaml
@@ -26,10 +26,6 @@ spec:
     value: quay.io/redhat-user-workloads/ramalama-tenant/cann:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: build-platforms
-    value:
-    - linux-c4xlarge/amd64
-    - linux-c4xlarge/arm64
   - name: dockerfile
     value: container-images/cann/Containerfile
   pipelineRef:

--- a/.tekton/cann/cann-push.yaml
+++ b/.tekton/cann/cann-push.yaml
@@ -23,10 +23,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/ramalama-tenant/cann:{{revision}}
-  - name: build-platforms
-    value:
-    - linux-c4xlarge/amd64
-    - linux-c4xlarge/arm64
   - name: dockerfile
     value: container-images/cann/Containerfile
   pipelineRef:

--- a/.tekton/cann/cann-push.yaml
+++ b/.tekton/cann/cann-push.yaml
@@ -32,7 +32,8 @@ spec:
   pipelineRef:
     name: push-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/cuda-llama-server/cuda-llama-server-pull-request.yaml
+++ b/.tekton/cuda-llama-server/cuda-llama-server-pull-request.yaml
@@ -41,7 +41,8 @@ spec:
   pipelineRef:
     name: pull-request-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/cuda-llama-server/cuda-llama-server-pull-request.yaml
+++ b/.tekton/cuda-llama-server/cuda-llama-server-pull-request.yaml
@@ -26,10 +26,6 @@ spec:
     value: quay.io/redhat-user-workloads/ramalama-tenant/cuda-llama-server:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: build-platforms
-    value:
-    - linux-m2xlarge/amd64
-    - linux-m2xlarge/arm64
   - name: dockerfile
     value: container-images/common/Containerfile.entrypoint
   - name: parent-image

--- a/.tekton/cuda-llama-server/cuda-llama-server-push.yaml
+++ b/.tekton/cuda-llama-server/cuda-llama-server-push.yaml
@@ -23,10 +23,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/ramalama-tenant/cuda-llama-server:{{revision}}
-  - name: build-platforms
-    value:
-    - linux-m2xlarge/amd64
-    - linux-m2xlarge/arm64
   - name: dockerfile
     value: container-images/common/Containerfile.entrypoint
   - name: parent-image

--- a/.tekton/cuda-llama-server/cuda-llama-server-push.yaml
+++ b/.tekton/cuda-llama-server/cuda-llama-server-push.yaml
@@ -38,7 +38,8 @@ spec:
   pipelineRef:
     name: push-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/cuda-rag/cuda-rag-pull-request.yaml
+++ b/.tekton/cuda-rag/cuda-rag-pull-request.yaml
@@ -41,7 +41,8 @@ spec:
   pipelineRef:
     name: pull-request-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/cuda-rag/cuda-rag-pull-request.yaml
+++ b/.tekton/cuda-rag/cuda-rag-pull-request.yaml
@@ -26,10 +26,6 @@ spec:
     value: quay.io/redhat-user-workloads/ramalama-tenant/cuda-rag:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: build-platforms
-    value:
-    - linux-d160-c8xlarge/amd64
-    - linux-d160-c8xlarge/arm64
   - name: dockerfile
     value: container-images/common/Containerfile.rag
   - name: parent-image

--- a/.tekton/cuda-rag/cuda-rag-push.yaml
+++ b/.tekton/cuda-rag/cuda-rag-push.yaml
@@ -23,10 +23,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/ramalama-tenant/cuda-rag:{{revision}}
-  - name: build-platforms
-    value:
-    - linux-d160-c8xlarge/amd64
-    - linux-d160-c8xlarge/arm64
   - name: dockerfile
     value: container-images/common/Containerfile.rag
   - name: parent-image

--- a/.tekton/cuda-rag/cuda-rag-push.yaml
+++ b/.tekton/cuda-rag/cuda-rag-push.yaml
@@ -38,7 +38,8 @@ spec:
   pipelineRef:
     name: push-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/cuda-whisper-server/cuda-whisper-server-pull-request.yaml
+++ b/.tekton/cuda-whisper-server/cuda-whisper-server-pull-request.yaml
@@ -41,7 +41,8 @@ spec:
   pipelineRef:
     name: pull-request-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/cuda-whisper-server/cuda-whisper-server-pull-request.yaml
+++ b/.tekton/cuda-whisper-server/cuda-whisper-server-pull-request.yaml
@@ -26,10 +26,6 @@ spec:
     value: quay.io/redhat-user-workloads/ramalama-tenant/cuda-whisper-server:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: build-platforms
-    value:
-    - linux-m2xlarge/amd64
-    - linux-m2xlarge/arm64
   - name: dockerfile
     value: container-images/common/Containerfile.entrypoint
   - name: parent-image

--- a/.tekton/cuda-whisper-server/cuda-whisper-server-push.yaml
+++ b/.tekton/cuda-whisper-server/cuda-whisper-server-push.yaml
@@ -23,10 +23,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/ramalama-tenant/cuda-whisper-server:{{revision}}
-  - name: build-platforms
-    value:
-    - linux-m2xlarge/amd64
-    - linux-m2xlarge/arm64
   - name: dockerfile
     value: container-images/common/Containerfile.entrypoint
   - name: parent-image

--- a/.tekton/cuda-whisper-server/cuda-whisper-server-push.yaml
+++ b/.tekton/cuda-whisper-server/cuda-whisper-server-push.yaml
@@ -38,7 +38,8 @@ spec:
   pipelineRef:
     name: push-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/cuda/cuda-pull-request.yaml
+++ b/.tekton/cuda/cuda-pull-request.yaml
@@ -26,10 +26,6 @@ spec:
     value: quay.io/redhat-user-workloads/ramalama-tenant/cuda:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: build-platforms
-    value:
-    - linux-c4xlarge/amd64
-    - linux-c4xlarge/arm64
   - name: dockerfile
     value: container-images/cuda/Containerfile
   pipelineRef:

--- a/.tekton/cuda/cuda-pull-request.yaml
+++ b/.tekton/cuda/cuda-pull-request.yaml
@@ -35,7 +35,8 @@ spec:
   pipelineRef:
     name: pull-request-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/cuda/cuda-push.yaml
+++ b/.tekton/cuda/cuda-push.yaml
@@ -23,10 +23,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/ramalama-tenant/cuda:{{revision}}
-  - name: build-platforms
-    value:
-    - linux-c4xlarge/amd64
-    - linux-c4xlarge/arm64
   - name: dockerfile
     value: container-images/cuda/Containerfile
   pipelineRef:

--- a/.tekton/cuda/cuda-push.yaml
+++ b/.tekton/cuda/cuda-push.yaml
@@ -32,7 +32,8 @@ spec:
   pipelineRef:
     name: push-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/integration/pipelines/bats-integration.yaml
+++ b/.tekton/integration/pipelines/bats-integration.yaml
@@ -13,8 +13,8 @@ spec:
     description: VM platforms on which to run test commands
     type: array
     default:
-    - linux-c4xlarge/amd64
-    - linux-c4xlarge/arm64
+    - linux-c8xlarge/amd64
+    - linux-c8xlarge/arm64
   - name: commands
     description: Test commands to run
     type: array

--- a/.tekton/intel-gpu-llama-server/intel-gpu-llama-server-pull-request.yaml
+++ b/.tekton/intel-gpu-llama-server/intel-gpu-llama-server-pull-request.yaml
@@ -40,7 +40,8 @@ spec:
   pipelineRef:
     name: pull-request-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/intel-gpu-llama-server/intel-gpu-llama-server-pull-request.yaml
+++ b/.tekton/intel-gpu-llama-server/intel-gpu-llama-server-pull-request.yaml
@@ -28,7 +28,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux-m2xlarge/amd64
+    - linux-d160-c8xlarge/amd64
   - name: dockerfile
     value: container-images/common/Containerfile.entrypoint
   - name: parent-image

--- a/.tekton/intel-gpu-llama-server/intel-gpu-llama-server-push.yaml
+++ b/.tekton/intel-gpu-llama-server/intel-gpu-llama-server-push.yaml
@@ -25,7 +25,7 @@ spec:
     value: quay.io/redhat-user-workloads/ramalama-tenant/intel-gpu-llama-server:{{revision}}
   - name: build-platforms
     value:
-    - linux-m2xlarge/amd64
+    - linux-d160-c8xlarge/amd64
   - name: dockerfile
     value: container-images/common/Containerfile.entrypoint
   - name: parent-image

--- a/.tekton/intel-gpu-llama-server/intel-gpu-llama-server-push.yaml
+++ b/.tekton/intel-gpu-llama-server/intel-gpu-llama-server-push.yaml
@@ -37,7 +37,8 @@ spec:
   pipelineRef:
     name: push-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/intel-gpu-rag/intel-gpu-rag-pull-request.yaml
+++ b/.tekton/intel-gpu-rag/intel-gpu-rag-pull-request.yaml
@@ -40,7 +40,8 @@ spec:
   pipelineRef:
     name: pull-request-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/intel-gpu-rag/intel-gpu-rag-push.yaml
+++ b/.tekton/intel-gpu-rag/intel-gpu-rag-push.yaml
@@ -37,7 +37,8 @@ spec:
   pipelineRef:
     name: push-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/intel-gpu-whisper-server/intel-gpu-whisper-server-pull-request.yaml
+++ b/.tekton/intel-gpu-whisper-server/intel-gpu-whisper-server-pull-request.yaml
@@ -40,7 +40,8 @@ spec:
   pipelineRef:
     name: pull-request-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/intel-gpu-whisper-server/intel-gpu-whisper-server-pull-request.yaml
+++ b/.tekton/intel-gpu-whisper-server/intel-gpu-whisper-server-pull-request.yaml
@@ -28,7 +28,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux-m2xlarge/amd64
+    - linux-d160-c8xlarge/amd64
   - name: dockerfile
     value: container-images/common/Containerfile.entrypoint
   - name: parent-image

--- a/.tekton/intel-gpu-whisper-server/intel-gpu-whisper-server-push.yaml
+++ b/.tekton/intel-gpu-whisper-server/intel-gpu-whisper-server-push.yaml
@@ -25,7 +25,7 @@ spec:
     value: quay.io/redhat-user-workloads/ramalama-tenant/intel-gpu-whisper-server:{{revision}}
   - name: build-platforms
     value:
-    - linux-m2xlarge/amd64
+    - linux-d160-c8xlarge/amd64
   - name: dockerfile
     value: container-images/common/Containerfile.entrypoint
   - name: parent-image

--- a/.tekton/intel-gpu-whisper-server/intel-gpu-whisper-server-push.yaml
+++ b/.tekton/intel-gpu-whisper-server/intel-gpu-whisper-server-push.yaml
@@ -37,7 +37,8 @@ spec:
   pipelineRef:
     name: push-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/intel-gpu/intel-gpu-pull-request.yaml
+++ b/.tekton/intel-gpu/intel-gpu-pull-request.yaml
@@ -34,7 +34,8 @@ spec:
   pipelineRef:
     name: pull-request-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/intel-gpu/intel-gpu-pull-request.yaml
+++ b/.tekton/intel-gpu/intel-gpu-pull-request.yaml
@@ -28,7 +28,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux-c4xlarge/amd64
+    - linux-d160-c8xlarge/amd64
   - name: dockerfile
     value: container-images/intel-gpu/Containerfile
   pipelineRef:

--- a/.tekton/intel-gpu/intel-gpu-push.yaml
+++ b/.tekton/intel-gpu/intel-gpu-push.yaml
@@ -25,7 +25,7 @@ spec:
     value: quay.io/redhat-user-workloads/ramalama-tenant/intel-gpu:{{revision}}
   - name: build-platforms
     value:
-    - linux-c4xlarge/amd64
+    - linux-d160-c8xlarge/amd64
   - name: dockerfile
     value: container-images/intel-gpu/Containerfile
   pipelineRef:

--- a/.tekton/intel-gpu/intel-gpu-push.yaml
+++ b/.tekton/intel-gpu/intel-gpu-push.yaml
@@ -31,7 +31,8 @@ spec:
   pipelineRef:
     name: push-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/llama-stack/llama-stack-pull-request.yaml
+++ b/.tekton/llama-stack/llama-stack-pull-request.yaml
@@ -26,10 +26,6 @@ spec:
     value: quay.io/redhat-user-workloads/ramalama-tenant/llama-stack:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: build-platforms
-    value:
-    - linux-c4xlarge/amd64
-    - linux-c4xlarge/arm64
   - name: dockerfile
     value: container-images/llama-stack/Containerfile
   pipelineRef:

--- a/.tekton/llama-stack/llama-stack-pull-request.yaml
+++ b/.tekton/llama-stack/llama-stack-pull-request.yaml
@@ -35,7 +35,8 @@ spec:
   pipelineRef:
     name: pull-request-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/llama-stack/llama-stack-push.yaml
+++ b/.tekton/llama-stack/llama-stack-push.yaml
@@ -23,10 +23,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/ramalama-tenant/llama-stack:{{revision}}
-  - name: build-platforms
-    value:
-    - linux-c4xlarge/amd64
-    - linux-c4xlarge/arm64
   - name: dockerfile
     value: container-images/llama-stack/Containerfile
   pipelineRef:

--- a/.tekton/llama-stack/llama-stack-push.yaml
+++ b/.tekton/llama-stack/llama-stack-push.yaml
@@ -32,7 +32,8 @@ spec:
   pipelineRef:
     name: push-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/musa-llama-server/musa-llama-server-pull-request.yaml
+++ b/.tekton/musa-llama-server/musa-llama-server-pull-request.yaml
@@ -40,7 +40,8 @@ spec:
   pipelineRef:
     name: pull-request-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/musa-llama-server/musa-llama-server-pull-request.yaml
+++ b/.tekton/musa-llama-server/musa-llama-server-pull-request.yaml
@@ -28,7 +28,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux-m2xlarge/amd64
+    - linux-d160-c8xlarge/amd64
   - name: dockerfile
     value: container-images/common/Containerfile.entrypoint
   - name: parent-image

--- a/.tekton/musa-llama-server/musa-llama-server-push.yaml
+++ b/.tekton/musa-llama-server/musa-llama-server-push.yaml
@@ -25,7 +25,7 @@ spec:
     value: quay.io/redhat-user-workloads/ramalama-tenant/musa-llama-server:{{revision}}
   - name: build-platforms
     value:
-    - linux-m2xlarge/amd64
+    - linux-d160-c8xlarge/amd64
   - name: dockerfile
     value: container-images/common/Containerfile.entrypoint
   - name: parent-image

--- a/.tekton/musa-llama-server/musa-llama-server-push.yaml
+++ b/.tekton/musa-llama-server/musa-llama-server-push.yaml
@@ -37,7 +37,8 @@ spec:
   pipelineRef:
     name: push-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/musa-rag/musa-rag-pull-request.yaml
+++ b/.tekton/musa-rag/musa-rag-pull-request.yaml
@@ -40,7 +40,8 @@ spec:
   pipelineRef:
     name: pull-request-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/musa-rag/musa-rag-push.yaml
+++ b/.tekton/musa-rag/musa-rag-push.yaml
@@ -37,7 +37,8 @@ spec:
   pipelineRef:
     name: push-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/musa-whisper-server/musa-whisper-server-pull-request.yaml
+++ b/.tekton/musa-whisper-server/musa-whisper-server-pull-request.yaml
@@ -40,7 +40,8 @@ spec:
   pipelineRef:
     name: pull-request-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/musa-whisper-server/musa-whisper-server-pull-request.yaml
+++ b/.tekton/musa-whisper-server/musa-whisper-server-pull-request.yaml
@@ -28,7 +28,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux-m2xlarge/amd64
+    - linux-d160-c8xlarge/amd64
   - name: dockerfile
     value: container-images/common/Containerfile.entrypoint
   - name: parent-image

--- a/.tekton/musa-whisper-server/musa-whisper-server-push.yaml
+++ b/.tekton/musa-whisper-server/musa-whisper-server-push.yaml
@@ -25,7 +25,7 @@ spec:
     value: quay.io/redhat-user-workloads/ramalama-tenant/musa-whisper-server:{{revision}}
   - name: build-platforms
     value:
-    - linux-m2xlarge/amd64
+    - linux-d160-c8xlarge/amd64
   - name: dockerfile
     value: container-images/common/Containerfile.entrypoint
   - name: parent-image

--- a/.tekton/musa-whisper-server/musa-whisper-server-push.yaml
+++ b/.tekton/musa-whisper-server/musa-whisper-server-push.yaml
@@ -37,7 +37,8 @@ spec:
   pipelineRef:
     name: push-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/musa/musa-pull-request.yaml
+++ b/.tekton/musa/musa-pull-request.yaml
@@ -28,7 +28,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux-c4xlarge/amd64
+    - linux-d160-c8xlarge/amd64
   - name: dockerfile
     value: container-images/musa/Containerfile
   pipelineRef:

--- a/.tekton/musa/musa-pull-request.yaml
+++ b/.tekton/musa/musa-pull-request.yaml
@@ -34,7 +34,8 @@ spec:
   pipelineRef:
     name: pull-request-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/musa/musa-push.yaml
+++ b/.tekton/musa/musa-push.yaml
@@ -25,7 +25,7 @@ spec:
     value: quay.io/redhat-user-workloads/ramalama-tenant/musa:{{revision}}
   - name: build-platforms
     value:
-    - linux-c4xlarge/amd64
+    - linux-d160-c8xlarge/amd64
   - name: dockerfile
     value: container-images/musa/Containerfile
   pipelineRef:

--- a/.tekton/musa/musa-push.yaml
+++ b/.tekton/musa/musa-push.yaml
@@ -31,7 +31,8 @@ spec:
   pipelineRef:
     name: push-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/openvino/openvino-pull-request.yaml
+++ b/.tekton/openvino/openvino-pull-request.yaml
@@ -34,7 +34,8 @@ spec:
   pipelineRef:
     name: pull-request-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/openvino/openvino-pull-request.yaml
+++ b/.tekton/openvino/openvino-pull-request.yaml
@@ -28,7 +28,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux-c4xlarge/amd64
+    - linux-d160-c8xlarge/amd64
   - name: dockerfile
     value: container-images/openvino/Containerfile
   pipelineRef:

--- a/.tekton/openvino/openvino-push.yaml
+++ b/.tekton/openvino/openvino-push.yaml
@@ -25,7 +25,7 @@ spec:
     value: quay.io/redhat-user-workloads/ramalama-tenant/openvino:{{revision}}
   - name: build-platforms
     value:
-    - linux-c4xlarge/amd64
+    - linux-d160-c8xlarge/amd64
   - name: dockerfile
     value: container-images/openvino/Containerfile
   pipelineRef:

--- a/.tekton/openvino/openvino-push.yaml
+++ b/.tekton/openvino/openvino-push.yaml
@@ -31,7 +31,8 @@ spec:
   pipelineRef:
     name: push-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/pipelines/pull-request-pipeline.yaml
+++ b/.tekton/pipelines/pull-request-pipeline.yaml
@@ -178,6 +178,7 @@ spec:
       value: $(params.parent-image)
     taskRef:
       name: wait-for-image
+    timeout: 10h
     when:
     - input: $(params.parent-image)
       operator: notin
@@ -229,6 +230,7 @@ spec:
       - name: kind
         value: task
       resolver: bundles
+    timeout: 10h
     when:
     - input: $(tasks.init.results.build)
       operator: in

--- a/.tekton/pipelines/pull-request-pipeline.yaml
+++ b/.tekton/pipelines/pull-request-pipeline.yaml
@@ -67,7 +67,8 @@ spec:
     name: privileged-nested
     type: string
   - default:
-    - linux-c4xlarge/amd64
+    - linux-d160-c8xlarge/amd64
+    - linux-d160-c8xlarge/arm64
     description: List of platforms to build the container images on. The available set of values is determined by the configuration of the multi-platform-controller.
     name: build-platforms
     type: array

--- a/.tekton/pipelines/push-pipeline.yaml
+++ b/.tekton/pipelines/push-pipeline.yaml
@@ -178,6 +178,7 @@ spec:
       value: $(params.parent-image)
     taskRef:
       name: wait-for-image
+    timeout: 10h
     when:
     - input: $(params.parent-image)
       operator: notin
@@ -229,6 +230,7 @@ spec:
       - name: kind
         value: task
       resolver: bundles
+    timeout: 10h
     when:
     - input: $(tasks.init.results.build)
       operator: in

--- a/.tekton/pipelines/push-pipeline.yaml
+++ b/.tekton/pipelines/push-pipeline.yaml
@@ -67,7 +67,8 @@ spec:
     name: privileged-nested
     type: string
   - default:
-    - linux-c4xlarge/amd64
+    - linux-d160-c8xlarge/amd64
+    - linux-d160-c8xlarge/arm64
     description: List of platforms to build the container images on. The available set of values is determined by the configuration of the multi-platform-controller.
     name: build-platforms
     type: array

--- a/.tekton/ramalama-cli/ramalama-cli-pull-request.yaml
+++ b/.tekton/ramalama-cli/ramalama-cli-pull-request.yaml
@@ -26,10 +26,6 @@ spec:
     value: quay.io/redhat-user-workloads/ramalama-tenant/ramalama-cli:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: build-platforms
-    value:
-    - linux-c4xlarge/amd64
-    - linux-c4xlarge/arm64
   - name: dockerfile
     value: container-images/ramalama-cli/Containerfile
   pipelineRef:

--- a/.tekton/ramalama-cli/ramalama-cli-pull-request.yaml
+++ b/.tekton/ramalama-cli/ramalama-cli-pull-request.yaml
@@ -35,7 +35,8 @@ spec:
   pipelineRef:
     name: pull-request-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/ramalama-cli/ramalama-cli-push.yaml
+++ b/.tekton/ramalama-cli/ramalama-cli-push.yaml
@@ -23,10 +23,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/ramalama-tenant/ramalama-cli:{{revision}}
-  - name: build-platforms
-    value:
-    - linux-c4xlarge/amd64
-    - linux-c4xlarge/arm64
   - name: dockerfile
     value: container-images/ramalama-cli/Containerfile
   pipelineRef:

--- a/.tekton/ramalama-cli/ramalama-cli-push.yaml
+++ b/.tekton/ramalama-cli/ramalama-cli-push.yaml
@@ -32,7 +32,8 @@ spec:
   pipelineRef:
     name: push-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/ramalama-llama-server/ramalama-llama-server-pull-request.yaml
+++ b/.tekton/ramalama-llama-server/ramalama-llama-server-pull-request.yaml
@@ -41,7 +41,8 @@ spec:
   pipelineRef:
     name: pull-request-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/ramalama-llama-server/ramalama-llama-server-pull-request.yaml
+++ b/.tekton/ramalama-llama-server/ramalama-llama-server-pull-request.yaml
@@ -26,10 +26,6 @@ spec:
     value: quay.io/redhat-user-workloads/ramalama-tenant/ramalama-llama-server:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: build-platforms
-    value:
-    - linux-m2xlarge/amd64
-    - linux-m2xlarge/arm64
   - name: dockerfile
     value: container-images/common/Containerfile.entrypoint
   - name: parent-image

--- a/.tekton/ramalama-llama-server/ramalama-llama-server-push.yaml
+++ b/.tekton/ramalama-llama-server/ramalama-llama-server-push.yaml
@@ -23,10 +23,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/ramalama-tenant/ramalama-llama-server:{{revision}}
-  - name: build-platforms
-    value:
-    - linux-m2xlarge/amd64
-    - linux-m2xlarge/arm64
   - name: dockerfile
     value: container-images/common/Containerfile.entrypoint
   - name: parent-image

--- a/.tekton/ramalama-llama-server/ramalama-llama-server-push.yaml
+++ b/.tekton/ramalama-llama-server/ramalama-llama-server-push.yaml
@@ -38,7 +38,8 @@ spec:
   pipelineRef:
     name: push-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/ramalama-rag/ramalama-rag-pull-request.yaml
+++ b/.tekton/ramalama-rag/ramalama-rag-pull-request.yaml
@@ -41,7 +41,8 @@ spec:
   pipelineRef:
     name: pull-request-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/ramalama-rag/ramalama-rag-pull-request.yaml
+++ b/.tekton/ramalama-rag/ramalama-rag-pull-request.yaml
@@ -26,10 +26,6 @@ spec:
     value: quay.io/redhat-user-workloads/ramalama-tenant/ramalama-rag:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: build-platforms
-    value:
-    - linux-d160-c8xlarge/amd64
-    - linux-d160-c8xlarge/arm64
   - name: dockerfile
     value: container-images/common/Containerfile.rag
   - name: parent-image

--- a/.tekton/ramalama-rag/ramalama-rag-push.yaml
+++ b/.tekton/ramalama-rag/ramalama-rag-push.yaml
@@ -23,10 +23,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/ramalama-tenant/ramalama-rag:{{revision}}
-  - name: build-platforms
-    value:
-    - linux-d160-c8xlarge/amd64
-    - linux-d160-c8xlarge/arm64
   - name: dockerfile
     value: container-images/common/Containerfile.rag
   - name: parent-image

--- a/.tekton/ramalama-rag/ramalama-rag-push.yaml
+++ b/.tekton/ramalama-rag/ramalama-rag-push.yaml
@@ -38,7 +38,8 @@ spec:
   pipelineRef:
     name: push-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/ramalama-vllm-llama-server/ramalama-vllm-llama-server-pull-request.yaml
+++ b/.tekton/ramalama-vllm-llama-server/ramalama-vllm-llama-server-pull-request.yaml
@@ -40,7 +40,8 @@ spec:
   pipelineRef:
     name: pull-request-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/ramalama-vllm-llama-server/ramalama-vllm-llama-server-pull-request.yaml
+++ b/.tekton/ramalama-vllm-llama-server/ramalama-vllm-llama-server-pull-request.yaml
@@ -26,9 +26,6 @@ spec:
     value: quay.io/redhat-user-workloads/ramalama-tenant/ramalama-vllm-llama-server:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: build-platforms
-    value:
-    - linux-m2xlarge/amd64
   - name: dockerfile
     value: container-images/common/Containerfile.entrypoint
   - name: parent-image

--- a/.tekton/ramalama-vllm-llama-server/ramalama-vllm-llama-server-push.yaml
+++ b/.tekton/ramalama-vllm-llama-server/ramalama-vllm-llama-server-push.yaml
@@ -37,7 +37,8 @@ spec:
   pipelineRef:
     name: push-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/ramalama-vllm-llama-server/ramalama-vllm-llama-server-push.yaml
+++ b/.tekton/ramalama-vllm-llama-server/ramalama-vllm-llama-server-push.yaml
@@ -23,9 +23,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/ramalama-tenant/ramalama-vllm-llama-server:{{revision}}
-  - name: build-platforms
-    value:
-    - linux-m2xlarge/amd64
   - name: dockerfile
     value: container-images/common/Containerfile.entrypoint
   - name: parent-image

--- a/.tekton/ramalama-vllm-rag/ramalama-vllm-rag-pull-request.yaml
+++ b/.tekton/ramalama-vllm-rag/ramalama-vllm-rag-pull-request.yaml
@@ -40,7 +40,8 @@ spec:
   pipelineRef:
     name: pull-request-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/ramalama-vllm-rag/ramalama-vllm-rag-pull-request.yaml
+++ b/.tekton/ramalama-vllm-rag/ramalama-vllm-rag-pull-request.yaml
@@ -26,9 +26,6 @@ spec:
     value: quay.io/redhat-user-workloads/ramalama-tenant/ramalama-vllm-rag:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: build-platforms
-    value:
-    - linux-d160-c8xlarge/amd64
   - name: dockerfile
     value: container-images/common/Containerfile.rag
   - name: parent-image

--- a/.tekton/ramalama-vllm-rag/ramalama-vllm-rag-push.yaml
+++ b/.tekton/ramalama-vllm-rag/ramalama-vllm-rag-push.yaml
@@ -23,9 +23,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/ramalama-tenant/ramalama-vllm-rag:{{revision}}
-  - name: build-platforms
-    value:
-    - linux-d160-c8xlarge/amd64
   - name: dockerfile
     value: container-images/common/Containerfile.rag
   - name: parent-image

--- a/.tekton/ramalama-vllm-rag/ramalama-vllm-rag-push.yaml
+++ b/.tekton/ramalama-vllm-rag/ramalama-vllm-rag-push.yaml
@@ -37,7 +37,8 @@ spec:
   pipelineRef:
     name: push-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/ramalama-vllm-whisper-server/ramalama-vllm-whisper-server-pull-request.yaml
+++ b/.tekton/ramalama-vllm-whisper-server/ramalama-vllm-whisper-server-pull-request.yaml
@@ -40,7 +40,8 @@ spec:
   pipelineRef:
     name: pull-request-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/ramalama-vllm-whisper-server/ramalama-vllm-whisper-server-pull-request.yaml
+++ b/.tekton/ramalama-vllm-whisper-server/ramalama-vllm-whisper-server-pull-request.yaml
@@ -26,9 +26,6 @@ spec:
     value: quay.io/redhat-user-workloads/ramalama-tenant/ramalama-vllm-whisper-server:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: build-platforms
-    value:
-    - linux-m2xlarge/amd64
   - name: dockerfile
     value: container-images/common/Containerfile.entrypoint
   - name: parent-image

--- a/.tekton/ramalama-vllm-whisper-server/ramalama-vllm-whisper-server-push.yaml
+++ b/.tekton/ramalama-vllm-whisper-server/ramalama-vllm-whisper-server-push.yaml
@@ -23,9 +23,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/ramalama-tenant/ramalama-vllm-whisper-server:{{revision}}
-  - name: build-platforms
-    value:
-    - linux-m2xlarge/amd64
   - name: dockerfile
     value: container-images/common/Containerfile.entrypoint
   - name: parent-image

--- a/.tekton/ramalama-vllm-whisper-server/ramalama-vllm-whisper-server-push.yaml
+++ b/.tekton/ramalama-vllm-whisper-server/ramalama-vllm-whisper-server-push.yaml
@@ -37,7 +37,8 @@ spec:
   pipelineRef:
     name: push-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/ramalama-vllm/ramalama-vllm-pull-request.yaml
+++ b/.tekton/ramalama-vllm/ramalama-vllm-pull-request.yaml
@@ -39,7 +39,8 @@ spec:
   pipelineRef:
     name: pull-request-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/ramalama-vllm/ramalama-vllm-pull-request.yaml
+++ b/.tekton/ramalama-vllm/ramalama-vllm-pull-request.yaml
@@ -26,9 +26,6 @@ spec:
     value: quay.io/redhat-user-workloads/ramalama-tenant/ramalama-vllm:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: build-platforms
-    value:
-    - linux-c4xlarge/amd64
   - name: dockerfile
     value: container-images/ramalama-vllm/Containerfile
   - name: parent-image

--- a/.tekton/ramalama-vllm/ramalama-vllm-push.yaml
+++ b/.tekton/ramalama-vllm/ramalama-vllm-push.yaml
@@ -23,9 +23,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/ramalama-tenant/ramalama-vllm:{{revision}}
-  - name: build-platforms
-    value:
-    - linux-c4xlarge/amd64
   - name: dockerfile
     value: container-images/ramalama-vllm/Containerfile
   - name: parent-image

--- a/.tekton/ramalama-vllm/ramalama-vllm-push.yaml
+++ b/.tekton/ramalama-vllm/ramalama-vllm-push.yaml
@@ -36,7 +36,8 @@ spec:
   pipelineRef:
     name: push-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/ramalama-whisper-server/ramalama-whisper-server-pull-request.yaml
+++ b/.tekton/ramalama-whisper-server/ramalama-whisper-server-pull-request.yaml
@@ -41,7 +41,8 @@ spec:
   pipelineRef:
     name: pull-request-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/ramalama-whisper-server/ramalama-whisper-server-pull-request.yaml
+++ b/.tekton/ramalama-whisper-server/ramalama-whisper-server-pull-request.yaml
@@ -26,10 +26,6 @@ spec:
     value: quay.io/redhat-user-workloads/ramalama-tenant/ramalama-whisper-server:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: build-platforms
-    value:
-    - linux-m2xlarge/amd64
-    - linux-m2xlarge/arm64
   - name: dockerfile
     value: container-images/common/Containerfile.entrypoint
   - name: parent-image

--- a/.tekton/ramalama-whisper-server/ramalama-whisper-server-push.yaml
+++ b/.tekton/ramalama-whisper-server/ramalama-whisper-server-push.yaml
@@ -23,10 +23,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/ramalama-tenant/ramalama-whisper-server:{{revision}}
-  - name: build-platforms
-    value:
-    - linux-m2xlarge/amd64
-    - linux-m2xlarge/arm64
   - name: dockerfile
     value: container-images/common/Containerfile.entrypoint
   - name: parent-image

--- a/.tekton/ramalama-whisper-server/ramalama-whisper-server-push.yaml
+++ b/.tekton/ramalama-whisper-server/ramalama-whisper-server-push.yaml
@@ -38,7 +38,8 @@ spec:
   pipelineRef:
     name: push-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/ramalama/ramalama-pull-request.yaml
+++ b/.tekton/ramalama/ramalama-pull-request.yaml
@@ -45,7 +45,8 @@ spec:
   pipelineRef:
     name: pull-request-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/ramalama/ramalama-pull-request.yaml
+++ b/.tekton/ramalama/ramalama-pull-request.yaml
@@ -26,10 +26,6 @@ spec:
     value: quay.io/redhat-user-workloads/ramalama-tenant/ramalama:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: build-platforms
-    value:
-    - linux-c4xlarge/amd64
-    - linux-c4xlarge/arm64
   - name: dockerfile
     value: container-images/ramalama/Containerfile
   - name: test-image

--- a/.tekton/ramalama/ramalama-push.yaml
+++ b/.tekton/ramalama/ramalama-push.yaml
@@ -42,7 +42,8 @@ spec:
   pipelineRef:
     name: push-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/ramalama/ramalama-push.yaml
+++ b/.tekton/ramalama/ramalama-push.yaml
@@ -23,10 +23,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/ramalama-tenant/ramalama:{{revision}}
-  - name: build-platforms
-    value:
-    - linux-c4xlarge/amd64
-    - linux-c4xlarge/arm64
   - name: dockerfile
     value: container-images/ramalama/Containerfile
   - name: test-image

--- a/.tekton/rocm-llama-server/rocm-llama-server-pull-request.yaml
+++ b/.tekton/rocm-llama-server/rocm-llama-server-pull-request.yaml
@@ -40,7 +40,8 @@ spec:
   pipelineRef:
     name: pull-request-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/rocm-llama-server/rocm-llama-server-pull-request.yaml
+++ b/.tekton/rocm-llama-server/rocm-llama-server-pull-request.yaml
@@ -28,7 +28,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux-m2xlarge/amd64
+    - linux-d160-c8xlarge/amd64
   - name: dockerfile
     value: container-images/common/Containerfile.entrypoint
   - name: parent-image

--- a/.tekton/rocm-llama-server/rocm-llama-server-push.yaml
+++ b/.tekton/rocm-llama-server/rocm-llama-server-push.yaml
@@ -25,7 +25,7 @@ spec:
     value: quay.io/redhat-user-workloads/ramalama-tenant/rocm-llama-server:{{revision}}
   - name: build-platforms
     value:
-    - linux-m2xlarge/amd64
+    - linux-d160-c8xlarge/amd64
   - name: dockerfile
     value: container-images/common/Containerfile.entrypoint
   - name: parent-image

--- a/.tekton/rocm-llama-server/rocm-llama-server-push.yaml
+++ b/.tekton/rocm-llama-server/rocm-llama-server-push.yaml
@@ -37,7 +37,8 @@ spec:
   pipelineRef:
     name: push-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/rocm-rag/rocm-rag-pull-request.yaml
+++ b/.tekton/rocm-rag/rocm-rag-pull-request.yaml
@@ -40,7 +40,8 @@ spec:
   pipelineRef:
     name: pull-request-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/rocm-rag/rocm-rag-pull-request.yaml
+++ b/.tekton/rocm-rag/rocm-rag-pull-request.yaml
@@ -28,7 +28,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux-d160-c8xlarge/amd64
+    - linux-d160-m7-8xlarge/amd64
   - name: dockerfile
     value: container-images/common/Containerfile.rag
   - name: parent-image

--- a/.tekton/rocm-rag/rocm-rag-push.yaml
+++ b/.tekton/rocm-rag/rocm-rag-push.yaml
@@ -25,7 +25,7 @@ spec:
     value: quay.io/redhat-user-workloads/ramalama-tenant/rocm-rag:{{revision}}
   - name: build-platforms
     value:
-    - linux-d160-c8xlarge/amd64
+    - linux-d160-m7-8xlarge/amd64
   - name: dockerfile
     value: container-images/common/Containerfile.rag
   - name: parent-image

--- a/.tekton/rocm-rag/rocm-rag-push.yaml
+++ b/.tekton/rocm-rag/rocm-rag-push.yaml
@@ -37,7 +37,8 @@ spec:
   pipelineRef:
     name: push-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/rocm-whisper-server/rocm-whisper-server-pull-request.yaml
+++ b/.tekton/rocm-whisper-server/rocm-whisper-server-pull-request.yaml
@@ -40,7 +40,8 @@ spec:
   pipelineRef:
     name: pull-request-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/rocm-whisper-server/rocm-whisper-server-pull-request.yaml
+++ b/.tekton/rocm-whisper-server/rocm-whisper-server-pull-request.yaml
@@ -28,7 +28,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux-m2xlarge/amd64
+    - linux-d160-c8xlarge/amd64
   - name: dockerfile
     value: container-images/common/Containerfile.entrypoint
   - name: parent-image

--- a/.tekton/rocm-whisper-server/rocm-whisper-server-push.yaml
+++ b/.tekton/rocm-whisper-server/rocm-whisper-server-push.yaml
@@ -25,7 +25,7 @@ spec:
     value: quay.io/redhat-user-workloads/ramalama-tenant/rocm-whisper-server:{{revision}}
   - name: build-platforms
     value:
-    - linux-m2xlarge/amd64
+    - linux-d160-c8xlarge/amd64
   - name: dockerfile
     value: container-images/common/Containerfile.entrypoint
   - name: parent-image

--- a/.tekton/rocm-whisper-server/rocm-whisper-server-push.yaml
+++ b/.tekton/rocm-whisper-server/rocm-whisper-server-push.yaml
@@ -37,7 +37,8 @@ spec:
   pipelineRef:
     name: push-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/rocm/rocm-pull-request.yaml
+++ b/.tekton/rocm/rocm-pull-request.yaml
@@ -34,7 +34,8 @@ spec:
   pipelineRef:
     name: pull-request-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/rocm/rocm-pull-request.yaml
+++ b/.tekton/rocm/rocm-pull-request.yaml
@@ -28,7 +28,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux-fast/amd64
+    - linux-d160-m7-8xlarge/amd64
   - name: dockerfile
     value: container-images/rocm/Containerfile
   pipelineRef:

--- a/.tekton/rocm/rocm-push.yaml
+++ b/.tekton/rocm/rocm-push.yaml
@@ -25,7 +25,7 @@ spec:
     value: quay.io/redhat-user-workloads/ramalama-tenant/rocm:{{revision}}
   - name: build-platforms
     value:
-    - linux-fast/amd64
+    - linux-d160-m7-8xlarge/amd64
   - name: dockerfile
     value: container-images/rocm/Containerfile
   pipelineRef:

--- a/.tekton/rocm/rocm-push.yaml
+++ b/.tekton/rocm/rocm-push.yaml
@@ -31,7 +31,8 @@ spec:
   pipelineRef:
     name: push-pipeline
   timeouts:
-    pipeline: 6h
+    pipeline: 12h
+    finally: 15m
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/stable-diffusion/stable-diffusion-pull-request.yaml
+++ b/.tekton/stable-diffusion/stable-diffusion-pull-request.yaml
@@ -26,10 +26,6 @@ spec:
     value: quay.io/redhat-user-workloads/ramalama-tenant/stable-diffusion:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: build-platforms
-    value:
-    - linux-c8xlarge/amd64
-    - linux-c8xlarge/arm64
   - name: dockerfile
     value: container-images/stable-diffusion/Containerfile
   pipelineRef:

--- a/.tekton/stable-diffusion/stable-diffusion-push.yaml
+++ b/.tekton/stable-diffusion/stable-diffusion-push.yaml
@@ -23,10 +23,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/ramalama-tenant/stable-diffusion:{{revision}}
-  - name: build-platforms
-    value:
-    - linux-c8xlarge/amd64
-    - linux-c8xlarge/arm64
   - name: dockerfile
     value: container-images/stable-diffusion/Containerfile
   pipelineRef:


### PR DESCRIPTION
Build on the fastest instance types available in Konflux to accelerate developer feedback.

Increase pipeline timeouts to avoid unnecessary failures.