### PR TITLE
Suppress stderr when chatting without container

### DIFF
--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -788,7 +788,7 @@ class Model(ModelBase):
             if args.dryrun:
                 dry_run(exec_args)
                 return
-            exec_cmd(exec_args, stdout2null=args.noout)
+            exec_cmd(exec_args, stdout2null=args.noout, stderr2null=args.noout)
         except FileNotFoundError as e:
             if args.container:
                 raise NotImplementedError(


### PR DESCRIPTION
llama.cpp is notorious of its stderr pollution, so it makes it nearly
impossible to use `--nocontainer run` with it.

I think it's ok to stderr when container is used because the output goes
to the container log, but not when running on the host where
llama-server shares the same tty.

## Summary by Sourcery

Enhancements:
- Add stderr2null argument to exec_cmd to mute stderr when noout flag is set during host execution