### PR TITLE
tests: generate tmpdir store for ollama pull testcase

### DIFF
--- a/test/unit/test_ollama.py
+++ b/test/unit/test_ollama.py
@@ -1,3 +1,4 @@
+import tempfile
 from unittest.mock import patch
 
 import pytest
@@ -14,7 +15,8 @@ def ollama_model(args: StoreArgs):
 
 @pytest.fixture
 def args():
-    return StoreArgs(store="/tmp/ramalama/store", engine="podman", container=True)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield StoreArgs(store=tmpdir, engine="podman", container=True)
 
 
 def test_ollama_model_initialization(ollama_model):


### PR DESCRIPTION
Two reasons to do so:

1. The directory is cleaned up on test completed;

2. The hardcoded directory may not be available for write to the current
   process (because some other process is running the test suite in
   parallel, or because someone chmod -rwx the directory for some
   reason).

In which case the test case fails with:
PermissionError: [Errno 13] Permission denied: '/tmp/ramalama/store'

This failure was triggered in nixpkgs CI:
https://hydra.nixos.org/build/305125672

## Summary by Sourcery

Tests:
- Update the args fixture in test_ollama to create a temporary store directory using tempfile.TemporaryDirectory