### PR TITLE
Renaming huggingface-cli -> hf

### DIFF
--- a/README.md
+++ b/README.md
@@ -834,7 +834,7 @@ $ cat /usr/share/ramalama/shortnames.conf
     $ ramalama login --token=XYZ
     ```
 
-    Logging in to Hugging Face requires the `huggingface-cli tool`. For installation and usage instructions, see the documentation of the [Hugging Face command line interface](https://huggingface.co/docs/huggingface_hub/en/guides/cli).
+    Logging in to Hugging Face requires the `hf tool`. For installation and usage instructions, see the documentation of the [Hugging Face command line interface](https://huggingface.co/docs/huggingface_hub/en/guides/cli).
 </details>
 
 ### [`ramalama-logout`](https://github.com/containers/ramalama/blob/main/docs/ramalama-logout.1.md)

--- a/docs/ramalama-login.1.md
+++ b/docs/ramalama-login.1.md
@@ -54,7 +54,7 @@ Login to huggingface registry
 $ export RAMALAMA_TRANSPORT=huggingface
 $ ramalama login --token=XYZ
 ```
-Logging in to Hugging Face requires the `huggingface-cli` tool. For installation and usage instructions, see the documentation of the Hugging Face command line interface: [*https://huggingface.co/docs/huggingface_hub/en/guides/cli*](https://huggingface.co/docs/huggingface_hub/en/guides/cli).
+Logging in to Hugging Face requires the `hf` tool. For installation and usage instructions, see the documentation of the Hugging Face command line interface: [*https://huggingface.co/docs/huggingface_hub/en/guides/cli*](https://huggingface.co/docs/huggingface_hub/en/guides/cli).
 
 Login to ModelScope registry
 ```

--- a/docsite/docs/commands/ramalama/login.mdx
+++ b/docsite/docs/commands/ramalama/login.mdx
@@ -58,7 +58,7 @@ Login to huggingface registry
 $ export RAMALAMA_TRANSPORT=huggingface
 $ ramalama login --token=XYZ
 ```
-Logging in to Hugging Face requires the `huggingface-cli` tool. For installation and usage instructions, see the documentation of the Hugging Face command line interface: [*https://huggingface.co/docs/huggingface_hub/en/guides/cli*](https://huggingface.co/docs/huggingface_hub/en/guides/cli).
+Logging in to Hugging Face requires the `hf` tool. For installation and usage instructions, see the documentation of the Hugging Face command line interface: [*https://huggingface.co/docs/huggingface_hub/en/guides/cli*](https://huggingface.co/docs/huggingface_hub/en/guides/cli).
 
 Login to ModelScope registry
 ```bash

--- a/ramalama/hf_style_repo_base.py
+++ b/ramalama/hf_style_repo_base.py
@@ -186,7 +186,7 @@ class HFStyleRepoModel(Transport, ABC):
 
     @abstractmethod
     def get_cli_command(self):
-        """Return the CLI command name (e.g., 'huggingface-cli', 'modelscope')"""
+        """Return the CLI command name (e.g., 'hf', 'modelscope')"""
         pass
 
     @abstractmethod

--- a/ramalama/transports/huggingface.py
+++ b/ramalama/transports/huggingface.py
@@ -25,9 +25,9 @@ sudo dnf install python3-huggingface-hub
 """
 
 
-def is_huggingface_cli_available():
+def is_hf_cli_available():
     """Check if huggingface-cli is available on the system."""
-    return available("huggingface-cli")
+    return available("hf")
 
 
 def huggingface_token():
@@ -150,10 +150,10 @@ class Huggingface(HFStyleRepoModel):
         super().__init__(model, model_store_path)
 
         self.type = "huggingface"
-        self.hf_cli_available = is_huggingface_cli_available()
+        self.hf_cli_available = is_hf_cli_available()
 
     def get_cli_command(self):
-        return "huggingface-cli"
+        return "hf"
 
     def get_missing_message(self):
         return missing_huggingface
@@ -177,7 +177,7 @@ class Huggingface(HFStyleRepoModel):
             return HuggingfaceRepository(name, organization, tag)
 
     def get_cli_download_args(self, directory_path, model):
-        return ["huggingface-cli", "download", "--local-dir", directory_path, model]
+        return ["hf", "download", "--local-dir", directory_path, model]
 
     def extract_model_identifiers(self):
         model_name, model_tag, model_organization = super().extract_model_identifiers()
@@ -230,7 +230,7 @@ class Huggingface(HFStyleRepoModel):
             raise NotImplementedError(self.get_missing_message())
         proc = run_cmd(
             [
-                "huggingface-cli",
+                "hf",
                 "upload",
                 "--repo-type",
                 "model",

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -70,8 +70,6 @@ skip_if_gh_actions_darwin = pytest.mark.skipif(
     reason="GitHub Actions Darwin has not container support",
 )
 
-skip_if_no_huggingface_cli = pytest.mark.skipif(
-    shutil.which("huggingface-cli") is None, reason="huggingface-cli not installed"
-)
+skip_if_no_huggingface_cli = pytest.mark.skipif(shutil.which("hf") is None, reason="hf cli not installed")
 
 skip_if_no_llama_bench = pytest.mark.skipif(shutil.which("llama-bench") is None, reason="llama-bench not installed")

--- a/test/system/050-pull.bats
+++ b/test/system/050-pull.bats
@@ -77,7 +77,7 @@ load setup_suite
     is "$output" ".*Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS" "image was actually pulled locally"
     run_ramalama rm huggingface://Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS.gguf
 
-    skip_if_no_hf-cli
+    skip_if_no_hf_cli
     run_ramalama pull hf://HuggingFaceTB/SmolLM-135M
     run_ramalama list
     is "$output" ".*HuggingFaceTB/SmolLM-135M" "image was actually pulled locally"
@@ -118,9 +118,9 @@ load setup_suite
 }
 
 # bats test_tags=distro-integration
-@test "ramalama pull huggingface-cli cache" {
-    skip_if_no_hf-cli
-    huggingface-cli download Felladrin/gguf-smollm-360M-instruct-add-basics smollm-360M-instruct-add-basics.IQ2_XXS.gguf
+@test "ramalama pull hf cli cache" {
+    skip_if_no_hf_cli
+    hf download Felladrin/gguf-smollm-360M-instruct-add-basics smollm-360M-instruct-add-basics.IQ2_XXS.gguf
 
     run_ramalama pull hf://Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS.gguf
     run_ramalama list

--- a/test/system/helpers.bash
+++ b/test/system/helpers.bash
@@ -268,10 +268,10 @@ function is_apple_silicon() {
     fi
 }
 
-function skip_if_no_hf-cli(){
-    if ! command -v huggingface-cli 2>&1 >/dev/null
+function skip_if_no_hf_cli(){
+    if ! command -v hf 2>&1 >/dev/null
     then
-        skip "Not supported without huggingface-cli"
+        skip "Not supported without hf client"
     fi
 }
 


### PR DESCRIPTION
Based on that announcment

https://huggingface.co/blog/hf-cli?utm_source=chatgpt.com
The change is a straightforward rename that affects documentation (README.md, man pages, docsite), Python implementation (huggingface.py transport and base class), and test infrastructure to align with Hugging Face's current CLI tooling.

## Summary by Sourcery

Rename the Hugging Face CLI command from “huggingface-cli” to “hf” to align with the official tool, updating all relevant code, documentation, and tests.

Enhancements:
- Replace all code references to the “huggingface-cli” command with “hf” in transport modules and base classes.

Documentation:
- Update README, man pages, and docsite pages to refer to the “hf” tool instead of “huggingface-cli”.

Tests:
- Adjust system and pytest tests (helpers, conftest, bats scripts) to use “hf” for availability checks and download/upload commands.