### PR TITLE
Docsite builds remove extraneous manpage number labels

### DIFF
--- a/docsite/convert_manpages.py
+++ b/docsite/convert_manpages.py
@@ -30,6 +30,12 @@ def extract_title_and_description(content, filename):
 
     if base_name == 'ramalama.1.md':
         title = 'ramalama'  # Base command page
+    elif base_name.startswith('ramalama-') and base_name.endswith('.1.md'):
+        # Command pages: ramalama-chat.1.md -> chat
+        title = base_name.replace('ramalama-', '').replace('.1.md', '')
+    elif base_name.endswith('.7.md'):
+        # Platform guides: ramalama-cuda.7.md -> CUDA Support
+        title = base_name.replace('ramalama-', '').replace('.7.md', '')
     elif base_name.endswith('.5.md'):
         # Config files with custom titles
         if base_name == 'ramalama.conf.5.md':

--- a/docsite/docs/commands/ramalama/bench.mdx
+++ b/docsite/docs/commands/ramalama/bench.mdx
@@ -1,11 +1,11 @@
 ---
-title: ramalama bench.1
+title: bench
 description: benchmark specified AI Model
 # This file is auto-generated from manpages. Do not edit manually.
 # Source: ramalama-bench.1.md
 ---
 
-# ramalama bench.1
+# bench
 
 ## Synopsis
 **ramalama bench** [*options*] *model* [arg ...]
@@ -63,7 +63,7 @@ OCI container image to run with specified AI model. RamaLama defaults to using
 images based on the accelerator it discovers. For example:
 `quay.io/ramalama/ramalama`. See the table below for all default images.
 The default image tag is based on the minor version of the RamaLama package.
-Version 0.12.1 of RamaLama pulls an image with a `:0.12` tag from the quay.io/ramalama OCI repository. The --image option overrides this default.
+Version 0.13.0 of RamaLama pulls an image with a `:0.12` tag from the quay.io/ramalama OCI repository. The --image option overrides this default.
 
 The default can be overridden in the ramalama.conf file or via the
 RAMALAMA_IMAGE environment variable. `export RAMALAMA_IMAGE=quay.io/ramalama/aiimage:1.2` tells

--- a/docsite/docs/commands/ramalama/chat.mdx
+++ b/docsite/docs/commands/ramalama/chat.mdx
@@ -1,11 +1,11 @@
 ---
-title: ramalama chat.1
+title: chat
 description: OpenAI chat with the specified REST API URL
 # This file is auto-generated from manpages. Do not edit manually.
 # Source: ramalama-chat.1.md
 ---
 
-# ramalama chat.1
+# chat
 
 ## Synopsis
 **ramalama chat** [*options*] [arg...]
@@ -21,7 +21,7 @@ Chat with an OpenAI Rest API
 
 #### **--api-key**
 OpenAI-compatible API key.
-Can also be set via the API_KEY environment variable.
+Can also be set via the RAMALAMA_API_KEY environment variable.
 
 #### **--color**
 Indicate whether or not to use color in the chat.
@@ -32,6 +32,11 @@ Show this help message and exit
 
 #### **--list**
 List the available models at an endpoint
+
+#### **--mcp**=SERVER_URL
+MCP (Model Context Protocol) servers to use for enhanced tool calling capabilities.
+Can be specified multiple times to connect to multiple MCP servers.
+Each server provides tools that can be automatically invoked during chat conversations.
 
 #### **--model**=MODEL
 Model for inferencing (may not be required for endpoints that only serve one model)

--- a/docsite/docs/commands/ramalama/containers.mdx
+++ b/docsite/docs/commands/ramalama/containers.mdx
@@ -1,11 +1,11 @@
 ---
-title: ramalama containers.1
+title: containers
 description: list all RamaLama containers
 # This file is auto-generated from manpages. Do not edit manually.
 # Source: ramalama-containers.1.md
 ---
 
-# ramalama containers.1
+# containers
 
 ## Synopsis
 **ramalama containers** [*options*]

--- a/docsite/docs/commands/ramalama/convert.mdx
+++ b/docsite/docs/commands/ramalama/convert.mdx
@@ -1,11 +1,11 @@
 ---
-title: ramalama convert.1
+title: convert
 description: convert AI Models from local storage to OCI Image
 # This file is auto-generated from manpages. Do not edit manually.
 # Source: ramalama-convert.1.md
 ---
 
-# ramalama convert.1
+# convert
 
 ## Synopsis
 **ramalama convert** [*options*] *model* [*target*]
@@ -65,7 +65,7 @@ $ ramalama run oci://quay.io/kugupta/granite-3.2-q4-k-m:latest
 ```
 
 ## See Also
-[ramalama(1)](/docs/commands/ramalama/), [ramalama-push(1)](../../commands/ramalama/push)
+[ramalama(1)](/docs/commands/ramalama/), [ramalama-push(1)](/docs/commands/ramalama/push)
 
 ---
 

--- a/docsite/docs/commands/ramalama/daemon.mdx
+++ b/docsite/docs/commands/ramalama/daemon.mdx
@@ -1,11 +1,11 @@
 ---
-title: ramalama daemon.1
+title: daemon
 description: run a RamaLama REST server
 # This file is auto-generated from manpages. Do not edit manually.
 # Source: ramalama-daemon.1.md
 ---
 
-# ramalama daemon.1
+# daemon
 
 ## Synopsis
 **ramalama daemon** [*options*] [start|run]

--- a/docsite/docs/commands/ramalama/info.mdx
+++ b/docsite/docs/commands/ramalama/info.mdx
@@ -1,11 +1,11 @@
 ---
-title: ramalama info.1
+title: info
 description: display RamaLama configuration information
 # This file is auto-generated from manpages. Do not edit manually.
 # Source: ramalama-info.1.md
 ---
 
-# ramalama info.1
+# info
 
 ## Synopsis
 **ramalama info** [*options*]

--- a/docsite/docs/commands/ramalama/inspect.mdx
+++ b/docsite/docs/commands/ramalama/inspect.mdx
@@ -1,11 +1,11 @@
 ---
-title: ramalama inspect.1
+title: inspect
 description: inspect the specified AI Model
 # This file is auto-generated from manpages. Do not edit manually.
 # Source: ramalama-inspect.1.md
 ---
 
-# ramalama inspect.1
+# inspect
 
 ## Synopsis
 **ramalama inspect** [*options*] *model*

--- a/docsite/docs/commands/ramalama/list.mdx
+++ b/docsite/docs/commands/ramalama/list.mdx
@@ -1,11 +1,11 @@
 ---
-title: ramalama list.1
+title: list
 description: list all downloaded AI Models
 # This file is auto-generated from manpages. Do not edit manually.
 # Source: ramalama-list.1.md
 ---
 
-# ramalama list.1
+# list
 
 ## Synopsis
 **ramalama list** [*options*]

--- a/docsite/docs/commands/ramalama/login.mdx
+++ b/docsite/docs/commands/ramalama/login.mdx
@@ -1,11 +1,11 @@
 ---
-title: ramalama login.1
+title: login
 description: login to remote registry
 # This file is auto-generated from manpages. Do not edit manually.
 # Source: ramalama-login.1.md
 ---
 
-# ramalama login.1
+# login
 
 ## Synopsis
 **ramalama login** [*options*] [*registry*]

--- a/docsite/docs/commands/ramalama/logout.mdx
+++ b/docsite/docs/commands/ramalama/logout.mdx
@@ -1,11 +1,11 @@
 ---
-title: ramalama logout.1
+title: logout
 description: logout from remote registry
 # This file is auto-generated from manpages. Do not edit manually.
 # Source: ramalama-logout.1.md
 ---
 
-# ramalama logout.1
+# logout
 
 ## Synopsis
 **ramalama logout** [*options*] [*registry*]

--- a/docsite/docs/commands/ramalama/perplexity.mdx
+++ b/docsite/docs/commands/ramalama/perplexity.mdx
@@ -1,11 +1,11 @@
 ---
-title: ramalama perplexity.1
+title: perplexity
 description: calculate the perplexity value of an AI Model
 # This file is auto-generated from manpages. Do not edit manually.
 # Source: ramalama-perplexity.1.md
 ---
 
-# ramalama perplexity.1
+# perplexity
 
 ## Synopsis
 **ramalama perplexity** [*options*] *model* [arg ...]
@@ -66,7 +66,7 @@ OCI container image to run with specified AI model. RamaLama defaults to using
 images based on the accelerator it discovers. For example:
 `quay.io/ramalama/ramalama`. See the table below for all default images.
 The default image tag is based on the minor version of the RamaLama package.
-Version 0.12.1 of RamaLama pulls an image with a `:0.12` tag from the quay.io/ramalama OCI repository. The --image option overrides this default.
+Version 0.13.0 of RamaLama pulls an image with a `:0.12` tag from the quay.io/ramalama OCI repository. The --image option overrides this default.
 
 The default can be overridden in the ramalama.conf file or via the
 RAMALAMA_IMAGE environment variable. `export RAMALAMA_IMAGE=quay.io/ramalama/aiimage:1.2` tells
@@ -87,6 +87,13 @@ Accelerated images:
 #### **--keep-groups**
 pass --group-add keep-groups to podman (default: False)
 If GPU device on host system is accessible to user via group access, this option leaks the groups into the container.
+
+#### **--max-tokens**=*integer*
+Maximum number of tokens to generate. Set to 0 for unlimited output (default: 0).
+This parameter is mapped to the appropriate runtime-specific parameter:
+- llama.cpp: `-n` parameter
+- MLX: `--max-tokens` parameter
+- vLLM: `--max-tokens` parameter
 
 #### **--name**, **-n**
 name of the container to run the Model in

--- a/docsite/docs/commands/ramalama/pull.mdx
+++ b/docsite/docs/commands/ramalama/pull.mdx
@@ -1,11 +1,11 @@
 ---
-title: ramalama pull.1
+title: pull
 description: pull AI Models from Model registries to local storage
 # This file is auto-generated from manpages. Do not edit manually.
 # Source: ramalama-pull.1.md
 ---
 
-# ramalama pull.1
+# pull
 
 ## Synopsis
 **ramalama pull** [*options*] *model*
@@ -23,6 +23,9 @@ Print usage message
 
 #### **--tls-verify**=*true*
 require HTTPS and verify certificates when contacting OCI registries
+
+#### **--verify**=*true*
+verify the model after pull, disable to allow pulling of models with different endianness
 
 ## See Also
 [ramalama(1)](/docs/commands/ramalama/)

--- a/docsite/docs/commands/ramalama/push.mdx
+++ b/docsite/docs/commands/ramalama/push.mdx
@@ -1,11 +1,11 @@
 ---
-title: ramalama push.1
+title: push
 description: push AI Models from local storage to remote registries
 # This file is auto-generated from manpages. Do not edit manually.
 # Source: ramalama-push.1.md
 ---
 
-# ramalama push.1
+# push
 
 ## Synopsis
 **ramalama push** [*options*] *model* [*target*]
@@ -74,7 +74,7 @@ Writing manifest to image destination
 ```
 
 ## See Also
-[ramalama(1)](/docs/commands/ramalama/), [ramalama-convert(1)](../../commands/ramalama/convert)
+[ramalama(1)](/docs/commands/ramalama/), [ramalama-convert(1)](/docs/commands/ramalama/convert)
 
 ---
 

--- a/docsite/docs/commands/ramalama/rag.mdx
+++ b/docsite/docs/commands/ramalama/rag.mdx
@@ -1,11 +1,11 @@
 ---
-title: ramalama rag.1
+title: rag
 description: generate and convert Retrieval Augmented Generation (RAG) data from provided documents into an OCI Image
 # This file is auto-generated from manpages. Do not edit manually.
 # Source: ramalama-rag.1.md
 ---
 
-# ramalama rag.1
+# rag
 
 ## Synopsis
 **ramalama rag** [options] [path ...] image
@@ -56,7 +56,7 @@ OCI container image to run with specified AI model. RamaLama defaults to using
 images based on the accelerator it discovers. For example:
 `quay.io/ramalama/ramalama-rag`. See the table below for all default images.
 The default image tag is based on the minor version of the RamaLama package.
-Version 0.12.1 of RamaLama pulls an image with a `:0.12` tag from the quay.io/ramalama OCI repository. The --image option overrides this default.
+Version 0.13.0 of RamaLama pulls an image with a `:0.12` tag from the quay.io/ramalama OCI repository. The --image option overrides this default.
 
 The default can be overridden in the ramalama.conf file or via the
 RAMALAMA_IMAGE environment variable. `export RAMALAMA_IMAGE=quay.io/ramalama/aiimage:1.2` tells

--- a/docsite/docs/commands/ramalama/rm.mdx
+++ b/docsite/docs/commands/ramalama/rm.mdx
@@ -1,11 +1,11 @@
 ---
-title: ramalama rm.1
+title: rm
 description: remove AI Models from local storage
 # This file is auto-generated from manpages. Do not edit manually.
 # Source: ramalama-rm.1.md
 ---
 
-# ramalama rm.1
+# rm
 
 ## Synopsis
 **ramalama rm** [*options*] *model* [...]

--- a/docsite/docs/commands/ramalama/run.mdx
+++ b/docsite/docs/commands/ramalama/run.mdx
@@ -1,11 +1,11 @@
 ---
-title: ramalama run.1
+title: run
 description: run specified AI Model as a chatbot
 # This file is auto-generated from manpages. Do not edit manually.
 # Source: ramalama-run.1.md
 ---
 
-# ramalama run.1
+# run
 
 ## Synopsis
 **ramalama run** [*options*] *model* [arg ...]
@@ -77,7 +77,7 @@ OCI container image to run with specified AI model. RamaLama defaults to using
 images based on the accelerator it discovers. For example:
 `quay.io/ramalama/ramalama`. See the table below for all default images.
 The default image tag is based on the minor version of the RamaLama package.
-Version 0.12.1 of RamaLama pulls an image with a `:0.12` tag from the quay.io/ramalama OCI repository. The --image option overrides this default.
+Version 0.13.0 of RamaLama pulls an image with a `:0.12` tag from the quay.io/ramalama OCI repository. The --image option overrides this default.
 
 The default can be overridden in the ramalama.conf file or via the
 RAMALAMA_IMAGE environment variable. `export RAMALAMA_IMAGE=quay.io/ramalama/aiimage:1.2` tells
@@ -101,6 +101,18 @@ If GPU device on host system is accessible to user via group access, this option
 
 #### **--keepalive**
 duration to keep a model loaded (e.g. 5m)
+
+#### **--max-tokens**=*integer*
+Maximum number of tokens to generate. Set to 0 for unlimited output (default: 0).
+This parameter is mapped to the appropriate runtime-specific parameter:
+- llama.cpp: `-n` parameter
+- MLX: `--max-tokens` parameter
+- vLLM: `--max-tokens` parameter
+
+#### **--mcp**=SERVER_URL
+MCP (Model Context Protocol) servers to use for enhanced tool calling capabilities.
+Can be specified multiple times to connect to multiple MCP servers.
+Each server provides tools that can be automatically invoked during chat conversations.
 
 #### **--name**, **-n**
 name of the container to run the Model in
@@ -229,10 +241,10 @@ $ ramalama run granite
 
 ## NVIDIA CUDA Support
 
-See [ramalama-cuda(7)](../../platform-guides/cuda) for setting up the host Linux system for CUDA support.
+See [ramalama-cuda(7)](/docs/platform-guides/cuda) for setting up the host Linux system for CUDA support.
 
 ## See Also
-[ramalama(1)](/docs/commands/ramalama/), [ramalama-cuda(7)](../../platform-guides/cuda)
+[ramalama(1)](/docs/commands/ramalama/), [ramalama-cuda(7)](/docs/platform-guides/cuda)
 
 ---
 

--- a/docsite/docs/commands/ramalama/serve.mdx
+++ b/docsite/docs/commands/ramalama/serve.mdx
@@ -1,11 +1,11 @@
 ---
-title: ramalama serve.1
+title: serve
 description: serve REST API on specified AI Model
 # This file is auto-generated from manpages. Do not edit manually.
 # Source: ramalama-serve.1.md
 ---
 
-# ramalama serve.1
+# serve
 
 ## Synopsis
 **ramalama serve** [*options*] _model_
@@ -106,6 +106,7 @@ Generate specified configuration format for running the AI Model as a service
 | quadlet      | Podman supported container definition for running AI Model under systemd |
 | kube         | Kubernetes YAML definition for running the AI Model as a service         |
 | quadlet/kube | Kubernetes YAML definition for running the AI Model as a service and Podman supported container definition for running the Kube YAML specified pod under systemd|
+| compose      | Compose YAML definition for running the AI Model as a service            |
 
 Optionally, an output directory for the generated files can be specified by
 appending the path to the type, e.g. `--generate kube:/etc/containers/systemd`.
@@ -121,7 +122,7 @@ OCI container image to run with specified AI model. RamaLama defaults to using
 images based on the accelerator it discovers. For example:
 `quay.io/ramalama/ramalama`. See the table above for all default images.
 The default image tag is based on the minor version of the RamaLama package.
-Version 0.12.1 of RamaLama pulls an image with a `:0.12` tag from the quay.io/ramalama OCI repository. The --image option overrides this default.
+Version 0.13.0 of RamaLama pulls an image with a `:0.12` tag from the quay.io/ramalama OCI repository. The --image option overrides this default.
 
 The default can be overridden in the ramalama.conf file or via the
 RAMALAMA_IMAGE environment variable. `export RAMALAMA_IMAGE=quay.io/ramalama/aiimage:1.2` tells
@@ -142,6 +143,13 @@ Accelerated images:
 #### **--keep-groups**
 pass --group-add keep-groups to podman (default: False)
 If GPU device on host system is accessible to user via group access, this option leaks the groups into the container.
+
+#### **--max-tokens**=*integer*
+Maximum number of tokens to generate. Set to 0 for unlimited output (default: 0).
+This parameter is mapped to the appropriate runtime-specific parameter:
+- llama.cpp: `-n` parameter
+- MLX: `--max-tokens` parameter
+- vLLM: `--max-tokens` parameter
 
 #### **--model-draft**
 
@@ -402,6 +410,30 @@ spec:
 	name: dri
 ```
 
+### Generate Compose file
+```bash
+$ ramalama serve --name=my-smollm-server --port 1234 --generate=compose smollm:135m
+Generating Compose YAML file: docker-compose.yaml
+$ cat docker-compose.yaml
+version: '3.8'
+services:
+  my-smollm-server:
+    image: quay.io/ramalama/ramalama:latest
+    container_name: my-smollm-server
+    command: ramalama serve --host 0.0.0.0 --port 1234 smollm:135m
+    ports:
+      - "1234:1234"
+    volumes:
+      - ~/.local/share/ramalama/models/smollm-135m-instruct:/mnt/models/model.file:ro
+    environment:
+      - HOME=/tmp
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges
+      - label=disable
+```
+
 ### Generate a Llama Stack Kubernetes YAML file named MyLamaStack
 ```bash
 $ ramalama serve --api llama-stack --name MyLamaStack --generate=kube oci://quay.io/rhatdan/granite:latest
@@ -520,7 +552,7 @@ WantedBy=multi-user.target default.target
 
 ## NVIDIA CUDA Support
 
-See [ramalama-cuda(7)](../../platform-guides/cuda) for setting up the host Linux system for CUDA support.
+See [ramalama-cuda(7)](/docs/platform-guides/cuda) for setting up the host Linux system for CUDA support.
 
 ## MLX Support
 
@@ -529,13 +561,13 @@ The MLX runtime is designed for Apple Silicon Macs and provides optimized perfor
 - **Operating System**: macOS only
 - **Hardware**: Apple Silicon (M1, M2, M3, or later)
 - **Container Mode**: MLX requires `--nocontainer` as it cannot run inside containers
-- **Dependencies**: Requires `mlx-lm` package to be installed on the host system
+- **Dependencies**: The `mlx-lm` uv package installed on the host system as a uv tool
 
-To install MLX dependencies, use either `uv` or `pip`:
+To install MLX dependencies, use `uv`:
 ```bash
-uv pip install mlx-lm
-# or pip:
-pip install mlx-lm
+uv tool install mlx-lm
+# or upgrade to the latest version:
+uv tool upgrade mlx-lm
 ```
 
 Example usage:
@@ -544,7 +576,7 @@ ramalama --runtime=mlx serve hf://mlx-community/Unsloth-Phi-4-4bit
 ```
 
 ## See Also
-[ramalama(1)](/docs/commands/ramalama/), [ramalama-stop(1)](../../commands/ramalama/stop), **quadlet(1)**, **systemctl(1)**, **podman(1)**, **podman-ps(1)**, [ramalama-cuda(7)](../../platform-guides/cuda)
+[ramalama(1)](/docs/commands/ramalama/), [ramalama-stop(1)](/docs/commands/ramalama/stop), **quadlet(1)**, **systemctl(1)**, **podman(1)**, **podman-ps(1)**, [ramalama-cuda(7)](/docs/platform-guides/cuda)
 
 ---
 

--- a/docsite/docs/commands/ramalama/stop.mdx
+++ b/docsite/docs/commands/ramalama/stop.mdx
@@ -1,11 +1,11 @@
 ---
-title: ramalama stop.1
+title: stop
 description: stop named container that is running AI Model
 # This file is auto-generated from manpages. Do not edit manually.
 # Source: ramalama-stop.1.md
 ---
 
-# ramalama stop.1
+# stop
 
 ## Synopsis
 **ramalama stop** [*options*] *name*
@@ -38,7 +38,7 @@ $ ramalama stop --all
 ```
 
 ## See Also
-[ramalama(1)](/docs/commands/ramalama/), [ramalama-run(1)](../../commands/ramalama/run), [ramalama-serve(1)](../../commands/ramalama/serve)
+[ramalama(1)](/docs/commands/ramalama/), [ramalama-run(1)](/docs/commands/ramalama/run), [ramalama-serve(1)](/docs/commands/ramalama/serve)
 
 ---
 

--- a/docsite/docs/commands/ramalama/version.mdx
+++ b/docsite/docs/commands/ramalama/version.mdx
@@ -1,11 +1,11 @@
 ---
-title: ramalama version.1
+title: version
 description: display version of RamaLama
 # This file is auto-generated from manpages. Do not edit manually.
 # Source: ramalama-version.1.md
 ---
 
-# ramalama version.1
+# version
 
 ## Synopsis
 **ramalama version**
@@ -22,9 +22,9 @@ Print usage message
 
 ```bash
 $ ramalama version
-ramalama version 0.12.1
+ramalama version 0.13.0
 $ ramalama -q version
-0.12.1
+0.13.0
 >
 ```
 ## See Also

--- a/docsite/docs/configuration/conf.mdx
+++ b/docsite/docs/configuration/conf.mdx
@@ -7,10 +7,6 @@ description: Configuration file reference
 
 # Configuration File
 
-# NAME
-ramalama.conf - These configuration files specifies default
-configuration options and command-line flags for RamaLama.
-
 # DESCRIPTION
 RamaLama reads all ramalama.conf files, if they exists
 and modify the defaults for running RamaLama on the host. ramalama.conf uses
@@ -71,6 +67,10 @@ The ramalama table contains settings to configure and manage the OCI runtime.
 Unified API layer for Inference, RAG, Agents, Tools, Safety, Evals, and Telemetry.
 Options: llama-stack, none
 
+**api_key**=""
+
+OpenAI-compatible API key. Can also be set via the RAMALAMA_API_KEY environment variable.
+
 **carimage**="registry.access.redhat.com/ubi10-micro:latest"
 
 OCI model car image
@@ -125,6 +125,11 @@ specified vllm model runtime.
 
 Pass `--group-add keep-groups` to podman, when using podman.
 In some cases this is needed to access the gpu from a rootless container
+
+**max_tokens**=0
+
+Maximum number of tokens to generate. Set to 0 for unlimited output (default: 0).
+This parameter is mapped to the appropriate runtime-specific parameter when executing models.
 
 **ngl**=-1
 

--- a/docsite/docs/configuration/ramalama-oci.mdx
+++ b/docsite/docs/configuration/ramalama-oci.mdx
@@ -7,9 +7,6 @@ description: Configuration file reference
 
 # OCI Spec
 
-# NAME
-ramalama-oci - RamaLama oci:// Image Format
-
 # DESCRIPTION
 RamaLama’s `oci://` transport uses [OpenContainers image registries](https://github.com/opencontainers/distribution-spec) to store AI models.
 

--- a/docsite/docs/platform-guides/cann.mdx
+++ b/docsite/docs/platform-guides/cann.mdx
@@ -1,11 +1,11 @@
 ---
-title: ramalama cann.7
+title: cann
 description: Platform-specific setup guide
 # This file is auto-generated from manpages. Do not edit manually.
 # Source: ramalama-cann.7.md
 ---
 
-# ramalama cann.7
+# cann
 
 # Setting Up RamaLama with Ascend NPU Support on Linux systems
 

--- a/docsite/docs/platform-guides/cuda.mdx
+++ b/docsite/docs/platform-guides/cuda.mdx
@@ -1,11 +1,11 @@
 ---
-title: ramalama cuda.7
+title: cuda
 description: Platform-specific setup guide
 # This file is auto-generated from manpages. Do not edit manually.
 # Source: ramalama-cuda.7.md
 ---
 
-# ramalama cuda.7
+# cuda
 
 # Setting Up RamaLama with CUDA Support on Linux systems
 

--- a/docsite/docs/platform-guides/macos.mdx
+++ b/docsite/docs/platform-guides/macos.mdx
@@ -1,11 +1,11 @@
 ---
-title: ramalama macos.7
+title: macos
 description: Platform-specific setup guide
 # This file is auto-generated from manpages. Do not edit manually.
 # Source: ramalama-macos.7.md
 ---
 
-# ramalama macos.7
+# macos
 
 # Configure Podman Machine on Mac for GPU Acceleration
 

--- a/docsite/docs/platform-guides/musa.mdx
+++ b/docsite/docs/platform-guides/musa.mdx
@@ -1,11 +1,11 @@
 ---
-title: ramalama musa.7
+title: musa
 description: Platform-specific setup guide
 # This file is auto-generated from manpages. Do not edit manually.
 # Source: ramalama-musa.7.md
 ---
 
-# ramalama musa.7
+# musa
 
 # Setting Up RamaLama with MUSA Support on Linux systems
 

--- a/docsite/package-lock.json
+++ b/docsite/package-lock.json
@@ -16786,7 +16786,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/type-fest": {
       "version": "2.19.0",
@@ -17986,6 +17987,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
       "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
## Summary by Sourcery

Update documentation for RamaLama 0.13.0: strip manpage numbering, introduce new CLI options, enhance serve outputs, revise config entries, and adjust links.

New Features:
- Add --max-tokens option to serve, run, and perplexity commands
- Add --mcp option to run and chat commands

Enhancements:
- Add compose output type to ramalama serve with sample Docker Compose YAML
- Add api_key and max_tokens settings to ramalama.conf reference
- Revise MLX dependency installation to use uv tool install/upgrade
- Switch cross-link URLs to consistent /docs/ paths
- Bump all version references to 0.13.0
- Add --verify flag to ramalama pull

Documentation:
- Remove manpage number suffixes from document titles and headings via convert_manpages script