### PR TITLE
Added data-files path to default config dirs list

### DIFF
--- a/ramalama/config.py
+++ b/ramalama/config.py
@@ -23,6 +23,7 @@ DEFAULT_CONFIG_DIRS = [
     Path(f"{sys.prefix}/share/ramalama"),
     Path(f"{sys.prefix}/local/share/ramalama"),
     Path("/etc/ramalama"),
+    Path(os.path.expanduser(os.path.join(os.getenv("XDG_DATA_HOME", "~/.local/share"), "ramalama"))),
     Path(os.path.expanduser(os.path.join(os.getenv("XDG_CONFIG_HOME", "~/.config"), "ramalama"))),
 ]
 


### PR DESCRIPTION
Relates to: https://github.com/containers/ramalama/issues/2026

Previousy, RamaLama did not use the configuration and inference spec files installed in the pyproject.toml data-files directory. This led to a failure for the inference spec when RamaLama was installed via pip. Also, it didn't use the configuration file in there as well.

## Summary by Sourcery

Bug Fixes:
- Include the data-files directory (~/.local/share/ramalama) in the default configuration search paths to ensure installed spec and config files are loaded