### PR TITLE
docker: fix list command for oci images when running in a non-UTC timezone

### DIFF
--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -135,7 +135,7 @@ def exec_cmd(args, stdout2null: bool = False, stderr2null: bool = False):
         raise
 
 
-def run_cmd(args, cwd=None, stdout=subprocess.PIPE, ignore_stderr=False, ignore_all=False, encoding=None):
+def run_cmd(args, cwd=None, stdout=subprocess.PIPE, ignore_stderr=False, ignore_all=False, encoding=None, env=None):
     """
     Run the given command arguments.
 
@@ -151,6 +151,7 @@ def run_cmd(args, cwd=None, stdout=subprocess.PIPE, ignore_stderr=False, ignore_
     logger.debug(f"Working directory: {cwd}")
     logger.debug(f"Ignore stderr: {ignore_stderr}")
     logger.debug(f"Ignore all: {ignore_all}")
+    logger.debug(f"env: {env}")
 
     serr = None
     if ignore_all or ignore_stderr:
@@ -160,7 +161,10 @@ def run_cmd(args, cwd=None, stdout=subprocess.PIPE, ignore_stderr=False, ignore_
     if ignore_all:
         sout = subprocess.DEVNULL
 
-    result = subprocess.run(args, check=True, cwd=cwd, stdout=sout, stderr=serr, encoding=encoding)
+    if env:
+        env = os.environ | env
+
+    result = subprocess.run(args, check=True, cwd=cwd, stdout=sout, stderr=serr, encoding=encoding, env=env)
     logger.debug(f"Command finished with return code: {result.returncode}")
 
     return result

--- a/ramalama/oci_tools.py
+++ b/ramalama/oci_tools.py
@@ -27,8 +27,8 @@ def list_manifests(args: EngineArgType):
         "manifest=true",
         "--format",
         (
-            '{"name":"oci://{{ .Repository }}:{{ .Tag }}","modified":"{{ .CreatedAt }}",        "size":{{ .VirtualSize'
-            ' }}, "ID":"{{ .ID }}"},'
+            '{"name":"oci://{{ .Repository }}:{{ .Tag }}","modified":"{{ .CreatedAt }}",'
+            '"size":{{ .VirtualSize }}, "ID":"{{ .ID }}"},'
         ),
     ]
     output = run_cmd(conman_args).stdout.decode("utf-8").strip()
@@ -91,7 +91,7 @@ def list_models(args: EngineArgType):
         "--format",
         formatLine,
     ]
-    output = run_cmd(conman_args).stdout.decode("utf-8").strip()
+    output = run_cmd(conman_args, env={"TZ": "UTC"}).stdout.decode("utf-8").strip()
     if output == "":
         return []
 


### PR DESCRIPTION
`docker images` outputs the `CreatedAt` field in the local timezone, which breaks the code in `oci_tools.list_models()` that assumes the timezone is always `UTC`, as it is with `podman`. Explicitly set the `TZ=UTC` environment variable when running `docker images` to avoid the error.

Also includes a minor formatting fix in `list_manifests()` to make debug output more readable.

## Summary by Sourcery

Allow injecting environment variables into run_cmd and use TZ=UTC for docker image listings to fix timezone mismatches, while cleaning up JSON formatting in manifest debug output.

Bug Fixes:
- Fix timezone assumption in list_models by setting TZ=UTC for docker image list commands

Enhancements:
- Add env parameter to run_cmd to allow custom environment variables
- Merge provided env with existing environment and log it for debugging
- Reformat JSON string in list_manifests for improved readability