### PR TITLE
Fix progress bar not reaching 100%

### DIFF
--- a/ramalama/http_client.py
+++ b/ramalama/http_client.py
@@ -59,24 +59,27 @@ class HttpClient:
         self.start_time = time.time()
         accumulated_size = 0
         last_update_time = time.time()
-        while True:
-            data = self.response.read(1024)
-            if not data:
-                return
+        try:
+            while True:
+                data = self.response.read(1024)
+                if not data:
+                    break
 
-            size = file.write(data)
+                size = file.write(data)
+                if show_progress:
+                    accumulated_size += size
+                    if time.time() - last_update_time >= 0.1:
+                        self.update_progress(accumulated_size)
+                        accumulated_size = 0
+                        last_update_time = time.time()
+
             if show_progress:
-                accumulated_size += size
-                if time.time() - last_update_time >= 0.1:
+                if accumulated_size > 0:
                     self.update_progress(accumulated_size)
-                    accumulated_size = 0
-                    last_update_time = time.time()
-
-        if accumulated_size > 0:
-            self.update_progress(accumulated_size)
-
-        if show_progress:
-            perror("\033[K", end="\r")
+        finally:
+            if show_progress:
+                # Output a newline after the progress bar
+                perror("")
 
     def human_readable_time(self, seconds):
         hrs = int(seconds) // 3600


### PR DESCRIPTION
Progress bar never reached 100% as the method was returning as soon as the download completed - skipping the final progress update.

## Summary by Sourcery

Fix progress bar not reaching 100% by replacing the early return with a loop break, restoring the final update_progress call, and adjusting the line-clearing behavior

Bug Fixes:
- Prevent early exit from download loop to allow final progress update
- Ensure final progress update occurs when show_progress is enabled