### PR TITLE
Add NVIDIA GPU support to quadlet generation for `ramalama serve`

### DIFF
--- a/ramalama/quadlet.py
+++ b/ramalama/quadlet.py
@@ -56,6 +56,7 @@ class Quadlet:
         quadlet_file.add("Container", "AddDevice", "-/dev/accel")
         quadlet_file.add("Container", "AddDevice", "-/dev/dri")
         quadlet_file.add("Container", "AddDevice", "-/dev/kfd")
+        quadlet_file.add("Container", "AddDevice", "nvidia.com/gpu=all")
         quadlet_file.add("Container", "Image", f"{self.image}")
         quadlet_file.add("Container", "RunInit", "true")
         quadlet_file.add("Container", "Environment", "HOME=/tmp")

--- a/test/unit/data/test_quadlet/basic/tinyllama.container
+++ b/test/unit/data/test_quadlet/basic/tinyllama.container
@@ -6,6 +6,7 @@ After=local-fs.target
 AddDevice=-/dev/accel
 AddDevice=-/dev/dri
 AddDevice=-/dev/kfd
+AddDevice=nvidia.com/gpu=all
 Image=testimage
 RunInit=true
 Environment=HOME=/tmp

--- a/test/unit/data/test_quadlet/empty/tinyllama.container
+++ b/test/unit/data/test_quadlet/empty/tinyllama.container
@@ -6,6 +6,7 @@ After=local-fs.target
 AddDevice=-/dev/accel
 AddDevice=-/dev/dri
 AddDevice=-/dev/kfd
+AddDevice=nvidia.com/gpu=all
 Image=testimage
 RunInit=true
 Environment=HOME=/tmp

--- a/test/unit/data/test_quadlet/localhost/tinyllama.container
+++ b/test/unit/data/test_quadlet/localhost/tinyllama.container
@@ -6,6 +6,7 @@ After=local-fs.target
 AddDevice=-/dev/accel
 AddDevice=-/dev/dri
 AddDevice=-/dev/kfd
+AddDevice=nvidia.com/gpu=all
 Image=testimage
 RunInit=true
 Environment=HOME=/tmp

--- a/test/unit/data/test_quadlet/modelfromstore/modelfromstore.container
+++ b/test/unit/data/test_quadlet/modelfromstore/modelfromstore.container
@@ -6,6 +6,7 @@ After=local-fs.target
 AddDevice=-/dev/accel
 AddDevice=-/dev/dri
 AddDevice=-/dev/kfd
+AddDevice=nvidia.com/gpu=all
 Image=testimage
 RunInit=true
 Environment=HOME=/tmp

--- a/test/unit/data/test_quadlet/modelfromstore_add_to_unit/modelfromstore_add_to_unit.container
+++ b/test/unit/data/test_quadlet/modelfromstore_add_to_unit/modelfromstore_add_to_unit.container
@@ -6,6 +6,7 @@ After=local-fs.target
 AddDevice=-/dev/accel
 AddDevice=-/dev/dri
 AddDevice=-/dev/kfd
+AddDevice=nvidia.com/gpu=all
 Image=testimage
 RunInit=true
 Environment=HOME=/tmp

--- a/test/unit/data/test_quadlet/modelfromstore_ct/modelfromstore_ct.container
+++ b/test/unit/data/test_quadlet/modelfromstore_ct/modelfromstore_ct.container
@@ -6,6 +6,7 @@ After=local-fs.target
 AddDevice=-/dev/accel
 AddDevice=-/dev/dri
 AddDevice=-/dev/kfd
+AddDevice=nvidia.com/gpu=all
 Image=testimage
 RunInit=true
 Environment=HOME=/tmp

--- a/test/unit/data/test_quadlet/modelfromstore_mmproj/modelfromstore_mmproj.container
+++ b/test/unit/data/test_quadlet/modelfromstore_mmproj/modelfromstore_mmproj.container
@@ -6,6 +6,7 @@ After=local-fs.target
 AddDevice=-/dev/accel
 AddDevice=-/dev/dri
 AddDevice=-/dev/kfd
+AddDevice=nvidia.com/gpu=all
 Image=testimage
 RunInit=true
 Environment=HOME=/tmp

--- a/test/unit/data/test_quadlet/oci_basic/oci-model.container
+++ b/test/unit/data/test_quadlet/oci_basic/oci-model.container
@@ -6,6 +6,7 @@ After=local-fs.target
 AddDevice=-/dev/accel
 AddDevice=-/dev/dri
 AddDevice=-/dev/kfd
+AddDevice=nvidia.com/gpu=all
 Image=testimage
 RunInit=true
 Environment=HOME=/tmp

--- a/test/unit/data/test_quadlet/oci_port/oci-model-port.container
+++ b/test/unit/data/test_quadlet/oci_port/oci-model-port.container
@@ -6,6 +6,7 @@ After=local-fs.target
 AddDevice=-/dev/accel
 AddDevice=-/dev/dri
 AddDevice=-/dev/kfd
+AddDevice=nvidia.com/gpu=all
 Image=testimage
 RunInit=true
 Environment=HOME=/tmp

--- a/test/unit/data/test_quadlet/oci_rag/oci-model-rag.container
+++ b/test/unit/data/test_quadlet/oci_rag/oci-model-rag.container
@@ -6,6 +6,7 @@ After=local-fs.target
 AddDevice=-/dev/accel
 AddDevice=-/dev/dri
 AddDevice=-/dev/kfd
+AddDevice=nvidia.com/gpu=all
 Image=testimage
 RunInit=true
 Environment=HOME=/tmp

--- a/test/unit/data/test_quadlet/portmapping/tinyllama.container
+++ b/test/unit/data/test_quadlet/portmapping/tinyllama.container
@@ -6,6 +6,7 @@ After=local-fs.target
 AddDevice=-/dev/accel
 AddDevice=-/dev/dri
 AddDevice=-/dev/kfd
+AddDevice=nvidia.com/gpu=all
 Image=testimage
 RunInit=true
 Environment=HOME=/tmp


### PR DESCRIPTION
**Summary:**  
When running `ramalama serve` the tool automatically detects NVIDIA GPUs and mounts the required devices (`/dev/nvidia*`) into the podman container. However, the same command used with the `--generate=quadlet` option produces a `.container` file that lacks the necessary `AddDevice` entries for the GPU devices. As a result, the generated systemd service cannot utilize the GPU, leading to CPU‑only execution or a failure to start the container on NVIDIA hardware.

**What was changed:**  
* Updated the quadlet generation logic in `ramalama-serve` to:
  1. Add the appropriate `AddDevice` entries for all required NVIDIA device nodes.
* Updated unit tests to verify that the generated quadlet file contains the expected GPU device entries.

**Impact:**  
* Users can now generate quadlet services that correctly use NVIDIA GPUs out of the box, without manual editing of the `.container` file.
* The `ramalama serve --generate=quadlet` command behaves consistently with the normal `ramalama serve` command regarding GPU usage.

**Testing:**  
* All unit tests passed.
* Run `ramalama serve --generate=quadlet <model>` on a machine with NVIDIA GPU – the resulting `.container` file contains `AddDevice=nvidia.com/gpu=all` lines.
* Verify that the container starts and the GPU is visible inside (e.g., via `nvidia-smi` inside the container or by checking CUDA runtime success).

