### PR TITLE
Changed from google-chrome to firefox

### DIFF
--- a/docs/demo/ramalama.sh
+++ b/docs/demo/ramalama.sh
@@ -176,7 +176,7 @@ multi-modal() {
     echo ""
 
     echo_color "Use web browser to show interaction"
-    exec_color "google-chrome docs/demo/camera-demo.html"
+    exec_color "firefox \"$(dirname \"$1\")/camera-demo.html\""
 
     echo_color "Stop the ramalama container"
     exec_color "ramalama stop multi-modal	"


### PR DESCRIPTION
The camera-demo.html app is failing when used with Google Chrome due to some restrictions with permissions, so Firefox will work better. Also, the path given was not working either, so it was changed to point to the current directory instead.

## Summary by Sourcery

Update docs/demo script to launch camera-demo in Firefox using the correct local path

Bug Fixes:
- Replace google-chrome invocation with firefox for camera-demo
- Fix camera-demo.html path to use the current directory