### PR TITLE
Added the GGUF field tokenizer.chat_template for getting chat template

### DIFF
--- a/ramalama/model_inspect/gguf_info.py
+++ b/ramalama/model_inspect/gguf_info.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict, Union
+from typing import Any, Dict, Optional, Union
 
 from ramalama.endian import GGUFEndian
 from ramalama.model_inspect.base_info import ModelInfoBase, Tensor, adjust_new_line
@@ -27,8 +27,15 @@ class GGUFModelInfo(ModelInfoBase):
         self.Tensors: list[Tensor] = tensors
         self.Endianness: GGUFEndian = endianness
 
-    def get_chat_template(self) -> str:
-        return self.Metadata.get("chat_template", "")
+    def get_chat_template(self) -> Optional[str]:
+        return next(
+            (
+                self.Metadata.get(template)
+                for template in ["chat_template", "tokenizer.chat_template"]
+                if template in self.Metadata
+            ),
+            None,
+        )
 
     def serialize(self, json: bool = False, all: bool = False) -> str:
         if json:


### PR DESCRIPTION
Relates to: https://github.com/containers/ramalama/issues/1882

The tokenizer.chat_template field in the GGUF metadata contains a jinja template. This can be passed to llama.cpp for inference. In addition, this field is also sometimes available in Ollama models so that a potentially erroneous conversion is not needed.

## Summary by Sourcery

Improve handling of chat templates in GGUF metadata by supporting the new tokenizer.chat_template field, centralizing conversion logic into a helper, and refining file naming and extraction behavior.

Enhancements:
- Extract chat template conversion into a dedicated helper method to streamline logic.
- Prefer existing chat_template files in the snapshot and fall back to parsing the GGUF model when missing.
- Detect and return both “chat_template” and “tokenizer.chat_template” metadata fields in GGUF models.
- Rename generated snapshot files to “chat_template_converted” or “chat_template_extracted” for clarity.