### PR TITLE
Fix the rpm name in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ RamaLama eliminates the need to configure the host system by instead pulling a c
 ### Install on Fedora
 RamaLama is available in [Fedora](https://fedoraproject.org/) and later. To install it, run:
 ```
-sudo dnf install python3-ramalama
+sudo dnf install ramalama
 ```
 
 ### Install via PyPI

--- a/docsite/docs/getting-started/installation.mdx
+++ b/docsite/docs/getting-started/installation.mdx
@@ -27,7 +27,7 @@ This script will automatically detect your system and install RamaLama with the 
 On Fedora systems, you can install RamaLama directly from the official repositories:
 
 ```bash
-sudo dnf install python3-ramalama
+sudo dnf install ramalama
 ```
 
 ### PyPI (All Platforms)


### PR DESCRIPTION
The rpm name changed from python3-ramalama to ramalama in https://github.com/containers/ramalama/pull/1693.

The rpm name in README.md was updated at that time but the change seems to have been lost in a subsequent commit.

## Summary by Sourcery

Correct the RPM package name in documentation to reflect the change from python3-ramalama to ramalama.

Documentation:
- Update Fedora install instructions in README.md to use ramalama instead of python3-ramalama
- Update Fedora install instructions in installation.mdx to use ramalama instead of python3-ramalama