### PR TITLE
[ci] Update repo for ubuntu podman 5

### DIFF
--- a/.github/workflows/ci-images.yml
+++ b/.github/workflows/ci-images.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           set -e
           # Enable universe repository which contains podman
-          sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu oracular universe"
+          sudo add-apt-repository "deb http://old-releases.ubuntu.com/ubuntu oracular universe"
           # Update package lists
           sudo apt-get update
           sudo apt-get purge firefox

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
            sudo chown runner:runner /mnt/runner /home/runner/.local
            sudo mount --bind /mnt/runner /home/runner/.local
            # Enable universe repository which contains podman
-           sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu oracular universe"
+           sudo add-apt-repository "deb http://old-releases.ubuntu.com/ubuntu oracular universe"
            # Update package lists
            sudo apt-get update
            sudo apt-get purge firefox
@@ -95,7 +95,7 @@ jobs:
         run: |
            set -e
            # Enable universe repository which contains podman
-           sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu oracular universe"
+           sudo add-apt-repository "deb http://old-releases.ubuntu.com/ubuntu oracular universe"
            # Update package lists
            sudo apt-get update
            sudo apt-get purge firefox
@@ -136,7 +136,7 @@ jobs:
         run: |
            set -e
            # Enable universe repository which contains podman
-           sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu oracular universe"
+           sudo add-apt-repository "deb http://old-releases.ubuntu.com/ubuntu oracular universe"
            # Update package lists
            sudo apt-get update
            sudo apt-get purge firefox
@@ -174,7 +174,7 @@ jobs:
         run: |
            set -e
            # Enable universe repository which contains podman
-           sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu oracular universe"
+           sudo add-apt-repository "deb http://old-releases.ubuntu.com/ubuntu oracular universe"
            # Update package lists
            sudo apt-get update
            sudo apt-get purge firefox
@@ -209,7 +209,7 @@ jobs:
         run: |
            set -e
            # Enable universe repository which contains podman
-           sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu oracular universe"
+           sudo add-apt-repository "deb http://old-releases.ubuntu.com/ubuntu oracular universe"
            # Update package lists
            sudo apt-get update
            sudo apt-get purge firefox

--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
            set -e
            # Enable universe repository which contains podman
-           sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu oracular universe"
+           sudo add-apt-repository "deb http://old-releases.ubuntu.com/ubuntu oracular universe"
            # Update package lists
            sudo apt-get update
            sudo apt-get purge firefox
@@ -89,7 +89,7 @@ jobs:
           run: |
              set -e
              # Enable universe repository which contains podman
-             sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu oracular universe"
+             sudo add-apt-repository "deb http://old-releases.ubuntu.com/ubuntu oracular universe"
              # Update package lists
              sudo apt-get update
              sudo apt-get purge firefox

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
            set -e
            # Enable universe repository which contains podman
-           sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu oracular universe"
+           sudo add-apt-repository "deb http://old-releases.ubuntu.com/ubuntu oracular universe"
            # Update package lists
            sudo apt-get update
            sudo apt-get purge firefox
@@ -88,7 +88,7 @@ jobs:
           run: |
             set -e
             # Enable universe repository which contains podman
-            sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu oracular universe"
+            sudo add-apt-repository "deb http://old-releases.ubuntu.com/ubuntu oracular universe"
             # Update package lists
             sudo apt-get update
             sudo apt-get purge firefox


### PR DESCRIPTION
24.10 is now EOL and the repo has been moved to old-releases.ubuntu.com.

## Summary by Sourcery

CI:
- Switch apt repository URL from archive.ubuntu.com to old-releases.ubuntu.com across all GitHub Actions workflows