### PR TITLE
Bats test fixes

### DIFF
--- a/test/system/040-serve.bats
+++ b/test/system/040-serve.bats
@@ -202,7 +202,7 @@ verify_begin=".*run --rm"
     quadlet="$model.container"
     name=c_$(safename)
     run_ramalama pull $model_quant
-    run_ramalama -q serve --port 1234 --generate=quadlet $model
+    run_ramalama -q serve --port 1234 --generate=quadlet $model_quant
     is "$output" "Generating quadlet file: $quadlet" "generate $quadlet"
 
     run cat $quadlet
@@ -210,18 +210,17 @@ verify_begin=".*run --rm"
     is "$output" ".*Exec=.*llama-server --port 1234 --model .*" "Exec line should be correct"
     is "$output" ".*Mount=type=bind,.*$model" "Mount line should be correct"
 
-    HIP_VISIBLE_DEVICES=99 run_ramalama -q serve --port 1234 --generate=quadlet $model
+    HIP_VISIBLE_DEVICES=99 run_ramalama -q serve --port 1234 --generate=quadlet $model_quant
     is "$output" "Generating quadlet file: $quadlet" "generate $quadlet"
 
     run cat $quadlet
     is "$output" ".*Environment=HIP_VISIBLE_DEVICES=99" "Should contain env property"
 
     rm $quadlet
-    run_ramalama 2 serve --name=${name} --port 1234 --generate=bogus $model
+    run_ramalama 2 serve --name=${name} --port 1234 --generate=bogus $model_quant
     is "$output" ".*error: argument --generate: invalid choice: .*bogus.* (choose from.*quadlet.*kube.*quadlet/kube.*)" "Should fail"
 
-        run_ramalama pull $model_quant
-    run_ramalama -q serve --port 1234 --generate=quadlet --add-to-unit "section1:key0:value0" $model
+    run_ramalama -q serve --port 1234 --generate=quadlet --add-to-unit "section1:key0:value0" $model_quant
     is "$output" "Generating quadlet file: $quadlet" "generate $quadlet"
 
     run cat $quadlet
@@ -230,11 +229,11 @@ verify_begin=".*run --rm"
     is "$output" ".*Mount=type=bind,.*$model" "Mount line should be correct"
     is "$output" ".*key0=value0.*" "added unit should be correct"
 
-    run_ramalama 2 -q serve --port 1234 --generate=quadlet --add-to-unit "section1:key0:" $model
+    run_ramalama 2 -q serve --port 1234 --generate=quadlet --add-to-unit "section1:key0:" $model_quant
     is "$output" ".*error: --add-to-unit parameters must be of the form <section>:<key>:<value>.*"
 
     rm $quadlet
-    run_ramalama 2 serve --name=${name} --port 1234 --add-to-unit "section1:key0:value0"  $model
+    run_ramalama 2 serve --name=${name} --port 1234 --add-to-unit "section1:key0:value0"  $model_quant
     is "$output" ".*error: --add-to-unit can only be used with --generate.*"
 }
 

--- a/test/system/050-pull.bats
+++ b/test/system/050-pull.bats
@@ -78,10 +78,10 @@ load setup_suite
     run_ramalama rm huggingface://Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS.gguf
 
     skip_if_no_hf-cli
-    run_ramalama pull hf://TinyLlama/TinyLlama-1.1B-Chat-v1.0
+    run_ramalama pull hf://HuggingFaceTB/SmolLM-135M
     run_ramalama list
-    is "$output" ".*TinyLlama/TinyLlama-1.1B-Chat-v1.0" "image was actually pulled locally"
-    run_ramalama rm huggingface://TinyLlama/TinyLlama-1.1B-Chat-v1.0
+    is "$output" ".*HuggingFaceTB/SmolLM-135M" "image was actually pulled locally"
+    run_ramalama rm huggingface://HuggingFaceTB/SmolLM-135M
 
     run_ramalama pull hf://ggml-org/SmolVLM-256M-Instruct-GGUF
     run_ramalama list


### PR DESCRIPTION
Fix model used in generate quadlet tests
Use smaller model for hf pull test

## Summary by Sourcery

Fix system BATS tests by correcting the model variable used in quadlet generation and switching to a smaller Hugging Face model in pull tests

Tests:
- Use model_quant instead of model in all quadlet generation tests
- Change HF pull test to use huggingface://HuggingFaceTB/SmolLM-135M for faster execution