### PR TITLE
konflux: fix creation of the PipelineRun when a tag is pushed

### DIFF
--- a/.tekton/release/pipelineruns/ramalama-release-tag.yaml
+++ b/.tekton/release/pipelineruns/ramalama-release-tag.yaml
@@ -13,6 +13,7 @@ metadata:
   labels:
     appstudio.openshift.io/application: ramalama
     pipelines.appstudio.openshift.io/type: release
+    pac.test.appstudio.openshift.io/event-type: push
   name: ramalama-release-tag
   namespace: ramalama-tenant
 spec:
@@ -25,4 +26,4 @@ spec:
     pipeline: 6h
     finally: 15m
   taskRunTemplate:
-    serviceAccountName: appstudio-pipeline
+    serviceAccountName: konflux-integration-runner


### PR DESCRIPTION
The `event-type` label isn't created automatically, need to specify it manually.
Use the newer `konflux-integration-runner` service account.

## Summary by Sourcery

Fix the PipelineRun configuration for tag push events by adding the required event-type label and updating the service account

Bug Fixes:
- Add the missing pac.test.appstudio.io/event-type: push label to the release PipelineRun

Enhancements:
- Switch the taskRunTemplate service account to konflux-integration-runner