### PR TITLE
fix: split model regex match model without path

### DIFF
--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -38,7 +38,7 @@ RAG_CONTENT = f"{MNT_DIR}/vector.db"
 
 MIN_VRAM_BYTES = 1073741824  # 1GiB
 
-SPLIT_MODEL_PATH_RE = r'(.*)/([^/]*)-00001-of-(\d{5})\.gguf'
+SPLIT_MODEL_PATH_RE = r'(.*?)(?:/)?([^/]*)-00001-of-(\d{5})\.gguf'
 
 
 def is_split_file_model(model_path):


### PR DESCRIPTION
Fixes: #1878

Fixed split model path regex not matching split model filename without a path (e.g. split models placed in registry top level path)