### PR TITLE
Fix python environment in ci jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,26 +13,28 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v5
-      
-      - name: Install the latest version of uv and activate the environment
+
+      - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v6
-        with:
-          activate-environment: true
-          
+
       - name: Install dependencies
         shell: bash
         run: |
           sudo apt-get update
-          sudo apt-get install -y bash codespell python3-argcomplete
-          make install-requirements
+          sudo apt-get install -y bash codespell podman
+          uv run -- make install-requirements
 
       - name: Run format check
         run: |
-          make check-format
+          uv run -- make check-format
 
       - name: Run lint
         run: |
-          make lint
+          uv run -- make lint
+
+      - name: Run man check
+        run: |
+          uv run -- make man-check
 
   build-image:
     runs-on: ubuntu-24.04
@@ -40,18 +42,16 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Install the latest version of uv and activate the environment
+      - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v6
-        with:
-          activate-environment: true
 
       - name: Install dependencies
         shell: bash
         run: |
           df -h
           sudo apt-get update
-          sudo apt-get install -y bash codespell python3-argcomplete pipx podman
-          make install-requirements
+          sudo apt-get install -y bash codespell pipx podman
+          uv run -- make install-requirements
 
       - name: Upgrade to podman 5
         run: |
@@ -80,18 +80,16 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v5
-      - name: Install the latest version of uv and activate the environment
+      - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v6
-        with:
-          activate-environment: true
-          
+
       - name: Install dependencies
         shell: bash
         run: |
           df -h
           sudo apt-get update
-          sudo apt-get install -y bash codespell python3-argcomplete pipx podman
-          make install-requirements
+          sudo apt-get install -y bash codespell pipx podman
+          uv run -- make install-requirements
 
       - name: Upgrade to podman 5
         run: |
@@ -106,19 +104,17 @@ jobs:
 
       - name: Run unit tests
         run: |
-          make unit-tests
+          uv run -- make unit-tests
 
   bats:
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v5
-      
-      - name: Install the latest version of uv and activate the environment
+
+      - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v6
-        with:
-          activate-environment: true
-          
+
       - name: install bats
         shell: bash
         run: |
@@ -129,8 +125,8 @@ jobs:
            sudo chown runner:runner /mnt/runner /home/runner/.local
            sudo mount --bind /mnt/runner /home/runner/.local
            sudo apt-get update
-           sudo apt-get install podman bats bash codespell python3-argcomplete
-           make install-requirements
+           sudo apt-get install podman bats bash codespell
+           uv run -- make install-requirements
 
       - name: install ollama
         shell: bash
@@ -150,29 +146,25 @@ jobs:
       - name: run bats
         run: |
            TEMPDIR=/mnt/tmp
-           make validate
-           make bats
+           uv run -- make bats
 
   bats-nocontainer:
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v5
-      
-      - name: Install the latest version of uv and activate the environment
+
+      - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v6
-        with:
-          activate-environment: true
-          
+
       - name: install bats
         shell: bash
         run: |
            df -h
            sudo apt-get update
-           sudo apt-get install podman bats bash codespell python3-argcomplete git cmake libcurl4-openssl-dev
-           make install-requirements
+           sudo apt-get install podman bats bash codespell git cmake libcurl4-openssl-dev
            sudo ./container-images/scripts/build_llama_and_whisper.sh
-           sudo python -m pip install . --prefix=/usr
+           uv run -- make install-requirements
 
       - name: install ollama
         shell: bash
@@ -189,27 +181,25 @@ jobs:
            # Install specific podman version
            sudo apt-get upgrade
 
-      - name: bats-nocontainer
+      - name: run bats-nocontainer
         run: |
-           make bats-nocontainer
+           uv run -- make bats-nocontainer
 
   docker:
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v5
-      
-      - name: Install the latest version of uv and activate the environment
+
+      - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v6
-        with:
-          activate-environment: true
-          
+
       - name: install bats
         shell: bash
         run: |
            sudo apt-get update
-           sudo apt-get install bats bash codespell python3-argcomplete
-           make install-requirements
+           sudo apt-get install bats bash codespell
+           uv run -- make install-requirements
 
       - name: install ollama
         shell: bash
@@ -249,43 +239,39 @@ jobs:
            sudo mount --bind /mnt/runner /home/runner/.local
            df -h
 
-      - name: bats-docker
+      - name: run bats-docker
         run: |
            docker info
-           make bats-docker
+           uv run -- make bats-docker
 
   macos:
     runs-on: macos-14
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v5
-      
-      - name: Install the latest version of uv and activate the environment
+
+      - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v6
-        with:
-          activate-environment: true
 
       - name: install mlx-lm
         shell: bash
         run: |
-          uv pip install mlx-lm
-          
+          uv run -- pip install mlx-lm
+
       - name: install golang
         shell: bash
         run: |
            brew install go bats bash jq llama.cpp shellcheck
-           make install-requirements
+           uv run -- make install-requirements
 
       - name: install ollama
         shell: bash
         run: ./.github/scripts/install-ollama.sh
 
-      - name: Run a one-line script
+      - name: run bats
         shell: bash
         run: |
-           make install-requirements
-           make validate
-           make bats-nocontainer
+           uv run -- make bats-nocontainer
 
 # FIXME: ci script should be able to run on MAC.
 #      - name: Run ci

--- a/Makefile
+++ b/Makefile
@@ -50,9 +50,12 @@ install-detailed-cov-requirements:
 install-cov-requirements:
 	${MYPIP} install ".[cov]"
 
+.PHONY: install-uv
+install-uv:
+	./install-uv.sh
+
 .PHONY: install-requirements
 install-requirements:
-	./install-uv.sh
 	${MYPIP} install ".[dev]"
 
 .PHONY: install-completions
@@ -137,12 +140,15 @@ test-run:
 	_RAMALAMA_TEST=local RAMALAMA=$(CURDIR)/bin/ramalama bats -T test/system/030-run.bats
 	_RAMALAMA_OPTIONS=--nocontainer _RAMALAMA_TEST=local bats -T test/system/030-run.bats
 
-.PHONY: validate
-validate: codespell lint check-format
+.PHONY: man-check
+man-check:
 ifeq ($(OS),Linux)
 	hack/man-page-checker
 	hack/xref-helpmsgs-manpages
 endif
+
+.PHONY: validate
+validate: codespell lint check-format man-check
 
 .PHONY: pypi-build
 pypi-build:   clean


### PR DESCRIPTION
Was installing uv 2 different ways (github action and make install-requirement).
Use `uv run` explicitly instead of activating the virtualenv in the uv github action (it's docs advise not to use this option).

## Summary by Sourcery

Streamline CI workflows by switching to explicit uv run commands for tasks, consolidate dependency installation steps, and refactor Makefile with install-uv and man-check targets.

Enhancements:
- Add install-uv phony target and refactor install-requirements in the Makefile
- Introduce man-check phony target and include it in the validate make workflow

CI:
- Remove uv environment activation from GitHub Actions and use uv run to invoke make targets in all CI jobs
- Standardize apt-get installs across CI workflows by removing python3-argcomplete and adding podman and pipx where needed
- Add a new ‘Run man check’ step in CI to invoke the man-check make target