### PR TITLE
allow the llama-stack image to be configured via an env var

### DIFF
--- a/.tekton/integration/pipelines/bats-integration.yaml
+++ b/.tekton/integration/pipelines/bats-integration.yaml
@@ -65,6 +65,7 @@ spec:
     - name: envs
       value:
       - RAMALAMA_IMAGE=$(tasks.init.results.ramalama-image)
+      - RAMALAMA_STACK_IMAGE=$(tasks.init.results.stack-image)
     taskRef:
       resolver: git
       params:

--- a/.tekton/integration/tasks/init-snapshot.yaml
+++ b/.tekton/integration/tasks/init-snapshot.yaml
@@ -21,6 +21,8 @@ spec:
     description: URI of the bats image included in the snapshot
   - name: ramalama-image
     description: URI of the ramalama image included in the snapshot
+  - name: stack-image
+    description: URI of the llama-stack image included in the snapshot
   - name: TEST_OUTPUT
     description: Test result in json format
   steps:
@@ -47,6 +49,8 @@ spec:
       value: $(results.bats-image.path)
     - name: RESULTS_RAMALAMA_IMAGE_PATH
       value: $(results.ramalama-image.path)
+    - name: RESULTS_STACK_IMAGE_PATH
+      value: $(results.stack-image.path)
     - name: RESULTS_TEST_OUTPUT_PATH
       value: $(results.TEST_OUTPUT.path)
     script: |
@@ -68,6 +72,8 @@ spec:
       component_image bats | tee "$RESULTS_BATS_IMAGE_PATH"
       echo
       component_image ramalama | tee "$RESULTS_RAMALAMA_IMAGE_PATH"
+      echo
+      component_image llama-stack | tee "$RESULTS_STACK_IMAGE_PATH"
       echo
       jq -jnc '{result: "SUCCESS", timestamp: now | todateiso8601, failures: 0, successes: 1, warnings: 0}' | tee "$RESULTS_TEST_OUTPUT_PATH"
       echo

--- a/ramalama/config.py
+++ b/ramalama/config.py
@@ -13,6 +13,7 @@ PathStr: TypeAlias = str
 DEFAULT_PORT_RANGE: tuple[int, int] = (8080, 8090)
 DEFAULT_PORT: int = DEFAULT_PORT_RANGE[0]
 DEFAULT_IMAGE: str = "quay.io/ramalama/ramalama"
+DEFAULT_STACK_IMAGE: str = "quay.io/ramalama/llama-stack"
 SUPPORTED_ENGINES: TypeAlias = Literal["podman", "docker"] | PathStr
 SUPPORTED_RUNTIMES: TypeAlias = Literal["llama.cpp", "vllm", "mlx"]
 COLOR_OPTIONS: TypeAlias = Literal["auto", "always", "never"]
@@ -96,6 +97,7 @@ class BaseConfig:
     runtime: SUPPORTED_RUNTIMES = "llama.cpp"
     selinux: bool = False
     settings: RamalamaSettings = field(default_factory=RamalamaSettings)
+    stack_image: str = DEFAULT_STACK_IMAGE
     store: str = field(default_factory=get_default_store)
     temp: str = "0.8"
     thinking: bool = True

--- a/ramalama/stack.py
+++ b/ramalama/stack.py
@@ -10,6 +10,7 @@ from ramalama.common import (
     get_accel_env_vars,
     tagged_image,
 )
+from ramalama.config import CONFIG
 from ramalama.engine import add_labels
 from ramalama.model import compute_serving_port
 from ramalama.model_factory import New
@@ -29,7 +30,7 @@ class Stack:
         self.model = New(args.MODEL, args)
         self.model_type = self.model.type
         self.model_port = str(int(self.args.port) + 1)
-        self.stack_image = tagged_image("quay.io/ramalama/llama-stack")
+        self.stack_image = tagged_image(CONFIG.stack_image)
         self.labels = ""
 
     def add_label(self, label):

--- a/test/system/040-serve.bats
+++ b/test/system/040-serve.bats
@@ -476,7 +476,7 @@ verify_begin=".*run --rm"
     run cat /tmp/$name.yaml
     is "$output" ".*llama-server" "Should command"
     is "$output" ".*hostPort: 1234" "Should container container port"
-    is "$output" ".*quay.io/ramalama/llama-stack" "Should container llama-stack"
+    is "$output" ".*quay.io/.*/llama-stack" "Should contain llama-stack"
     rm /tmp/$name.yaml
 }
 

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -423,6 +423,15 @@ class TestLoadEnvConfig:
             "INTEL_VISIBLE_DEVICES": "custom/intel:latest",
         }
 
+    def test_stack_image(self):
+        """Test that the llama-stack image can be set from an env var."""
+        env = {
+            "RAMALAMA_STACK_IMAGE": "custom/llama-stack:latest",
+        }
+        result = load_env_config(env)
+        assert "stack_image" in result
+        assert result["stack_image"] == "custom/llama-stack:latest"
+
 
 class TestConfigIntegration:
     """Integration tests for the complete config system with deep merge and env loading."""


### PR DESCRIPTION
Previously, the location of the `llama-stack` image was hard-coded. Allow it to be configured via an env var, in the same way that the `ramalama` and gpu-specific images are.

Update the integration tests to use the newly-built `llama-stack` image.