### PR TITLE
konflux: migrate to per-component service accounts

### DIFF
--- a/.tekton/asahi-llama-server/asahi-llama-server-pull-request.yaml
+++ b/.tekton/asahi-llama-server/asahi-llama-server-pull-request.yaml
@@ -39,6 +39,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-asahi-llama-server
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/asahi-llama-server/asahi-llama-server-push.yaml
+++ b/.tekton/asahi-llama-server/asahi-llama-server-push.yaml
@@ -36,6 +36,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-asahi-llama-server
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/asahi-rag/asahi-rag-pull-request.yaml
+++ b/.tekton/asahi-rag/asahi-rag-pull-request.yaml
@@ -39,6 +39,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-asahi-rag
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/asahi-rag/asahi-rag-push.yaml
+++ b/.tekton/asahi-rag/asahi-rag-push.yaml
@@ -36,6 +36,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-asahi-rag
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/asahi-whisper-server/asahi-whisper-server-pull-request.yaml
+++ b/.tekton/asahi-whisper-server/asahi-whisper-server-pull-request.yaml
@@ -39,6 +39,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-asahi-whisper-server
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/asahi-whisper-server/asahi-whisper-server-push.yaml
+++ b/.tekton/asahi-whisper-server/asahi-whisper-server-push.yaml
@@ -36,6 +36,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-asahi-whisper-server
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/asahi/asahi-pull-request.yaml
+++ b/.tekton/asahi/asahi-pull-request.yaml
@@ -33,6 +33,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-asahi
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/asahi/asahi-push.yaml
+++ b/.tekton/asahi/asahi-push.yaml
@@ -30,6 +30,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-asahi
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/bats/bats-pull-request.yaml
+++ b/.tekton/bats/bats-pull-request.yaml
@@ -33,6 +33,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-bats
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/bats/bats-push.yaml
+++ b/.tekton/bats/bats-push.yaml
@@ -30,6 +30,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-bats
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/cann-llama-server/cann-llama-server-pull-request.yaml
+++ b/.tekton/cann-llama-server/cann-llama-server-pull-request.yaml
@@ -39,6 +39,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-cann-llama-server
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/cann-llama-server/cann-llama-server-push.yaml
+++ b/.tekton/cann-llama-server/cann-llama-server-push.yaml
@@ -36,6 +36,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-cann-llama-server
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/cann-rag/cann-rag-pull-request.yaml
+++ b/.tekton/cann-rag/cann-rag-pull-request.yaml
@@ -39,6 +39,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-cann-rag
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/cann-rag/cann-rag-push.yaml
+++ b/.tekton/cann-rag/cann-rag-push.yaml
@@ -36,6 +36,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-cann-rag
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/cann-whisper-server/cann-whisper-server-pull-request.yaml
+++ b/.tekton/cann-whisper-server/cann-whisper-server-pull-request.yaml
@@ -39,6 +39,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-cann-whisper-server
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/cann-whisper-server/cann-whisper-server-push.yaml
+++ b/.tekton/cann-whisper-server/cann-whisper-server-push.yaml
@@ -36,6 +36,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-cann-whisper-server
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/cann/cann-pull-request.yaml
+++ b/.tekton/cann/cann-pull-request.yaml
@@ -33,6 +33,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-cann
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/cann/cann-push.yaml
+++ b/.tekton/cann/cann-push.yaml
@@ -30,6 +30,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-cann
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/cuda-llama-server/cuda-llama-server-pull-request.yaml
+++ b/.tekton/cuda-llama-server/cuda-llama-server-pull-request.yaml
@@ -39,6 +39,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-cuda-llama-server
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/cuda-llama-server/cuda-llama-server-push.yaml
+++ b/.tekton/cuda-llama-server/cuda-llama-server-push.yaml
@@ -36,6 +36,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-cuda-llama-server
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/cuda-rag/cuda-rag-pull-request.yaml
+++ b/.tekton/cuda-rag/cuda-rag-pull-request.yaml
@@ -39,6 +39,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-cuda-rag
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/cuda-rag/cuda-rag-push.yaml
+++ b/.tekton/cuda-rag/cuda-rag-push.yaml
@@ -36,6 +36,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-cuda-rag
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/cuda-whisper-server/cuda-whisper-server-pull-request.yaml
+++ b/.tekton/cuda-whisper-server/cuda-whisper-server-pull-request.yaml
@@ -39,6 +39,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-cuda-whisper-server
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/cuda-whisper-server/cuda-whisper-server-push.yaml
+++ b/.tekton/cuda-whisper-server/cuda-whisper-server-push.yaml
@@ -36,6 +36,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-cuda-whisper-server
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/cuda/cuda-pull-request.yaml
+++ b/.tekton/cuda/cuda-pull-request.yaml
@@ -33,6 +33,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-cuda
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/cuda/cuda-push.yaml
+++ b/.tekton/cuda/cuda-push.yaml
@@ -30,6 +30,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-cuda
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/intel-gpu-llama-server/intel-gpu-llama-server-pull-request.yaml
+++ b/.tekton/intel-gpu-llama-server/intel-gpu-llama-server-pull-request.yaml
@@ -42,6 +42,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-intel-gpu-llama-server
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/intel-gpu-llama-server/intel-gpu-llama-server-push.yaml
+++ b/.tekton/intel-gpu-llama-server/intel-gpu-llama-server-push.yaml
@@ -39,6 +39,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-intel-gpu-llama-server
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/intel-gpu-rag/intel-gpu-rag-pull-request.yaml
+++ b/.tekton/intel-gpu-rag/intel-gpu-rag-pull-request.yaml
@@ -42,6 +42,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-intel-gpu-rag
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/intel-gpu-rag/intel-gpu-rag-push.yaml
+++ b/.tekton/intel-gpu-rag/intel-gpu-rag-push.yaml
@@ -39,6 +39,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-intel-gpu-rag
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/intel-gpu-whisper-server/intel-gpu-whisper-server-pull-request.yaml
+++ b/.tekton/intel-gpu-whisper-server/intel-gpu-whisper-server-pull-request.yaml
@@ -42,6 +42,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-intel-gpu-whisper-server
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/intel-gpu-whisper-server/intel-gpu-whisper-server-push.yaml
+++ b/.tekton/intel-gpu-whisper-server/intel-gpu-whisper-server-push.yaml
@@ -39,6 +39,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-intel-gpu-whisper-server
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/intel-gpu/intel-gpu-pull-request.yaml
+++ b/.tekton/intel-gpu/intel-gpu-pull-request.yaml
@@ -36,6 +36,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-intel-gpu
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/intel-gpu/intel-gpu-push.yaml
+++ b/.tekton/intel-gpu/intel-gpu-push.yaml
@@ -33,6 +33,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-intel-gpu
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/llama-stack/llama-stack-pull-request.yaml
+++ b/.tekton/llama-stack/llama-stack-pull-request.yaml
@@ -33,6 +33,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-llama-stack
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/llama-stack/llama-stack-push.yaml
+++ b/.tekton/llama-stack/llama-stack-push.yaml
@@ -30,6 +30,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-llama-stack
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/musa-llama-server/musa-llama-server-pull-request.yaml
+++ b/.tekton/musa-llama-server/musa-llama-server-pull-request.yaml
@@ -42,6 +42,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-musa-llama-server
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/musa-llama-server/musa-llama-server-push.yaml
+++ b/.tekton/musa-llama-server/musa-llama-server-push.yaml
@@ -39,6 +39,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-musa-llama-server
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/musa-rag/musa-rag-pull-request.yaml
+++ b/.tekton/musa-rag/musa-rag-pull-request.yaml
@@ -42,6 +42,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-musa-rag
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/musa-rag/musa-rag-push.yaml
+++ b/.tekton/musa-rag/musa-rag-push.yaml
@@ -39,6 +39,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-musa-rag
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/musa-whisper-server/musa-whisper-server-pull-request.yaml
+++ b/.tekton/musa-whisper-server/musa-whisper-server-pull-request.yaml
@@ -42,6 +42,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-musa-whisper-server
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/musa-whisper-server/musa-whisper-server-push.yaml
+++ b/.tekton/musa-whisper-server/musa-whisper-server-push.yaml
@@ -39,6 +39,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-musa-whisper-server
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/musa/musa-pull-request.yaml
+++ b/.tekton/musa/musa-pull-request.yaml
@@ -36,6 +36,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-musa
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/musa/musa-push.yaml
+++ b/.tekton/musa/musa-push.yaml
@@ -33,6 +33,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-musa
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/openvino/openvino-pull-request.yaml
+++ b/.tekton/openvino/openvino-pull-request.yaml
@@ -36,6 +36,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-openvino
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/openvino/openvino-push.yaml
+++ b/.tekton/openvino/openvino-push.yaml
@@ -33,6 +33,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-openvino
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/ramalama-cli/ramalama-cli-pull-request.yaml
+++ b/.tekton/ramalama-cli/ramalama-cli-pull-request.yaml
@@ -33,6 +33,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-ramalama-cli
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/ramalama-cli/ramalama-cli-push.yaml
+++ b/.tekton/ramalama-cli/ramalama-cli-push.yaml
@@ -30,6 +30,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-ramalama-cli
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/ramalama-llama-server/ramalama-llama-server-pull-request.yaml
+++ b/.tekton/ramalama-llama-server/ramalama-llama-server-pull-request.yaml
@@ -39,6 +39,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-ramalama-llama-server
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/ramalama-llama-server/ramalama-llama-server-push.yaml
+++ b/.tekton/ramalama-llama-server/ramalama-llama-server-push.yaml
@@ -36,6 +36,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-ramalama-llama-server
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/ramalama-rag/ramalama-rag-pull-request.yaml
+++ b/.tekton/ramalama-rag/ramalama-rag-pull-request.yaml
@@ -39,6 +39,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-ramalama-rag
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/ramalama-rag/ramalama-rag-push.yaml
+++ b/.tekton/ramalama-rag/ramalama-rag-push.yaml
@@ -36,6 +36,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-ramalama-rag
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/ramalama-vllm-llama-server/ramalama-vllm-llama-server-pull-request.yaml
+++ b/.tekton/ramalama-vllm-llama-server/ramalama-vllm-llama-server-pull-request.yaml
@@ -39,6 +39,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-ramalama-vllm-llama-server
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/ramalama-vllm-llama-server/ramalama-vllm-llama-server-push.yaml
+++ b/.tekton/ramalama-vllm-llama-server/ramalama-vllm-llama-server-push.yaml
@@ -36,6 +36,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-ramalama-vllm-llama-server
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/ramalama-vllm-rag/ramalama-vllm-rag-pull-request.yaml
+++ b/.tekton/ramalama-vllm-rag/ramalama-vllm-rag-pull-request.yaml
@@ -39,6 +39,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-ramalama-vllm-rag
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/ramalama-vllm-rag/ramalama-vllm-rag-push.yaml
+++ b/.tekton/ramalama-vllm-rag/ramalama-vllm-rag-push.yaml
@@ -36,6 +36,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-ramalama-vllm-rag
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/ramalama-vllm-whisper-server/ramalama-vllm-whisper-server-pull-request.yaml
+++ b/.tekton/ramalama-vllm-whisper-server/ramalama-vllm-whisper-server-pull-request.yaml
@@ -39,6 +39,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-ramalama-vllm-whisper-server
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/ramalama-vllm-whisper-server/ramalama-vllm-whisper-server-push.yaml
+++ b/.tekton/ramalama-vllm-whisper-server/ramalama-vllm-whisper-server-push.yaml
@@ -36,6 +36,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-ramalama-vllm-whisper-server
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/ramalama-vllm/ramalama-vllm-pull-request.yaml
+++ b/.tekton/ramalama-vllm/ramalama-vllm-pull-request.yaml
@@ -38,6 +38,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-ramalama-vllm
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/ramalama-vllm/ramalama-vllm-push.yaml
+++ b/.tekton/ramalama-vllm/ramalama-vllm-push.yaml
@@ -35,6 +35,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-ramalama-vllm
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/ramalama-whisper-server/ramalama-whisper-server-pull-request.yaml
+++ b/.tekton/ramalama-whisper-server/ramalama-whisper-server-pull-request.yaml
@@ -39,6 +39,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-ramalama-whisper-server
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/ramalama-whisper-server/ramalama-whisper-server-push.yaml
+++ b/.tekton/ramalama-whisper-server/ramalama-whisper-server-push.yaml
@@ -36,6 +36,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-ramalama-whisper-server
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/ramalama/ramalama-pull-request.yaml
+++ b/.tekton/ramalama/ramalama-pull-request.yaml
@@ -43,6 +43,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-ramalama
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/ramalama/ramalama-push.yaml
+++ b/.tekton/ramalama/ramalama-push.yaml
@@ -40,6 +40,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-ramalama
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/rocm-llama-server/rocm-llama-server-pull-request.yaml
+++ b/.tekton/rocm-llama-server/rocm-llama-server-pull-request.yaml
@@ -42,6 +42,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-rocm-llama-server
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/rocm-llama-server/rocm-llama-server-push.yaml
+++ b/.tekton/rocm-llama-server/rocm-llama-server-push.yaml
@@ -39,6 +39,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-rocm-llama-server
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/rocm-rag/rocm-rag-pull-request.yaml
+++ b/.tekton/rocm-rag/rocm-rag-pull-request.yaml
@@ -42,6 +42,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-rocm-rag
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/rocm-rag/rocm-rag-push.yaml
+++ b/.tekton/rocm-rag/rocm-rag-push.yaml
@@ -39,6 +39,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-rocm-rag
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/rocm-whisper-server/rocm-whisper-server-pull-request.yaml
+++ b/.tekton/rocm-whisper-server/rocm-whisper-server-pull-request.yaml
@@ -42,6 +42,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-rocm-whisper-server
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/rocm-whisper-server/rocm-whisper-server-push.yaml
+++ b/.tekton/rocm-whisper-server/rocm-whisper-server-push.yaml
@@ -39,6 +39,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-rocm-whisper-server
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/rocm/rocm-pull-request.yaml
+++ b/.tekton/rocm/rocm-pull-request.yaml
@@ -36,6 +36,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-rocm
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/rocm/rocm-push.yaml
+++ b/.tekton/rocm/rocm-push.yaml
@@ -33,6 +33,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-rocm
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/stable-diffusion/stable-diffusion-pull-request.yaml
+++ b/.tekton/stable-diffusion/stable-diffusion-pull-request.yaml
@@ -33,6 +33,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-stable-diffusion
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/stable-diffusion/stable-diffusion-push.yaml
+++ b/.tekton/stable-diffusion/stable-diffusion-push.yaml
@@ -30,6 +30,8 @@ spec:
   timeouts:
     pipeline: 12h
     finally: 15m
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-stable-diffusion
   workspaces:
   - name: git-auth
     secret:


### PR DESCRIPTION
Konflux is moving from a shared `appstudio-pipeline` service account to a separate service account for each component, to increase security and improve efficiency.