### PR TITLE
fix: with the new llama.cpp version and chat templates rag_framework …

### DIFF
--- a/container-images/scripts/rag_framework
+++ b/container-images/scripts/rag_framework
@@ -195,9 +195,10 @@ class Rag(cmd.Cmd):
         # Collect the AI response and add it to chat history
         full_response = ""
         for chunk in response:
-            if chunk.choices[0].delta.content:
-                full_response += chunk.choices[0].delta.content
-                print(chunk.choices[0].delta.content, end="", flush=True)
+            if chunk.choices and chunk.choices[0].delta.content:
+                content = chunk.choices[0].delta.content
+                full_response += content
+                print(content, end="", flush=True)
 
         # Add AI response to chat history
         self.chat_history.append({"role": "assistant", "content": full_response})


### PR DESCRIPTION
…can no longer assume chunks

can only be of type content. Adjusted the code so it doesnt break

## Summary by Sourcery

Update RAG framework script to handle new chunk types introduced by the latest llama.cpp version and chat templates

Bug Fixes:
- Remove assumption that chunks are only of type 'content' to prevent breakage with new llama.cpp and chat templates

Enhancements:
- Adjust chunk processing logic to support various chunk types in the RAG pipeline