### PR TITLE
fix: Prevent duplicate CLI debug logs by stopping logger propagation

### DIFF
--- a/ramalama/logger.py
+++ b/ramalama/logger.py
@@ -13,12 +13,15 @@ def configure_logger(verbosity="WARNING") -> None:
         lvl = typing.cast(int, getattr(logging, verbosity))
 
     logger.setLevel(lvl)
+    logger.propagate = False
 
     fmt = "%(asctime)s - %(levelname)s - %(message)s"
     datefmt = "%Y-%m-%d %H:%M:%S"
     formatter = logging.Formatter(fmt, datefmt)
 
-    handler = logging.StreamHandler(sys.stderr)
-    handler.setLevel(lvl)
-    handler.setFormatter(formatter)
-    logger.addHandler(handler)
+    if not logger.handlers:
+        logger.addHandler(logging.StreamHandler(sys.stderr))
+
+    for handler in logger.handlers:
+        handler.setLevel(lvl)
+        handler.setFormatter(formatter)


### PR DESCRIPTION
- stop the CLI logger from propagating to the root logger so we only emit the timestamped formatter once
- reuse existing handlers on reconfiguration so debug mode can adjust level/format without stacking duplicates

Before:
```
 ramalama --debug run -c 50000 --temp 0.7 --runtime-args="--top-k 20 --top-p 0.8 --frequency-penalty 1.05" hf://unsloth/Qwen3-30B-A3B-Instruct-2507-GGUF/Qwen3-30B-A3B-Instruct-2507-UD-Q4_K_XL.gguf
2025-11-11 10:05:34 - DEBUG - Checking if 8080 is available
DEBUG:ramalama:Checking if 8080 is available
2025-11-11 10:05:34 - DEBUG - run_cmd: podman inspect quay.io/ramalama/rocm:0.14
DEBUG:ramalama:run_cmd: podman inspect quay.io/ramalama/rocm:0.14
2025-11-11 10:05:34 - DEBUG - Working directory: None
DEBUG:ramalama:Working directory: None
2025-11-11 10:05:34 - DEBUG - Ignore stderr: False
DEBUG:ramalama:Ignore stderr: False
2025-11-11 10:05:34 - DEBUG - Ignore all: True
DEBUG:ramalama:Ignore all: True
2025-11-11 10:05:34 - DEBUG - env: None
DEBUG:ramalama:env: None
2025-11-11 10:05:34 - DEBUG - run_cmd: podman inspect quay.io/ramalama/rocm:0.14
DEBUG:ramalama:run_cmd: podman inspect quay.io/ramalama/rocm:0.14
2025-11-11 10:05:34 - DEBUG - Working directory: None
DEBUG:ramalama:Working directory: None
2025-11-11 10:05:34 - DEBUG - Ignore stderr: False
DEBUG:ramalama:Ignore stderr: False
2025-11-11 10:05:34 - DEBUG - Ignore all: True
DEBUG:ramalama:Ignore all: True
2025-11-11 10:05:34 - DEBUG - env: None
DEBUG:ramalama:env: None
2025-11-11 10:05:34 - DEBUG - exec_cmd: podman run...
```

After:
```
❯ ramalama --debug run -c 50000 --temp 0.7 --runtime-args="--top-k 20 --top-p 0.8 --frequency-penalty 1.05" hf://unsloth/Qwen3-30B-A3B-Instruct-2507-GGUF/Qwen3-30B-A3B-Instruct-2507-UD-Q4_K_XL.gguf
2025-11-11 10:07:42 - DEBUG - Checking if 8080 is available
2025-11-11 10:07:42 - DEBUG - Checking if 8113 is available
2025-11-11 10:07:42 - DEBUG - run_cmd: podman inspect quay.io/ramalama/rocm:0.14
2025-11-11 10:07:42 - DEBUG - Working directory: None
2025-11-11 10:07:42 - DEBUG - Ignore stderr: False
2025-11-11 10:07:42 - DEBUG - Ignore all: True
2025-11-11 10:07:42 - DEBUG - env: None
2025-11-11 10:07:42 - DEBUG - run_cmd: podman inspect quay.io/ramalama/rocm:0.14
2025-11-11 10:07:42 - DEBUG - Working directory: None
2025-11-11 10:07:42 - DEBUG - Ignore stderr: False
2025-11-11 10:07:42 - DEBUG - Ignore all: True
2025-11-11 10:07:42 - DEBUG - env: None
2025-11-11 10:07:42 - DEBUG - exec_cmd: podman run...
```

Tangentially related to #2132 but most certainly does **not** close it out.

## Summary by Sourcery

Prevent duplicate CLI debug logs by disabling logger propagation and reusing handlers when reconfiguring the logger.

Bug Fixes:
- Disable CLI logger propagation to root logger to eliminate duplicate log entries.

Enhancements:
- Reuse existing handlers on logger reconfiguration to update level and formatter without stacking duplicates.