### PR TITLE
--flash-attn requires an option in llama-server now

### DIFF
--- a/ramalama/daemon/service/command_factory.py
+++ b/ramalama/daemon/service/command_factory.py
@@ -105,7 +105,7 @@ class CommandFactory:
             cmd.extend(["--no-webui"])
 
         if check_nvidia() or check_metal(SimpleNamespace({"container": False})):
-            cmd.extend(["--flash-attn"])
+            cmd.extend(["--flash-attn", "on"])
 
         # gpu arguments
         ngl = self.request_args.get("ngl")

--- a/test/system/040-serve.bats
+++ b/test/system/040-serve.bats
@@ -74,7 +74,7 @@ verify_begin=".*run --rm"
 	assert "$output" =~ ".*--host 0.0.0.0" "Outside container sets host to 0.0.0.0"
 	is "$output" ".*--cache-reuse 256" "should use cache"
 	if is_darwin; then
-	   is "$output" ".*--flash-attn" "use flash-attn on Darwin metal"
+	   is "$output" ".*--flash-attn on" "use flash-attn on Darwin metal"
 	fi
 
 	run_ramalama -q --dryrun serve --seed abcd --host 127.0.0.1 ${model}


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Include "on" argument with --flash-attn flag in llama-server command invocation