### PR TITLE
s390x: switch to a smaller bigendian model for testing

### DIFF
--- a/shortnames/shortnames.conf
+++ b/shortnames/shortnames.conf
@@ -26,6 +26,7 @@
   "granite:8b" = "ollama://granite3.1-dense:8b"
   "granite-be-3.0:1b" = "hf://taronaeo/Granite-3.0-1B-A400M-Instruct-BE-GGUF/granite-3.0-1b-a400m-instruct-be.Q2_K.gguf"
   "granite-be-3.3:2b" = "hf://taronaeo/Granite-3.3-2B-Instruct-BE-GGUF/granite-3.3-2b-instruct-be.Q4_K_M.gguf"
+  "stories-be:260k" = "hf://taronaeo/tinyllamas-BE/stories260K-be.gguf"
   "hermes" = "huggingface://NousResearch/Hermes-2-Pro-Mistral-7B-GGUF/Hermes-2-Pro-Mistral-7B.Q4_K_M.gguf"
   "ibm/granite" = "ollama://granite3.1-dense:8b"
   "ibm/granite:2b" = "ollama://granite3.1-dense:2b"

--- a/test/system/002-bench.bats
+++ b/test/system/002-bench.bats
@@ -16,9 +16,6 @@ function setup() {
 # bats test_tags=distro-integration
 @test "ramalama bench" {
     skip_if_no_llama_bench
-    if is_s390x; then
-        local RAMALAMA_TIMEOUT=1200
-    fi
     run_ramalama bench -t 2 $(test_model smollm:135m)
     is "$output" ".*model.*size.*" "model and size in output"
 }

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -126,7 +126,7 @@ EOF
 }
 
 @test "ramalama run with prompt" {
-    run_ramalama run --temp 0 $(test_model ${MODEL} granite-be-3.3:2b) "What is the first line of the declaration of independence?"
+    run_ramalama run --temp 0 $(test_model ${MODEL}) "What is the first line of the declaration of independence?"
 }
 
 @test "ramalama run --keepalive" {

--- a/test/system/050-pull.bats
+++ b/test/system/050-pull.bats
@@ -180,8 +180,8 @@ load setup_suite
     if is_bigendian; then
         skip "Testing pulls of opposite-endian models"
     fi
-    run_ramalama rm --ignore granite-be-3.0:1b
-    run_ramalama 1 pull --verify=on granite-be-3.0:1b
+    run_ramalama rm --ignore stories-be:260k
+    run_ramalama 1 pull --verify=on stories-be:260k
     is "$output" ".*Endian mismatch of host (LITTLE) and model (BIG).*" "detected big-endian model"
 }
 

--- a/test/system/helpers.bash
+++ b/test/system/helpers.bash
@@ -315,8 +315,7 @@ function is_bigendian() {
 
 function test_model() {
     if is_bigendian; then
-        # If there's a smaller, functional bigendian model, put it here
-        echo ${2:-granite-be-3.0:1b}
+        echo ${2:-stories-be:260k}
     else
         echo ${1:-smollm:135m}
     fi


### PR DESCRIPTION
Should improve performance of integration tests.

## Summary by Sourcery

Switch integration tests on big-endian s390x to a smaller test model for improved performance and clean up related configurations.

Enhancements:
- Replace granite-be-3.0:1b with a smaller stories-be:260k model for big-endian tests
- Add stories-be:260k shortname mapping in shortnames.conf
- Remove s390x-specific timeout override in the bench test

Tests:
- Update pull and run system tests to use the new default big-endian model and remove explicit granite model overrides