### PR TITLE
Pass the encoding argument to run_cmd().

### DIFF
--- a/test/unit/test_common.py
+++ b/test/unit/test_common.py
@@ -163,7 +163,7 @@ def test_apple_vm_returns_result(mock_handle_provider, mock_run_cmd, mock_config
 
     assert result is True
     mock_run_cmd.assert_called_once_with(
-        ["podman", "machine", "list", "--format", "json", "--all-providers"], ignore_stderr=True
+        ["podman", "machine", "list", "--format", "json", "--all-providers"], ignore_stderr=True, encoding="utf-8"
     )
     mock_handle_provider.assert_called_once_with({"Name": "myvm"}, mock_config)
 


### PR DESCRIPTION
Commit 14c4aaca added an encoding argument to run_cmd() that is passed through to subprocess.run(). Use it to let subprocess.run() handle decoding. Also catch errors if "podman machine list" fails to produce valid output.

## Summary by Sourcery

Delegate output decoding to subprocess.run by passing the encoding argument in run_cmd across several functions and enhance error handling for podman machine listing.

Enhancements:
- Pass encoding="utf-8" to run_cmd in multiple utilities to remove manual .decode() calls
- Log a warning when "podman machine list" fails to produce valid JSON

Tests:
- Update unit tests to expect the encoding argument in run_cmd calls