### PR TITLE
Add RAG modes and strengthen strict mode

### DIFF
--- a/container-images/scripts/rag_framework
+++ b/container-images/scripts/rag_framework
@@ -27,6 +27,12 @@ from pymilvus import AnnSearchRequest, AsyncMilvusClient, RRFRanker  # type: ign
 
 warnings.filterwarnings("ignore", category=UserWarning)
 
+# RAG mode constants
+RAG_MODE_STRICT = "strict"
+RAG_MODE_AUGMENT = "augment"
+VALID_RAG_MODES = {RAG_MODE_STRICT, RAG_MODE_AUGMENT}
+DEFAULT_RAG_MODE = RAG_MODE_AUGMENT
+
 # Global Vars
 EMBED_MODEL = os.getenv("EMBED_MODEL", "jinaai/jina-embeddings-v2-small-en")
 SPARSE_MODEL = os.getenv("SPARSE_MODEL", "prithivida/Splade_PP_en_v1")
@@ -253,12 +259,32 @@ class OpenAICompatibleRagService:
         conversation_history = self._extract_conversation_context(messages[:-1])
 
         # Enhanced system prompt with RAG context
-        system_prompt = (
-            textwrap.dedent(
-                """
-            You are an expert software architect assistant.
-            Use the provided context and conversation history to answer questions accurately and concisely.
-            If the answer is not in the context, respond with "I don't know" - do not fabricate details.
+        # Support two RAG modes via RAG_MODE environment variable:
+        # - strict: Only answer from documents, refuse general knowledge
+        # - augment: Use documents + general knowledge (default)
+        rag_mode = os.getenv("RAG_MODE", DEFAULT_RAG_MODE).lower()
+
+        # Validate RAG_MODE and warn if invalid
+        if rag_mode not in VALID_RAG_MODES:
+            logging.warning(
+                f"Invalid RAG_MODE '{rag_mode}' specified. "
+                f"Valid modes are '{', '.join(sorted(VALID_RAG_MODES))}'. "
+                f"Defaulting to '{DEFAULT_RAG_MODE}'."
+            )
+            rag_mode = DEFAULT_RAG_MODE
+
+        if rag_mode == RAG_MODE_STRICT:
+            system_prompt = (
+                textwrap.dedent(
+                    """
+            You are a strict document-based assistant. You MUST ONLY answer
+            questions using information from the provided context.
+
+            **CRITICAL RULES:**
+            - If the answer is NOT EXPLICITLY in the context below, you MUST respond with EXACTLY: "I don't know."
+            - Do NOT use your general knowledge
+            - Do NOT make assumptions or inferences beyond what's stated
+            - Do NOT provide answers from your training data
 
             ### Conversation History:
             {0}
@@ -269,12 +295,35 @@ class OpenAICompatibleRagService:
             ### Current Question:
             {2}
 
-            Provide a helpful and accurate response based on the context above.
+            Answer ONLY from the context above, or say "I don't know."
             """
+                )
+                .strip()
+                .format(conversation_history, rag_context, latest_message.content)
             )
-            .strip()
-            .format(conversation_history, rag_context, latest_message.content)
-        )
+        else:  # augment mode (default)
+            system_prompt = (
+                textwrap.dedent(
+                    """
+            You are an expert software architect assistant.
+            Use the provided context and conversation history to answer questions accurately and concisely.
+            You may supplement with your general knowledge when helpful.
+
+            ### Conversation History:
+            {0}
+
+            ### Retrieved Context:
+            {1}
+
+            ### Current Question:
+            {2}
+
+            Provide a helpful and accurate response.
+            """
+                )
+                .strip()
+                .format(conversation_history, rag_context, latest_message.content)
+            )
 
         return [{"role": "user", "content": system_prompt}]
 

--- a/docs/ramalama-serve.1.md
+++ b/docs/ramalama-serve.1.md
@@ -220,6 +220,13 @@ Note: RAG support requires AI Models be run within containers, --nocontainer not
 The image to use to process the RAG database specified by the `--rag` option. The image must contain the `/usr/bin/rag_framework` executable, which
 will create a proxy which embellishes client requests with RAG data before passing them on to the LLM, and returns the responses.
 
+The RAG proxy behavior can be controlled via the **RAG_MODE** environment variable (set via `--env RAG_MODE=<mode>` or in `ramalama.conf`):
+
+- **strict**: Only answer from retrieved documents. Refuses to answer questions not covered by the indexed documents. Use for compliance, legal, or privacy-sensitive scenarios.
+- **augment**: (Default) Freely combines retrieved documents with the model's general knowledge.
+
+Example: `ramalama serve --env RAG_MODE=strict --rag /path/to/db model`
+
 #### **--runtime-args**="*args*"
 Add *args* to the runtime (llama.cpp or vllm) invocation.
 

--- a/docs/ramalama.conf
+++ b/docs/ramalama.conf
@@ -142,6 +142,15 @@
 #HIP_VISIBLE_DEVICES="quay.io/ramalama/rocm-rag"
 #INTEL_VISIBLE_DEVICES="quay.io/ramalama/intel-gpu-rag"
 
+# Specify the default RAG operational mode when using `ramalama serve --rag`.
+# Controls how the RAG proxy balances document retrieval with the model's general knowledge.
+# Options: strict, augment
+# - strict: Only answer from retrieved documents. Refuses questions not covered by documents.
+# - augment: (Default) Freely combines documents with general AI knowledge.
+# RAG_MODE environment variable overrides this field.
+#
+#rag_mode = "augment"
+
 # Specify the AI runtime to use; valid options are 'llama.cpp', 'vllm', and 'mlx' (default: llama.cpp)
 # Options: llama.cpp, vllm, mlx
 #

--- a/docs/ramalama.conf.5.md
+++ b/docs/ramalama.conf.5.md
@@ -181,6 +181,17 @@ OCI container image to run with the specified AI model when using RAG content.
   GGML_VK_VISIBLE_DEVICES = "quay.io/ramalama/ramalama"
 
 
+**rag_mode**="augment"
+
+Specify the default RAG operational mode when using `ramalama serve --rag`.
+Controls how the RAG proxy balances document retrieval with the model's general knowledge.
+Options: strict, augment
+
+- **strict**: Only answer from retrieved documents. Refuses questions not covered by documents.
+- **augment**: (Default) Freely combines documents with general AI knowledge.
+
+RAG_MODE environment variable overrides this field.
+
 **runtime**="llama.cpp"
 
 Specify the AI runtime to use; valid options are 'llama.cpp', 'vllm', and 'mlx' (default: llama.cpp)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ dev = [
     "hypothesis>=6.135.26",
     "isort~=7.0",
     "pytest~=9.0",
+    "requests~=2.32",
     "wheel~=0.45.0",
     "mypy",
     "types-PyYAML",

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -1098,6 +1098,12 @@ def _rag_args(args):
     rag_args.model_port = args.port = compute_serving_port(args, exclude=[rag_args.port])
     rag_args.model_args = args
     rag_args.generate = ""
+
+    # Add RAG_MODE from config if not already specified via --env
+    env_list = getattr(rag_args, 'env', []) or []
+    if not any(e.startswith('RAG_MODE=') for e in env_list):
+        rag_args.env = list(env_list) + [f"RAG_MODE={CONFIG.rag_mode}"]
+
     return rag_args
 
 

--- a/ramalama/config.py
+++ b/ramalama/config.py
@@ -17,6 +17,7 @@ DEFAULT_STACK_IMAGE: str = "quay.io/ramalama/llama-stack"
 DEFAULT_RAG_IMAGE: str = "quay.io/ramalama/ramalama-rag"
 SUPPORTED_ENGINES: TypeAlias = Literal["podman", "docker"]
 SUPPORTED_RUNTIMES: TypeAlias = Literal["llama.cpp", "vllm", "mlx"]
+RAG_MODES: TypeAlias = Literal["strict", "augment"]
 COLOR_OPTIONS: TypeAlias = Literal["auto", "always", "never"]
 GGUF_QUANTIZATION_MODES: TypeAlias = Literal[
     "Q2_K",
@@ -239,6 +240,7 @@ class BaseConfig:
     prefix: str = None  # type: ignore
     pull: str = "newer"
     rag_format: Literal["qdrant", "json", "markdown", "milvus"] = "qdrant"
+    rag_mode: RAG_MODES = "augment"
     runtime: SUPPORTED_RUNTIMES = "llama.cpp"
     selinux: bool = False
     settings: RamalamaSettings = field(default_factory=RamalamaSettings)

--- a/test/e2e/test_rag_modes.py
+++ b/test/e2e/test_rag_modes.py
@@ -1,0 +1,221 @@
+"""
+E2E tests for RAG mode enforcement via RAG_MODE environment variable.
+
+Tests two operational modes:
+- strict: Document-only responses, refuses general knowledge
+- augment: Freely combines documents with general AI knowledge (default)
+
+Requires:
+- deepseek-r1:14b model (or similar 7B+ reasoning model)
+- RAG container with RAG_MODE support in rag_framework script
+
+Note: Tests use dynamic port discovery to avoid conflicts when run sequentially.
+The RAG container must include the updated rag_framework script with RAG_MODE
+environment variable support (see container-images/scripts/rag_framework).
+"""
+
+import random
+import string
+import subprocess
+import time
+from pathlib import Path
+from test.conftest import skip_if_darwin, skip_if_docker, skip_if_no_container
+from test.e2e.utils import RamalamaExecWorkspace
+
+import pytest
+import requests
+
+# Model used for testing
+SUPPORTED_MODELS = ["deepseek-r1:14b"]
+
+
+def create_test_documents(docs_dir):
+    """Create simple test documents for RAG testing"""
+    docs_dir = Path(docs_dir)
+    docs_dir.mkdir(parents=True, exist_ok=True)
+
+    # Document 1: Simple facts
+    (docs_dir / "facts.md").write_text(
+        """
+Alex's favorite ice cream is mint chocolate chip.
+The camping trip is June 15-18 at Pine Lake.
+The trip costs $85 per person.
+    """.strip()
+    )
+
+    return docs_dir
+
+
+def get_container_port(container_name):
+    """Get the port that a container is listening on"""
+    try:
+        result = subprocess.run(["podman", "port", container_name], capture_output=True, text=True, timeout=5)
+        if result.returncode == 0:
+            # Output format: "8080/tcp -> 0.0.0.0:8163"
+            for line in result.stdout.strip().split('\n'):
+                if '->' in line:
+                    port = line.split(':')[-1]
+                    return int(port)
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError):
+        pass
+    return None
+
+
+def wait_for_server(url, timeout=120):
+    """Wait for server to be ready (120s for RAG container startup)"""
+    start = time.time()
+    last_error = None
+    while time.time() - start < timeout:
+        try:
+            response = requests.get(f"{url}/health", timeout=2)
+            if response.status_code == 200:
+                return True
+            last_error = f"HTTP {response.status_code}"
+        except requests.RequestException as e:
+            last_error = str(e)
+        time.sleep(2)  # Check every 2 seconds
+    print(f"Server failed to start after {timeout}s. Last error: {last_error}")
+    return False
+
+
+def query_rag_server(url, question):
+    """Query the RAG server and return response"""
+    try:
+        response = requests.post(
+            f"{url}/v1/chat/completions",
+            json={"model": "test", "messages": [{"role": "user", "content": question}], "stream": False},
+            timeout=30,
+        )
+        if response.status_code == 200:
+            data = response.json()
+            return data["choices"][0]["message"]["content"]
+    except requests.RequestException as e:
+        print(f"Query failed: {e}")
+    return None
+
+
+@pytest.fixture
+def prepared_rag_workspace():
+    """Prepare RAG workspace with test documents and indexed database"""
+
+    def _prepare(test_model):
+        with RamalamaExecWorkspace() as ctx:
+            docs_dir = create_test_documents(Path(ctx.workspace_dir) / "docs")
+            rag_db = Path(ctx.workspace_dir) / "rag_db"
+            rag_db.mkdir(parents=True, exist_ok=True)
+
+            ctx.check_call(["ramalama", "pull", test_model])
+            ctx.check_call(["ramalama", "rag", docs_dir.as_posix(), rag_db.as_posix()])
+
+            yield ctx, rag_db
+
+    return _prepare
+
+
+@pytest.mark.e2e
+@skip_if_no_container
+@skip_if_docker
+@skip_if_darwin
+@pytest.mark.parametrize("test_model", SUPPORTED_MODELS)
+def test_rag_strict_mode(test_model, prepared_rag_workspace):
+    """Test RAG strict mode - should only answer from documents"""
+    for ctx, rag_db in prepared_rag_workspace(test_model):
+        container_name = f"rag_strict_{''.join(random.choices(string.ascii_letters + string.digits, k=5))}"
+
+        ctx.check_call(
+            [
+                "ramalama",
+                "serve",
+                "--name",
+                container_name,
+                "--detach",
+                "--env",
+                "RAG_MODE=strict",
+                "--rag",
+                rag_db.as_posix(),
+                test_model,
+            ]
+        )
+
+        try:
+            # Discover which port the container is actually using
+            port = get_container_port(container_name)
+            assert port is not None, f"Could not determine port for container {container_name}"
+            server_url = f"http://localhost:{port}"
+            assert wait_for_server(server_url, timeout=120), "Server did not become ready"
+
+            # Test 1: Query in documents (should answer)
+            response1 = query_rag_server(server_url, "What is Alex's favorite ice cream?")
+            assert response1 is not None, "Query failed"
+            assert any(
+                term in response1.lower() for term in ["mint", "chocolate"]
+            ), f"Should mention mint chocolate chip. Got: {response1}"
+
+            # Test 2: Query NOT in documents (should refuse)
+            response2 = query_rag_server(server_url, "What is the capital of France?")
+            assert response2 is not None, "Query failed"
+
+            # Should refuse in strict mode with "I don't know" as per system prompt
+            response_lower = response2.lower()
+            # Check for explicit refusal (required by strict mode prompt)
+            has_refusal = any(
+                phrase in response_lower for phrase in ["i don't know", "i do not know", "don't know", "do not know"]
+            )
+            assert has_refusal, f"Strict mode should refuse with 'I don't know'. Got: {response2}"
+            # Ensure no general knowledge leaked
+            assert (
+                "paris" not in response_lower
+            ), f"Strict mode should not answer from general knowledge. Got: {response2}"
+
+        finally:
+            ctx.check_call(["ramalama", "stop", container_name])
+
+
+@pytest.mark.e2e
+@skip_if_no_container
+@skip_if_docker
+@skip_if_darwin
+@pytest.mark.parametrize("test_model", SUPPORTED_MODELS)
+def test_rag_augment_mode(test_model, prepared_rag_workspace):
+    """Test RAG augment mode - should freely combine docs with general knowledge"""
+    for ctx, rag_db in prepared_rag_workspace(test_model):
+        container_name = f"rag_augment_{''.join(random.choices(string.ascii_letters + string.digits, k=5))}"
+
+        ctx.check_call(
+            [
+                "ramalama",
+                "serve",
+                "--name",
+                container_name,
+                "--detach",
+                "--env",
+                "RAG_MODE=augment",
+                "--rag",
+                rag_db.as_posix(),
+                test_model,
+            ]
+        )
+
+        try:
+            # Discover which port the container is actually using
+            port = get_container_port(container_name)
+            assert port is not None, f"Could not determine port for container {container_name}"
+            server_url = f"http://localhost:{port}"
+            assert wait_for_server(server_url, timeout=120), "Server did not become ready"
+
+            # Test 1: Query about documents (should answer from docs)
+            response1 = query_rag_server(server_url, "Tell me about the camping trip cost")
+            assert response1 is not None, "Document query failed"
+            assert any(
+                term in response1.lower() for term in ["85", "cost", "price", "dollar"]
+            ), f"Should mention cost from documents. Got: {response1}"
+
+            # Test 2: General knowledge query (should answer, not refuse)
+            response2 = query_rag_server(server_url, "What is 2+2?")
+            assert response2 is not None, "General knowledge query failed"
+            assert any(
+                term in response2.lower() for term in ["4", "four"]
+            ), f"Augment mode should answer general knowledge. Got: {response2}"
+
+        finally:
+            ctx.check_call(["ramalama", "stop", container_name])


### PR DESCRIPTION
This PR adds RAG mode control via the `RAG_MODE` environment variable, giving users clear control over how the RAG proxy balances document retrieval with general AI knowledge.

## RAG Modes

Two operational modes are provided:

1. **strict**: Document-only responses, refuses general knowledge queries
   - Use case: Compliance, legal, private/sensitive data
   - Behavior: Answers ONLY from retrieved documents, says "I don't know" for anything else

2. **augment** (default): Freely combines documents with general AI knowledge
   - Use case: General assistant with access to local documents
   - Behavior: Uses documents when relevant, supplements with general knowledge when helpful

## Usage

```bash
# Strict mode (documents only)
ramalama serve --env RAG_MODE=strict --rag /path/to/db model

# Augment mode (documents + general knowledge, default)
ramalama serve --env RAG_MODE=augment --rag /path/to/db model
```

## Implementation

- Simple if/else logic for mode-specific system prompts
- Each mode has distinct instructions controlling RAG behavior
- Default mode is `augment` if `RAG_MODE` is not set

## Testing

E2E tests included for both modes with positive/negative test cases:
- Strict mode: Correctly refuses general knowledge, answers from documents
- Augment mode: Answers both document and general knowledge queries

Tests are designed for models ≥7B parameters (e.g., deepseek-r1:14b, mistral:7b) which provide reliable retrieval and extraction.

## Container Changes Required

This PR requires the RAG container to include the updated `rag_framework` script. The container image needs to be rebuilt with the changes from this branch.