### PR TITLE
Don't print llama stack api endpoint info unless --debug *is* passed

### DIFF
--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -388,7 +388,7 @@ class Model(ModelBase):
         # The Run command will first launch a daemonized service
         # and run chat to communicate with it.
 
-        args.port = compute_serving_port(args, quiet=args.debug)
+        args.port = compute_serving_port(args, quiet=not args.debug)
         if args.container:
             args.name = self.get_container_name(args)
 


### PR DESCRIPTION
I think the logic here should be in reverse: print debug info about API
endpoint used only when --debug is passed; not vice versa.

## Summary by Sourcery

Bug Fixes:
- Correct logic to suppress API endpoint information unless the debug flag is enabled