### PR TITLE
automatic chat summerizor to prevent context growth

### DIFF
--- a/docs/ramalama-chat.1.md
+++ b/docs/ramalama-chat.1.md
@@ -43,6 +43,12 @@ Prefix for the user prompt (default: 🦭 > )
 #### **--rag**=path
 A file or directory of files to be loaded and provided as local context in the chat history.
 
+#### **--summarize-after**=*N*
+Automatically summarize conversation history after N messages to prevent context growth.
+When enabled, ramalama will periodically condense older messages into a summary,
+keeping only recent messages and the summary. This prevents the context from growing
+indefinitely during long chat sessions. Set to 0 to disable (default: 4).
+
 #### **--url**=URL
 The host to send requests to (default: http://127.0.0.1:8080)
 

--- a/docs/ramalama-run.1.md
+++ b/docs/ramalama-run.1.md
@@ -179,6 +179,12 @@ Specify seed rather than using random seed model interaction
 #### **--selinux**=*true*
 Enable SELinux container separation
 
+#### **--summarize-after**=*N*
+Automatically summarize conversation history after N messages to prevent context growth.
+When enabled, ramalama will periodically condense older messages into a summary,
+keeping only recent messages and the summary. This prevents the context from growing
+indefinitely during long chat sessions. Set to 0 to disable (default: 4).
+
 #### **--temp**="0.8"
 Temperature of the response from the AI Model
 llama.cpp explains this as:

--- a/docs/ramalama.conf
+++ b/docs/ramalama.conf
@@ -136,6 +136,13 @@
 #
 #store = "$HOME/.local/share/ramalama"
 
+# Automatically summarize conversation history after N messages to prevent context growth
+# When enabled, ramalama will periodically condense older messages into a summary,
+# keeping only recent messages and the summary. This prevents the context from growing
+# indefinitely during long chat sessions. Set to 0 to disable.
+#
+#summarize_after = 4
+
 # Temperature of the response from the AI Model
 # llama.cpp explains this as:
 #

--- a/docs/ramalama.conf.5.md
+++ b/docs/ramalama.conf.5.md
@@ -180,6 +180,13 @@ SELinux container separation enforcement
 
 Store AI Models in the specified directory
 
+**summarize_after**=4
+
+Automatically summarize conversation history after N messages to prevent context growth.
+When enabled, ramalama will periodically condense older messages into a summary,
+keeping only recent messages and the summary. This prevents the context from growing
+indefinitely during long chat sessions. Set to 0 to disable (default: 4).
+
 **temp**="0.8"
 Temperature of the response from the AI Model
 llama.cpp explains this as:

--- a/docsite/package-lock.json
+++ b/docsite/package-lock.json
@@ -6106,9 +6106,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001754",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001754.tgz",
-      "integrity": "sha512-x6OeBXueoAceOmotzx3PO4Zpt4rzpeIFsSr6AAePTZxSkXiYDUmpypEl7e2+8NCd9bD7bXjqyef8CJYPC1jfxg==",
+      "version": "1.0.30001755",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001755.tgz",
+      "integrity": "sha512-44V+Jm6ctPj7R52Na4TLi3Zri4dWUljJd+RDm+j8LtNCc/ihLCT+X1TzoOAkRETEWqjuLnh9581Tl80FvK7jVA==",
       "funding": [
         {
           "type": "opencollective",
@@ -7209,9 +7209,9 @@
       "license": "CC0-1.0"
     },
     "node_modules/csstype": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.1.tgz",
-      "integrity": "sha512-98XGutrXoh75MlgLihlNxAGbUuFQc7l1cqcnEZlLNKc0UrVdPndgmaDmYTDDh929VS/eqTZV0rozmhu2qqT1/g==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.2.tgz",
+      "integrity": "sha512-D80T+tiqkd/8B0xNlbstWDG4x6aqVfO52+OlSUNIdkTvmNw0uQpJLeos2J/2XvpyidAFuTPmpad+tUxLndwj6g==",
       "license": "MIT"
     },
     "node_modules/debounce": {
@@ -9436,9 +9436,9 @@
       }
     },
     "node_modules/inline-style-parser": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.6.tgz",
-      "integrity": "sha512-gtGXVaBdl5mAes3rPcMedEBm12ibjt1kDMFfheul1wUAOVEJW60voNdMVzVkfLN06O7ZaD/rxhfKgtlgtTbMjg==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
       "license": "MIT"
     },
     "node_modules/invariant": {
@@ -16475,21 +16475,21 @@
       }
     },
     "node_modules/style-to-js": {
-      "version": "1.1.20",
-      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.20.tgz",
-      "integrity": "sha512-gfXNMzSpR4EU8xCJRQOh69ex6vtO+HWSbSZo58uBfT0UCgpVH84Yr8IQIqSAmjbDBFFG/6fwQUt6SqBGz/Jj2g==",
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
       "license": "MIT",
       "dependencies": {
-        "style-to-object": "1.0.12"
+        "style-to-object": "1.0.14"
       }
     },
     "node_modules/style-to-object": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.12.tgz",
-      "integrity": "sha512-ddJqYnoT4t97QvN2C95bCgt+m7AAgXjVnkk/jxAfmp7EAB8nnqqZYEbMd3em7/vEomDb2LAQKAy1RFfv41mdNw==",
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
       "license": "MIT",
       "dependencies": {
-        "inline-style-parser": "0.2.6"
+        "inline-style-parser": "0.2.7"
       }
     },
     "node_modules/stylehacks": {

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -1075,6 +1075,13 @@ def chat_run_options(parser):
     )
     parser.add_argument("--prefix", type=str, help="prefix for the user prompt", default=default_prefix())
     parser.add_argument("--mcp", nargs="*", help="MCP servers to use for the chat")
+    parser.add_argument(
+        "--summarize-after",
+        type=int,
+        default=CONFIG.summarize_after,
+        metavar="N",
+        help="automatically summarize conversation history after N messages to prevent context growth (0=disabled)",
+    )
 
 
 def chat_parser(subparsers):

--- a/ramalama/config.py
+++ b/ramalama/config.py
@@ -206,6 +206,7 @@ class BaseConfig:
     settings: RamalamaSettings = field(default_factory=RamalamaSettings)
     stack_image: str = DEFAULT_STACK_IMAGE
     store: str = field(default_factory=get_default_store)
+    summarize_after: int = 4
     temp: str = "0.8"
     thinking: bool = True
     threads: int = -1
@@ -311,7 +312,7 @@ def load_env_config(env: Mapping[str, str] | None = None) -> dict[str, Any]:
         if key in config:
             config[key] = coerce_to_bool(config[key])
 
-    for key in ['threads', 'ctx_size', 'ngl']:
+    for key in ['threads', 'ctx_size', 'ngl', 'summarize_after']:
         if key in config:
             config[key] = int(config[key])
     return config


### PR DESCRIPTION
Fixes: https://github.com/containers/ramalama/issues/2100
Fixes: https://github.com/containers/ramalama/issues/1914

Implement conversation history summarization that automatically condenses older messages to prevent the context from growing indefinitely during long chat sessions. This addresses excessive token usage, context window overflow, and performance degradation in extended conversations.

Implementation:
- Add summarize_after config option (default: 4 messages)
- Periodically summarize conversation history using the LLM
- Preserve first message (system/RAG context) and recent messages
- Replace middle messages with a concise summary
- Track message count and trigger summarization at threshold

Configuration:
- Set in ramalama.conf: summarize_after = 4
- Override via CLI: --summarize-after N
- Environment variable: RAMALAMA_SUMMARIZE_AFTER=N
- Set to 0 to disable

How it works:
After N message exchanges, the conversation history is restructured:
  Before: [system, user1, assistant1, user2, assistant2, user3, assistant3, ...]
  After:  [system, summary_of_middle, user3, assistant3]

This keeps the context bounded while preserving conversation continuity.

Cursor-AI-Generated

## Summary by Sourcery

Prevent unbounded context growth by summarizing older messages after a configurable number of exchanges, keeping only the system context, a summary, and the most recent messages.

New Features:
- Add automatic conversation summarization to condense older chat messages when threshold is reached
- Introduce summarize_after setting with config file, CLI flag, and environment variable to control summarization frequency

Enhancements:
- Track message count in Chat and trigger summarization to rebuild history with system context, summary, and recent messages

Documentation:
- Document summarize_after option in ramalama.conf, man pages, and CLI help