### PR TITLE
Daemon bugfix for docker users and better pull config handling

### DIFF
--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -24,6 +24,7 @@ except Exception:
 import ramalama.chat as chat
 from ramalama import engine
 from ramalama.chat import default_prefix
+from ramalama.cli_arg_normalization import normalize_pull_arg
 from ramalama.command.factory import assemble_command
 from ramalama.common import accel_image, get_accel, perror
 from ramalama.config import CONFIG, coerce_to_bool, load_file_config
@@ -318,6 +319,9 @@ def post_parse_setup(args):
         if getattr(args, "container", None) is True:
             logger.info("MLX runtime automatically uses --nocontainer mode")
         args.container = False
+
+    if hasattr(args, 'pull'):
+        args.pull = normalize_pull_arg(args.pull, getattr(args, 'engine', None))
 
     configure_logger("DEBUG" if args.debug else "WARNING")
 
@@ -1221,7 +1225,7 @@ def daemon_start_cli(args):
         daemon_model_store_dir = "/ramalama/models"
 
         daemon_cmd += [
-            "podman",
+            args.engine,
             "run",
             "--pull",
             args.pull,
@@ -1244,7 +1248,6 @@ def daemon_start_cli(args):
         "--host",
         CONFIG.host if is_daemon_in_container else args.host,
     ]
-
     exec_cmd(daemon_cmd)
 
 

--- a/ramalama/cli_arg_normalization.py
+++ b/ramalama/cli_arg_normalization.py
@@ -1,0 +1,2 @@
+def normalize_pull_arg(pull: str, engine: str | None):
+    return "always" if engine == "docker" and pull == "newer" else pull

--- a/ramalama/config.py
+++ b/ramalama/config.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal, Mapping, TypeAlias
 
+from ramalama.cli_arg_normalization import normalize_pull_arg
 from ramalama.common import apple_vm, available
 from ramalama.layered_config import LayeredMixin
 from ramalama.toml_parser import TOMLParser
@@ -161,6 +162,7 @@ class BaseConfig:
     def __post_init__(self):
         self.container = coerce_to_bool(self.container) if self.container is not None else self.engine is not None
         self.image = self.image if self.image is not None else self.default_image
+        self.pull = normalize_pull_arg(self.pull, self.engine)
 
 
 class Config(LayeredMixin, BaseConfig):

--- a/test/e2e/test_run.py
+++ b/test/e2e/test_run.py
@@ -20,6 +20,7 @@ CONFIG_WITH_PULL_NEVER = """
 [ramalama]
 pull="never"
 """
+DEFAULT_PULL_PATTERN = r".*--pull (?:always|newer)"
 
 
 @pytest.fixture(scope="module")
@@ -122,7 +123,7 @@ def test_basic_dry_run():
             id="check pull policy with RAMALAMA_CONFIG=/dev/null", marks=[skip_if_no_container, skip_if_docker],
         ),
         pytest.param(
-            [], r".*--pull newer", None, None, True,
+            [], DEFAULT_PULL_PATTERN, None, None, True,
             id="check default pull policy",
             marks=[skip_if_no_container],
         ),

--- a/test/unit/test_cli_arg_normalization.py
+++ b/test/unit/test_cli_arg_normalization.py
@@ -1,0 +1,31 @@
+import pytest
+
+from ramalama.cli_arg_normalization import normalize_pull_arg
+
+
+class TestNormalizePullArg:
+    @pytest.mark.parametrize(
+        "pull_value,expected",
+        [
+            ("always", "always"),
+            ("missing", "missing"),
+            ("never", "never"),
+            ("newer", "always"),
+        ],
+    )
+    def test_docker_normalization(self, pull_value, expected):
+        assert normalize_pull_arg(pull_value, "docker") == expected
+
+    @pytest.mark.parametrize(
+        "engine,pull_value",
+        [
+            ("podman", "newer"),
+            ("podman", "always"),
+            ("podman", "missing"),
+            ("podman", "never"),
+            ("custom", "newer"),
+            (None, "newer"),
+        ],
+    )
+    def test_non_docker_engines_are_unchanged(self, engine, pull_value):
+        assert normalize_pull_arg(pull_value, engine) == pull_value

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -3,7 +3,14 @@ from unittest.mock import patch
 
 import pytest
 
-from ramalama.config import DEFAULT_PORT, default_config, get_default_engine, get_default_store, load_env_config
+from ramalama.config import (
+    DEFAULT_PORT,
+    BaseConfig,
+    default_config,
+    get_default_engine,
+    get_default_store,
+    load_env_config,
+)
 
 
 def test_correct_config_defaults(monkeypatch):
@@ -26,7 +33,7 @@ def test_correct_config_defaults(monkeypatch):
     assert cfg.ngl == -1
     assert cfg.threads == -1
     assert cfg.port == str(DEFAULT_PORT)
-    assert cfg.pull == "newer"
+    assert cfg.pull in ["newer", "always"]  # depends on engine
     assert cfg.runtime == "llama.cpp"
     assert cfg.store == get_default_store()
     assert cfg.temp == "0.8"
@@ -61,6 +68,16 @@ def test_config_defaults_not_set(monkeypatch):
     assert cfg.is_set("transport") is False
     assert cfg.is_set("ocr") is False
     assert cfg.is_set("verify") is False
+
+
+def test_base_config_normalizes_pull_for_docker():
+    config = BaseConfig(engine="docker", pull="newer")
+    assert config.pull == "always"
+
+
+def test_base_config_preserves_pull_for_non_docker():
+    config = BaseConfig(engine="podman", pull="newer")
+    assert config.pull == "newer"
 
 
 def test_file_config_overrides_defaults():


### PR DESCRIPTION
## Summary by Sourcery

Normalize pull policy for Docker users and use the selected container engine in the daemon command.

Bug Fixes:
- Map 'newer' pull policy to 'always' for Docker engine to prevent unsupported policy errors
- Replace hardcoded podman with the user-specified engine when starting the daemon

Enhancements:
- Introduce a PullAction arg parser to normalize pull arguments based on the engine
- Automatically normalize pull configuration in BaseConfig post-initialization