### PR TITLE
konflux: run clamav-scan as a matrixed task

### DIFF
--- a/.tekton/pipelines/pull-request-pipeline.yaml
+++ b/.tekton/pipelines/pull-request-pipeline.yaml
@@ -400,7 +400,12 @@ spec:
       operator: in
       values:
       - "false"
-  - name: clamav-scan
+  - matrix:
+      params:
+      - name: image-arch
+        value:
+        - $(params.build-platforms)
+    name: clamav-scan
     params:
     - name: image-digest
       value: $(tasks.build-image-index.results.IMAGE_DIGEST)

--- a/.tekton/pipelines/push-pipeline.yaml
+++ b/.tekton/pipelines/push-pipeline.yaml
@@ -400,7 +400,12 @@ spec:
       operator: in
       values:
       - "false"
-  - name: clamav-scan
+  - matrix:
+      params:
+      - name: image-arch
+        value:
+        - $(params.build-platforms)
+    name: clamav-scan
     params:
     - name: image-digest
       value: $(tasks.build-image-index.results.IMAGE_DIGEST)


### PR DESCRIPTION
This will reduce build times.

## Summary by Sourcery

CI:
- Convert the clamav-scan task in pull-request and push pipelines to a matrixed task parameterized by image architectures