### PR TITLE
Fix the application of codespell in "make validate".

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ format:
 
 .PHONY: codespell
 codespell:
-	codespell -w $(PROJECT_DIR) $(PYTHON_SCRIPTS)
+	codespell $(PROJECT_DIR) $(PYTHON_SCRIPTS)
 
 .PHONY: test-run
 test-run:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,9 +87,18 @@ line_length = 120
 skip = [".venv", "venv"]
 
 [tool.codespell]
-skip = ["build","ramalama.egg-info", "logos", ".git", "venv", ".venv"]
+skip = ["build", "ramalama.egg-info", "logos", ".git", "venv", ".venv"]
 dictionary = ".codespelldict"
-ignore-words-list = ["cann", "clos", "creat", "ro", "hastable", "shouldnot", "mountns", "passt" ,"assertin"]
+ignore-words-list = [
+  "assertin",
+  "cann",
+  "clos",
+  "creat",
+  "hastable",
+  "passt",
+  "ro",
+  "shouldnot",
+]
 check-hidden = true
 
 [tool.ruff]


### PR DESCRIPTION
codespell should not update files in place, it should only spellcheck. Updating in place messes up the git tree and potentially causes problems.

"mountns" is in both the ignore-words-list specified in the toml file and in the .codespelldict. The latter has priority, which means that codespell tries to correct the ignore-words-list in the toml file. Assuming that the word belongs in the .codespelldict, it makes no sense to list it in the ignore-words-list so remove it.  Also fix the formatting of the list.

## Summary by Sourcery

Prevent codespell from modifying files during validation and clean up its configuration in pyproject.toml.

Bug Fixes:
- Remove the `-w` write flag from the `codespell` make target to stop in-place file edits.

Enhancements:
- Reformat the `ignore-words-list` in `pyproject.toml` as a multi-line, sorted list for readability.
- Remove the redundant `mountns` entry from the ignore-words-list.