### PR TITLE
feat: support safetensors-only repos across runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,7 +256,7 @@ jobs:
       - name: install mlx-lm
         shell: bash
         run: |
-          uv run -- pip install mlx-lm
+          uv tool install mlx-lm
 
       - name: install golang
         shell: bash

--- a/inference-spec/engines/mlx.yaml
+++ b/inference-spec/engines/mlx.yaml
@@ -17,6 +17,7 @@ commands:
         - name: "--max-tokens"
           description: "Size of the prompt context"
           value: "{{ args.ctx_size }}"
+          if: "{{ (args.ctx_size or 0) > 0 }}"
         - name: "--host"
           description: "IP address for the AI model server to listen on"
           value: "{{ args.host }}"

--- a/ramalama/chat.py
+++ b/ramalama/chat.py
@@ -304,7 +304,8 @@ class RamaLamaShell(cmd.Cmd):
             "stream": True,
             "messages": self.conversation_history,
         }
-        if self.args.model is not None:
+        # For MLX runtime, omit explicit model to allow server default ("default_model")
+        if getattr(self.args, "runtime", None) != "mlx" and self.args.model is not None:
             data["model"] = self.args.model
 
         json_data = json.dumps(data).encode("utf-8")

--- a/ramalama/hf_style_repo_base.py
+++ b/ramalama/hf_style_repo_base.py
@@ -276,6 +276,8 @@ class HFStyleRepoModel(Transport, ABC):
                 raise KeyError(f"Failed to pull model: {str(e)}")
 
             # Create temporary directory for downloading via CLI
+            # Ensure the base store path exists before creating the temp directory inside it
+            os.makedirs(self.model_store.base_path, exist_ok=True)
             with tempfile.TemporaryDirectory(prefix="tmp_hfcli_", dir=self.model_store.base_path) as tempdir:
                 model = f"{organization}/{name}"
                 conman_args = self.get_cli_download_args(tempdir, model)

--- a/ramalama/model_store/reffile.py
+++ b/ramalama/model_store/reffile.py
@@ -134,6 +134,7 @@ def migrate_reffile_to_refjsonfile(ref_file_path: str, snapshot_directory: str) 
 
 class StoreFileType(StrEnum):
     GGUF_MODEL = "gguf"
+    SAFETENSOR_MODEL = "safetensor"
     MMPROJ = "mmproj"
     CHAT_TEMPLATE = "chat_template"
     OTHER = "other"
@@ -142,6 +143,8 @@ class StoreFileType(StrEnum):
     def from_str(s: str) -> "StoreFileType":
         if s == StoreFileType.GGUF_MODEL.value:
             return StoreFileType.GGUF_MODEL
+        if s == StoreFileType.SAFETENSOR_MODEL.value:
+            return StoreFileType.SAFETENSOR_MODEL
         if s == StoreFileType.MMPROJ.value:
             return StoreFileType.MMPROJ
         if s == StoreFileType.CHAT_TEMPLATE.value:
@@ -175,6 +178,10 @@ class RefJSONFile:
     @property
     def model_files(self) -> list[StoreFile]:
         return [file for file in self.files if file.type == StoreFileType.GGUF_MODEL]
+
+    @property
+    def safetensor_model_files(self) -> list[StoreFile]:
+        return [file for file in self.files if file.type == StoreFileType.SAFETENSOR_MODEL]
 
     @property
     def chat_templates(self) -> list[StoreFile]:

--- a/test/e2e/test_run.py
+++ b/test/e2e/test_run.py
@@ -261,10 +261,17 @@ def test_params_errors(extra_params, pattern, config, env_vars, expected_exit_co
 
 @pytest.mark.e2e
 def test_run_model_with_prompt(shared_ctx_with_models, test_model):
+    import platform
+
     ctx = shared_ctx_with_models
-    ctx.check_call(
-        ["ramalama", "run", "--temp", "0", test_model, "What is the first line of the declaration of independence?"]
-    )
+
+    run_cmd = ["ramalama", "run", "--temp", "0"]
+    if platform.system() == "Darwin":
+        # Reduce context size and limit output for faster macOS testing
+        run_cmd.extend(["-c", "512", "--runtime-args='-n 15'"])
+
+    run_cmd.extend([test_model, "What is the first line of the declaration of independence?"])
+    ctx.check_call(run_cmd)
 
 
 @pytest.mark.e2e

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -126,7 +126,7 @@ EOF
 }
 
 @test "ramalama run with prompt" {
-    run_ramalama run --temp 0 $(test_model ${MODEL}) "What is the first line of the declaration of independence?"
+    run_ramalama run --runtime-args='-n 25' --temp 0 $(test_model ${MODEL}) "What is the first line of the declaration of independence?"
 }
 
 @test "ramalama run --keepalive" {

--- a/test/system/080-mlx.bats
+++ b/test/system/080-mlx.bats
@@ -11,7 +11,7 @@ function skip_if_not_apple_silicon() {
 }
 
 function skip_if_no_mlx() {
-    if ! python3 -c "import mlx_lm" 2>/dev/null; then
+    if ! uv tool list | grep -q '^mlx-lm'; then
         skip "MLX runtime requires mlx-lm package to be installed"
     fi
 }
@@ -99,7 +99,8 @@ function skip_if_no_mlx() {
     is "$status" "0" "MLX serve should work"
     # Should use python -m mlx_lm.server
     is "$output" ".*mlx_lm.server.*" "should use MLX server command"
-    is "$output" ".*--port.*8080.*" "should include default port"
+    # Accept any port in the default range 8080-8090
+    is "$output" ".*--port.*80[89][0-9].*" "should include default-range port"
 }
 
 @test "ramalama --runtime=mlx --dryrun serve with custom port" {

--- a/test/unit/test_transport_base.py
+++ b/test/unit/test_transport_base.py
@@ -227,7 +227,7 @@ class TestMLXRuntime:
         mock_chat.assert_called_once()
 
         # Verify args were set up correctly for server-client model
-        # MLX runtime should include /v1 in the URL
+        # MLX runtime uses OpenAI-compatible endpoints under /v1
         assert args.url == "http://127.0.0.1:8080/v1"
         assert args.pid2kill == 123
 


### PR DESCRIPTION
Fixes #1883 

- Centralize model argument resolution in ModelStore.resolve_model_argument for safetensor only repos
- For repos with .safetensors and no GGUF, pass the repository directory as the model argument (MNT_DIR in container; snapshot dir on host). Otherwise fall back to the GGUF entry path. Honor --dryrun. No change to GGUF flow.
- MLX: fix detection and omit explicit model arg for OpenAI-compatible /v1 endpoints to use the server default ("default_model").
- CI: align mlx-lm installation steps with the real install script.
- Tests: fix runtime argument usage and clarify MLX /v1 endpoint comment.
- Guardrail: limit output for very small models to avoid runaway responses.

Allows for the following to work again:
```
ramalama --runtime=mlx run hf://mlx-community/Unsloth-Phi-4-4bit
```

## Summary by Sourcery

Centralize model argument resolution to support safetensors-only repositories and adapt runtimes accordingly, update CI installation for mlx-lm, and align tests with the new behavior.

New Features:
- Add ModelStore.resolve_model_argument to return directory paths for safetensors-only repos.
- Allow passing repository directory as the model argument when no GGUF files are present.

Enhancements:
- Refactor model.py and transports/base.py to use the new resolution logic for model paths.
- Omit explicit model flag for MLX /v1 endpoints to leverage the server default_model.
- Guardrail small-model outputs to prevent runaway responses.

CI:
- Update CI workflow to install mlx-lm via ‘uv tool install’ instead of pip.

Tests:
- Adjust system tests for runtime-args usage and MLX installation checks.
- Clarify unit test comments for MLX runtime endpoint behavior.