### PR TITLE
Link to Ollama Registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -790,7 +790,7 @@ $ cat /usr/share/ramalama/shortnames.conf
 
 - <details>
     <summary>
-        Log in to 
+        Log in to Ollama Registry
     </summary>
     <br>
 

--- a/README.md
+++ b/README.md
@@ -790,7 +790,7 @@ $ cat /usr/share/ramalama/shortnames.conf
 
 - <details>
     <summary>
-        Log in to ollama registry
+        Log in to 
     </summary>
     <br>
 
@@ -871,7 +871,7 @@ $ cat /usr/share/ramalama/shortnames.conf
     </summary>
     <br>
 
-    You can `pull` a model using the `pull` command. By default, it pulls from the Ollama registry.
+    You can `pull` a model using the `pull` command. By default, it pulls from the <a href="https://ollama.com/library">Ollama registry</a>.
     ```
     $ ramalama pull granite3-moe
     ```
@@ -950,7 +950,7 @@ This command uses a specific container image containing the docling tool to conv
 
 - <details>
     <summary>
-        Run a chatbot on a model using the run command. By default, it pulls from the Ollama registry.
+        Run a chatbot on a model using the run command. By default, it pulls from the <a href="https://ollama.com/library">Ollama registry</a>.
     </summary>
     <br>
 


### PR DESCRIPTION
Makes it easier for user to get to see models available "out of the box"

## Summary by Sourcery

Add hyperlink to the Ollama registry in the README to help users discover available models

Documentation:
- Add clickable link to the Ollama registry in pull command documentation
- Add clickable link to the Ollama registry in run command documentation