### PR TITLE
Extended inspect command by --get option with auto-complete

### DIFF
--- a/docs/ramalama-inspect.1.md
+++ b/docs/ramalama-inspect.1.md
@@ -14,7 +14,14 @@ like the repository, its metadata and tensor information.
 
 #### **--all**
 Print all available information about the AI Model.
-By default, only a basic subset is printed.
+By default, only a basic subset is printed. 
+
+#### **--get**=*field*
+Print the value of a specific metadata field of the AI Model.
+This option supports autocomplete with the available metadata
+fields of the given model.
+The special value `all` will print all available metadata
+fields and values.
 
 #### **--help**, **-h**
 Print usage message
@@ -68,6 +75,40 @@ $ ramalama inspect smollm:135m --all --json
         ...
     ]
 }
+```
+
+Use the autocomplete function of `--get` to view a list of fields:
+```
+$ ramalama inspect smollm:135m --get general.
+general.architecture               general.languages
+general.base_model.0.name          general.license
+general.base_model.0.organization  general.name
+general.base_model.0.repo_url      general.organization
+general.base_model.count           general.quantization_version
+general.basename                   general.size_label
+general.datasets                   general.tags
+general.file_type                  general.type
+general.finetune                   
+```
+
+Print the value of a specific field of the smollm:135m model:
+```
+$ ramalama inspect smollm:135m --get tokenizer.chat_template
+{% for message in messages %}{{'<|im_start|>' + message['role'] + '
+' + message['content'] + '<|im_end|>' + '
+'}}{% endfor %}{% if add_generation_prompt %}{{ '<|im_start|>assistant
+' }}{% endif %}
+```
+
+Print all key-value pairs of the metadata of the smollm:135m model:
+```
+$ ramalama inspect smollm:135m --get all
+general.architecture: llama
+general.base_model.0.name: SmolLM 135M
+general.base_model.0.organization: HuggingFaceTB
+general.base_model.0.repo_url: https://huggingface.co/HuggingFaceTB/SmolLM-135M
+general.base_model.count: 1
+...
 ```
 
 ## SEE ALSO

--- a/ramalama/model_inspect/gguf_info.py
+++ b/ramalama/model_inspect/gguf_info.py
@@ -5,6 +5,24 @@ from ramalama.endian import GGUFEndian
 from ramalama.model_inspect.base_info import ModelInfoBase, Tensor, adjust_new_line
 
 
+class GGUFModelMetadata:
+
+    def __init__(self, data: Dict[str, Any]):
+        self.data = data
+
+    def get(self, key: str) -> Any:
+        return self.data.get(key)
+
+    def serialize(self, json: bool = False) -> str:
+        if json:
+            return json.dumps(self.data, sort_keys=True, indent=4)
+
+        ret = ""
+        for key, value in sorted(self.data.items()):
+            ret = ret + adjust_new_line(f"{key}: {value}")
+        return ret
+
+
 class GGUFModelInfo(ModelInfoBase):
     MAGIC_NUMBER = "GGUF"
     VERSION = 3
@@ -23,7 +41,7 @@ class GGUFModelInfo(ModelInfoBase):
 
         self.Format = GGUFModelInfo.MAGIC_NUMBER
         self.Version = Version
-        self.Metadata: Dict[str, Any] = metadata
+        self.Metadata: GGUFModelMetadata = GGUFModelMetadata(metadata)
         self.Tensors: list[Tensor] = tensors
         self.Endianness: GGUFEndian = endianness
 
@@ -32,7 +50,7 @@ class GGUFModelInfo(ModelInfoBase):
             (
                 self.Metadata.get(template)
                 for template in ["chat_template", "tokenizer.chat_template"]
-                if template in self.Metadata
+                if template in self.Metadata.data
             ),
             None,
         )
@@ -47,10 +65,10 @@ class GGUFModelInfo(ModelInfoBase):
         ret = ret + adjust_new_line(f"   Endianness: {'little' if self.Endianness == GGUFEndian.LITTLE else 'big'}")
         metadata_header = "   Metadata: "
         if not all:
-            metadata_header = metadata_header + f"{len(self.Metadata)} entries"
+            metadata_header = metadata_header + f"{len(self.Metadata.data)} entries"
         ret = ret + adjust_new_line(metadata_header)
         if all:
-            for key, value in sorted(self.Metadata.items()):
+            for key, value in sorted(self.Metadata.data.items()):
                 ret = ret + adjust_new_line(f"      {key}: {value}")
         tensor_header = "   Tensors: "
         if not all:
@@ -71,6 +89,6 @@ class GGUFModelInfo(ModelInfoBase):
             return json.dumps(self, default=lambda o: o.__dict__, sort_keys=True, indent=4)
 
         d = {k: v for k, v in self.__dict__.items() if k != "Metadata" and k != "Tensors"}
-        d["Metadata"] = len(self.Metadata)
+        d["Metadata"] = len(self.Metadata.data)
         d["Tensors"] = len(self.Tensors)
         return json.dumps(d, sort_keys=True, indent=4)

--- a/ramalama/stack.py
+++ b/ramalama/stack.py
@@ -3,13 +3,7 @@ import tempfile
 
 import ramalama.kube as kube
 import ramalama.quadlet as quadlet
-from ramalama.common import (
-    check_nvidia,
-    exec_cmd,
-    genname,
-    get_accel_env_vars,
-    tagged_image,
-)
+from ramalama.common import check_nvidia, exec_cmd, genname, get_accel_env_vars, tagged_image
 from ramalama.config import CONFIG
 from ramalama.engine import add_labels
 from ramalama.model import compute_serving_port

--- a/test/system/100-inspect.bats
+++ b/test/system/100-inspect.bats
@@ -8,7 +8,7 @@ load setup_suite
 @test "ramalama inspect GGUF model" {
     MODEL=c_$(safename)
     run_ramalama 22 inspect ${MODEL}
-    is "$output" "Error: ${MODEL} does not exists" "error on missing models"
+    is "$output" "Error: No ref file found for '${MODEL}'. Please pull model."
     
     run_ramalama pull tiny
     run_ramalama inspect tiny
@@ -25,6 +25,7 @@ load setup_suite
 
 # bats test_tags=distro-integration
 @test "ramalama inspect GGUF model with --all" {
+    run_ramalama pull tiny
     run_ramalama inspect --all tiny
 
     is "${lines[0]}" "tinyllama" "model name"
@@ -38,6 +39,42 @@ load setup_suite
 }
 
 # bats test_tags=distro-integration
+@test "ramalama inspect GGUF model with --get" {
+    run_ramalama pull tiny
+
+    run_ramalama inspect --get general.architecture tiny
+    is "$output" "llama"
+
+    run_ramalama inspect --get general.name tiny
+    is "$output" "TinyLlama"
+}
+
+# bats test_tags=distro-integration
+@test "ramalama inspect GGUF model with --get all" {
+    run_ramalama pull tiny
+
+    run_ramalama inspect --get all tiny
+    is "${lines[0]}" "general.architecture: llama" "check for general.architecture"
+    is "${lines[1]}" "general.file_type: 2" "check for general.file_type"
+    is "${lines[2]}" "general.name: TinyLlama" "check for general.name"
+    is "${lines[3]}" "general.quantization_version: 2" "check for general.quantization_version"
+    is "${lines[4]}" "llama.attention.head_count: 32" "check for llama.attention.head_count"
+    is "${lines[5]}" "llama.attention.head_count_kv: 4" "check for llama.attention.head_count_kv"
+    is "${lines[6]}" "llama.attention.layer_norm_rms_epsilon: 9.999999747378752e-06" "check for llama.attention.layer_norm_rms_epsilon"
+    is "${lines[7]}" "llama.block_count: 22" "check for llama.block_count"
+    is "${lines[8]}" "llama.context_length: 2048" "check for llama.context_length"
+    is "${lines[9]}" "llama.embedding_length: 2048" "check for llama.embedding_length"
+    is "${lines[10]}" "llama.feed_forward_length: 5632" "check for llama.feed_forward_length"
+    is "${lines[11]}" "llama.rope.dimension_count: 64" "check for llama.rope.dimension_count"
+    is "${lines[12]}" "llama.rope.freq_base: 10000.0" "check for llama.rope.freq_base"
+    is "${lines[13]}" "tokenizer.ggml.bos_token_id: 1" "check for tokenizer.ggml.bos_token_id"
+    is "${lines[14]}" "tokenizer.ggml.eos_token_id: 2" "check for tokenizer.ggml.eos_token_id"
+    is "${lines[15]}" "tokenizer.ggml.model: llama" "check for tokenizer.ggml.model"
+    is "${lines[16]}" "tokenizer.ggml.padding_token_id: 2" "check for tokenizer.ggml.padding_token_id"
+    is "${lines[17]}" "tokenizer.ggml.unknown_token_id: 0" "check for tokenizer.ggml.unknown_token_id"
+}
+
+# bats test_tags=distro-integrationfields
 @test "ramalama inspect safetensors model" {
     ST_MODEL="https://huggingface.co/LiheYoung/depth-anything-small-hf/resolve/main/model.safetensors"
 


### PR DESCRIPTION
By adding the --get option to the inspect command, users are able to view the value of any metadata field of a GGUF  model. The available field names can be auto-completed to explore them. In addition, the special value "all" will print all metadata key and values.

## Summary by Sourcery

Extend the inspect command to support listing and retrieving individual metadata fields via new --fields and --get flags, update CLI parsing, documentation, and add corresponding tests.

New Features:
- Add --fields option to list all metadata fields of a GGUF model
- Add --get option to retrieve a specific metadata field's value from a GGUF model

Enhancements:
- Enforce mutual exclusivity among --all, --fields, and --get options in the inspect command

Documentation:
- Document new --fields and --get options with usage examples in the inspect man page

Tests:
- Add system tests for --fields and --get behaviors and mutual exclusion errors