### PR TITLE
testing Konflux performance, do not merge

### DIFF
--- a/.tekton/rocm-rag/rocm-rag-pull-request.yaml
+++ b/.tekton/rocm-rag/rocm-rag-pull-request.yaml
@@ -34,7 +34,7 @@ spec:
   - name: output-image
     value: quay.io/redhat-user-workloads/ramalama-tenant/rocm-rag:on-pr-{{revision}}
   - name: image-expires-after
-    value: 5d
+    value: 4d
   - name: build-platforms
     value:
     - linux-d160-c8xlarge/amd64


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Reduce the temporary PR image expiry period from 5 days to 4 days in the rocm-rag Tekton configuration.