### PR TITLE
Improving ramalama rag section in README.md 

### DIFF
--- a/README.md
+++ b/README.md
@@ -936,11 +936,17 @@ $ cat /usr/share/ramalama/shortnames.conf
     IMAGE OCI Image name to contain processed rag data
 
     ```
-    ./bin/ramalama rag ./README.md https://github.com/containers/podman/blob/main/README.md quay.io/rhatdan/myrag
+    ramalama rag ./README.md https://github.com/containers/podman/blob/main/README.md quay.io/ramalama/myrag
     100% |███████████████████████████████████████████████████████|  114.00 KB/    0.00 B 922.89 KB/s   59m 59s
     Building quay.io/ramalama/myrag...
     adding vectordb...
     c857ebc65c641084b34e39b740fdb6a2d9d2d97be320e6aa9439ed0ab8780fe0
+    ```
+
+    The image can then be used with:
+
+    ```
+    ramalama run --rag quay.io/ramalama/myrag instructlab/merlinite-7b-lab
     ```
 </details>
 


### PR DESCRIPTION
The existing text didn't properly roll up in the details section. The command used also wasn't in line with the other examples and there wasn't an example showing what to do with the generated database.

## Summary by Sourcery

Improve the README ramalama rag documentation by fixing formatting, updating the example command to match other CLI usage, and adding instructions on how to run the generated vector database.

Documentation:
- Correct the indentation of the details summary text in the README.
- Replace the example invocation with the ‘ramalama rag’ command and update the sample image name.
- Add a usage example showing how to run the generated RAG database with ‘ramalama run’.