### PR TITLE
Fallback to default image when CUDA version is out of date

### DIFF
--- a/docs/ramalama.conf
+++ b/docs/ramalama.conf
@@ -49,15 +49,17 @@
 #
 #image = "quay.io/ramalama/ramalama:latest"
 
-# Alternative images to use when RamaLama recognizes specific hardware
+# Alternative images to use when RamaLama recognizes specific hardware,
+# or user specified vllm model runtime.
 #
 #[ramalama.images]
-#HIP_VISIBLE_DEVICES="quay.io/ramalama/rocm"
-#CUDA_VISIBLE_DEVICES="quay.io/ramalama/cuda"
 #ASAHI_VISIBLE_DEVICES="quay.io/ramalama/asahi"
-#INTEL_VISIBLE_DEVICES="quay.io/ramalama/intel-gpu"
 #ASCEND_VISIBLE_DEVICES="quay.io/ramalama/cann"
+#CUDA_VISIBLE_DEVICES="quay.io/ramalama/cuda"
+#HIP_VISIBLE_DEVICES="quay.io/ramalama/rocm"
+#INTEL_VISIBLE_DEVICES="quay.io/ramalama/intel-gpu"
 #MUSA_VISIBLE_DEVICES="quay.io/ramalama/musa"
+#VLLM="registry.redhat.io/rhelai1/ramalama-vllm"
 
 # IP address for llama.cpp to listen on.
 #

--- a/docs/ramalama.conf.5.md
+++ b/docs/ramalama.conf.5.md
@@ -106,8 +106,10 @@ RAMALAMA_IMAGE environment variable overrides this field.
   INTEL_VISIBLE_DEVICES  = "quay.io/ramalama/intel-gpu"
   ASCEND_VISIBLE_DEVICES = "quay.io/ramalama/cann"
   MUSA_VISIBLE_DEVICES   = "quay.io/ramalama/musa"
+  VLLM                   = "registry.redhat.io/rhelai1/ramalama-vllm"
 
-Alternative images to use when RamaLama recognizes specific hardware
+Alternative images to use when RamaLama recognizes specific hardware or user
+specified vllm model runtime.
 
 **keep_groups**=false
 

--- a/ramalama/config.py
+++ b/ramalama/config.py
@@ -85,6 +85,7 @@ class BaseConfig:
             "HIP_VISIBLE_DEVICES": "quay.io/ramalama/rocm",
             "INTEL_VISIBLE_DEVICES": "quay.io/ramalama/intel-gpu",
             "MUSA_VISIBLE_DEVICES": "quay.io/ramalama/musa",
+            "VLLM": "registry.redhat.io/rhelai1/ramalama-vllm",
         }
     )
     keep_groups: bool = False


### PR DESCRIPTION
Fixes: https://github.com/containers/ramalama/issues/1864

## Summary by Sourcery

Provide a fallback to the default image when selecting a CUDA-optimized image fails due to an unsupported CUDA version, and streamline runtime-specific image handling.

Enhancements:
- Return the dedicated vllm image early before GPU detection when runtime is set to "vllm"
- Wrap CUDA image selection in a try/catch to log a warning and revert to the default image on NotImplementedError