### PR TITLE
e2e: fix llama-stack test failure caused by lack of disk space

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,6 +295,11 @@ jobs:
         shell: bash
         run: |
            df -h
+           # /mnt has ~ 65 GB free disk space. / is too small.
+           sudo mkdir -m a=rwx -p /mnt/runner
+           sudo mkdir -m o=rwx -p /home/runner/.local
+           sudo chown runner:runner /mnt/runner /home/runner/.local
+           sudo mount --bind /mnt/runner /home/runner/.local
            sudo apt-get update
            sudo apt-get install podman bash codespell
            uv tool install tox --with tox-uv


### PR DESCRIPTION
The `test_serve_api` test was failing when downloading the llama-stack image. Solve the disk space issues by bind-mounting /mnt (with ~65G free) onto `~/.local`.

This is the same method used to address disk space issues with other Github Actions workflows.

## Summary by Sourcery

CI:
- Update the GitHub Actions CI job to bind-mount /mnt into the runner's home local directory to increase available disk space for e2e tests.