### PR TITLE
Disable preview flag for black formatter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,6 @@ version = {attr = "ramalama.version.version"}
 [tool.black]
 line-length = 120
 skip-string-normalization = true
-preview = true
 target-version = ["py310", "py311", "py312", "py313"]
 extend-exclude = "(.history|build|dist|docs|hack)"
 


### PR DESCRIPTION
The preview flag is exempt from the [stability policy](https://black.readthedocs.io/en/stable/the_black_code_style/index.html#stability-policy). It enables style changing features that will become default in 26.x.

black 25.11.0, which has just been released, includes "Move multiline_string_handling from --unstable to --preview" which is causing CI to now fail.