### PR TITLE
Add tests for `--device none`

### DIFF
--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -152,4 +152,16 @@ EOF
     is "$output" ".*quay.io/ramalama/ramalama:1.0"
 }
 
+@test "ramalama --dryrun run with a device" {
+    skip_if_nocontainer
+    run_ramalama --dryrun run --device /dev/null --pull=never tiny
+    is "$output" ".*--device /dev/null .*"
+}
+
+@test "ramalama --dryrun run with no device" {
+    skip_if_nocontainer
+    run_ramalama --dryrun run --device none --pull=never tiny
+    assert "$output" != ".*--device.*"
+}
+
 # vim: filetype=sh


### PR DESCRIPTION
Follow up of https://github.com/containers/ramalama/pull/1909 to add systems tests to validate the behavior of `--device none` and `--device DEVICE`

## Summary by Sourcery

Add system tests to verify that dry-run invocations omit device flags when using `--device DEVICE` and `--device none`

Tests:
- Add a system test to ensure `--device DEVICE` is not included in dry-run output
- Add a system test to ensure `--device none` results in no device flags in dry-run output