### PR TITLE
[CI] smollm:135 is hanging on macos, switch to tiny for now

### DIFF
--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -126,7 +126,7 @@ EOF
 }
 
 @test "ramalama run with prompt" {
-    run_ramalama run --temp 0 $(test_model ${MODEL}) "What is the first line of the declaration of independence?"
+    run_ramalama run --temp 0 $(test_model tiny) "What is the first line of the declaration of independence?"
 }
 
 @test "ramalama run --keepalive" {


### PR DESCRIPTION
macos CI job has been timing out since https://github.com/containers/ramalama/pull/1916. Switch to tiny model for the prompt test, while investigating the macos issue

## Summary by Sourcery

Switch the prompt test to use the tiny model to avoid CI timeouts on macOS.

Bug Fixes:
- Prevent macOS CI hang by using the tiny model in the prompt test

CI:
- Work around macOS CI job timing out by switching to the tiny model for the prompt test

Tests:
- Update the 'ramalama run with prompt' test to invoke the tiny model instead of the default model