### PR TITLE
renovate: only update the docsite lockfiles once a week

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -85,6 +85,18 @@
         "custom.rocm"
       ],
       "groupName": "amdgpu-rocm"
+    },
+    {
+      "matchPaths": [
+        "docsite/**"
+      ],
+      "matchUpdateTypes": [
+        "lockFileMaintenance"
+      ],
+      "groupName": "docsite lockfile maintenance",
+      "schedule": [
+        "before 9am on Monday"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary by Sourcery

Adjust Renovate configuration to update the documentation site’s lockfiles on a weekly schedule instead of on every run.

Enhancements:
- Limit Renovate updates for docsite lockfiles to a once-weekly schedule in renovate.json

CI:
- Add a schedule override for docsite lockfile updates to run weekly