### PR TITLE
build_rag.sh: add libraries required by opencv-python

### DIFF
--- a/container-images/scripts/build_rag.sh
+++ b/container-images/scripts/build_rag.sh
@@ -83,9 +83,9 @@ main() {
     python=$(python_version)
     local pkgs
     if available dnf; then
-        pkgs=("git-core" "gcc" "gcc-c++" "cmake")
+        pkgs=("git-core" "gcc" "gcc-c++" "cmake" "libglvnd-glx")
     else
-        pkgs=("git" "gcc" "g++" "cmake")
+        pkgs=("git" "gcc" "g++" "cmake" "libgl1" "libglib2.0-0")
     fi
     if [ "${gpu}" = "cuda" ]; then
         pkgs+=("libcudnn9-devel-cuda-12" "libcusparselt0" "cuda-cupti-12-*")


### PR DESCRIPTION
Fixes the following error when importing "cv2":

  ImportError: libGL.so.1: cannot open shared object file: No such file or directory

## Summary by Sourcery

Add missing system libraries to the build script to resolve cv2 import errors due to a missing libGL dependency

Bug Fixes:
- Include libglvnd-glx in dnf package list to provide libGL
- Include libgl1 and libglib2.0-0 in apt package list to provide libGL