### PR TITLE
DNM: ci test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,26 +13,28 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v5
-      
-      - name: Install the latest version of uv and activate the environment
+
+      - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v6
-        with:
-          activate-environment: true
-          
+
       - name: Install dependencies
         shell: bash
         run: |
           sudo apt-get update
-          sudo apt-get install -y bash codespell python3-argcomplete
-          make install-requirements
+          sudo apt-get install -y bash codespell podman
+          uv run -- make install-requirements
 
       - name: Run format check
         run: |
-          make check-format
+          uv run -- make check-format
 
       - name: Run lint
         run: |
-          make lint
+          uv run -- make lint
+
+      - name: Run man check
+        run: |
+          uv run -- make man-check
 
   build-image:
     runs-on: ubuntu-24.04
@@ -40,18 +42,16 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Install the latest version of uv and activate the environment
+      - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v6
-        with:
-          activate-environment: true
 
       - name: Install dependencies
         shell: bash
         run: |
           df -h
           sudo apt-get update
-          sudo apt-get install -y bash codespell python3-argcomplete pipx podman
-          make install-requirements
+          sudo apt-get install -y bash codespell pipx podman
+          uv run -- make install-requirements
 
       - name: Upgrade to podman 5
         run: |
@@ -80,18 +80,16 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v5
-      - name: Install the latest version of uv and activate the environment
+      - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v6
-        with:
-          activate-environment: true
-          
+
       - name: Install dependencies
         shell: bash
         run: |
           df -h
           sudo apt-get update
-          sudo apt-get install -y bash codespell python3-argcomplete pipx podman
-          make install-requirements
+          sudo apt-get install -y bash codespell pipx podman
+          uv run -- make install-requirements
 
       - name: Upgrade to podman 5
         run: |
@@ -106,19 +104,17 @@ jobs:
 
       - name: Run unit tests
         run: |
-          make unit-tests
+          uv run -- make unit-tests
 
   bats:
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v5
-      
-      - name: Install the latest version of uv and activate the environment
+
+      - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v6
-        with:
-          activate-environment: true
-          
+
       - name: install bats
         shell: bash
         run: |
@@ -129,8 +125,8 @@ jobs:
            sudo chown runner:runner /mnt/runner /home/runner/.local
            sudo mount --bind /mnt/runner /home/runner/.local
            sudo apt-get update
-           sudo apt-get install podman bats bash codespell python3-argcomplete
-           make install-requirements
+           sudo apt-get install podman bats bash codespell
+           uv run -- make install-requirements
 
       - name: install ollama
         shell: bash
@@ -150,29 +146,25 @@ jobs:
       - name: run bats
         run: |
            TEMPDIR=/mnt/tmp
-           make validate
-           make bats
+           uv run -- make bats
 
   bats-nocontainer:
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v5
-      
-      - name: Install the latest version of uv and activate the environment
+
+      - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v6
-        with:
-          activate-environment: true
-          
+
       - name: install bats
         shell: bash
         run: |
            df -h
            sudo apt-get update
-           sudo apt-get install podman bats bash codespell python3-argcomplete git cmake libcurl4-openssl-dev
-           make install-requirements
+           sudo apt-get install podman bats bash codespell git cmake libcurl4-openssl-dev
            sudo ./container-images/scripts/build_llama_and_whisper.sh
-           sudo python -m pip install . --prefix=/usr
+           uv run -- make install-requirements
 
       - name: install ollama
         shell: bash
@@ -189,27 +181,25 @@ jobs:
            # Install specific podman version
            sudo apt-get upgrade
 
-      - name: bats-nocontainer
+      - name: run bats-nocontainer
         run: |
-           make bats-nocontainer
+           uv run -- make bats-nocontainer
 
   docker:
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v5
-      
-      - name: Install the latest version of uv and activate the environment
+
+      - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v6
-        with:
-          activate-environment: true
-          
+
       - name: install bats
         shell: bash
         run: |
            sudo apt-get update
-           sudo apt-get install bats bash codespell python3-argcomplete
-           make install-requirements
+           sudo apt-get install bats bash codespell
+           uv run -- make install-requirements
 
       - name: install ollama
         shell: bash
@@ -249,43 +239,39 @@ jobs:
            sudo mount --bind /mnt/runner /home/runner/.local
            df -h
 
-      - name: bats-docker
+      - name: run bats-docker
         run: |
            docker info
-           make bats-docker
+           uv run -- make bats-docker
 
   macos:
     runs-on: macos-14
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v5
-      
-      - name: Install the latest version of uv and activate the environment
+
+      - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v6
-        with:
-          activate-environment: true
 
       - name: install mlx-lm
         shell: bash
         run: |
-          uv pip install mlx-lm
-          
+          uv run -- pip install mlx-lm
+
       - name: install golang
         shell: bash
         run: |
            brew install go bats bash jq llama.cpp shellcheck
-           make install-requirements
+           uv run -- make install-requirements
 
       - name: install ollama
         shell: bash
         run: ./.github/scripts/install-ollama.sh
 
-      - name: Run a one-line script
+      - name: run bats
         shell: bash
         run: |
-           make install-requirements
-           make validate
-           make bats-nocontainer
+           uv run -- make bats-nocontainer
 
 # FIXME: ci script should be able to run on MAC.
 #      - name: Run ci

--- a/Makefile
+++ b/Makefile
@@ -50,9 +50,12 @@ install-detailed-cov-requirements:
 install-cov-requirements:
 	${MYPIP} install ".[cov]"
 
+.PHONY: install-uv
+install-uv:
+	./install-uv.sh
+
 .PHONY: install-requirements
 install-requirements:
-	./install-uv.sh
 	${MYPIP} install ".[dev]"
 
 .PHONY: install-completions
@@ -137,12 +140,15 @@ test-run:
 	_RAMALAMA_TEST=local RAMALAMA=$(CURDIR)/bin/ramalama bats -T test/system/030-run.bats
 	_RAMALAMA_OPTIONS=--nocontainer _RAMALAMA_TEST=local bats -T test/system/030-run.bats
 
-.PHONY: validate
-validate: codespell lint check-format
+.PHONY: man-check
+man-check:
 ifeq ($(OS),Linux)
 	hack/man-page-checker
 	hack/xref-helpmsgs-manpages
 endif
+
+.PHONY: validate
+validate: codespell lint check-format man-check
 
 .PHONY: pypi-build
 pypi-build:   clean

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ requires-python = ">=3.10"
 keywords = ["ramalama", "llama", "AI"]
 dependencies = [
   "argcomplete",
+  "pyyaml",
 ]
 maintainers = [
    { name="Dan Walsh", email = "dwalsh@redhat.com" },
@@ -33,10 +34,12 @@ dev = [
     "pytest~=8.3",
     "wheel~=0.45.0",
     "mypy",
+    "pyyaml",
 ]
 
 cov = [
     "pytest-cov",
+    "pyyaml",
 ]
 
 cov-detailed = [
@@ -44,7 +47,8 @@ cov-detailed = [
     "pytest-func-cov",
     "pytest-report",
     "pytest-json",
-    "pytest-html"
+    "pytest-html",
+    "pyyaml",
 ]
 
 [project.urls]

--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -17,6 +17,8 @@ from collections.abc import Callable, Iterable
 from functools import lru_cache
 from typing import TYPE_CHECKING, Literal, Protocol, TypeAlias, TypedDict, cast, get_args
 
+import yaml
+
 import ramalama.amdkfd as amdkfd
 from ramalama.logger import logger
 from ramalama.version import version
@@ -248,11 +250,14 @@ def load_cdi_yaml(stream: Iterable[str]) -> CDI_RETURN_TYPE:
     # same line following a colon.
 
     data: CDI_RETURN_TYPE = {"devices": []}
-    for line in stream:
-        if ':' in line:
-            key, value = line.split(':', 1)
-            if key.strip() == "- name":
-                data['devices'].append({'name': value.strip().strip('"')})
+    parsed = yaml.safe_load(stream) or {}
+    devices = parsed.get("devices") or []
+    for device in devices:
+        if not isinstance(device, dict):
+            continue
+        for key, value in device.items():
+            if key == "name":
+                data['devices'].append({'name': value})
     return data
 
 

--- a/test/tmt/no-rpm.fmf
+++ b/test/tmt/no-rpm.fmf
@@ -21,6 +21,7 @@ require:
     - python3-argcomplete
     - python3-huggingface-hub
     - shellcheck
+    - python3-pyyaml
 
 /gpu_info:
     summary: Display GPU info


### PR DESCRIPTION
## Summary by Sourcery

Standardize CI workflows to install and use the uv tool for all make tasks, add a man page validation step, refactor YAML parsing in the common module to use yaml.safe_load, update Makefile targets for uv installation and validation, and introduce the pyyaml dependency to support YAML handling.

New Features:
- Add a CI step to run man-check for validating man pages

Bug Fixes:
- Fix load_cdi_yaml to parse devices using yaml.safe_load instead of manual line scanning

Enhancements:
- Unify invocation of all make commands in CI under the ‘uv run’ wrapper
- Add a PHONY install-uv target and include man-check in the Makefile’s validate target

Build:
- Add pyyaml as a project dependency in pyproject.toml for YAML support

CI:
- Standardize installation of uv via astral-sh/setup-uv and remove redundant activate-environment flags
- Update CI apt dependencies (drop python3-argcomplete, add pipx where needed) across all jobs