### PR TITLE
Fix nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1762363567,
+        "narHash": "sha256-YRqMDEtSMbitIMj+JLpheSz0pwEr0Rmy5mC7myl17xs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ae814fd3904b621d8ab97418f1d0f2eb0d3716f4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,15 @@
               python3Packages.buildPythonPackage ({
                 name = "ramalama";
                 src = ./.;
-                dependencies = [ (llama-cpp.override llamaCppOverrides) ];
+                pyproject = true;
+                build-system = with python3Packages; [ setuptools ];
+                dependencies = with python3Packages; [
+                  argcomplete
+                  pyyaml
+                  jsonschema
+                  jinja2
+                  (llama-cpp.override llamaCppOverrides)
+                ];
                 nativeBuildInputs =
                   (with pkgs; [ codespell shellcheck isort bats jq apacheHttpd ]) ++
                   (with pkgs.python3Packages; [ flake8 black pytest ]);
@@ -52,7 +60,7 @@
         default = ramalama.${system}.package;
       });
 
-      apps = forAllSystems (system :{
+      apps = forAllSystems (system: {
         ramalama = ramalama.${system}.app;
         default = ramalama.${system}.app;
       });


### PR DESCRIPTION
* fix python build
* add missing runtime dependencies

## Summary by Sourcery

Fix nix flake by correcting the Python build configuration and adding missing runtime dependencies

Bug Fixes:
- Enable pyproject-based build and specify setuptools as the build-system for the Python package

Enhancements:
- Include argcomplete, pyyaml, jsonschema, and jinja2 in the Python package dependencies

Chores:
- Regenerate flake.lock