### PR TITLE
Use correct chat template file for ollama models

### DIFF
--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -272,8 +272,8 @@ class Model(ModelBase):
         if not ref_file.chat_templates:
             return None
 
-        # Use the first chat template file
-        chat_template_file = ref_file.chat_templates[0]
+        # Use the last chat template file (may have been go template converted to jinja)
+        chat_template_file = ref_file.chat_templates[-1]
         if use_container or should_generate:
             return os.path.join(MNT_DIR, chat_template_file.name)
         return self.model_store.get_blob_file_path(chat_template_file.hash)


### PR DESCRIPTION
ollama uses go-template for chat template files. llama.cpp uses jinja2. The go-templates are converted to jinja2 but since the first chat template file is always chosen this file is not used. Pick the last file instead of the first to resolve this.

Fixes #1855

## Summary by Sourcery

Bug Fixes:
- Select the last chat template file rather than the first to resolve missing converted templates