### PR TITLE
Added export and import command to RamaLama

### DIFF
--- a/docs/ramalama-export.1.md
+++ b/docs/ramalama-export.1.md
@@ -1,0 +1,46 @@
+% ramalama-export 1
+
+## NAME
+ramalama\-export - export all AI Models to a tarball
+
+## SYNOPSIS
+**ramalama export**
+
+## DESCRIPTION
+Export all AI Models in the store of RamaLama as tarball so it can be imported on another machine.
+
+## OPTIONS
+
+#### **--filename**
+The name of the produced tarball containing all AI Models of the store.
+Defaults to ramalama.tar.gz.
+
+#### **--help**, **-h**
+Print usage message
+
+#### **--output**
+The output directory to save the ramalama.tar.gz to.
+Defaults to /var/tmp.
+
+## EXAMPLES
+
+```
+$ ramalama export --output /tmp
+Exporting store '/usr/share/ramalama/store' to '/tmp/ramalama.tar.gz'
+   Processing '/usr/share/ramalama/store/huggingface'...
+   Processing '/usr/share/ramalama/store/file'...
+
+$ ramalama --store /usr/share/ramalama export --output /tmp
+Exporting store '/usr/share/ramalama/store' to '/tmp/ramalama.tar.gz'
+   Processing '/usr/share/ramalama/store/huggingface'...
+   Processing '/usr/share/ramalama/store/ollama'...
+   Processing '/usr/share/ramalama/store/https'...
+   Processing '/usr/share/ramalama/store/file'...
+>
+```
+## SEE ALSO
+**[ramalama(1)](ramalama.1.md)**
+**[ramalama-import(1)](ramalama-import.1.md)**
+
+## HISTORY
+Oct 2025, Originally compiled by Michael Engel <mengel@redhat.com>

--- a/docs/ramalama-import.1.md
+++ b/docs/ramalama-import.1.md
@@ -1,0 +1,35 @@
+% ramalama-import 1
+
+## NAME
+ramalama\-import - import an tarball of AI Models
+
+## SYNOPSIS
+**ramalama import**
+
+## DESCRIPTION
+Import all AI Models of a previously exported RamaLama tarball into the current store.
+
+## OPTIONS
+
+#### **--help**, **-h**
+Print usage message
+
+#### **--input**
+The path to the ramalama.tar.gz tarball to import into the current model store.
+
+## EXAMPLES
+
+```
+$ ramalama import --input /tmp/ramalama.tar.gz
+Importing '/tmp/ramalama.tar.gz' into '/usr/share/ramalama/store
+
+$ ramalama --store /tmp/ramalama import --input /tmp/ramalama.tar.gz
+Importing '/tmp/ramalama.tar.gz' into '/tmp/ramalama/store
+>
+```
+## SEE ALSO
+**[ramalama(1)](ramalama.1.md)**
+**[ramalama-export(1)](ramalama-export.1.md)**
+
+## HISTORY
+Oct 2025, Originally compiled by Michael Engel <mengel@redhat.com>

--- a/docs/ramalama.1.md
+++ b/docs/ramalama.1.md
@@ -141,6 +141,8 @@ The default can be overridden in the ramalama.conf file.
 | [ramalama-containers(1)](ramalama-containers.1.md)|list all RamaLama containers|
 | [ramalama-convert(1)](ramalama-convert.1.md)      |convert AI Models from local storage to OCI Image|
 | [ramalama-daemon(1)](ramalama-daemon.1.md)        |run a RamaLama REST server|
+| [ramalama-export(1)](ramalama-export.1.md)        |export all AI Models to a tarball|
+| [ramalama-import(1)](ramalama-import.1.md)        |import an tarball of AI Models|
 | [ramalama-info(1)](ramalama-info.1.md)            |display RamaLama configuration information|
 | [ramalama-inspect(1)](ramalama-inspect.1.md)      |inspect the specified AI Model|
 | [ramalama-list(1)](ramalama-list.1.md)            |list all downloaded AI Models|

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -304,6 +304,8 @@ def configure_subcommands(parser):
     stop_parser(subparsers)
     version_parser(subparsers)
     daemon_parser(subparsers)
+    export_parser(subparsers)
+    import_parser(subparsers)
 
 
 def parse_arguments(parser):
@@ -1309,6 +1311,39 @@ def daemon_run_cli(args):
     from ramalama.daemon.daemon import run
 
     run(host=args.host, port=int(args.port), model_store_path=args.store)
+
+
+def export_parser(subparsers):
+    parser: ArgumentParserWithDefaults = subparsers.add_parser("export", help="export the model store as tarball")
+    parser.add_argument(
+        "--output",
+        default="/var/tmp/",
+        help="output directory to place the tarball",
+    )
+    parser.add_argument(
+        "--filename",
+        default="ramalama.tar.gz",
+        help="name of the tarball",
+    )
+    parser.set_defaults(func=export_cli)
+
+
+def export_cli(args):
+    GlobalModelStore(args.store).tar_export(Path(args.output), args.filename)
+
+
+def import_parser(subparsers):
+    parser: ArgumentParserWithDefaults = subparsers.add_parser("import", help="import a model store tarball")
+    parser.add_argument(
+        "--input",
+        help="path to the model store tarball to import",
+        required=True,
+    )
+    parser.set_defaults(func=import_cli)
+
+
+def import_cli(args):
+    GlobalModelStore(args.store).tar_import(Path(args.input))
 
 
 def version_parser(subparsers):

--- a/ramalama/model_store/global_store.py
+++ b/ramalama/model_store/global_store.py
@@ -1,4 +1,6 @@
 import os
+import pathlib
+import tarfile
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Dict, List
@@ -97,3 +99,27 @@ class GlobalModelStore:
     #    3. for empty folders -> delete
     def cleanup(self):
         pass
+
+    def tar_export(self, output_directory: pathlib.Path, tar_name: str):
+        if not output_directory.exists():
+            raise FileNotFoundError(f"Directory not found: '{output_directory.as_posix()}'")
+        if not output_directory.is_dir():
+            raise NotADirectoryError(f"Output path '{output_directory}' not a directory")
+
+        target_path = os.path.join(output_directory.as_posix(), tar_name)
+        print(f"Exporting store '{self.path}' to '{target_path}'")
+        with tarfile.open(target_path, "w:gz") as tar:
+            for entry in os.listdir(self.path):
+                p = pathlib.Path(os.path.join(self.path), entry)
+                if not p.is_dir():
+                    continue
+                print(f"   Processing '{p.as_posix()}'...")
+                tar.add(p, arcname=os.path.basename(p))
+
+    def tar_import(self, tarball_path: pathlib.Path):
+        if not tarball_path.exists():
+            raise FileNotFoundError(f"tarball not found: '{tarball_path.as_posix()}'")
+
+        print(f"Importing '{tarball_path.as_posix()}' into '{self.path}")
+        with tarfile.open(tarball_path, "r:gz") as tar:
+            tar.extractall(self.path)

--- a/test/e2e/test_export_import.py
+++ b/test/e2e/test_export_import.py
@@ -1,0 +1,24 @@
+from test.e2e.utils import RamalamaExecWorkspace
+
+import pytest
+
+
+@pytest.mark.e2e
+def test_export_import():
+
+    old_store_path = "{workspace_dir}/.local/share/ramalama"
+    new_store_path = "{workspace_dir}/.local/share/ramalama-new"
+
+    with RamalamaExecWorkspace() as ctx:
+        assert 0 == ctx.check_call(["ramalama", "--store", old_store_path, "pull", "smollm:135m"])
+        assert "hf://HuggingFaceTB/smollm-135M-instruct-v0.2-Q8_0-GGUF" in ctx.check_output(
+            ["ramalama", "--store", old_store_path, "ls"]
+        )
+
+        assert 0 == ctx.check_call(["ramalama", "--store", old_store_path, "export", "--output", "/var/tmp"])
+        assert 0 == ctx.check_call(
+            ["ramalama", "--store", new_store_path, "import", "--input", "/var/tmp/ramalama.tar.gz"]
+        )
+        assert "hf://HuggingFaceTB/smollm-135M-instruct-v0.2-Q8_0-GGUF" in ctx.check_output(
+            ["ramalama", "--store", new_store_path, "ls"]
+        )


### PR DESCRIPTION
Solves: https://github.com/containers/ramalama/issues/2054

Added export and import command to RamaLama to simplify moving the model store to another machine.

## Summary by Sourcery

Introduce export and import commands to the CLI for migrating the model store via tarball, implement the underlying tarball logic in GlobalModelStore, add corresponding documentation, and include an end-to-end test for the workflow

New Features:
- Add 'export' CLI subcommand to package the model store into a compressed tarball
- Add 'import' CLI subcommand to restore a model store from a tarball
- Implement tar_export and tar_import methods in GlobalModelStore for tarball operations

Documentation:
- Add user-facing documentation pages for the export and import commands

Tests:
- Add end-to-end test to verify the export-import workflow preserves models