### PR TITLE
Add GPU-specific VLLM image support

### DIFF
--- a/docs/ramalama.conf
+++ b/docs/ramalama.conf
@@ -72,7 +72,13 @@
 #HIP_VISIBLE_DEVICES="quay.io/ramalama/rocm"
 #INTEL_VISIBLE_DEVICES="quay.io/ramalama/intel-gpu"
 #MUSA_VISIBLE_DEVICES="quay.io/ramalama/musa"
-#VLLM="registry.redhat.io/rhelai1/ramalama-vllm"
+#VLLM_ASAHI_VISIBLE_DEVICES="docker.io/vllm/vllm-openai"
+#VLLM_ASCEND_VISIBLE_DEVICES="docker.io/vllm/vllm-openai"
+#VLLM_CUDA_VISIBLE_DEVICES="docker.io/vllm/vllm-openai"
+#VLLM_GGML_VK_VISIBLE_DEVICES="docker.io/vllm/vllm-openai"
+#VLLM_HIP_VISIBLE_DEVICES="docker.io/vllm/vllm-openai"
+#VLLM_INTEL_VISIBLE_DEVICES="docker.io/vllm/vllm-openai"
+#VLLM_MUSA_VISIBLE_DEVICES="docker.io/vllm/vllm-openai"
 
 # IP address for llama.cpp to listen on.
 #

--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -690,12 +690,20 @@ def accel_image(config: Config, images: dict[str, str] | None = None, conf_key: 
     if not images:
         images = config.images
 
-    if config.runtime == "vllm":
-        return config.images["VLLM"]
-
     set_gpu_type_env_vars()
     gpu_type = next(iter(get_gpu_type_env_vars()), "")
 
+    if config.runtime == "vllm":
+        # Check for GPU-specific VLLM image, with a fallback to the generic one.
+        image = None
+        if gpu_type:
+            image = config.images.get(f"VLLM_{gpu_type}")
+
+        if not image:
+            image = config.images.get("VLLM", "docker.io/vllm/vllm-openai")
+
+        # If the image from the config is specified by tag or digest, return it unmodified
+        return image if ":" in image else f"{image}:latest"
     # Get image based on detected GPU type
     image = images.get(gpu_type, getattr(config, f"default_{conf_key}"))
 

--- a/ramalama/config.py
+++ b/ramalama/config.py
@@ -150,7 +150,13 @@ class BaseConfig:
             "HIP_VISIBLE_DEVICES": "quay.io/ramalama/rocm",
             "INTEL_VISIBLE_DEVICES": "quay.io/ramalama/intel-gpu",
             "MUSA_VISIBLE_DEVICES": "quay.io/ramalama/musa",
-            "VLLM": "registry.redhat.io/rhelai1/ramalama-vllm",
+            "VLLM_ASAHI_VISIBLE_DEVICES": "docker.io/vllm/vllm-openai",
+            "VLLM_ASCEND_VISIBLE_DEVICES": "docker.io/vllm/vllm-openai",
+            "VLLM_CUDA_VISIBLE_DEVICES": "docker.io/vllm/vllm-openai",
+            "VLLM_GGML_VK_VISIBLE_DEVICES": "docker.io/vllm/vllm-openai",
+            "VLLM_HIP_VISIBLE_DEVICES": "docker.io/vllm/vllm-openai",
+            "VLLM_INTEL_VISIBLE_DEVICES": "docker.io/vllm/vllm-openai",
+            "VLLM_MUSA_VISIBLE_DEVICES": "docker.io/vllm/vllm-openai",
         }
     )
     rag_image: str | None = None


### PR DESCRIPTION
Fixes #2118

RamaLama now supports different VLLM container images based on the detected GPU type (CUDA, HIP, Intel, etc.), similar to how it handles other runtime images.

Changes:
- Added VLLM_<GPU_TYPE> image keys to the default config for each supported GPU type (CUDA, HIP, ASAHI, ASCEND, Intel, MUSA, Vulkan)
- Updated accel_image() to detect GPU type and select the appropriate VLLM image based on the detected GPU
- Falls back to generic VLLM image if no GPU-specific image is found
- Defaults to upstream docker.io/vllm/vllm-openai images for GPU-specific configurations
- Updated ramalama.conf documentation to reflect new configuration options

Users can now override the default VLLM images per GPU type in their configuration files. For example:

[ramalama.images]
VLLM_CUDA_VISIBLE_DEVICES="registry.redhat.io/rhelai1/vllm-cuda-rhel9" VLLM_HIP_VISIBLE_DEVICES="registry.redhat.io/rhelai1/vllm-rocm-rhel9"

This PR was created with the help of Cursor AI.

## Summary by Sourcery

Enable GPU-specific VLLM container image selection by detecting GPU type and using VLLM_<GPU_TYPE> configuration keys with fallback to a generic image, updating defaults and documentation accordingly.

New Features:
- Add VLLM_<GPU_TYPE> image keys for CUDA, HIP, ASAHI, ASCEND, INTEL, MUSA, and GGML_VK in the default configuration
- Detect GPU type in accel_image and select the corresponding VLLM_<GPU_TYPE> image with fallback to the generic VLLM image

Enhancements:
- Always append the :latest tag to unversioned VLLM images
- Default GPU-specific VLLM images to upstream docker.io/vllm/vllm-openai repositories

Documentation:
- Update ramalama.conf to document the new VLLM_<GPU_TYPE> configuration options and default values