### PR TITLE
konflux: on PRs, only build images when there is a change that's relevant to the image content

### DIFF
--- a/.tekton/asahi/asahi-pull-request.yaml
+++ b/.tekton/asahi/asahi-pull-request.yaml
@@ -9,7 +9,14 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: >-
-      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review"
+      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review" &&
+      (
+        "container-images/scripts/build_llama_and_whisper.sh".pathChanged() ||
+        "container-images/scripts/lib.sh".pathChanged() ||
+        "container-images/asahi/*".pathChanged() ||
+        ".tekton/pipelines/pull-request-pipeline.yaml".pathChanged() ||
+        ".tekton/asahi/asahi-pull-request.yaml".pathChanged()
+      )
   labels:
     appstudio.openshift.io/application: ramalama
     appstudio.openshift.io/component: asahi

--- a/.tekton/cann/cann-pull-request.yaml
+++ b/.tekton/cann/cann-pull-request.yaml
@@ -9,7 +9,14 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: >-
-      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review"
+      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review" &&
+      (
+        "container-images/scripts/build_llama_and_whisper.sh".pathChanged() ||
+        "container-images/scripts/lib.sh".pathChanged() ||
+        "container-images/cann/*".pathChanged() ||
+        ".tekton/pipelines/pull-request-pipeline.yaml".pathChanged() ||
+        ".tekton/cann/cann-pull-request.yaml".pathChanged()
+      )
   labels:
     appstudio.openshift.io/application: ramalama
     appstudio.openshift.io/component: cann

--- a/.tekton/cuda-llama-server/cuda-llama-server-pull-request.yaml
+++ b/.tekton/cuda-llama-server/cuda-llama-server-pull-request.yaml
@@ -9,7 +9,17 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: >-
-      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review"
+      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review" &&
+      (
+        "container-images/common/Containerfile.entrypoint".pathChanged() ||
+        "container-images/scripts/build_llama_and_whisper.sh".pathChanged() ||
+        "container-images/scripts/lib.sh".pathChanged() ||
+        "container-images/scripts/llama-server.sh".pathChanged() ||
+        "container-images/cuda/*".pathChanged() ||
+        ".tekton/pipelines/pull-request-pipeline.yaml".pathChanged() ||
+        ".tekton/cuda/cuda-pull-request.yaml".pathChanged() ||
+        ".tekton/cuda-llama-server/cuda-llama-server-pull-request.yaml".pathChanged()
+      )
   labels:
     appstudio.openshift.io/application: ramalama
     appstudio.openshift.io/component: cuda-llama-server

--- a/.tekton/cuda-rag/cuda-rag-pull-request.yaml
+++ b/.tekton/cuda-rag/cuda-rag-pull-request.yaml
@@ -9,7 +9,16 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: >-
-      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review"
+      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review" &&
+      (
+        "container-images/common/Containerfile.rag".pathChanged() ||
+        "container-images/common/requirements-rag-cu128*.txt".pathChanged() ||
+        "container-images/scripts/build_rag.sh".pathChanged() ||
+        "container-images/scripts/doc2rag".pathChanged() ||
+        "container-images/scripts/rag_framework".pathChanged() ||
+        ".tekton/pipelines/pull-request-pipeline.yaml".pathChanged() ||
+        ".tekton/cuda-rag/cuda-rag-pull-request.yaml".pathChanged()
+      )
   labels:
     appstudio.openshift.io/application: ramalama
     appstudio.openshift.io/component: cuda-rag

--- a/.tekton/cuda/cuda-pull-request.yaml
+++ b/.tekton/cuda/cuda-pull-request.yaml
@@ -9,7 +9,14 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: >-
-      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review"
+      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review" &&
+      (
+        "container-images/scripts/build_llama_and_whisper.sh".pathChanged() ||
+        "container-images/scripts/lib.sh".pathChanged() ||
+        "container-images/cuda/*".pathChanged() ||
+        ".tekton/pipelines/pull-request-pipeline.yaml".pathChanged() ||
+        ".tekton/cuda/cuda-pull-request.yaml".pathChanged()
+      )
   labels:
     appstudio.openshift.io/application: ramalama
     appstudio.openshift.io/component: cuda

--- a/.tekton/intel-gpu-rag/intel-gpu-rag-pull-request.yaml
+++ b/.tekton/intel-gpu-rag/intel-gpu-rag-pull-request.yaml
@@ -9,7 +9,16 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: >-
-      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review"
+      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review" &&
+      (
+        "container-images/common/Containerfile.rag".pathChanged() ||
+        "container-images/common/requirements-rag-xpu.txt".pathChanged() ||
+        "container-images/scripts/build_rag.sh".pathChanged() ||
+        "container-images/scripts/doc2rag".pathChanged() ||
+        "container-images/scripts/rag_framework".pathChanged() ||
+        ".tekton/pipelines/pull-request-pipeline.yaml".pathChanged() ||
+        ".tekton/intel-gpu-rag/intel-gpu-rag-pull-request.yaml".pathChanged()
+      )
   labels:
     appstudio.openshift.io/application: ramalama
     appstudio.openshift.io/component: intel-gpu-rag

--- a/.tekton/intel-gpu/intel-gpu-pull-request.yaml
+++ b/.tekton/intel-gpu/intel-gpu-pull-request.yaml
@@ -9,7 +9,14 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: >-
-      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review"
+      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review" &&
+      (
+        "container-images/scripts/build_llama_and_whisper.sh".pathChanged() ||
+        "container-images/scripts/lib.sh".pathChanged() ||
+        "container-images/intel-gpu/*".pathChanged() ||
+        ".tekton/pipelines/pull-request-pipeline.yaml".pathChanged() ||
+        ".tekton/intel-gpu/intel-gpu-pull-request.yaml".pathChanged()
+      )
   labels:
     appstudio.openshift.io/application: ramalama
     appstudio.openshift.io/component: intel-gpu

--- a/.tekton/llama-stack/llama-stack-pull-request.yaml
+++ b/.tekton/llama-stack/llama-stack-pull-request.yaml
@@ -9,7 +9,12 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: >-
-      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review"
+      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review" &&
+      (
+        "container-images/llama-stack/*".pathChanged() ||
+        ".tekton/pipelines/pull-request-pipeline.yaml".pathChanged() ||
+        ".tekton/llama-stack/llama-stack-pull-request.yaml".pathChanged()
+      )
   labels:
     appstudio.openshift.io/application: ramalama
     appstudio.openshift.io/component: llama-stack

--- a/.tekton/openvino/openvino-pull-request.yaml
+++ b/.tekton/openvino/openvino-pull-request.yaml
@@ -9,7 +9,12 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: >-
-      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review"
+      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review" &&
+      (
+        "container-images/openvino/*".pathChanged() ||
+        ".tekton/pipelines/pull-request-pipeline.yaml".pathChanged() ||
+        ".tekton/openvino/openvino-pull-request.yaml".pathChanged()
+      )
   labels:
     appstudio.openshift.io/application: ramalama
     appstudio.openshift.io/component: openvino

--- a/.tekton/ramalama-llama-server/ramalama-llama-server-pull-request.yaml
+++ b/.tekton/ramalama-llama-server/ramalama-llama-server-pull-request.yaml
@@ -9,7 +9,17 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: >-
-      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review"
+      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review" &&
+      (
+        "container-images/common/Containerfile.entrypoint".pathChanged() ||
+        "container-images/scripts/build_llama_and_whisper.sh".pathChanged() ||
+        "container-images/scripts/lib.sh".pathChanged() ||
+        "container-images/scripts/llama-server.sh".pathChanged() ||
+        "container-images/ramalama/*".pathChanged() ||
+        ".tekton/pipelines/pull-request-pipeline.yaml".pathChanged() ||
+        ".tekton/ramalama/ramalama-pull-request.yaml".pathChanged() ||
+        ".tekton/ramalama-llama-server/ramalama-llama-server-pull-request.yaml".pathChanged()
+      )
   labels:
     appstudio.openshift.io/application: ramalama
     appstudio.openshift.io/component: ramalama-llama-server

--- a/.tekton/ramalama-rag/ramalama-rag-pull-request.yaml
+++ b/.tekton/ramalama-rag/ramalama-rag-pull-request.yaml
@@ -9,7 +9,16 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: >-
-      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review"
+      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review" &&
+      (
+        "container-images/common/Containerfile.rag".pathChanged() ||
+        "container-images/common/requirements-rag-cpu*.txt".pathChanged() ||
+        "container-images/scripts/build_rag.sh".pathChanged() ||
+        "container-images/scripts/doc2rag".pathChanged() ||
+        "container-images/scripts/rag_framework".pathChanged() ||
+        ".tekton/pipelines/pull-request-pipeline.yaml".pathChanged() ||
+        ".tekton/ramalama-rag/ramalama-rag-pull-request.yaml".pathChanged()
+      )
   labels:
     appstudio.openshift.io/application: ramalama
     appstudio.openshift.io/component: ramalama-rag

--- a/.tekton/ramalama-whisper-server/ramalama-whisper-server-pull-request.yaml
+++ b/.tekton/ramalama-whisper-server/ramalama-whisper-server-pull-request.yaml
@@ -9,7 +9,17 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: >-
-      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review"
+      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review" &&
+      (
+        "container-images/common/Containerfile.entrypoint".pathChanged() ||
+        "container-images/scripts/build_llama_and_whisper.sh".pathChanged() ||
+        "container-images/scripts/lib.sh".pathChanged() ||
+        "container-images/scripts/whisper-server.sh".pathChanged() ||
+        "container-images/ramalama/*".pathChanged() ||
+        ".tekton/pipelines/pull-request-pipeline.yaml".pathChanged() ||
+        ".tekton/ramalama/ramalama-pull-request.yaml".pathChanged() ||
+        ".tekton/ramalama-whisper-server/ramalama-whisper-server-pull-request.yaml".pathChanged()
+      )
   labels:
     appstudio.openshift.io/application: ramalama
     appstudio.openshift.io/component: ramalama-whisper-server

--- a/.tekton/ramalama/ramalama-pull-request.yaml
+++ b/.tekton/ramalama/ramalama-pull-request.yaml
@@ -9,7 +9,14 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: >-
-      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review"
+      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review" &&
+      (
+        "container-images/scripts/build_llama_and_whisper.sh".pathChanged() ||
+        "container-images/scripts/lib.sh".pathChanged() ||
+        "container-images/ramalama/*".pathChanged() ||
+        ".tekton/pipelines/pull-request-pipeline.yaml".pathChanged() ||
+        ".tekton/ramalama/ramalama-pull-request.yaml".pathChanged()
+      )
   labels:
     appstudio.openshift.io/application: ramalama
     appstudio.openshift.io/component: ramalama

--- a/.tekton/rocm-rag/rocm-rag-pull-request.yaml
+++ b/.tekton/rocm-rag/rocm-rag-pull-request.yaml
@@ -9,7 +9,16 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: >-
-      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review"
+      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review" &&
+      (
+        "container-images/common/Containerfile.rag".pathChanged() ||
+        "container-images/common/requirements-rag-rocm6.3.txt".pathChanged() ||
+        "container-images/scripts/build_rag.sh".pathChanged() ||
+        "container-images/scripts/doc2rag".pathChanged() ||
+        "container-images/scripts/rag_framework".pathChanged() ||
+        ".tekton/pipelines/pull-request-pipeline.yaml".pathChanged() ||
+        ".tekton/rocm-rag/rocm-rag-pull-request.yaml".pathChanged()
+      )
   labels:
     appstudio.openshift.io/application: ramalama
     appstudio.openshift.io/component: rocm-rag

--- a/.tekton/rocm/rocm-pull-request.yaml
+++ b/.tekton/rocm/rocm-pull-request.yaml
@@ -9,7 +9,14 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: >-
-      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review"
+      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review" &&
+      (
+        "container-images/scripts/build_llama_and_whisper.sh".pathChanged() ||
+        "container-images/scripts/lib.sh".pathChanged() ||
+        "container-images/rocm/*".pathChanged() ||
+        ".tekton/pipelines/pull-request-pipeline.yaml".pathChanged() ||
+        ".tekton/rocm/rocm-pull-request.yaml".pathChanged()
+      )
   labels:
     appstudio.openshift.io/application: ramalama
     appstudio.openshift.io/component: rocm

--- a/.tekton/stable-diffusion/stable-diffusion-pull-request.yaml
+++ b/.tekton/stable-diffusion/stable-diffusion-pull-request.yaml
@@ -9,7 +9,13 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: >-
-      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review"
+      event == "pull_request" && target_branch == "main" && body.action != "ready_for_review" &&
+      (
+        "container-images/scripts/build_stable_diffusion.sh".pathChanged() ||
+        "container-images/stable-diffusion/*".pathChanged() ||
+        ".tekton/pipelines/pull-request-pipeline.yaml".pathChanged() ||
+        ".tekton/stable-diffusion/stable-diffusion-pull-request.yaml".pathChanged()
+      )
   labels:
     appstudio.openshift.io/application: ramalama
     appstudio.openshift.io/component: stable-diffusion


### PR DESCRIPTION
Avoid rebuilding all images on every PR by only triggering a build when there is a change that will affect the content of the image. If an image is unaffected by a PR, the last successful build triggered by a merge to the main branch will be used for testing.

## Summary by Sourcery

Restrict pull request image builds by adding path-based filters to Tekton on-cel expressions so pipelines only run when relevant container image or pipeline files are modified.

Enhancements:
- Add pathChanged conditions in each .tekton/*-pull-request.yaml to detect changes in container-images, scripts, and pipeline definitions.
- Use the last successful main branch build for unaffected images to avoid redundant builds on PRs.

CI:
- Update Tekton Pipelines on-cel-expression filters across all PR pipeline configs to only trigger on relevant file changes.