### PR TITLE
konflux: disable builds on s390x

### DIFF
--- a/.tekton/bats/bats-pull-request.yaml
+++ b/.tekton/bats/bats-pull-request.yaml
@@ -31,7 +31,6 @@ spec:
     - linux-d160-c8xlarge/amd64
     - linux-d160-c8xlarge/arm64
     - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: container-images/bats/Containerfile
   pipelineRef:

--- a/.tekton/bats/bats-push.yaml
+++ b/.tekton/bats/bats-push.yaml
@@ -28,7 +28,6 @@ spec:
     - linux-d160-c8xlarge/amd64
     - linux-d160-c8xlarge/arm64
     - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: container-images/bats/Containerfile
   pipelineRef:

--- a/.tekton/integration/pipelines/bats-integration.yaml
+++ b/.tekton/integration/pipelines/bats-integration.yaml
@@ -18,7 +18,6 @@ spec:
     - linux-c8xlarge/amd64
     - linux-c8xlarge/arm64
     - linux/ppc64le
-    - linux/s390x
     - linux-g64xlarge/amd64
   - name: commands
     description: Test commands to run

--- a/.tekton/ramalama/ramalama-pull-request.yaml
+++ b/.tekton/ramalama/ramalama-pull-request.yaml
@@ -31,7 +31,6 @@ spec:
     - linux-d160-c8xlarge/amd64
     - linux-d160-c8xlarge/arm64
     - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: container-images/ramalama/Containerfile
   - name: test-image

--- a/.tekton/ramalama/ramalama-push.yaml
+++ b/.tekton/ramalama/ramalama-push.yaml
@@ -28,7 +28,6 @@ spec:
     - linux-d160-c8xlarge/amd64
     - linux-d160-c8xlarge/arm64
     - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: container-images/ramalama/Containerfile
   - name: test-image


### PR DESCRIPTION
The latest version of `llama.cpp` isn't building on the s390x hosts available in Konflux. Disable the s390x builds for now until someone can fix them.

## Summary by Sourcery

Disable s390x builds across Konflux Tekton pipelines due to build failures on that architecture

Enhancements:
- Remove linux/s390x from bats pull-request pipeline platforms
- Remove linux/s390x from bats push pipeline platforms
- Remove linux/s390x from bats integration pipeline platforms
- Remove linux/s390x from ramalama pull-request pipeline platforms
- Remove linux/s390x from ramalama push pipeline platforms