### PR TITLE
fix(intel): detect xe driver

### DIFF
--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -472,10 +472,9 @@ def check_intel() -> Literal["intel"] | None:
         b"0x7dd5",
         b"0x7d55",
     )
+    intel_driver_glob_patterns = ["/sys/bus/pci/drivers/i915/*/device", "/sys/bus/pci/drivers/xe/*/device"]
     # Check to see if any of the device ids in intel_gpus are in the device id of the i915 / xe driver
-    for fp in sorted(
-        [*glob.glob('/sys/bus/pci/drivers/i915/*/device'), *glob.glob('/sys/bus/pci/drivers/xe/*/device')]
-    ):
+    for fp in sorted([i for p in intel_driver_glob_patterns for i in glob.glob(p)]):
         with open(fp, 'rb') as file:
             content = file.read()
             for gpu_id in intel_gpus:


### PR DESCRIPTION
Fix #1979 

After the fix:

```
 ➜  ~ uv run ramalama info | jq .Accelerator     
"intel"
```

## Summary by Sourcery

Bug Fixes:
- Add detection for Intel Xe driver by scanning /sys/bus/pci/drivers/xe in check_intel()