### PR TITLE
Catch KeyError exceptions

### DIFF
--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -1277,20 +1277,14 @@ def main():
         eprint(f"pulling {e.geturl()} failed: {e}", errno.EINVAL)
     except HelpException:
         parser.print_help()
-    except IndexError as e:
+    except (ConnectionError, IndexError, KeyError, ValueError) as e:
         eprint(e, errno.EINVAL)
-    except KeyError as e:
-        eprint(e, 1)
     except NotImplementedError as e:
-        eprint(e, errno.ENOTSUP)
+        eprint(e, errno.ENOSYS)
     except subprocess.CalledProcessError as e:
         eprint(e, e.returncode)
     except KeyboardInterrupt:
         sys.exit(0)
-    except ConnectionError as e:
-        eprint(e, errno.EINVAL)
-    except ValueError as e:
-        eprint(e, errno.EINVAL)
     except IOError as e:
         eprint(e, errno.EIO)
     except ParseError as e:

--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -574,13 +574,13 @@ def select_cuda_image(config: Config) -> str:
         str: The appropriate CUDA image name
 
     Raises:
-        RuntimeError: If CUDA version is less than 12.4
+        NotImplementedError: If CUDA version is less than 12.4
     """
     # Get the default CUDA image from config
     cuda_image = config.images.get("CUDA_VISIBLE_DEVICES")
 
     if cuda_image is None:
-        raise RuntimeError("No image repository found for CUDA_VISIBLE_DEVICES in config.")
+        raise NotImplementedError("No image repository found for CUDA_VISIBLE_DEVICES in config.")
 
     # Check CUDA version and select appropriate image
     cuda_version = check_cuda_version()
@@ -591,7 +591,7 @@ def select_cuda_image(config: Config) -> str:
     elif cuda_version >= (12, 4):
         return f"{cuda_image}-12.4.1"  # Use the specific version for older CUDA
     else:
-        raise RuntimeError(f"CUDA version {cuda_version} is not supported. Minimum required version is 12.4.")
+        raise NotImplementedError(f"CUDA version {cuda_version} is not supported. Minimum required version is 12.4.")
 
 
 class AccelImageArgsWithImage(Protocol):

--- a/test/system/010-list.bats
+++ b/test/system/010-list.bats
@@ -51,7 +51,7 @@ size              | [0-9]\\\+
 
 @test "ramalama rm --ignore" {
     random_image_name=i_$(safename)
-    run_ramalama 1 rm ${random_image_name}
+    run_ramalama 22 rm ${random_image_name}
     is "$output" "Error: Model '${random_image_name}' not found.*"
     run_ramalama rm --ignore ${random_image_name}
     is "$output" ""

--- a/test/system/015-help.bats
+++ b/test/system/015-help.bats
@@ -213,7 +213,7 @@ EOF
 
 @test "ramalama verify transport" {
     transport=e_$(safename)
-    RAMALAMA_TRANSPORT=${transport} run_ramalama 1 pull foobar
+    RAMALAMA_TRANSPORT=${transport} run_ramalama 22 pull foobar
     is "$output" "Error: transport \"${transport}\" not supported. Must be oci, huggingface, modelscope, or ollama."  "Verify bogus transport throws error"
 
 }

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -93,11 +93,11 @@ EOF
 	is "$output" '.*serve.*--ctx-size 4096 --temp 0.8.*' "dryrun correct"
 	is "$output" ".*--ctx-size 4096" "verify model name"
 
-	run_ramalama 1 run --ctx-size=4096 --name foobar ${MODEL}
+	run_ramalama 22 run --ctx-size=4096 --name foobar ${MODEL}
 	is "${lines[0]}"  "Error: --nocontainer and --name options conflict. The --name option requires a container." "conflict between nocontainer and --name line"
-	run_ramalama 1 run --name foobar ${MODEL}
+	run_ramalama 22 run --name foobar ${MODEL}
 	is "${lines[0]}"  "Error: --nocontainer and --name options conflict. The --name option requires a container." "conflict between nocontainer and --name line"
-	run_ramalama 1 run --privileged ${MODEL}
+	run_ramalama 22 run --privileged ${MODEL}
 	is "${lines[0]}"  "Error: --nocontainer and --privileged options conflict. The --privileged option requires a container." "conflict between nocontainer and --privileged line"
     fi
 }

--- a/test/system/040-serve.bats
+++ b/test/system/040-serve.bats
@@ -80,7 +80,7 @@ verify_begin=".*run --rm"
 	run_ramalama -q --dryrun serve --seed abcd --host 127.0.0.1 ${model}
 	assert "$output" =~ ".*--host 127.0.0.1" "Outside container overrides host to 127.0.0.1"
 	assert "$output" =~ ".*--seed abcd" "Verify seed is set"
-	run_ramalama 1 --nocontainer serve --name foobar tiny
+	run_ramalama 22 --nocontainer serve --name foobar tiny
 	is "${lines[0]}"  "Error: --nocontainer and --name options conflict. The --name option requires a container." "conflict between nocontainer and --name line"
     fi
 
@@ -100,7 +100,7 @@ verify_begin=".*run --rm"
     run_ramalama 22 -q --dryrun serve --runtime-args="--foo='a b c" ${model}
     assert "$output" =~ "No closing quotation" "error for improperly quoted runtime arguments"
 
-    run_ramalama 1 serve MODEL
+    run_ramalama 22 serve MODEL
     assert "$output" =~ "Error: Manifest for MODEL:latest was not found in the Ollama registry"
 }
 

--- a/test/system/050-pull.bats
+++ b/test/system/050-pull.bats
@@ -25,7 +25,7 @@ load setup_suite
     run_ramalama rm https://ollama.com/library/smollm:135m ollama://smollm:360m
 
     random_image_name=i_$(safename)
-    run_ramalama 1 -q pull ${random_image_name}
+    run_ramalama 22 -q pull ${random_image_name}
     is "$output" "Error: Manifest for ${random_image_name}:latest was not found in the Ollama registry"
 }
 
@@ -54,7 +54,7 @@ load setup_suite
     ollama rm smollm:135m smollm:360m
 
     random_image_name=i_$(safename)
-    run_ramalama 1 -q pull ${random_image_name}
+    run_ramalama 22 -q pull ${random_image_name}
     is "$output" "Error: Manifest for ${random_image_name}:latest was not found in the Ollama registry"
 
     pkill ollama

--- a/test/system/055-convert.bats
+++ b/test/system/055-convert.bats
@@ -9,7 +9,7 @@ load helpers
 	is "$output" ".*ramalama convert: error: the following arguments are required: SOURCE, TARGET"
 	run_ramalama 2 convert tiny
 	is "$output" ".*ramalama convert: error: the following arguments are required: TARGET"
-	run_ramalama 1 convert bogus foobar
+	run_ramalama 22 convert bogus foobar
 	is "$output" "Error: Manifest for bogus:latest was not found in the Ollama registry"
    else
 	run_ramalama 22 convert tiny quay.io/ramalama/foobar

--- a/test/system/080-mlx.bats
+++ b/test/system/080-mlx.bats
@@ -163,7 +163,7 @@ function skip_if_no_mlx() {
     skip_if_no_mlx
     
     # --name requires container mode, which MLX doesn't support
-    run_ramalama 1 --runtime=mlx run --name test ${MODEL}
+    run_ramalama 22 --runtime=mlx run --name test ${MODEL}
     is "$output" ".*--nocontainer.*--name.*conflict.*" "should show conflict error"
 }
 
@@ -172,6 +172,6 @@ function skip_if_no_mlx() {
     skip_if_no_mlx
     
     # --privileged requires container mode, which MLX doesn't support
-    run_ramalama 1 --runtime=mlx run --privileged ${MODEL}
+    run_ramalama 22 --runtime=mlx run --privileged ${MODEL}
     is "$output" ".*--nocontainer.*--privileged.*conflict.*" "should show conflict error"
 }


### PR DESCRIPTION
Found in https://github.com/containers/ramalama/issues/1864

Also combine like exceptions, within the catch block.

## Summary by Sourcery

Unify exception handling in the CLI by grouping similar errors and including KeyError in the invalid input catch block

Bug Fixes:
- Handle KeyError exceptions to prevent unhandled errors

Enhancements:
- Combine ConnectionError, IndexError, KeyError, and ValueError into a single invalid argument catch block
- Combine NotImplementedError and RuntimeError into a single not supported features catch block