### PR TITLE
bats: add procps-ng

### DIFF
--- a/container-images/bats/Containerfile
+++ b/container-images/bats/Containerfile
@@ -7,7 +7,7 @@ WORKDIR /src
 ENTRYPOINT ["/usr/bin/entrypoint.sh"]
 
 RUN dnf -y --setopt=install_weak_deps=false install \
-    make bats jq iproute podman openssl httpd-tools diffutils \
+    make bats jq iproute podman openssl httpd-tools diffutils procps-ng \
     $([ $(uname -m) == "x86_64" ] && echo ollama) \
     # for validate and unit-tests
     shellcheck \


### PR DESCRIPTION
The `pkill` command is required by `050-pull.bats`.

## Summary by Sourcery

Enhancements:
- Install procps-ng in the Bats Containerfile to provide the pkill command required by tests