### PR TITLE
Update SECURITY.md. Use github issues for security vulnerabilities

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,27 @@
 ## Security and Disclosure Information Policy for the RamaLama Project
 
-The RamaLama Project follows the [Security and Disclosure Information Policy](https://github.com/containers/common/blob/main/SECURITY.md) for the Containers Projects.
+## Reporting Security Vulnerabilities
+
+If you discover a security vulnerability in RamaLama, please report it through GitHub's Security Advisory system. This allows us to coordinate a fix and disclosure process that protects users.
+
+Please DO NOT report the issue publicly via the GitHub issue tracker,
+mailing list, or IRC.  Please do **not** create a public issue.
+
+### How to Report
+
+1. Go to [our security advisory page](https://github.com/containers/ramalama/security/advisories/new) to privately report the vulnerability.
+2. Provide detailed information about the vulnerability, including:
+   - Description of the issue
+   - Steps to reproduce
+   - Potential impact
+   - Suggested fix (if available)
+
+Your report will be reviewed by the maintainers, and we will work with you to understand and address the issue promptly.
+
+### What to Expect
+
+- **Acknowledgment**: We will acknowledge receipt of your vulnerability report within 48 hours
+- **Updates**: We will keep you informed about our progress in addressing the vulnerability
+- **Credit**: We will credit you for the discovery when we publish the fix (unless you prefer to remain anonymous)
+
+Thank you for helping keep RamaLama and its users secure!


### PR DESCRIPTION
Fixes: https://github.com/containers/ramalama/issues/2063

## Summary by Sourcery

Update SECURITY.md to direct vulnerability reports through GitHub's Security Advisory, provide detailed reporting instructions, and outline maintainer response expectations

Documentation:
- Revise security disclosure policy to instruct users to use GitHub's private security advisory system
- Add step-by-step instructions for reporting vulnerabilities via the repository issues page
- Outline expected maintainer responses including acknowledgment timelines, progress updates, and credit for reporters