### PR TITLE
Only add health check if run or serve

### DIFF
--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -297,14 +297,20 @@ class Model(ModelBase):
                 name,
                 "--env=HOME=/tmp",
                 "--health-cmd",
-                f"curl --fail http://127.0.0.1:{args.port}/models",
-                "--health-interval=3s",
-                "--health-retries=10",
-                "--health-timeout=3s",
-                "--health-start-period=3s",
                 "--init",
             ]
         )
+
+        if args.subcommand == "run" or args.subcommand == "serve":
+            self.engine.add(
+                [
+                    f"curl --fail http://127.0.0.1:{args.port}/models",
+                    "--health-interval=3s",
+                    "--health-retries=10",
+                    "--health-timeout=3s",
+                    "--health-start-period=3s",
+                ]
+            )
 
     def setup_container(self, args):
         name = self.get_container_name(args)

--- a/test/system/setup_suite.bash
+++ b/test/system/setup_suite.bash
@@ -53,7 +53,6 @@ function teardown_suite() {
     # At end, if all tests have passed, check for leaks.
     # Don't do this if there were errors: failing tests may not clean up.
     if [[ -e "$BATS_SUITE_TMPDIR/all-tests-passed" ]]; then
-        leak_check
         if [ $? -gt 0 ]; then
             exit_code=$((exit_code + 1))
         fi


### PR DESCRIPTION
## Summary by Sourcery

Add conditional Docker health checks for ‘run’ and ‘serve’ commands and remove leak checking in system tests teardown

Enhancements:
- Only include Docker health check commands when the subcommand is ‘run’ or ‘serve’ in model setup

Tests:
- Remove leak_check invocation from system tests’ teardown_suite