### PR TITLE
Switch DEFAULT_PORT_RANGE to use 100 ports

### DIFF
--- a/docs/ramalama-run.1.md
+++ b/docs/ramalama-run.1.md
@@ -29,7 +29,7 @@ URL support means if a model is on a web site or even on your local system, you 
 
 #### **--api**=**llama-stack** | none**
 unified API layer for Inference, RAG, Agents, Tools, Safety, Evals, and Telemetry.(default: none)
-The default can be overridden in the ramalama.conf file.
+The default can be overridden in the `ramalama.conf` file.
 
 #### **--authfile**=*password*
 path of the authentication file for OCI registries
@@ -75,7 +75,7 @@ images based on the accelerator it discovers. For example:
 The default image tag is based on the minor version of the RamaLama package.
 Version 0.14.0 of RamaLama pulls an image with a `:0.14` tag from the quay.io/ramalama OCI repository. The --image option overrides this default.
 
-The default can be overridden in the ramalama.conf file or via the
+The default can be overridden in the `ramalama.conf` file or via the
 RAMALAMA_IMAGE environment variable. `export RAMALAMA_IMAGE=quay.io/ramalama/aiimage:1.2` tells
 RamaLama to use the `quay.io/ramalama/aiimage:1.2` image.
 
@@ -131,6 +131,8 @@ On Nvidia based GPU systems, RamaLama defaults to using the
 
 #### **--port**, **-p**=*port*
 Port for AI Model server to listen on (default: 8080)
+
+The default can be overridden in the `ramalama.conf` file.
 
 #### **--prefix**
 Prefix for the user prompt (default: 🦭 > )
@@ -254,7 +256,7 @@ $ ramalama run granite
 See **[ramalama-cuda(7)](ramalama-cuda.7.md)** for setting up the host Linux system for CUDA support.
 
 ## SEE ALSO
-**[ramalama(1)](ramalama.1.md)**, **[ramalama-cuda(7)](ramalama-cuda.7.md)**
+**[ramalama(1)](ramalama.1.md)**, **[ramalama-cuda(7)](ramalama-cuda.7.md)**, **[ramalama.conf(5)](ramalama.conf.5.md)**
 
 ## HISTORY
 Aug 2024, Originally compiled by Dan Walsh <dwalsh@redhat.com>

--- a/docs/ramalama-serve.1.md
+++ b/docs/ramalama-serve.1.md
@@ -53,7 +53,7 @@ Section, key and value are required and must be separated by colons.
 
 #### **--api**=**llama-stack** | none**
 Unified API layer for Inference, RAG, Agents, Tools, Safety, Evals, and Telemetry.(default: none)
-The default can be overridden in the ramalama.conf file.
+The default can be overridden in the `ramalama.conf` file.
 
 #### **--authfile**=*password*
 Path of the authentication file for OCI registries
@@ -122,7 +122,7 @@ images based on the accelerator it discovers. For example:
 The default image tag is based on the minor version of the RamaLama package.
 Version 0.14.0 of RamaLama pulls an image with a `:0.14` tag from the quay.io/ramalama OCI repository. The --image option overrides this default.
 
-The default can be overridden in the ramalama.conf file or via the
+The default can be overridden in the `ramalama.conf` file or via the
 RAMALAMA_IMAGE environment variable. `export RAMALAMA_IMAGE=quay.io/ramalama/aiimage:1.2` tells
 RamaLama to use the `quay.io/ramalama/aiimage:1.2` image.
 
@@ -182,7 +182,9 @@ On Nvidia based GPU systems, RamaLama defaults to using the
 
 #### **--port**, **-p**
 port for AI Model server to listen on. It must be available. If not specified,
-the serving port will be 8080 if available, otherwise a free port in 8081-8090 range.
+a free port in the 8080-8180 range is selected, starting with 8080.
+
+The default can be overridden in the `ramalama.conf` file.
 
 #### **--privileged**
 By default, RamaLama containers are unprivileged (=false) and cannot, for
@@ -577,7 +579,7 @@ ramalama --runtime=mlx serve hf://mlx-community/Unsloth-Phi-4-4bit
 ```
 
 ## SEE ALSO
-**[ramalama(1)](ramalama.1.md)**, **[ramalama-stop(1)](ramalama-stop.1.md)**, **quadlet(1)**, **systemctl(1)**, **podman(1)**, **podman-ps(1)**, **[ramalama-cuda(7)](ramalama-cuda.7.md)**
+**[ramalama(1)](ramalama.1.md)**, **[ramalama-stop(1)](ramalama-stop.1.md)**, **quadlet(1)**, **systemctl(1)**, **podman(1)**, **podman-ps(1)**, **[ramalama-cuda(7)](ramalama-cuda.7.md)**, **[ramalama.conf(5)](ramalama.conf.5.md)**
 
 ## HISTORY
 Aug 2024, Originally compiled by Dan Walsh <dwalsh@redhat.com>

--- a/docs/ramalama.conf
+++ b/docs/ramalama.conf
@@ -88,7 +88,8 @@
 #
 #ngl = -1
 
-# Specify default port for services to listen on
+# Specify initial port for a range of 100 ports for services to listen on.
+# If the specified port is 8080, a free port in the 8080-8179 range (100 ports) is selected.
 #
 #port = "8080"
 

--- a/docs/ramalama.conf.5.md
+++ b/docs/ramalama.conf.5.md
@@ -152,7 +152,8 @@ is based on the container engine used.
 
 **port**="8080"
 
-Specify default port for services to listen on
+Specify initial port for a range of 101 ports for services to listen on.
+If this port is unavailable, another free port from this range will be selected.
 
 **pull**="newer"
 

--- a/docsite/docs/commands/ramalama/run.mdx
+++ b/docsite/docs/commands/ramalama/run.mdx
@@ -33,7 +33,7 @@ URL support means if a model is on a web site or even on your local system, you 
 
 #### **--api**=**llama-stack** | none**
 unified API layer for Inference, RAG, Agents, Tools, Safety, Evals, and Telemetry.(default: none)
-The default can be overridden in the ramalama.conf file.
+The default can be overridden in the `ramalama.conf` file.
 
 #### **--authfile**=*password*
 path of the authentication file for OCI registries
@@ -79,7 +79,7 @@ images based on the accelerator it discovers. For example:
 The default image tag is based on the minor version of the RamaLama package.
 Version 0.14.0 of RamaLama pulls an image with a `:0.14` tag from the quay.io/ramalama OCI repository. The --image option overrides this default.
 
-The default can be overridden in the ramalama.conf file or via the
+The default can be overridden in the `ramalama.conf` file or via the
 RAMALAMA_IMAGE environment variable. `export RAMALAMA_IMAGE=quay.io/ramalama/aiimage:1.2` tells
 RamaLama to use the `quay.io/ramalama/aiimage:1.2` image.
 
@@ -135,6 +135,8 @@ On Nvidia based GPU systems, RamaLama defaults to using the
 
 #### **--port**, **-p**=*port*
 Port for AI Model server to listen on (default: 8080)
+
+The default can be overridden in the `ramalama.conf` file.
 
 #### **--prefix**
 Prefix for the user prompt (default: 🦭 > )
@@ -257,7 +259,7 @@ $ ramalama run granite
 See [ramalama-cuda(7)](/docs/platform-guides/cuda) for setting up the host Linux system for CUDA support.
 
 ## See Also
-[ramalama(1)](/docs/commands/ramalama/), [ramalama-cuda(7)](/docs/platform-guides/cuda)
+[ramalama(1)](/docs/commands/ramalama/), [ramalama-cuda(7)](/docs/platform-guides/cuda), [ramalama.conf(5)](/docs/configuration/conf)
 
 ---
 

--- a/docsite/docs/commands/ramalama/serve.mdx
+++ b/docsite/docs/commands/ramalama/serve.mdx
@@ -57,7 +57,7 @@ Section, key and value are required and must be separated by colons.
 
 #### **--api**=**llama-stack** | none**
 Unified API layer for Inference, RAG, Agents, Tools, Safety, Evals, and Telemetry.(default: none)
-The default can be overridden in the ramalama.conf file.
+The default can be overridden in the `ramalama.conf` file.
 
 #### **--authfile**=*password*
 Path of the authentication file for OCI registries
@@ -124,7 +124,7 @@ images based on the accelerator it discovers. For example:
 The default image tag is based on the minor version of the RamaLama package.
 Version 0.14.0 of RamaLama pulls an image with a `:0.14` tag from the quay.io/ramalama OCI repository. The --image option overrides this default.
 
-The default can be overridden in the ramalama.conf file or via the
+The default can be overridden in the `ramalama.conf` file or via the
 RAMALAMA_IMAGE environment variable. `export RAMALAMA_IMAGE=quay.io/ramalama/aiimage:1.2` tells
 RamaLama to use the `quay.io/ramalama/aiimage:1.2` image.
 
@@ -184,7 +184,9 @@ On Nvidia based GPU systems, RamaLama defaults to using the
 
 #### **--port**, **-p**
 port for AI Model server to listen on. It must be available. If not specified,
-the serving port will be 8080 if available, otherwise a free port in 8081-8090 range.
+a free port in the 8080-8180 range is selected, starting with 8080.
+
+The default can be overridden in the `ramalama.conf` file.
 
 #### **--privileged**
 By default, RamaLama containers are unprivileged (=false) and cannot, for
@@ -580,7 +582,7 @@ ramalama --runtime=mlx serve hf://mlx-community/Unsloth-Phi-4-4bit
 ```
 
 ## See Also
-[ramalama(1)](/docs/commands/ramalama/), [ramalama-stop(1)](/docs/commands/ramalama/stop), **quadlet(1)**, **systemctl(1)**, **podman(1)**, **podman-ps(1)**, [ramalama-cuda(7)](/docs/platform-guides/cuda)
+[ramalama(1)](/docs/commands/ramalama/), [ramalama-stop(1)](/docs/commands/ramalama/stop), **quadlet(1)**, **systemctl(1)**, **podman(1)**, **podman-ps(1)**, [ramalama-cuda(7)](/docs/platform-guides/cuda), [ramalama.conf(5)](/docs/configuration/conf)
 
 ---
 

--- a/docsite/docs/configuration/conf.mdx
+++ b/docsite/docs/configuration/conf.mdx
@@ -154,7 +154,8 @@ is based on the container engine used.
 
 **port**="8080"
 
-Specify default port for services to listen on
+Specify initial port for a range of 101 ports for services to listen on.
+If this port is unavailable, another free port from this range will be selected.
 
 **pull**="newer"
 

--- a/ramalama/config.py
+++ b/ramalama/config.py
@@ -292,4 +292,4 @@ def default_config(env: Mapping[str, str] | None = None) -> Config:
 
 CONFIG = default_config()
 DEFAULT_PORT: int = int(CONFIG.port)
-DEFAULT_PORT_RANGE: tuple[int, int] = (DEFAULT_PORT, DEFAULT_PORT + 10)
+DEFAULT_PORT_RANGE: tuple[int, int] = (DEFAULT_PORT, DEFAULT_PORT + 100)

--- a/test/unit/test_transport_base.py
+++ b/test/unit/test_transport_base.py
@@ -98,10 +98,10 @@ def test_compute_ports():
 @pytest.mark.parametrize(
     "exclude,count,first",
     [
-        (None, 11, DEFAULT_PORT),
-        ([], 11, DEFAULT_PORT),
-        ([str(DEFAULT_PORT)], 10, DEFAULT_PORT + 1),
-        ([str(DEFAULT_PORT), str(DEFAULT_PORT + 1)], 9, DEFAULT_PORT + 2),
+        (None, 101, DEFAULT_PORT),
+        ([], 101, DEFAULT_PORT),
+        ([str(DEFAULT_PORT)], 100, DEFAULT_PORT + 1),
+        ([str(DEFAULT_PORT), str(DEFAULT_PORT + 1)], 99, DEFAULT_PORT + 2),
         (list(map(str, range(*DEFAULT_PORT_RANGE))), 1, DEFAULT_PORT_RANGE[1]),
     ],
 )


### PR DESCRIPTION
Currently we limit the number of ports that ramalama serve will attempt to 10, expand this to 100 so that we are more likely to get an open port.

## Summary by Sourcery

Extend the default port selection window to 100 ports and update documentation and tests to reflect the new configuration

New Features:
- Expand the default service port range from 10 to 100 ports

Documentation:
- Revise ramalama-serve and ramalama-run man pages to document the expanded port range, format config file references with backticks, and include ramalama.conf in SEE ALSO sections

Tests:
- Update test_compute_ports to expect 101 ports in the default range