### PR TITLE
Pin black linter to 25.9.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,6 @@ version = {attr = "ramalama.version.version"}
 [tool.black]
 line-length = 120
 skip-string-normalization = true
-preview = true
 target-version = ["py310", "py311", "py312", "py313"]
 extend-exclude = "(.history|build|dist|docs|hack)"
 


### PR DESCRIPTION
black 25.11.0 is reformatting 25.9.0 formatted code. Pin to the previous version until this is resolved.

## Summary by Sourcery

Pin the Black code formatter to version 25.9.0 to prevent unintended reformatting by newer releases

Build:
- Add --required-version 25.9.0 flag to Black commands in the Makefile
- Lock Black dependency to 25.9.0 in pyproject.toml