### PR TITLE
Revert "Switch default ramalama image build to use VULKAN"

### DIFF
--- a/container-images/scripts/build_llama_and_whisper.sh
+++ b/container-images/scripts/build_llama_and_whisper.sh
@@ -277,7 +277,7 @@ add_common_flags() {
   case "$containerfile" in
   ramalama)
     if [ "$uname_m" = "x86_64" ] || [ "$uname_m" = "aarch64" ]; then
-      common_flags+=("-DGGML_VULKAN=ON")
+      common_flags+=("-DGGML_KOMPUTE=ON")
     elif [ "$uname_m" = "s390x" ]; then
       common_flags+=("-DGGML_VXE=ON" "-DGGML_BLAS=ON")
       common_flags+=("-DGGML_BLAS_VENDOR=OpenBLAS")


### PR DESCRIPTION
This change makes ramalama container generate garbage on MacOS, as was
originally reported at:

https://github.com/containers/ramalama/issues/1126

I believe the original promise was that VULKAN will work fine with
podman 5.5+, but I'm on 5.5.1 and still experience this problem.

DKOMPUTE_OPT_DISABLE_VULKAN_VERSION_CHECK is no longer supported by
upstream, so leaving it out of the revert.

This reverts commit b6d5e95e2c175311fc88cf18d337a5fd1727745b.

## Summary by Sourcery

Bug Fixes:
- Restore GGML_KOMPUTE as the default flag instead of GGML_VULKAN for x86_64 and aarch64 platforms in the build script for ramalama