### PR TITLE
Fix handling of nvidia settings in /etc/cdi/nvidia.yaml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         shell: bash
         run: |
           sudo apt-get update
-          sudo apt-get install -y bash codespell python3-argcomplete
+          sudo apt-get install -y bash codespell python3-argcomplete python3-yaml
           make install-requirements
 
       - name: Run format check
@@ -50,7 +50,7 @@ jobs:
         run: |
           df -h
           sudo apt-get update
-          sudo apt-get install -y bash codespell python3-argcomplete pipx podman
+          sudo apt-get install -y bash codespell python3-argcomplete python3-yaml pipx podman
           make install-requirements
 
       - name: Upgrade to podman 5
@@ -90,7 +90,7 @@ jobs:
         run: |
           df -h
           sudo apt-get update
-          sudo apt-get install -y bash codespell python3-argcomplete pipx podman
+          sudo apt-get install -y bash codespell python3-argcomplete python3-yaml pipx podman
           make install-requirements
 
       - name: Upgrade to podman 5
@@ -129,7 +129,7 @@ jobs:
            sudo chown runner:runner /mnt/runner /home/runner/.local
            sudo mount --bind /mnt/runner /home/runner/.local
            sudo apt-get update
-           sudo apt-get install podman bats bash codespell python3-argcomplete
+           sudo apt-get install podman bats bash codespell python3-argcomplete python3-yaml
            make install-requirements
 
       - name: install ollama
@@ -169,7 +169,7 @@ jobs:
         run: |
            df -h
            sudo apt-get update
-           sudo apt-get install podman bats bash codespell python3-argcomplete git cmake libcurl4-openssl-dev
+           sudo apt-get install podman bats bash codespell python3-argcomplete python3-yaml git cmake libcurl4-openssl-dev
            make install-requirements
            sudo ./container-images/scripts/build_llama_and_whisper.sh
            sudo python -m pip install . --prefix=/usr
@@ -208,7 +208,7 @@ jobs:
         shell: bash
         run: |
            sudo apt-get update
-           sudo apt-get install bats bash codespell python3-argcomplete
+           sudo apt-get install bats bash codespell python3-argcomplete python3-yaml
            make install-requirements
 
       - name: install ollama

--- a/container-images/scripts/build-cli.sh
+++ b/container-images/scripts/build-cli.sh
@@ -14,7 +14,7 @@ dnf_remove() {
 
 dnf_install() {
   local rpm_list=("podman-remote" "python3" "python3-pip" \
-		  "python3-argcomplete" "python3-devel" "git-core" \
+		  "python3-argcomplete" "python3-yaml" "python3-devel" "git-core" \
 		  "vim" "procps-ng" \
                   )
   dnf install -y "${rpm_list[@]}"

--- a/container-images/scripts/build_llama_and_whisper.sh
+++ b/container-images/scripts/build_llama_and_whisper.sh
@@ -108,7 +108,7 @@ dnf_install_ffmpeg() {
 dnf_install() {
   local rpm_exclude_list="selinux-policy,container-selinux"
   local rpm_list=("${PYTHON}" "${PYTHON}-pip"
-    "python3-argcomplete" "python3-dnf-plugin-versionlock"
+    "python3-argcomplete" "python3-yaml" "python3-dnf-plugin-versionlock"
     "${PYTHON}-devel" "gcc-c++" "cmake" "vim" "procps-ng" "git-core"
     "dnf-plugins-core" "libcurl-devel" "gawk")
   local vulkan_rpms=("vulkan-headers" "vulkan-loader-devel" "vulkan-tools"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ requires-python = ">=3.10"
 keywords = ["ramalama", "llama", "AI"]
 dependencies = [
   "argcomplete",
+  "pyyaml",
 ]
 maintainers = [
    { name="Dan Walsh", email = "dwalsh@redhat.com" },
@@ -33,10 +34,12 @@ dev = [
     "pytest~=8.3",
     "wheel~=0.45.0",
     "mypy",
+    "pyyaml",
 ]
 
 cov = [
     "pytest-cov",
+    "pyyaml",
 ]
 
 cov-detailed = [
@@ -44,7 +47,8 @@ cov-detailed = [
     "pytest-func-cov",
     "pytest-report",
     "pytest-json",
-    "pytest-html"
+    "pytest-html",
+    "pyyaml",
 ]
 
 [project.urls]

--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -17,6 +17,8 @@ from collections.abc import Callable, Iterable
 from functools import lru_cache
 from typing import TYPE_CHECKING, Literal, Protocol, TypeAlias, TypedDict, cast, get_args
 
+import yaml
+
 import ramalama.amdkfd as amdkfd
 from ramalama.logger import logger
 from ramalama.version import version
@@ -248,11 +250,14 @@ def load_cdi_yaml(stream: Iterable[str]) -> CDI_RETURN_TYPE:
     # same line following a colon.
 
     data: CDI_RETURN_TYPE = {"devices": []}
-    for line in stream:
-        if ':' in line:
-            key, value = line.split(':', 1)
-            if key.strip() == "- name":
-                data['devices'].append({'name': value.strip().strip('"')})
+    parsed = yaml.safe_load(stream) or {}
+    devices = parsed.get("devices") or []
+    for device in devices:
+        if not isinstance(device, dict):
+            continue
+        for key, value in device.items():
+            if key == "name":
+                data['devices'].append({'name': value})
     return data
 
 

--- a/test/tmt/no-rpm.fmf
+++ b/test/tmt/no-rpm.fmf
@@ -19,6 +19,7 @@ require:
     - podman-docker
     - pytest
     - python3-argcomplete
+    - python3-yaml
     - python3-huggingface-hub
     - shellcheck
 


### PR DESCRIPTION
Fixes: https://github.com/containers/ramalama/issues/1844 Use PyYAML to read Nvidia CDI config

Copied from @cschellenger PR https://github.com/containers/ramalama/pull/1849

## Summary by Sourcery

Use PyYAML to parse Nvidia CDI configuration and ensure python3-yaml is available across the project.

New Features:
- Switch load_cdi_yaml to use yaml.safe_load for parsing Nvidia CDI config.

Enhancements:
- Add PyYAML as a dependency in pyproject.toml.
- Install python3-yaml in CI workflows and container build scripts to support YAML parsing.