### PR TITLE
Remove tag in model name for health check

### DIFF
--- a/ramalama/engine.py
+++ b/ramalama/engine.py
@@ -374,8 +374,9 @@ def is_healthy(args, timeout=3):
             logger.debug(f"Container {args.name} does not include a model list in the response")
             return False
         model_names = [m["name"] for m in body["models"]]
-        # The transport is not included in the model name returned by the endpoint
+        # The transport and tag is not included in the model name returned by the endpoint
         model_name = args.MODEL.split("://")[-1]
+        model_name = model_name.split(":")[0]
         if not any(model_name in name for name in model_names):
             logger.debug(f'Container {args.name} does not include "{model_name}" in the model list: {model_names}')
             return False


### PR DESCRIPTION
Remove tag in model name for health check

## Summary by Sourcery

Bug Fixes:
- Remove tag suffix from the model name before comparing against the list of models in is_healthy