### PR TITLE
Fix vllm runtime entrypoint

### DIFF
--- a/ramalama/config.py
+++ b/ramalama/config.py
@@ -107,6 +107,7 @@ class BaseConfig:
     transport: str = "ollama"
     user: UserConfig = field(default_factory=UserConfig)
     verify: bool = True
+    vllm_python_path: str = "/opt/venv/bin/python3"
 
     def __post_init__(self):
         self.container = coerce_to_bool(self.container) if self.container is not None else self.engine is not None

--- a/ramalama/model.py
+++ b/ramalama/model.py
@@ -622,14 +622,14 @@ class Model(ModelBase):
 
     def vllm_serve(self, args):
         exec_args = [
+            CONFIG.vllm_python_path,
+            "-m",
+            "vllm.entrypoints.openai.api_server",
             "--model",
             self._get_entry_model_path(args.container, args.generate, args.dryrun),
             "--port",
             args.port,
-            "--max-sequence-length",
-            f"{args.context}",
         ]
-        exec_args += args.runtime_args
         return exec_args
 
     def llama_serve(self, args):


### PR DESCRIPTION
Currently when using vllm runtime the following error is returned: ERROR (catatonit:50): failed to exec pid1: No such file or directory.

Also removing unrecognized arguments: --max-sequence-length

Should address https://github.com/containers/ramalama/issues/1948

## Summary by Sourcery

Fix the vllm runtime entrypoint invocation to avoid container execution errors

Bug Fixes:
- Invoke the API server via the Python interpreter and module path to ensure the entrypoint binary exists
- Replace the deprecated --max-sequence-length flag with --max-model-len

## Summary by Sourcery

Fix the VLLM runtime entrypoint to ensure the container starts the API server correctly and remove the deprecated flag

Bug Fixes:
- Invoke the VLLM API server via the Python interpreter and module path to avoid container execution errors
- Remove the deprecated --max-sequence-length flag from the runtime invocation