### PR TITLE
Fix ramalama run with prompt index error

### DIFF
--- a/ramalama/chat.py
+++ b/ramalama/chat.py
@@ -34,8 +34,11 @@ def res(response, color):
     for line in response:
         line = line.decode("utf-8").strip()
         if line.startswith("data: {"):
-            line = line[len("data: ") :]
-            choice = json.loads(line)["choices"][0]["delta"]
+            choice = ""
+
+            json_line = json.loads(line[len("data: ") :])
+            if "choices" in json_line and json_line["choices"]:
+                choice = json_line["choices"][0]["delta"]
             if "content" in choice:
                 choice = choice["content"]
             else:
@@ -270,7 +273,6 @@ def chat(args: ChatArgsType, operational_args: ChatOperationalArgs = ChatOperati
             ids = [model["id"] for model in data.get("data", [])]
             for id in ids:
                 print(id)
-
     try:
         shell = RamaLamaShell(args, operational_args)
         if shell.handle_args():


### PR DESCRIPTION
Fixes: https://github.com/containers/ramalama/issues/1908

Fixed an index error when a line of the assistant response does not include a choice field.

## Summary by Sourcery

Bug Fixes:
- Handle missing or empty 'choices' field in assistant response to avoid index errors when parsing streamed data