### PR TITLE
Fix cuda-vllm image build steps

### DIFF
--- a/container-images/cuda-vllm/Containerfile
+++ b/container-images/cuda-vllm/Containerfile
@@ -15,5 +15,7 @@ WORKDIR /
 # Final runtime image
 FROM quay.io/ramalama/cuda:latest
 
+COPY --from=builder /usr/local/cuda/ /usr/local/cuda/
 COPY --from=builder /opt /opt
 
+RUN dnf install -y gcc gcc-c++ numactl && pip3.11 install --no-cache-dir ninja && dnf clean all

--- a/container-images/scripts/build-vllm.sh
+++ b/container-images/scripts/build-vllm.sh
@@ -5,6 +5,7 @@ install_deps() {
     dnf install -y git wget ca-certificates gcc gcc-c++ libSM libXext \
       mesa-libGL jq lsof vim numactl
     if is_rhel_based; then
+      add_stream_repo "BaseOS"
       add_stream_repo "AppStream"
       dnf install -y numactl-devel
       rm_non_ubi_repos


### PR DESCRIPTION
Currently building cuda-vllm fails due to missing numactl-libs dependency.

Later when running vllm it fails finding nvcc and ninja.

## Summary by Sourcery

Fix the cuda-vllm container build by including missing CUDA binaries and installing essential build dependencies, and enable necessary RHEL repositories for numactl

Build:
- Copy CUDA binaries from the builder stage into the runtime image and install gcc, python3-pip, gcc-c++, and Ninja via pip
- Enable BaseOS and AppStream repositories on RHEL-based systems to install numactl-devel