### PR TITLE
Make the container build system more flexible

### DIFF
--- a/container-images/scripts/build_llama_and_whisper.sh
+++ b/container-images/scripts/build_llama_and_whisper.sh
@@ -235,15 +235,16 @@ configure_common_flags() {
 }
 
 clone_and_build_whisper_cpp() {
+  local DEFAULT_WHISPER_COMMIT="d0a9d8c7f8f7b91c51d77bbaa394b915f79cde6b"
+  local whisper_cpp_commit="${WHISPER_CPP_PULL_REF:-$DEFAULT_WHISPER_COMMIT}"
   local whisper_flags=("${common_flags[@]}")
-  local whisper_cpp_sha="d0a9d8c7f8f7b91c51d77bbaa394b915f79cde6b"
   whisper_flags+=("-DBUILD_SHARED_LIBS=OFF")
   # See: https://github.com/ggml-org/llama.cpp/blob/master/docs/build.md#compilation-options
   if [ "$containerfile" = "musa" ]; then
     whisper_flags+=("-DCMAKE_POSITION_INDEPENDENT_CODE=ON")
   fi
 
-  git_clone_specific_commit "https://github.com/ggerganov/whisper.cpp" "$whisper_cpp_sha"
+  git_clone_specific_commit "${WHISPER_CPP_REPO:-https://github.com/ggerganov/whisper.cpp}" "$whisper_cpp_commit"
   cmake_steps "${whisper_flags[@]}"
   mkdir -p "$install_prefix/bin"
   cd ..
@@ -253,10 +254,11 @@ clone_and_build_whisper_cpp() {
 }
 
 clone_and_build_llama_cpp() {
-  local llama_cpp_sha="1d72c841888b9450916bdd5a9b3274da380f5b36"
+  local DEFAULT_LLAMA_CPP_COMMIT=1d72c841888b9450916bdd5a9b3274da380f5b36
+  local llama_cpp_commit="${LLAMA_CPP_PULL_REF:-$DEFAULT_LLAMA_CPP_COMMIT}"
   local install_prefix
   install_prefix=$(set_install_prefix)
-  git_clone_specific_commit "https://github.com/ggml-org/llama.cpp" "$llama_cpp_sha"
+  git_clone_specific_commit "${LLAMA_CPP_REPO:-https://github.com/ggml-org/llama.cpp}" "$llama_cpp_commit"
   cmake_steps "${common_flags[@]}"
   install -m 755 build/bin/rpc-server "$install_prefix"/bin/rpc-server
   cd ..

--- a/container-images/scripts/build_llama_and_whisper.sh
+++ b/container-images/scripts/build_llama_and_whisper.sh
@@ -287,7 +287,6 @@ install_entrypoints() {
 }
 
 cleanup() {
-  clone_and_build_llama_cpp
   available dnf && dnf_remove
   rm -rf /var/cache/*dnf* /opt/rocm-*/lib/*/library/*gfx9*
   ldconfig # needed for libraries
@@ -338,6 +337,7 @@ main() {
   fi
 
   add_common_flags
+  clone_and_build_llama_cpp
   cleanup
 }
 

--- a/container-images/scripts/lib.sh
+++ b/container-images/scripts/lib.sh
@@ -41,7 +41,6 @@ git_clone_specific_commit() {
   cd "$repo" || return 1
   git remote add origin "$1"
   git fetch --depth 1 origin "$2"
-  git reset --hard "$2"
+  git reset --hard "FETCH_HEAD"
   git submodule update --init --recursive
 }
-

--- a/container_build.sh
+++ b/container_build.sh
@@ -34,6 +34,25 @@ add_build_platform() {
       conman_build+=("-t" "$REGISTRY_PATH/${target}")
   fi
   conman_build+=("-f" "container-images/${target}/Containerfile" ".")
+
+  # pass some optional environment variables to control the build system
+  local ENV_TO_PASS=(
+      # set to 'y' to include the debug tools and debug files in the image
+      "RAMALAMA_IMAGE_BUILD_DEBUG_MODE"
+
+      # reference of a whisper.cpp repo and commit to use
+      "WHISPER_CPP_REPO"
+      "WHISPER_CPP_PULL_REF"
+
+      # reference to a llama.cpp repo and commit to use
+      "LLAMA_CPP_REPO"
+      "LLAMA_CPP_PULL_REF"
+  )
+  for env_to_pass in "${ENV_TO_PASS[@]}"; do
+      if [ -n "${!env_to_pass:-}" ]; then
+          conman_build+=("--env" "$env_to_pass=${!env_to_pass}")
+      fi
+  done
 }
 
 rm_container_image() {


### PR DESCRIPTION
This PR adds the ability to build the Ramalama image ...
* in debug mode
    * with `strace` and `gdb` installed, 
    *  with llama.cpp/whisper.cpp built in debug mode
    * with llama.cpp/whisper.cpp source files kept in the image (for `gdb`)
* with a custom repo/commit for llama.cpp and whisper.cpp

These modifications are useful for developers working on new RamaLama images.

## Summary by Sourcery

Enhance the container build system by adding a debug mode, parameterizing external dependencies via environment variables, and improving the git clone logic.

Enhancements:
- Add optional debug mode for container builds with gdb, strace, and retained sources
- Allow llama.cpp and whisper.cpp to be built in Debug or Release based on an environment variable
- Introduce environment variables to override llama.cpp and whisper.cpp repository URLs and commit references
- Propagate build control environment variables into the container build invocation
- Use FETCH_HEAD for git resets in clone scripts for more reliable submodule checkouts