### PR TITLE
Feat/log level

### DIFF
--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -39,6 +39,7 @@ from ramalama.config import (
     load_file_config,
 )
 from ramalama.endian import EndianMismatchError
+from ramalama.log_levels import LogLevel
 from ramalama.logger import configure_logger, logger
 from ramalama.model_inspect.error import ParseError
 from ramalama.model_store.global_store import GlobalModelStore
@@ -369,7 +370,8 @@ def post_parse_setup(args):
     if hasattr(args, 'pull'):
         args.pull = normalize_pull_arg(args.pull, getattr(args, 'engine', None))
 
-    configure_logger("DEBUG" if args.debug else "WARNING")
+    log_level = LogLevel.DEBUG if args.debug else (CONFIG.log_level or LogLevel.WARNING)
+    configure_logger(log_level)
 
 
 def login_parser(subparsers):

--- a/ramalama/daemon/daemon.py
+++ b/ramalama/daemon/daemon.py
@@ -6,9 +6,11 @@ import socketserver
 import threading
 from datetime import datetime, timedelta
 
+from ramalama.config import CONFIG
 from ramalama.daemon.handler.ramalama import RamalamaHandler
-from ramalama.daemon.logging import LogLevel, configure_logger, logger
+from ramalama.daemon.logging import configure_logger, logger
 from ramalama.daemon.service.model_runner import ModelRunner
+from ramalama.log_levels import LogLevel
 
 
 class ShutdownHandler:
@@ -70,7 +72,6 @@ class ShutdownHandler:
 
 
 class RamalamaServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
-
     def __init__(
         self, host: str, port: int, model_store_path: str, idle_check_interval: timedelta, bind_and_activate=True
     ):
@@ -121,7 +122,7 @@ def parse_args():
 
 
 def run(host: str = "0.0.0.0", port: int = 8080, model_store_path: str = "/models"):
-    configure_logger(LogLevel.DEBUG)
+    configure_logger(CONFIG.log_level or LogLevel.DEBUG)
     logger.debug(f"Starting Ramalama daemon on {host}:{port}...")
     with RamalamaServer(host, port, model_store_path, timedelta(seconds=10)) as httpd:
         with ShutdownHandler(httpd):

--- a/ramalama/daemon/logging.py
+++ b/ramalama/daemon/logging.py
@@ -1,18 +1,9 @@
 import logging
 import os
-import typing
-from enum import IntEnum
+
+from ramalama.log_levels import LogLevel
 
 DEFAULT_LOG_DIR = "/var/tmp"
-
-
-class LogLevel(IntEnum):
-    DEBUG = typing.cast(int, getattr(logging, "DEBUG"))
-    INFO = typing.cast(int, getattr(logging, "INFO"))
-    WARNING = typing.cast(int, getattr(logging, "WARNING"))
-    ERROR = typing.cast(int, getattr(logging, "ERROR"))
-    CRITICAL = typing.cast(int, getattr(logging, "CRITICAL"))
-
 
 # Global logger
 logger = logging.getLogger("ramalama-daemon")

--- a/ramalama/log_levels.py
+++ b/ramalama/log_levels.py
@@ -1,0 +1,27 @@
+import logging
+from enum import IntEnum
+from typing import Union
+
+
+class LogLevel(IntEnum):
+    DEBUG = getattr(logging, "DEBUG")
+    INFO = getattr(logging, "INFO")
+    WARNING = getattr(logging, "WARNING")
+    ERROR = getattr(logging, "ERROR")
+    CRITICAL = getattr(logging, "CRITICAL")
+
+
+def coerce_log_level(level: Union["LogLevel", str, int]) -> LogLevel:
+    if isinstance(level, LogLevel):
+        return level
+    if isinstance(level, str):
+        try:
+            return LogLevel[level.upper()]
+        except KeyError as exc:
+            raise ValueError(f"Unsupported log level: {level}") from exc
+    if isinstance(level, int):
+        try:
+            return LogLevel(level)
+        except ValueError as exc:
+            raise ValueError(f"Unsupported log level value: {level}") from exc
+    raise TypeError(f"Cannot coerce {level!r} to LogLevel")

--- a/ramalama/logger.py
+++ b/ramalama/logger.py
@@ -1,18 +1,18 @@
 import logging
 import sys
-import typing
+
+from ramalama.log_levels import LogLevel, coerce_log_level
 
 logger = logging.getLogger("ramalama")
 
 
-def configure_logger(verbosity="WARNING") -> None:
+def configure_logger(level: LogLevel | str | int = LogLevel.WARNING) -> None:
     global logger
 
-    lvl = logging.WARNING
-    if verbosity in ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"):
-        lvl = typing.cast(int, getattr(logging, verbosity))
+    resolved_level = coerce_log_level(level)
+    lvl_value = int(resolved_level)
 
-    logger.setLevel(lvl)
+    logger.setLevel(lvl_value)
     logger.propagate = False
 
     fmt = "%(asctime)s - %(levelname)s - %(message)s"
@@ -23,5 +23,5 @@ def configure_logger(verbosity="WARNING") -> None:
         logger.addHandler(logging.StreamHandler(sys.stderr))
 
     for handler in logger.handlers:
-        handler.setLevel(lvl)
+        handler.setLevel(lvl_value)
         handler.setFormatter(formatter)

--- a/ramalama/mcp/mcp_agent.py
+++ b/ramalama/mcp/mcp_agent.py
@@ -7,10 +7,11 @@ import urllib.error
 import urllib.request
 from typing import Any, Dict, List
 
+from ramalama.config import CONFIG
 from ramalama.logger import logger
 from ramalama.mcp.mcp_client import PureMCPClient
 
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(level=CONFIG.log_level or logging.INFO)
 
 
 class LLMAgent:

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -12,6 +12,7 @@ from ramalama.config import (
     get_default_store,
     load_env_config,
 )
+from ramalama.log_levels import LogLevel
 
 
 def test_correct_config_defaults(monkeypatch):
@@ -163,6 +164,31 @@ def test_cfg_container_not_set():
         with patch("ramalama.config.load_env_config", return_value={}):
             assert cfg.is_set("container") is False
             assert cfg.container is (cfg.engine is not None)
+
+
+def test_base_config_accepts_none_log_level():
+    cfg = BaseConfig(engine=None)
+    assert cfg.log_level is None
+
+
+def test_base_config_coerces_log_level_strings():
+    cfg = BaseConfig(engine=None, log_level="info")
+    assert cfg.log_level == LogLevel.INFO
+
+
+def test_load_env_config_coerces_log_level():
+    cfg = load_env_config({"RAMALAMA_LOG_LEVEL": "debug"})
+    assert cfg["log_level"] == LogLevel.DEBUG
+
+
+@pytest.mark.xfail(raises=ValueError)
+def test_load_env_config_invalid_log_level_raises():
+    load_env_config({"RAMALAMA_LOG_LEVEL": "notalevel"})
+
+
+@pytest.mark.xfail(raises=ValueError)
+def test_load_env_config_invalid_log_level_case_raises():
+    load_env_config({"RAMALAMA_LOG_LEVEL": "InVaLiD"})
 
 
 class TestGetDefaultEngine:


### PR DESCRIPTION
## Summary by Sourcery

Introduce global log level configuration by adding a log_level setting to BaseConfig, coercion utilities, and updating all entry points (CLI, daemon, agent) to initialize logging accordingly.

New Features:
- Add configurable log level support via BaseConfig, environment variable, and CLI

Enhancements:
- Refactor configure_logger to accept LogLevel enum, strings, or integers with centralized coercion logic
- Update CLI, daemon, and mcp_agent to initialize logging based on configured log level or --debug flag

Documentation:
- Document log_level setting and RAMALAMA_LOG_LEVEL environment variable in the configuration manpage

Tests:
- Add unit tests for log level coercion and logger setup covering debug override, config default, and warning fallback