### PR TITLE
Always chosen port passed via CLI parameter

### DIFF
--- a/ramalama/transports/base.py
+++ b/ramalama/transports/base.py
@@ -21,7 +21,7 @@ from ramalama.common import (
     set_accel_env_vars,
 )
 from ramalama.compose import Compose
-from ramalama.config import CONFIG, DEFAULT_PORT, DEFAULT_PORT_RANGE
+from ramalama.config import CONFIG, DEFAULT_PORT_RANGE
 from ramalama.engine import Engine, dry_run, is_healthy, wait_for_healthy
 from ramalama.kube import Kube
 from ramalama.logger import logger
@@ -717,7 +717,7 @@ def get_available_port_if_any() -> int:
 
 def compute_serving_port(args, quiet=False) -> str:
     # user probably specified a custom port, don't override the choice
-    if getattr(args, "port", "") not in ["", str(DEFAULT_PORT)]:
+    if getattr(args, "port", None):
         target_port = args.port
     else:
         # otherwise compute a random serving port in the range

--- a/test/unit/test_transport_base.py
+++ b/test/unit/test_transport_base.py
@@ -90,28 +90,22 @@ def test_extract_model_identifiers(model_input: str, expected_name: str, expecte
     "inputPort,expectedRandomizedResult,expectedRandomPortsAvl,expectedOutput,expectedErr",
     [
         ("", [], [None], "8999", IOError),
+        (None, [], [None], "8080", IOError),
         ("8999", [], [None], "8999", None),
         ("8080", [8080, 8087, 8085, 8086, 8084, 8090, 8088, 8089, 8082, 8081, 8083], [None], "8080", None),
         (
             "8080",
             [8080, 8088, 8090, 8084, 8081, 8087, 8085, 8089, 8082, 8086, 8083],
             [OSError, None],
-            "8088",
+            "8080",
             None,
         ),
         (
-            "8080",
+            "8085",
             [8080, 8090, 8082, 8084, 8088, 8089, 8087, 8081, 8083, 8086, 8085],
             [OSError, OSError, None],
-            "8082",
+            "8085",
             None,
-        ),
-        (
-            "8080",
-            [8080, 8085, 8090, 8081, 8084, 8088, 8086, 8087, 8083, 8082, 8089],
-            [OSError, OSError, OSError, OSError, OSError, OSError, OSError, OSError, OSError, OSError, OSError],
-            "0",
-            IOError,
         ),
     ],
 )


### PR DESCRIPTION
The port passed in via CLI parameter should have highest priority. Previously, if the parameter was the same as the default port, then RamaLama calculated the next available port - ignoring the parameter.

/cc @bmahabirbu

## Summary by Sourcery

Bug Fixes:
- Always use the CLI-specified port in compute_serving_port even when it matches the default