### PR TITLE
Prefer the embedded chat template for ollama models

### DIFF
--- a/ramalama/model_store/reffile.py
+++ b/ramalama/model_store/reffile.py
@@ -165,7 +165,7 @@ class RefJSONFile:
     path: str
     files: list[StoreFile]
 
-    version: str = "v1.0"
+    version: str = "v1.0.1"
 
     def to_json(self) -> str:
         return json.dumps(self, default=lambda o: o.__dict__, sort_keys=True, indent=2)

--- a/ramalama/model_store/store.py
+++ b/ramalama/model_store/store.py
@@ -91,14 +91,16 @@ class ModelStore:
 
     def get_ref_file(self, model_tag: str) -> Optional[RefJSONFile]:
         ref_file_path = self.get_ref_file_path(model_tag)
-        ref = migrate_reffile_to_refjsonfile(ref_file_path, self.snapshots_directory)
-        if ref is not None:
-            return ref
-
-        if not os.path.exists(ref_file_path):
-            return None
-
-        return RefJSONFile.from_path(ref_file_path)
+        ref_file = migrate_reffile_to_refjsonfile(ref_file_path, self.snapshots_directory)
+        if ref_file is None:
+            if os.path.exists(ref_file_path):
+                ref_file = RefJSONFile.from_path(ref_file_path)
+        if ref_file is not None:
+            if ref_file.version != RefJSONFile.version:
+                # 0.13.0 chat template conversion logic was wrong, force a refresh
+                ref_file.version = RefJSONFile.version
+                self._ensure_chat_template(ref_file, snapshot_hash=ref_file.hash)
+        return ref_file
 
     def update_ref_file(
         self, model_tag: str, snapshot_hash: str = "", snapshot_files: Optional[list[SnapshotFile]] = None
@@ -195,7 +197,9 @@ class ModelStore:
 
         return (ref_file.hash, cached_files, len(cached_files) == len(ref_file.files))
 
-    def _prepare_new_snapshot(self, model_tag: str, snapshot_hash: str, snapshot_files: list[SnapshotFile]):
+    def _prepare_new_snapshot(
+        self, model_tag: str, snapshot_hash: str, snapshot_files: list[SnapshotFile]
+    ) -> RefJSONFile:
         validate_snapshot_files(snapshot_files)
         self.ensure_directory_setup()
 
@@ -209,12 +213,11 @@ class ModelStore:
 
         snapshot_directory = self.get_snapshot_directory(snapshot_hash)
         os.makedirs(snapshot_directory, exist_ok=True)
+        return ref_file
 
-    def _download_snapshot_files(self, model_tag: str, snapshot_hash: str, snapshot_files: Sequence[SnapshotFile]):
-        ref_file: None | RefJSONFile = self.get_ref_file(model_tag)
-        if ref_file is None:
-            raise ValueError("Cannot download snapshots without a valid ref file.")
-
+    def _download_snapshot_files(
+        self, ref_file: RefJSONFile, snapshot_hash: str, snapshot_files: Sequence[SnapshotFile]
+    ):
         for file in snapshot_files:
             dest_path = self.get_blob_file_path(file.hash)
             blob_relative_path = ""
@@ -247,11 +250,7 @@ class ModelStore:
         # save updated ref file
         ref_file.write_to_file()
 
-    def _try_convert_existing_chat_template(self, model_tag: str, snapshot_hash: str) -> bool:
-        ref_file = self.get_ref_file(model_tag)
-        if ref_file is None:
-            return False
-
+    def _try_convert_existing_chat_template(self, ref_file: RefJSONFile, snapshot_hash: str) -> bool:
         for file in ref_file.chat_templates:
             chat_template_file_path = self.get_blob_file_path(file.hash)
             with open(chat_template_file_path, "r") as template_file:
@@ -270,36 +269,36 @@ class ModelStore:
                     continue
 
             files = [LocalSnapshotFile(normalized_template, "chat_template_converted", SnapshotFileType.ChatTemplate)]
-            self.update_snapshot(model_tag, snapshot_hash, files)
+            self._update_snapshot(ref_file, snapshot_hash, files)
             return True
 
         return False
 
-    def _ensure_chat_template(self, model_tag: str, snapshot_hash: str):
-        # Give preference to a chat template that has been specified in the file list
-        # If it succeeds, then return. Otherwise continue and try to extract from model file
-        if self._try_convert_existing_chat_template(model_tag, snapshot_hash):
-            return
+    def _ensure_chat_template(self, ref_file: RefJSONFile, snapshot_hash: str):
+        # Give preference to the embedded chat template as it's most likely to be
+        # compatible with llama.cpp
 
-        ref = self.get_ref_file(model_tag)
-        if ref is None:
-            return
-        models = ref.model_files
-        if not models:
-            return
+        def get_embedded_template():
+            models = ref_file.model_files
+            if not models:
+                return
 
-        # Only the first model file is considered for chat template extraction
-        model_file_path = self.get_blob_file_path(models[0].hash)
-        if not GGUFInfoParser.is_model_gguf(model_file_path):
-            return
+            # Only the first model file is considered for chat template extraction
+            model_file_path = self.get_blob_file_path(models[0].hash)
+            if not GGUFInfoParser.is_model_gguf(model_file_path):
+                return
 
-        # Parse model, first and second parameter are irrelevant here
-        info: GGUFModelInfo = GGUFInfoParser.parse("model", "registry", model_file_path)
-        tmpl = info.get_chat_template()
+            # Parse model, first and second parameter are irrelevant here
+            info: GGUFModelInfo = GGUFInfoParser.parse("model", "registry", model_file_path)
+            return info.get_chat_template()
+
+        tmpl = get_embedded_template()
+
         if tmpl is None:
+            self._try_convert_existing_chat_template(ref_file, snapshot_hash)
             return
 
-        needs_conversion = not go2jinja.is_go_template(tmpl)
+        needs_conversion = go2jinja.is_go_template(tmpl)
 
         # Only jinja templates are usable for the supported backends, therefore don't mark file as
         # chat template if it is a Go Template (ollama-specific)
@@ -318,8 +317,14 @@ class ModelStore:
                 )
             except Exception as ex:
                 logger.debug(f"Failed to convert Go Template to Jinja: {ex}")
-
-        self.update_snapshot(model_tag, snapshot_hash, files)
+        else:
+            for file in ref_file.files:
+                if file.name == "chat_template_converted":
+                    # Should not exist but 0.13.0 needs_conversion logic was inverted
+                    self._remove_blob_file(self.get_snapshot_file_path(ref_file.hash, file.name))
+                    ref_file.remove_file(file.hash)
+                    break
+        self._update_snapshot(ref_file, snapshot_hash, files)
 
     def _verify_endianness(self, model_tag: str):
         ref_file = self.get_ref_file(model_tag)
@@ -346,9 +351,9 @@ class ModelStore:
         snapshot_hash = sanitize_filename(snapshot_hash)
 
         try:
-            self._prepare_new_snapshot(model_tag, snapshot_hash, snapshot_files)
-            self._download_snapshot_files(model_tag, snapshot_hash, snapshot_files)
-            self._ensure_chat_template(model_tag, snapshot_hash)
+            ref_file = self._prepare_new_snapshot(model_tag, snapshot_hash, snapshot_files)
+            self._download_snapshot_files(ref_file, snapshot_hash, snapshot_files)
+            self._ensure_chat_template(ref_file, snapshot_hash)
         except urllib.error.HTTPError as ex:
             perror(f"Failed to fetch required file: {ex}")
             perror("Removing snapshot...")
@@ -368,15 +373,13 @@ class ModelStore:
             self.remove_snapshot(model_tag)
             raise ex
 
-    def update_snapshot(self, model_tag: str, snapshot_hash: str, new_snapshot_files: Sequence[SnapshotFile]) -> bool:
+    def _update_snapshot(
+        self, ref_file: RefJSONFile, snapshot_hash: str, new_snapshot_files: Sequence[SnapshotFile]
+    ) -> bool:
         validate_snapshot_files(new_snapshot_files)
         snapshot_hash = sanitize_filename(snapshot_hash)
 
         if not self.directory_setup_exists():
-            return False
-
-        ref_file = self.get_ref_file(model_tag)
-        if ref_file is None:
             return False
 
         # update ref file with deduplication by file hash
@@ -392,7 +395,7 @@ class ModelStore:
                 )
         ref_file.write_to_file()
 
-        self._download_snapshot_files(model_tag, snapshot_hash, new_snapshot_files)
+        self._download_snapshot_files(ref_file, snapshot_hash, new_snapshot_files)
         return True
 
     def _remove_blob_file(self, snapshot_file_path: str):

--- a/test/unit/test_model_store.py
+++ b/test/unit/test_model_store.py
@@ -65,18 +65,18 @@ def test_try_convert_existing_chat_template_converts_flat_jinja(tmp_path, monkey
 
     captured = {}
 
-    def fake_update_snapshot(model_tag_arg, snapshot_hash_arg, files):
-        captured["model_tag"] = model_tag_arg
+    def fake_update_snapshot(ref_file_arg, snapshot_hash_arg, files):
+        captured["ref_file"] = ref_file_arg
         captured["snapshot_hash"] = snapshot_hash_arg
         captured["files"] = files
         return True
 
-    monkeypatch.setattr(model_store, "update_snapshot", fake_update_snapshot)
+    monkeypatch.setattr(model_store, "_update_snapshot", fake_update_snapshot)
 
-    converted = model_store._try_convert_existing_chat_template(model_tag, snapshot_hash)
+    converted = model_store._try_convert_existing_chat_template(ref, snapshot_hash)
 
     assert converted is True
-    assert captured["model_tag"] == model_tag
+    assert captured["ref_file"] == ref
     assert captured["snapshot_hash"] == snapshot_hash
     assert len(captured["files"]) == 1
     converted_file = captured["files"][0]


### PR DESCRIPTION
If a chat template is embedded in gguf it is more likely to be compatibe with llama.cpp. Converting ollama go templates works for older models but the logic has diverged significantly in more recent models with complex templates for tool calling.

Also cleanup a regression in the needs_conversion logic from 0.13

Fixes: #2033
Fixes: #1882

## Summary by Sourcery

Prefer embedded chat templates in GGUF-based Ollama models for compatibility, fix a regression in the chat-template conversion logic from version 0.13, and refactor snapshot and template-handling methods to use the RefJSONFile object directly.

Bug Fixes:
- Correct inverted conversion-necessity logic introduced in version 0.13

Enhancements:
- Give precedence to embedded chat templates over Go-to-Jinja conversions for recent models
- Refactor internal snapshot methods to accept and operate on RefJSONFile instances instead of model tags
- Automatically bump and refresh ref-file version when encountering outdated conversion logic
- Bump RefJSONFile version to v1.0.1

Tests:
- Update unit tests to reflect the new snapshot update method signature