### PR TITLE
Pass through reasoning_content in RAG proxy streaming

### DIFF
--- a/container-images/scripts/rag_framework
+++ b/container-images/scripts/rag_framework
@@ -82,6 +82,7 @@ class ChatCompletionResponse(BaseModel):
 class Delta(BaseModel):
     role: str | None = None
     content: str | None = None
+    reasoning_content: str | None = None
 
 
 class StreamChoice(BaseModel):
@@ -349,16 +350,26 @@ class OpenAICompatibleRagService:
             )
 
             async for chunk in response:
-                if chunk.choices and chunk.choices[0].delta.content:
-                    content = chunk.choices[0].delta.content
+                if chunk.choices and (delta := chunk.choices[0].delta):
+                    # Use getattr to safely access optional attributes
+                    content = getattr(delta, 'content', None)
+                    reasoning_content = getattr(delta, 'reasoning_content', None)
 
-                    stream_chunk = ChatCompletionStreamResponse(
-                        id=completion_id,
-                        created=created,
-                        model=request.model,
-                        choices=[StreamChoice(index=0, delta=Delta(content=content), finish_reason=None)],
-                    )
-                    yield f"data: {stream_chunk.model_dump_json()}\n\n"
+                    # Only send chunk if there's actual content or reasoning
+                    if content is not None or reasoning_content is not None:
+                        stream_chunk = ChatCompletionStreamResponse(
+                            id=completion_id,
+                            created=created,
+                            model=request.model,
+                            choices=[
+                                StreamChoice(
+                                    index=0,
+                                    delta=Delta(content=content, reasoning_content=reasoning_content),
+                                    finish_reason=None,
+                                )
+                            ],
+                        )
+                        yield f"data: {stream_chunk.model_dump_json()}\n\n"
 
                 # Handle finish reason
                 if chunk.choices and chunk.choices[0].finish_reason:


### PR DESCRIPTION
The RAG proxy was not forwarding reasoning_content from the upstream model server to clients, causing reasoning models (deepseek-r1, qwq, etc.) to appear to work but without returning their reasoning process.

Changes:
- Add reasoning_content field to Delta pydantic model
- Use getattr() to safely extract reasoning_content from upstream LLM responses (attribute may not exist in all chunks)
- Forward reasoning_content in ChatCompletionStreamResponse

The getattr() approach is necessary because the OpenAI Python client's ChoiceDelta object conditionally includes reasoning_content - present in reasoning chunks, absent in metadata/initial chunks. Direct attribute access would cause AttributeError on non-reasoning chunks.

Tested with deepseek-r1:14b and llama3.2 - reasoning content now correctly passes through the RAG proxy to clients.

Assisted-by: Cursor with Claude Sonnet 4.5

## Summary by Sourcery

Forward reasoning model content through the RAG proxy streaming pipeline so clients receive both answers and reasoning traces.

New Features:
- Expose reasoning_content in streamed chat completion responses from the RAG proxy when provided by upstream reasoning models.

Enhancements:
- Extend the streaming delta data model to include an optional reasoning_content field and safely populate it from upstream LLM chunks to avoid errors when absent.