### PR TITLE
Fix --exclude-dir arguments to grep in Makefile and add .tox.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,9 @@ PATH := $(PATH):$(HOME)/.local/bin
 MYPIP ?= pip
 IMAGE ?= ramalama
 PROJECT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
-PYTHON_SCRIPTS := $(shell grep -lEr "^\#\!\s*/usr/bin/(env +)?python(3)?(\s|$$)" --exclude-dir={.venv,venv,.tox} $(PROJECT_DIR) || true)
+EXCLUDE_DIRS := .venv venv .tox
+EXCLUDE_OPTS := $(addprefix --exclude-dir=,$(EXCLUDE_DIRS))
+PYTHON_SCRIPTS := $(shell grep -lEr "^\#\!\s*/usr/bin/(env +)?python(3)?(\s|$$)" $(EXCLUDE_OPTS) $(PROJECT_DIR) || true)
 BATS_IMAGE ?= localhost/bats:latest
 
 default: help
@@ -109,7 +111,7 @@ lint:
 ifneq (,$(wildcard /usr/bin/python3))
 	/usr/bin/python3 -m compileall -q -x '\.venv' .
 endif
-	! grep -ri --exclude-dir ".venv" --exclude-dir "*/.venv" "#\!/usr/bin/python3" .
+	! grep -ri $(EXCLUDE_OPTS) "#\!/usr/bin/python3" .
 	flake8 $(PROJECT_DIR) $(PYTHON_SCRIPTS)
 	shellcheck *.sh */*.sh */*/*.sh
 


### PR DESCRIPTION
Use the GNU Make addprefix function instead of relying on shell brace expansion to generate --exclude-dir arguments for grep.

GNU Make uses /bin/sh to run recipes by default. /bin/sh may not support brace expansion at all. On Fedora and RHEL, /bin/sh is an alias for bash. On Ubuntu, /bin/sh is an alias for dash. On MacOS, /bin/sh is an alias for zsh. Those all handle braces differently. In particular, dash on Ubuntu does not do brace expansion within a word with the result that PYTHON_SCRIPTS is generated incorrectly.

## Summary by Sourcery

Use GNU Make’s addprefix to generate grep --exclude-dir options for portable shell compatibility and include .tox in the exclusion list.

Bug Fixes:
- Fix generation of grep --exclude-dir arguments on shells that lack brace expansion

Enhancements:
- Define EXCLUDE_DIRS (.venv, venv, .tox) and EXCLUDE_OPTS in the Makefile to streamline grep exclusion
- Update grep invocations in script discovery and lint targets to use EXCLUDE_OPTS