### PR TITLE
fix: addressed rag read write error and timeout error

### DIFF
--- a/container-images/scripts/rag_framework
+++ b/container-images/scripts/rag_framework
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 
 # All imports first
+import asyncio
 import logging
 import os
-import socket
 import sys
 import textwrap
 import time
@@ -116,27 +116,31 @@ async def request(host: str, port: int, path: str, timeout: int = 10):
             return resp, data
 
 
-async def wait_for_llama_server(host: str, port: int, timeout: int = 10):
-    end_time = time.monotonic() + timeout
-    first_attempt = True
+async def wait_for_llama_server(host: str, port: int, total_timeout: int = 120, print_interval: int = 5):
+    end_time = time.monotonic() + total_timeout
+    last_print = 0
+    request_timeout = 1  # Timeout per individual HTTP request
 
     while time.monotonic() < end_time:
         try:
-            resp, data = await request(host, port, "/health", timeout=timeout)
+            resp, data = await request(host, port, "/health", timeout=request_timeout)
             if resp.status == 200:
                 return True
-            elif first_attempt:
+
+            now = time.monotonic()
+            if now - last_print >= print_interval:
                 print(f"Server at {host}:{port} is running but not ready (status={resp.status}), retrying...")
-                first_attempt = False
-        except OSError:
-            if first_attempt:
-                print(f"No server responding at {host}:{port}, retrying for up to {timeout} seconds...")
-                first_attempt = False
-        except socket.gaierror:
-            print(f"Cannot resolve host '{host}'", file=sys.stderr)
-            sys.exit(1)
-    print(f"Error: llama-server at {host}:{port} did not become ready after {timeout} seconds.")
-    sys.exit(1)
+                last_print = now
+
+        except Exception as e:
+            now = time.monotonic()
+            if now - last_print >= print_interval:
+                print(f"Error connecting to {host}:{port}: {e}, retrying...")
+                last_print = now
+
+        await asyncio.sleep(1)
+
+    raise TimeoutError(f"LLaMA server at {host}:{port} did not become ready after {total_timeout} seconds.")
 
 
 class qdrant:
@@ -393,7 +397,7 @@ def initialize_rag_service() -> OpenAICompatibleRagService:
 async def lifespan(app: FastAPI):
     args = get_args()
     initialize_rag_service()
-    await wait_for_llama_server(args.model_host, args.model_port)
+    await wait_for_llama_server(args.model_host, args.model_port, total_timeout=120)
     yield
 
 

--- a/test/e2e/test_serve.py
+++ b/test/e2e/test_serve.py
@@ -749,7 +749,7 @@ def test_serve_with_rag():
         assert re.search(r".*quay.io/ramalama/.*-rag:", result_a)
         assert re.search(r".*rag_framework serve", result_a)
         assert re.search(r".*--port 8080", result_a)
-        assert re.search(r".*--mount=type=image,source=quay.io/ramalama/rag,destination=/rag", result_a)
+        assert re.search(r".*--mount=type=image,source=quay.io/ramalama/rag,destination=/rag,rw=true", result_a)
 
         result_b = ctx.check_output(
             [

--- a/test/system/040-serve.bats
+++ b/test/system/040-serve.bats
@@ -544,7 +544,7 @@ verify_begin=".*run --rm"
     is "${lines[1]}" ".*quay.io/ramalama/.*-rag:" "Expected to use -rag image in separate container"
     is "${lines[1]}" ".*rag_framework serve" "Expected to run rag_framework in a separate container"
     is "${lines[1]}" ".*--port 8080" "Expected to run rag_framework on port 8080"
-    is "${lines[1]}" ".*--mount=type=image,source=quay.io/ramalama/rag,destination=/rag" "Expected RAG image to be mounted into separate container"
+    is "${lines[1]}" ".*--mount=type=image,source=quay.io/ramalama/rag,destination=/rag,rw=true" "Expected RAG image to be mounted into separate container"
 
     run_ramalama --dryrun serve --image quay.io/ramalama/ramalama:1.0 --rag quay.io/ramalama/rag --pull=never tiny
     is "${lines[0]}" ".*quay.io/ramalama/ramalama:1.0" "Expected --image to be used"

--- a/test/system/070-rag.bats
+++ b/test/system/070-rag.bats
@@ -59,8 +59,8 @@ load helpers
     is "${lines[1]}" ".*quay.io/ramalama/.*-rag:" "Expected to use -rag image in separate container"
     is "${lines[1]}" ".*rag_framework serve" "Expected to run rag_framework in a separate container"
     is "${lines[1]}" ".*--port 8080" "Expected to run rag_framework on port 8080"
-    is "${lines[1]}" ".*--mount=type=image,source=quay.io/ramalama/myrag:1.2,destination=/rag" "Expected RAG image to be mounted into separate container"
     if not_docker; then
+       is "${lines[1]}" ".*--mount=type=image,source=quay.io/ramalama/myrag:1.2,destination=/rag,rw=true" "Expected RAG image to be mounted into separate container with rw=true for Podman"
        is "$output" ".*--pull missing.*" "Expected to use --pull missing"
        RAMALAMA_CONFIG=/dev/null run_ramalama --dryrun run --rag quay.io/ramalama/myrag:1.2 ollama://smollm:135m
        is "$output" ".*--pull newer.*" "Expected to use --pull newer"


### PR DESCRIPTION
this fix address both errors that prevent rag run and service from starting

Fixes: https://github.com/containers/ramalama/issues/2079

## Summary by Sourcery

Fix RAG mount read/write errors by explicitly enabling write access for image mounts in Podman while preserving default behavior for Docker, and update tests to reflect the change

Bug Fixes:
- Add rw=true to Podman image mounts to allow write access and prevent RAG startup failures

Enhancements:
- Retain default read-write behavior for bind mounts on RAG DB sources without redundant temp mounting

Tests:
- Update end-to-end and system tests to expect the rw=true flag on RAG image mounts