### PR TITLE
Search the inference spec files in the source directory

### DIFF
--- a/ramalama/config.py
+++ b/ramalama/config.py
@@ -19,10 +19,10 @@ SUPPORTED_RUNTIMES: TypeAlias = Literal["llama.cpp", "vllm", "mlx"]
 COLOR_OPTIONS: TypeAlias = Literal["auto", "always", "never"]
 
 DEFAULT_CONFIG_DIRS = [
-    f"{sys.prefix}/share/ramalama",
-    f"{sys.prefix}/local/share/ramalama",
-    "/etc/ramalama",
-    os.path.expanduser(os.path.join(os.getenv("XDG_CONFIG_HOME", "~/.config"), "ramalama")),
+    Path(f"{sys.prefix}/share/ramalama"),
+    Path(f"{sys.prefix}/local/share/ramalama"),
+    Path("/etc/ramalama"),
+    Path(os.path.expanduser(os.path.join(os.getenv("XDG_CONFIG_HOME", "~/.config"), "ramalama"))),
 ]
 
 
@@ -44,16 +44,18 @@ def get_default_store() -> str:
     return os.path.expanduser("~/.local/share/ramalama")
 
 
+def get_all_inference_spec_dirs(subdir: str) -> list[Path]:
+    ramalama_root = Path(__file__).parent.parent
+    development_spec_dir = ramalama_root / "inference-spec" / subdir
+    all_dirs = [development_spec_dir, *[conf_dir / "inference" for conf_dir in DEFAULT_CONFIG_DIRS]]
+
+    return [d for d in all_dirs if d.exists()]
+
+
 def get_inference_spec_files() -> dict[str, Path]:
     files: dict[str, Path] = {}
 
-    ramalama_root = Path(__file__).parent.parent
-    development_spec_dir = ramalama_root / "inference-spec" / "engines"
-    default_inference_spec_dirs = [str(development_spec_dir)]
-    default_inference_spec_dirs.extend([os.path.join(conf_dir, "inference") for conf_dir in DEFAULT_CONFIG_DIRS])
-    for spec_dir in default_inference_spec_dirs:
-        if not os.path.exists(spec_dir):
-            continue
+    for spec_dir in get_all_inference_spec_dirs("engines"):
 
         # Give preference to .yaml, then .json spec files
         file_extensions = ["*.yaml", "*.yml", "*.json"]
@@ -71,13 +73,7 @@ def get_inference_spec_files() -> dict[str, Path]:
 def get_inference_schema_files() -> dict[str, Path]:
     files: dict[str, Path] = {}
 
-    ramalama_root = Path(__file__).parent.parent
-    development_schema_dir = ramalama_root / "inference-spec" / "schema"
-    default_inference_schema_dirs = [str(development_schema_dir)]
-    default_inference_schema_dirs.extend([os.path.join(conf_dir, "inference") for conf_dir in DEFAULT_CONFIG_DIRS])
-    for schema_dir in default_inference_schema_dirs:
-        if not os.path.exists(schema_dir):
-            continue
+    for schema_dir in get_all_inference_spec_dirs("schema"):
 
         for spec_file in sorted(Path(schema_dir).glob("schema.*.json")):
             file = Path(spec_file)


### PR DESCRIPTION
Without this, we cannot run ramalama without installing it:
```
Error: No specification file found for runtime 'llama.cpp' 
```

```
    Assisted-by-AI: Claude Code
```

## Summary by Sourcery

Include the local inference-spec directories in the search paths so ramalama can locate spec and schema files directly from the source tree without requiring installation.

Bug Fixes:
- Fix error when running ramalama from source by ensuring the llama.cpp inference spec can be found.

Enhancements:
- Add project-root-based paths for both inference-spec engines and schema directories in the config search logic.