### PR TITLE
Integrate daemon in ramalama cli

### DIFF
--- a/docs/ramalama.1.md
+++ b/docs/ramalama.1.md
@@ -132,6 +132,10 @@ The default can be overridden in the ramalama.conf file.
 store AI Models in the specified directory (default rootless: `$HOME/.local/share/ramalama`, default rootful: `/var/lib/ramalama`)
 The default can be overridden in the ramalama.conf file.
 
+#### **--use-daemon**
+Feature flag to enable using the RamaLama daemon as backend for [ramalama-serve(1)](ramalama-serve.1.md) and [ramalama-run(1)](ramalama-run.1.md).
+
+
 ## COMMANDS
 
 | Command                                           | Description                                                |

--- a/docsite/docs/commands/ramalama/ramalama.mdx
+++ b/docsite/docs/commands/ramalama/ramalama.mdx
@@ -142,6 +142,9 @@ The default can be overridden in the ramalama.conf file.
 store AI Models in the specified directory (default rootless: `$HOME/.local/share/ramalama`, default rootful: `/var/lib/ramalama`)
 The default can be overridden in the ramalama.conf file.
 
+#### **--use-daemon**
+Feature flag to enable using the RamaLama daemon as backend for [ramalama-serve(1)](/docs/commands/ramalama/serve) and [ramalama-run(1)](/docs/commands/ramalama/run).
+
 ## COMMANDS
 
 | Command                                           | Description                                                |

--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -282,8 +282,8 @@ def verify_checksum(filename: str) -> bool:
     return sha256_hash.hexdigest() == expected_checksum
 
 
-def genname():
-    return "ramalama_" + "".join(random.choices(string.ascii_letters + string.digits, k=10))
+def genname(prefix: str = "ramalama"):
+    return prefix + "_" + "".join(random.choices(string.ascii_letters + string.digits, k=10))
 
 
 def engine_version(engine: SUPPORTED_ENGINES) -> str:

--- a/ramalama/daemon/client.py
+++ b/ramalama/daemon/client.py
@@ -1,0 +1,104 @@
+import http
+import json
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any, Optional, Tuple
+
+from ramalama.daemon.dto.model import ModelResponse, RunningModelResponse
+from ramalama.daemon.dto.serve import ServeRequest, ServeResponse, StopServeRequest
+from ramalama.logger import logger
+
+
+class DaemonAPIError(Exception):
+
+    def __init__(self, reason: str, code: Optional[http.HTTPStatus] = None, *args):
+        super().__init__(*args)
+
+        self.reason = reason
+        self.code = code
+
+    def __str__(self):
+        if self.code:
+            return f"Call to daemon API failed ({self.code}): {self.reason}"
+        return f"Call to daemon API failed: {self.reason}"
+
+
+class DaemonClient:
+
+    def __init__(self, host: str, port: int):
+        self.host = host
+        self.port = port
+
+    @property
+    def base_url(self) -> str:
+        return f"{self.host}:{self.port}"
+
+    def list_available_models(self) -> list[ModelResponse]:
+        url = f"http://{self.base_url}/api/tags"
+        resp, _ = DaemonClient.call_api(url)
+        if resp:
+            return [ModelResponse(**model) for model in resp["models"]]
+
+    def list_running_models(self) -> list[RunningModelResponse]:
+        url = f"http://{self.base_url}/api/ps"
+        resp, _ = DaemonClient.call_api(url)
+        if resp:
+            return [RunningModelResponse(**model) for model in resp["models"]]
+
+    def start_model(self, model_name: str, runtime: str, exec_args: list[str]) -> Optional[str]:
+        url = f"http://{self.base_url}/api/serve"
+        request = ServeRequest(model_name, runtime, exec_args).to_dict()
+        resp, _ = DaemonClient.call_api(url, method=http.HTTPMethod.POST, json_data=request)
+        if resp:
+            return f"http://{self.base_url}{ServeResponse(**resp).serve_path}"
+        return None
+
+    def stop_model(self, model_name: str) -> Optional[str]:
+        url = f"http://{self.base_url}/api/stop"
+        request = StopServeRequest(model_name).to_dict()
+        DaemonClient.call_api(url, method=http.HTTPMethod.POST, json_data=request)
+
+    def is_healthy(self) -> bool:
+        url = f"http://{self.base_url}/api/health"
+        try:
+            _, code = DaemonClient.call_api(url)
+            logger.debug(f"Health check success, code: {code}")
+            return code == http.HTTPStatus.NO_CONTENT
+        except DaemonAPIError as e:
+            logger.debug(f"Health check failed: {e}")
+            return False
+
+    @staticmethod
+    def call_api(
+        url: str, method: http.HTTPMethod = http.HTTPMethod.GET, headers=None, params=None, json_data=None, timeout=10
+    ) -> Tuple[Any | None, http.HTTPStatus]:
+        headers = headers or {}
+
+        if params:
+            query_string = urllib.parse.urlencode(params)
+            separator = '&' if '?' in url else '?'
+            url = f"{url}{separator}{query_string}"
+
+        body = None
+        if json_data is not None:
+            body = json.dumps(json_data).encode('utf-8')
+            headers['Content-Type'] = 'application/json'
+
+        req = urllib.request.Request(url, data=body, headers=headers, method=method.value)
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as response:
+                response_code = response.getcode()
+                response_data = response.read().decode('utf-8')
+                try:
+                    return json.loads(response_data), response_code
+                except json.JSONDecodeError:
+                    return response_data, response_code
+        except urllib.error.HTTPError as e:
+            raise DaemonAPIError(e.reason, e.code)
+        except urllib.error.URLError as e:
+            raise DaemonAPIError(e.reason)
+        except ConnectionResetError:
+            raise DaemonAPIError("Connection reset")
+        except Exception as e:
+            raise DaemonAPIError(f"Unexpected error occurred: {e}")

--- a/ramalama/daemon/daemon.py
+++ b/ramalama/daemon/daemon.py
@@ -8,7 +8,7 @@ from datetime import datetime, timedelta
 
 from ramalama.config import CONFIG
 from ramalama.daemon.handler.ramalama import RamalamaHandler
-from ramalama.daemon.logging import configure_logger, logger
+from ramalama.daemon.logger import LogLevel, configure_logger, logger
 from ramalama.daemon.service.model_runner import ModelRunner
 from ramalama.log_levels import LogLevel
 
@@ -89,26 +89,22 @@ class RamalamaServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
 
     def check_model_expiration(self):
         curr_time = datetime.now()
-        for name, m in self.model_runner.managed_models.items():
+
+        for id in list(self.model_runner.managed_models.keys()):
+            m = self.model_runner.managed_models[id]
             if m.expiration_date > curr_time:
                 continue
 
             try:
-                logger.info(f"Stopping expired model '{name}'...")
+                logger.info(f"Stopping expired model '{m.model.model_organization}/{m.model.model_name}'...")
                 self.model_runner.stop_model(m.id)
             except Exception as e:
-                logger.error(f"Failed to stop expired model '{name}': {e}")
+                logger.error(f"Failed to stop expired model '{m.model.model_organization}/{m.model.model_name}': {e}")
 
     def shutdown(self):
         logger.info("Shutting down ramalama daemon...")
 
-        for name, managed_model in self.model_runner.managed_models.items():
-            try:
-                logger.info(f"Stopping model runner {name}...")
-                self.model_runner.stop_model(managed_model.id)
-            except Exception as e:
-                logger.error(f"Error stopping model runner {name}: {e}")
-
+        self.model_runner.stop()
         super().shutdown()
 
 

--- a/ramalama/daemon/dto/model.py
+++ b/ramalama/daemon/dto/model.py
@@ -78,6 +78,7 @@ class RunningModelResponse:
     size_vram: int
     digest: str
     cmd: str
+    serve_path: str
 
     def to_dict(self) -> dict:
         return {
@@ -91,6 +92,7 @@ class RunningModelResponse:
             "size_vram": self.size_vram,
             "digest": self.digest,
             "cmd": self.cmd,
+            "serve_path": self.serve_path,
         }
 
     def serialize(self) -> str:

--- a/ramalama/daemon/handler/base.py
+++ b/ramalama/daemon/handler/base.py
@@ -35,7 +35,7 @@ class APIHandler(ABC):
 
     def _handle_get_running_models(self, handler: http.server.SimpleHTTPRequestHandler):
         models: list[RunningModelResponse] = []
-        for _, m in self.model_runner.managed_models.items():
+        for serve_path, m in self.model_runner.served_models.items():
             assert m.expiration_date
             full_model_name = (
                 f"{m.model.model_type}://{m.model.model_organization}/{m.model.model_name}:{m.model.model_tag}"
@@ -52,6 +52,7 @@ class APIHandler(ABC):
                     size_vram=0,
                     digest=m.id.replace("sha-", ""),
                     cmd=" ".join(m.run_cmd),
+                    serve_path=serve_path,
                 )
             )
 

--- a/ramalama/daemon/handler/ramalama.py
+++ b/ramalama/daemon/handler/ramalama.py
@@ -4,7 +4,7 @@ import urllib.error
 
 from ramalama.daemon.handler.daemon import DaemonAPIHandler
 from ramalama.daemon.handler.proxy import ModelProxyHandler
-from ramalama.daemon.logging import logger
+from ramalama.daemon.logger import logger
 from ramalama.daemon.service.model_runner import ModelRunner
 
 

--- a/ramalama/daemon/logger.py
+++ b/ramalama/daemon/logger.py
@@ -10,9 +10,6 @@ logger = logging.getLogger("ramalama-daemon")
 
 
 def configure_logger(lvl: LogLevel = LogLevel.WARNING, log_file: str = DEFAULT_LOG_DIR) -> None:
-    if logger.hasHandlers():
-        return
-
     logger.setLevel(lvl)
 
     fmt = "%(asctime)s - %(levelname)s - %(message)s"

--- a/ramalama/daemon/service/model_runner.py
+++ b/ramalama/daemon/service/model_runner.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 from typing import Optional
 
 from ramalama.common import generate_sha256
+from ramalama.daemon.logger import logger
 from ramalama.transports.transport_factory import CLASS_MODEL_TYPES
 
 
@@ -100,4 +101,9 @@ class ModelRunner:
 
     def stop(self):
         for id in list(self._models.keys()):
-            self.stop_model(id)
+            m = self._models[id]
+            try:
+                logger.info(f"Stopping model runner for {m.model.model_organization}/{m.model.model_name}...")
+                self.stop_model(id)
+            except Exception as e:
+                logger.error(f"Error stopping model runner for {m.model.model_organization}/{m.model.model_name}: {e}")

--- a/ramalama/daemon_stub.py
+++ b/ramalama/daemon_stub.py
@@ -1,0 +1,182 @@
+import json
+import time
+from argparse import Namespace
+from typing import Optional, get_args
+
+from ramalama import engine
+from ramalama.chat import chat
+from ramalama.common import genname, perror, run_cmd
+from ramalama.config import CONFIG, SUPPORTED_ENGINES
+from ramalama.daemon.client import DaemonAPIError, DaemonClient
+from ramalama.shortnames import Shortnames
+
+
+class DaemonStub:
+
+    def __init__(
+        self, shortnames: Shortnames, args: Namespace, raw_args: list[str], wait_for_healthy_timeout: int = 10
+    ):
+        self.shortnames = shortnames
+        self.cli_args = args
+        self.raw_args = raw_args
+        self.wait_for_healthy_timeout = wait_for_healthy_timeout
+
+        self.client = DaemonClient("127.0.0.1", self.cli_args.port)
+
+    @property
+    def daemon_base_url(self) -> str:
+        return f"http://127.0.0.1:{self.cli_args.port}"
+
+    def prepare_serve_request(self) -> list[str]:
+        # Reconstruct the "original" ramalama command since the daemon will assemble the
+        # inference engine command based on this (similar to the CLI)
+        exec_args: list[str] = []
+        index = self.raw_args.index(self.cli_args.subcommand)
+        raw_args = self.raw_args[index + 1 :]
+        i = 0
+        while i < len(raw_args):
+            arg = raw_args[i]
+            i += 1
+            # skip model name for exec args
+            if arg in [self.cli_args.MODEL, self.cli_args.UNRESOLVED_MODEL]:
+                continue
+            # skip port and host incl. value since these are not needed for the daemon
+            if arg in ["--port", "-p", "--host"]:
+                i += 1
+                continue
+            exec_args.append(arg)
+
+        return exec_args
+
+    def get_host_port(self, daemon_name: str) -> Optional[str]:
+        try:
+            container = json.loads(engine.inspect(self.cli_args, daemon_name))
+            if not container:
+                return None
+        except Exception as ex:
+            return None
+
+        container = container[0]
+        is_daemon = engine.LABEL_CONTAINER_RAMALAMA_DAEMON in container.get("Config", {}).get("Labels", {})
+        if not is_daemon:
+            return None
+
+        ports = container.get("NetworkSettings", {}).get("Ports", {})
+        if not ports:
+            return None
+
+        port_entry = next(iter(ports.values()))
+        if not port_entry:
+            return None
+
+        return port_entry[0].get("HostPort", None)
+
+    def serve_model(self, daemon_name: Optional[str] = None) -> Optional[str]:
+
+        named_daemon_already_exists = False
+        if daemon_name:
+            host_port = self.get_host_port(daemon_name)
+            if host_port:
+                self.client = DaemonClient("127.0.0.1", int(host_port))
+                named_daemon_already_exists = True
+        else:
+            daemon_name = genname("ramalama_daemon")
+
+        if not named_daemon_already_exists:
+            self.start_daemon(daemon_name)
+
+        exec_args = self.prepare_serve_request()
+
+        try:
+            model_input = (
+                self.cli_args.MODEL
+                if not hasattr(self.cli_args, "UNRESOLVED_MODEL")
+                else self.cli_args.UNRESOLVED_MODEL
+            )
+            serve_url = self.client.start_model(model_input, self.cli_args.runtime, exec_args)
+            print(f"{model_input} available at: {serve_url}")
+            return serve_url
+        except DaemonAPIError as e:
+            perror(f"Failed to start '{model_input}': {e}")
+            return None
+
+    def wait_for_model(self, serve_path: str, timeout: int = 10):
+        if timeout > 0:
+            start_time = time.time()
+            while time.time() - start_time < self.wait_for_healthy_timeout:
+                models = self.client.list_running_models()
+                for model in models:
+                    if model.serve_path in serve_path:
+                        return
+                if self.cli_args.debug:
+                    print(f"{self.cli_args.MODEL} not yet served by Daemon at {serve_path}, retrying...")
+                time.sleep(1)
+            raise TimeoutError(f"Timeout while waiting for {self.cli_args.MODEL} to be served")
+
+    def wait_for_daemon(self):
+        if self.wait_for_healthy_timeout > 0:
+            start_time = time.time()
+            while time.time() - start_time < self.wait_for_healthy_timeout:
+                if self.client.is_healthy():
+                    return
+                if self.cli_args.debug:
+                    print(f"RamaLama Daemon not yet healthy at {self.daemon_base_url}, retrying...")
+                time.sleep(1)
+            raise TimeoutError("Health check for RamaLama Daemon timed out")
+
+    def start_daemon(self, daemon_name: str):
+        daemon_cmd = []
+        daemon_model_store_dir = self.cli_args.store
+        is_daemon_in_container = self.cli_args.container and self.cli_args.engine in get_args(SUPPORTED_ENGINES)
+
+        if is_daemon_in_container:
+            # If run inside a container, map the model store to the container internal directory
+            daemon_model_store_dir = "/ramalama/models"
+
+            daemon_cmd += [
+                self.cli_args.engine,
+                "run",
+                "--pull",
+                self.cli_args.pull,
+                "-d",
+                "-p",
+                f"{self.cli_args.port}:8080",
+                "-v",
+                f"{self.cli_args.store}:{daemon_model_store_dir}",
+                "--label",
+                engine.LABEL_CONTAINER_RAMALAMA_DAEMON,
+                "--name",
+                daemon_name,
+                self.cli_args.image,
+            ]
+
+        daemon_cmd += [
+            "ramalama",
+            "--store",
+            daemon_model_store_dir,
+            "daemon",
+            "run",
+            "--port",
+            "8080" if is_daemon_in_container else self.cli_args.port,
+            "--host",
+            CONFIG.host if is_daemon_in_container else self.cli_args.host,
+        ]
+        run_cmd(daemon_cmd)
+
+        self.wait_for_daemon()
+
+        if self.cli_args.debug:
+            print(f"RamaLama Daemon started on {self.daemon_base_url}")
+
+    def chat(self, serve_path: str):
+        # Overwrite the url field to mimic behavior as in transport/base.py
+        # Shallow copy to not change the url param
+        self.wait_for_model(serve_path)
+        self.cli_args.url = f"{serve_path}/v1"
+        chat(self.cli_args)
+
+
+def run_daemon(args):
+    from ramalama.daemon.daemon import run
+
+    run(host=args.host, port=int(args.port), model_store_path=args.store)

--- a/ramalama/engine.py
+++ b/ramalama/engine.py
@@ -14,6 +14,9 @@ import ramalama.common
 from ramalama.common import check_nvidia, exec_cmd, get_accel_env_vars, perror, run_cmd
 from ramalama.logger import logger
 
+LABEL_CONTAINER_RAMALAMA = "ai.ramalama"
+LABEL_CONTAINER_RAMALAMA_DAEMON = "ai.ramalama.daemon"
+
 
 class BaseEngine(ABC):
     """General-purpose engine for running podman or docker commands"""
@@ -290,12 +293,12 @@ def images(args):
         raise (e)
 
 
-def containers(args):
+def containers(args, label: str = LABEL_CONTAINER_RAMALAMA):
     conman = str(args.engine) if args.engine is not None else None
     if conman == "" or conman is None:
         raise ValueError("no container manager (Podman, Docker) found")
 
-    conman_args = [conman, "ps", "-a", "--filter", "label=ai.ramalama"]
+    conman_args = [conman, "ps", "-a", "--filter", f"label={label}"]
     if getattr(args, "noheading", False):
         if conman == "docker" and not args.format:
             # implement --noheading by using --format
@@ -306,7 +309,7 @@ def containers(args):
     if getattr(args, "notrunc", False):
         conman_args += ["--no-trunc"]
 
-    if args.format:
+    if getattr(args, "format", None):
         conman_args += [f"--format={args.format}"]
 
     try:

--- a/ramalama/shortnames.py
+++ b/ramalama/shortnames.py
@@ -55,3 +55,7 @@ class Shortnames:
 
     def resolve(self, model) -> str | None:
         return self.shortnames.get(model, model)
+
+    def get_shortname_for(self, resolved_model: str) -> str | None:
+        reverse = {value: key for key, value in self.shortnames.items()}
+        return reverse.get(resolved_model)

--- a/ramalama/transports/base.py
+++ b/ramalama/transports/base.py
@@ -22,7 +22,7 @@ from ramalama.common import (
 )
 from ramalama.compose import Compose
 from ramalama.config import CONFIG, DEFAULT_PORT_RANGE
-from ramalama.engine import Engine, dry_run, is_healthy, wait_for_healthy
+from ramalama.engine import LABEL_CONTAINER_RAMALAMA, Engine, dry_run, is_healthy, wait_for_healthy
 from ramalama.kube import Kube
 from ramalama.logger import logger
 from ramalama.model_inspect.base_info import ModelInfoBase
@@ -316,7 +316,7 @@ class Transport(TransportBase):
         self.engine.add(
             [
                 "--label",
-                "ai.ramalama",
+                LABEL_CONTAINER_RAMALAMA,
                 "--name",
                 name,
                 "--env=HOME=/tmp",


### PR DESCRIPTION


## Testing this PR

First, changes in this PR need to be built and embedded into a locally built ramalama container:
```bash
make pypi-build
podman build -t quay.io/ramalama/myramalama:latest -f container-images/myramalama .
```
This assumes that the container file `container-images/myramalama` contains something like this:
```
FROM quay.io/ramalama/rocm:latest

COPY dist/ramalama-0.14.0-py3-none-any.whl ./
RUN pip install --force ./ramalama-0.14.0-py3-none-any.whl
```

Now the integration can be tested. For example:
```bash
# serving a model
$ ./bin/ramalama --use-daemon serve smollm:135m --pull never --image quay.io/ramalama/myramalama:latest
smollm:135m available at: http://127.0.0.1:8080/models/library/smollm

# chatting with a model directly
$ ./bin/ramalama --use-daemon run smollm:135m --pull never --image quay.io/ramalama/myramalama:latest
smollm:135m available at: http://127.0.0.1:8080/models/library/smollm
🦭 > hi, how are you?

# serving multiple models in the same daemon
$ ./bin/ramalama --use-daemon --daemon-name=ramalama-daemon-multiple serve smollm:135m --pull never --image quay.io/ramalama/rocm:latest
Error: no such object: "ramalama-daemon-multiple"
smollm:135m available at: http://127.0.0.1:8080/models/library/smollm
$ ./bin/ramalama --use-daemon --daemon-name=ramalama-daemon-multiple serve tinyllama --pull never --image quay.io/ramalama/rocm:latest
tinyllama available at: http://127.0.0.1:8080/models/library/tinyllama
# The models served in the container can be viewed at
# http://127.0.0.1:8080/models
# or http://127.0.0.1:8080/api/ps

# listing all running daemon container
$ ./bin/ramalama --use-daemon ps
CONTAINER ID  IMAGE                         COMMAND               CREATED             STATUS             PORTS                   NAMES
d91bec54198a  quay.io/ramalama/rocm:latest  ramalama --store ...  About a minute ago  Up About a minute  0.0.0.0:8080->8080/tcp  ramalama-daemon-multiple

```
**$${\color{red}Important:}$$**
The webui of llama.cpp is available under `http://127.0.0.1:8080/models/library/smollm` directly, but will continuously try to redirect. This is due to an issue in the llama.cpp webui as it expects to be served at `http://127.0.0.1:8080` and not a subpath.



## Summary by Sourcery

Integrate support for using the RamaLama daemon as the backend for CLI commands by adding feature flags, client and stub logic, and updating handlers, engine, DTOs, and documentation to enable starting, serving, and chatting through a long-running daemon process.

New Features:
- Add --use-daemon and --daemon-name flags to the CLI to route run and serve commands through the daemon
- Introduce DaemonStub and DaemonClient classes to manage daemon lifecycle and interact with daemon HTTP API for serve, stop, and health operations

Enhancements:
- Refactor container listing to accept a dynamic label filter for distinguishing daemon-managed containers
- Simplify and extend daemon HTTP handlers: add a health endpoint, streamline proxy request forwarding, and improve expiration and shutdown logging
- Update ServeRequest DTO to use a list for exec_args and adjust serialization and parsing accordingly
- Extend common genname function to accept a prefix parameter
- Rename and clean up logger configuration to prevent duplicate handlers

Documentation:
- Add documentation for the --use-daemon feature flag in CLI man pages and MD reference guides