### PR TITLE
Add --port flag to ramalama run command

### DIFF
--- a/docs/ramalama-run.1.md
+++ b/docs/ramalama-run.1.md
@@ -129,6 +129,9 @@ use. Using this option RamaLama will override these defaults.
 On Nvidia based GPU systems, RamaLama defaults to using the
 `nvidia-container-runtime`. Use this option to override this selection.
 
+#### **--port**, **-p**=*port*
+Port for AI Model server to listen on (default: 8080)
+
 #### **--prefix**
 Prefix for the user prompt (default: 🦭 > )
 
@@ -211,6 +214,12 @@ ramalama run granite
 Run command with local downloaded model for 10 minutes
 ```
 ramalama run --keepalive 10m file:///tmp/mymodel
+>
+```
+
+Run command with a custom port to allow multiple models running simultaneously
+```
+ramalama run --port 8081 granite
 >
 ```
 

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -92,7 +92,7 @@ def parse_port_option(option: str) -> str:
     port = int(option)
     if port <= 0 or port >= 65535:
         raise ValueError(f"Invalid port '{port}'")
-    return str(port)
+    return option
 
 
 class OverrideDefaultAction(argparse.Action):
@@ -950,12 +950,13 @@ If GPU device on host is accessible to via group access, this option leaks the u
         help="override the default OCI runtime used to launch the container",
         completer=suppressCompleter,
     )
-    if command == "serve":
+    if command in ["run", "serve"]:
         parser.add_argument(
             "-p",
             "--port",
             type=parse_port_option,
             default=CONFIG.port,
+            action=OverrideDefaultAction,
             help="port for AI Model server to listen on",
             completer=suppressCompleter,
         )

--- a/ramalama/config.py
+++ b/ramalama/config.py
@@ -11,8 +11,6 @@ from ramalama.layered_config import LayeredMixin
 from ramalama.toml_parser import TOMLParser
 
 PathStr: TypeAlias = str
-DEFAULT_PORT_RANGE: tuple[int, int] = (8080, 8090)
-DEFAULT_PORT: int = DEFAULT_PORT_RANGE[0]
 DEFAULT_IMAGE: str = "quay.io/ramalama/ramalama"
 DEFAULT_STACK_IMAGE: str = "quay.io/ramalama/llama-stack"
 DEFAULT_RAG_IMAGE: str = "quay.io/ramalama/ramalama-rag"
@@ -167,7 +165,7 @@ class BaseConfig:
     max_tokens: int = 0
     ngl: int = -1
     ocr: bool = False
-    port: str = str(DEFAULT_PORT)
+    port: str = "8080"
     prefix: str = None  # type: ignore
     pull: str = "newer"
     rag_format: Literal["qdrant", "json", "markdown", "milvus"] = "qdrant"
@@ -293,3 +291,5 @@ def default_config(env: Mapping[str, str] | None = None) -> Config:
 
 
 CONFIG = default_config()
+DEFAULT_PORT: int = int(CONFIG.port)
+DEFAULT_PORT_RANGE: tuple[int, int] = (DEFAULT_PORT, DEFAULT_PORT + 10)

--- a/ramalama/transports/base.py
+++ b/ramalama/transports/base.py
@@ -714,7 +714,7 @@ def get_available_port_if_any(exclude: list[str] | None = None) -> int:
 
 def compute_serving_port(args, quiet: bool = False, exclude: list[str] | None = None) -> str:
     # user probably specified a custom port, don't override the choice
-    if getattr(args, "port", None):
+    if hasattr(args, 'port_override'):
         target_port = args.port
     else:
         # otherwise compute a random serving port in the range

--- a/test/unit/test_transport_base.py
+++ b/test/unit/test_transport_base.py
@@ -137,9 +137,17 @@ def test_compute_ports_exclude(exclude: list, count: int, first: int):
     ],
 )
 def test_compute_serving_port(
-    inputPort: str, expectedRandomizedResult: list, expectedRandomPortsAvl: list, expectedOutput: str, expectedErr
+    inputPort: str,
+    expectedRandomizedResult: list,
+    expectedRandomPortsAvl: list,
+    expectedOutput: str,
+    expectedErr,
 ):
     args = Namespace(port=inputPort, debug=False, api="")
+    # Set port_override if user specified a port (not empty or None)
+    if inputPort and inputPort != "":
+        args.port_override = True
+
     mock_socket = socket.socket
     mock_socket.bind = MagicMock(side_effect=expectedRandomPortsAvl)
     mock_compute_ports = Mock(return_value=expectedRandomizedResult)


### PR DESCRIPTION
Fixes #2078

Users can now specify a custom port for the ramalama run command using the --port or -p flag. This allows multiple models to run simultaneously on the same machine without port conflicts.

The default port remains 8080, but users can override it with:
  ramalama run --port 8081 model_name

Updated documentation with the new option and example usage.

## Summary by Sourcery

Add --port (-p) option to ramalama run command to allow specifying a custom server port (default 8080) and update documentation with usage examples

New Features:
- Allow users to set a custom port for the AI model server via --port/-p flag on the run command (defaulting to 8080)

Documentation:
- Update ramalama-run manual to document the new --port flag and include example usage for running on custom ports.