### PR TITLE
Fix HuggingFace login/logout CLI commands

### DIFF
--- a/ramalama/hf_style_repo_base.py
+++ b/ramalama/hf_style_repo_base.py
@@ -239,10 +239,18 @@ class HFStyleRepoModel(Transport, ABC):
         """Collect files from CLI download"""
         pass
 
+    def get_login_args(self):
+        """Return the login subcommand arguments. Can be overridden for different CLI structures."""
+        return ["login"]
+
+    def get_logout_args(self):
+        """Return the logout subcommand arguments. Can be overridden for different CLI structures."""
+        return ["logout"]
+
     def login(self, args):
         if not available(self.get_cli_command()):
             raise NotImplementedError(self.get_missing_message())
-        conman_args = [self.get_cli_command(), "login"]
+        conman_args = [self.get_cli_command()] + self.get_login_args()
         if args.token:
             conman_args.extend(["--token", args.token])
         self.exec(conman_args, args)
@@ -250,7 +258,7 @@ class HFStyleRepoModel(Transport, ABC):
     def logout(self, args):
         if not available(self.get_cli_command()):
             raise NotImplementedError(self.get_missing_message())
-        conman_args = [self.get_cli_command(), "logout"]
+        conman_args = [self.get_cli_command()] + self.get_logout_args()
         if args.token:
             conman_args.extend(["--token", args.token])
         self.exec(conman_args, args)

--- a/ramalama/transports/huggingface.py
+++ b/ramalama/transports/huggingface.py
@@ -155,6 +155,14 @@ class Huggingface(HFStyleRepoModel):
     def get_cli_command(self):
         return "hf"
 
+    def get_login_args(self):
+        """HuggingFace CLI uses 'hf auth login' instead of 'hf login'"""
+        return ["auth", "login"]
+
+    def get_logout_args(self):
+        """HuggingFace CLI uses 'hf auth logout' instead of 'hf logout'"""
+        return ["auth", "logout"]
+
     def get_missing_message(self):
         return missing_huggingface
 


### PR DESCRIPTION
Fixes #2101

The HuggingFace CLI has updated its authentication commands. The new commands are:
- 'hf auth login' instead of 'hf login'
- 'hf auth logout' instead of 'hf logout'

This change adds get_login_args() and get_logout_args() methods to the base HFStyleRepoModel class that can be overridden by subclasses to provide the correct subcommand structure.

The Huggingface class now overrides these methods to return ['auth', 'login'] and ['auth', 'logout'] respectively, which are combined with the CLI command to form the correct command.

For reference: https://huggingface.co/docs/huggingface_hub/guides/cli#hf-auth-login

This PR was created with the help of Cursor AI.

## Summary by Sourcery

Update authentication commands to support the new HuggingFace CLI structure by introducing overrideable methods for login and logout arguments and implementing them in the HuggingFace subclass.

Bug Fixes:
- Fix HuggingFace CLI login/logout commands to use the updated 'hf auth login' and 'hf auth logout' structure.

Enhancements:
- Add get_login_args and get_logout_args methods in the HFStyleRepoModel base class for flexible CLI subcommands.