### PR TITLE
Add community meetup references to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1218,7 +1218,6 @@ We host a public community and developer meetup on Discord every other week to d
 [**Join on Discord**](https://discord.gg/MkCXuTRBUn)
 [**Meeting Agenda**](https://docs.google.com/document/d/1wiqn7ItKgc8BgyTUQ46eeY23ms_hWbkhAoiP9D1ClfY/edit?tab=t.0#heading=h.b1x47hb6d0pt)
 
-
 ## Roadmap
 
 See the full [Roadmap](./Roadmap.md).


### PR DESCRIPTION
## Summary by Sourcery

Add a new Community / Develop Meetups section to the project README to highlight bi-weekly Discord gatherings and provide relevant links

Documentation:
- Add a Community / Develop Meetups heading and description to README
- Include Discord invitation link
- Include link to meeting agenda document