### PR TITLE
Bump to v0.12.0

### DIFF
--- a/docs/ramalama-bench.1.md
+++ b/docs/ramalama-bench.1.md
@@ -53,7 +53,7 @@ OCI container image to run with specified AI model. RamaLama defaults to using
 images based on the accelerator it discovers. For example:
 `quay.io/ramalama/ramalama`. See the table below for all default images.
 The default image tag is based on the minor version of the RamaLama package.
-Version 0.11.3 of RamaLama pulls an image with a `:0.11` tag from the quay.io/ramalama OCI repository. The --image option overrides this default.
+Version 0.12.0 of RamaLama pulls an image with a `:0.12` tag from the quay.io/ramalama OCI repository. The --image option overrides this default.
 
 The default can be overridden in the ramalama.conf file or via the
 RAMALAMA_IMAGE environment variable. `export RAMALAMA_IMAGE=quay.io/ramalama/aiimage:1.2` tells

--- a/docs/ramalama-perplexity.1.md
+++ b/docs/ramalama-perplexity.1.md
@@ -58,7 +58,7 @@ OCI container image to run with specified AI model. RamaLama defaults to using
 images based on the accelerator it discovers. For example:
 `quay.io/ramalama/ramalama`. See the table below for all default images.
 The default image tag is based on the minor version of the RamaLama package.
-Version 0.11.3 of RamaLama pulls an image with a `:0.11` tag from the quay.io/ramalama OCI repository. The --image option overrides this default.
+Version 0.12.0 of RamaLama pulls an image with a `:0.12` tag from the quay.io/ramalama OCI repository. The --image option overrides this default.
 
 The default can be overridden in the ramalama.conf file or via the
 RAMALAMA_IMAGE environment variable. `export RAMALAMA_IMAGE=quay.io/ramalama/aiimage:1.2` tells

--- a/docs/ramalama-rag.1.md
+++ b/docs/ramalama-rag.1.md
@@ -50,7 +50,7 @@ OCI container image to run with specified AI model. RamaLama defaults to using
 images based on the accelerator it discovers. For example:
 `quay.io/ramalama/ramalama-rag`. See the table below for all default images.
 The default image tag is based on the minor version of the RamaLama package.
-Version 0.11.3 of RamaLama pulls an image with a `:0.11` tag from the quay.io/ramalama OCI repository. The --image option overrides this default.
+Version 0.12.0 of RamaLama pulls an image with a `:0.12` tag from the quay.io/ramalama OCI repository. The --image option overrides this default.
 
 The default can be overridden in the ramalama.conf file or via the
 RAMALAMA_IMAGE environment variable. `export RAMALAMA_IMAGE=quay.io/ramalama/aiimage:1.2` tells

--- a/docs/ramalama-run.1.md
+++ b/docs/ramalama-run.1.md
@@ -66,7 +66,7 @@ OCI container image to run with specified AI model. RamaLama defaults to using
 images based on the accelerator it discovers. For example:
 `quay.io/ramalama/ramalama`. See the table below for all default images.
 The default image tag is based on the minor version of the RamaLama package.
-Version 0.11.3 of RamaLama pulls an image with a `:0.11` tag from the quay.io/ramalama OCI repository. The --image option overrides this default.
+Version 0.12.0 of RamaLama pulls an image with a `:0.12` tag from the quay.io/ramalama OCI repository. The --image option overrides this default.
 
 The default can be overridden in the ramalama.conf file or via the
 RAMALAMA_IMAGE environment variable. `export RAMALAMA_IMAGE=quay.io/ramalama/aiimage:1.2` tells

--- a/docs/ramalama-serve.1.md
+++ b/docs/ramalama-serve.1.md
@@ -112,7 +112,7 @@ OCI container image to run with specified AI model. RamaLama defaults to using
 images based on the accelerator it discovers. For example:
 `quay.io/ramalama/ramalama`. See the table above for all default images.
 The default image tag is based on the minor version of the RamaLama package.
-Version 0.11.3 of RamaLama pulls an image with a `:0.11` tag from the quay.io/ramalama OCI repository. The --image option overrides this default.
+Version 0.12.0 of RamaLama pulls an image with a `:0.12` tag from the quay.io/ramalama OCI repository. The --image option overrides this default.
 
 The default can be overridden in the ramalama.conf file or via the
 RAMALAMA_IMAGE environment variable. `export RAMALAMA_IMAGE=quay.io/ramalama/aiimage:1.2` tells

--- a/docs/ramalama-version.1.md
+++ b/docs/ramalama-version.1.md
@@ -18,9 +18,9 @@ Print usage message
 
 ```
 $ ramalama version
-ramalama version 0.11.3
+ramalama version 0.12.0
 $ ramalama -q version
-0.11.3
+0.12.0
 >
 ```
 ## SEE ALSO

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ramalama"
-version = "0.11.3"
+version = "0.12.0"
 description = "RamaLama is a command line tool for working with AI LLM models."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/ramalama/version.py
+++ b/ramalama/version.py
@@ -2,7 +2,7 @@
 
 
 def version():
-    return "0.11.3"
+    return "0.12.0"
 
 
 def print_version(args):

--- a/rpm/ramalama.spec
+++ b/rpm/ramalama.spec
@@ -1,7 +1,7 @@
 %global pypi_name ramalama
 %global forgeurl  https://github.com/containers/%{pypi_name}
 # see ramalama/version.py
-%global version0  0.11.3
+%global version0  0.12.0
 %forgemeta
 
 %global summary   Command line tool for working with AI LLM models
@@ -34,7 +34,7 @@ BuildRequires:    python3-pytest
 BuildRequires:    mailcap
 
 Provides: python3-ramalama = %{version}-%{release}
-Obsoletes: python3-ramalama < 0.11.3-1
+Obsoletes: python3-ramalama < 0.12.0-1
 
 Requires: podman
 


### PR DESCRIPTION
## Summary by Sourcery

Bump project version to v0.12.0 across metadata, documentation, and build configuration

Chores:
- Update version strings in pyproject.toml and version.py
- Update man pages and docs to reference version 0.12.0 and corresponding container image tags
- Update RPM spec file to bump version to 0.12.0 and adjust dependencies