### PR TITLE
Fix model paths when running with --nocontainer

### DIFF
--- a/ramalama/command/context.py
+++ b/ramalama/command/context.py
@@ -106,7 +106,7 @@ class RamalamaCommandContext:
     @staticmethod
     def from_argparse(cli_args: argparse.Namespace) -> "RamalamaCommandContext":
         args = RamalamaArgsContext.from_argparse(cli_args)
-        should_generate = hasattr(cli_args, "generate")
+        should_generate = getattr(cli_args, "generate", None) is not None
         dry_run = getattr(cli_args, "dryrun", False)
         is_container = getattr(cli_args, "container", True)
         model = RamalamaModelContext(New(cli_args.MODEL, cli_args), is_container, should_generate, dry_run)


### PR DESCRIPTION
The inference-spec context was evaulating cli_args.generate=None as True.

This affects the models path, similar to when container=True, resulting in the wrong model and chat template file paths being used with --nocontainer.

## Summary by Sourcery

Fix evaluation of the --generate flag to correctly determine model paths when running with --nocontainer.

Bug Fixes:
- Use getattr to default cli_args.generate to False instead of checking attribute presence
- Ensure should_generate is False when cli_args.generate is None to avoid incorrect model and template paths