### PR TITLE
Fix AMD GPU image selection on arm64 for issue #2045

### DIFF
--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -429,6 +429,10 @@ def check_ascend() -> Literal["cann"] | None:
 
 
 def check_rocm_amd() -> Literal["hip"] | None:
+    if is_arm():
+        # ROCm is not available for arm64, use Vulkan instead
+        return None
+
     gpu_num = 0
     gpu_bytes = 0
     for i, (np, props) in enumerate(amdkfd.gpus()):
@@ -455,6 +459,10 @@ def check_rocm_amd() -> Literal["hip"] | None:
         return "hip"
 
     return None
+
+
+def is_arm() -> bool:
+    return platform.machine() in ('arm64', 'aarch64')
 
 
 def check_intel() -> Literal["intel"] | None:


### PR DESCRIPTION
On arm64 systems with AMD GPUs, ROCm is not available, so we need
to use Vulkan instead. This change detects when running on arm64
architecture and returns no AMD support and allows normal selection
to continue.

Fixes: https://github.com/containers/ramalama/issues/2045

## Summary by Sourcery

Bug Fixes:
- Use Vulkan instead of ROCm on arm64 by setting GGML_VK_VISIBLE_DEVICES for AMD GPUs