### PR TITLE
Add e2e pytest test for list and rm commands

### DIFF
--- a/test/e2e/test_list.py
+++ b/test/e2e/test_list.py
@@ -1,0 +1,65 @@
+import json
+import re
+from datetime import datetime
+from test.e2e.utils import RamalamaExecWorkspace
+
+import pytest
+
+HEADING_REGEX = "NAME *MODIFIED *SIZE"
+
+TEST_IMAGE = "ollama://smollm:135m"
+
+
+@pytest.fixture(scope="module")
+def shared_ctx():
+    """Provides an isolated and shared context for all tests in the module.
+    Creates a ramalama workspace with configuration and pulls test image."""
+
+    config = """
+    [ramalama]
+    store="{workspace_dir}/.local/share/ramalama"
+    """
+    with RamalamaExecWorkspace(config=config) as ctx:
+        ctx.check_call(["ramalama", "-q", "pull", TEST_IMAGE])
+        yield ctx
+
+
+@pytest.mark.e2e
+@pytest.mark.parametrize(
+    "args,expected",
+    [
+        (["list"], True),
+        (["list", "--noheading"], False),
+        (["list", "-n"], False),
+        (["--quiet", "list"], False),
+        (["-q", "list"], False),
+    ],
+    ids=[
+        "ramalama list",
+        "ramalama list --noheading",
+        "ramalama list -n",
+        "ramalama --quiet list",
+        "ramalama -q list",
+    ],
+)
+def test_output(shared_ctx, args, expected):
+    result = shared_ctx.check_output(["ramalama"] + args)
+    assert bool(re.search(HEADING_REGEX, result)) is expected
+
+
+@pytest.mark.e2e
+def test_json_output(shared_ctx):
+    json_raw = shared_ctx.check_output(["ramalama", "list", "--json"])
+    result = json.loads(json_raw)
+
+    for image_data in result:
+        assert re.search(r"[\w:/]+", image_data["name"])
+        assert image_data["size"] > 0
+        assert datetime.fromisoformat(image_data["modified"])
+
+
+@pytest.mark.e2e
+def test_all_images_removed(shared_ctx):
+    shared_ctx.check_call(["ramalama", "rm", "-a"])
+    result = shared_ctx.check_output(["ramalama", "list", "--noheading"])
+    assert result == ""

--- a/test/e2e/test_rm.py
+++ b/test/e2e/test_rm.py
@@ -1,0 +1,26 @@
+import random
+import re
+from subprocess import STDOUT, CalledProcessError
+from test.e2e.utils import check_output
+
+import pytest
+
+
+@pytest.mark.e2e
+def test_delete_non_existing_image():
+    image_name = f"rm_random_image_{random.randint(0, 9999)}"
+    with pytest.raises(CalledProcessError) as exc_info:
+        check_output(["ramalama", "rm", image_name], stderr=STDOUT)
+
+    assert exc_info.value.returncode == 22
+    assert re.match(
+        f"Error: Model '{image_name}' not found\n",
+        exc_info.value.output.decode("utf-8"),
+    )
+
+
+@pytest.mark.e2e
+def test_delete_non_existing_image_with_ignore_flag():
+    image_name = f"rm_random_image_{random.randint(0, 9999)}"
+    result = check_output(["ramalama", "rm", "--ignore", image_name])
+    assert result == ""


### PR DESCRIPTION
- Migrate to e2e pytest the `test/system/010-list.bats` bat test.
- Add end-to-end tests for the `ramalama list` command, covering various output formats like default, no-heading, and JSON.
- Add end-to-end tests for the `ramalama rm` command, including scenarios for deleting non-existent images

## Summary by Sourcery

Add pytest-based end-to-end tests for the ramalama list and rm commands

Tests:
- Add list command tests covering headings, no-heading flags, quiet flags, JSON output, and field validation
- Add rm command tests for removing all images, handling errors on non-existent images, and ignoring missing images with the ignore flag