### PR TITLE
Add some convenience tweaks for developing with emacs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ uv.lock
 # pixi environments
 .pixi/*
 !.pixi/config.toml
+*~
+\#*#

--- a/Makefile
+++ b/Makefile
@@ -111,13 +111,17 @@ docs-manpages:
 docsite-docs:
 	$(MAKE) -C docsite convert
 
+ifeq (compile,$(findstring compile,$(INSIDE_EMACS)))
+FLAKE8_ARGS += --format=pylint
+endif
+
 .PHONY: lint
 lint:
 ifneq (,$(wildcard /usr/bin/python3))
 	/usr/bin/python3 -m compileall -q -x '\.venv' .
 endif
 	! grep -ri $(EXCLUDE_OPTS) "#\!/usr/bin/python3" .
-	flake8 $(PROJECT_DIR) $(PYTHON_SCRIPTS)
+	flake8 $(FLAKE8_ARGS) $(PROJECT_DIR) $(PYTHON_SCRIPTS)
 	shellcheck *.sh */*.sh */*/*.sh
 
 .PHONY: check-format


### PR DESCRIPTION
Make flake8 use pylint format if run in an emacs compile buffer.  This causes error messages to be formatted such that "C-x `" (next-error) will go to the flagged line of code.

Add emacs backup files to .gitignore.

## Summary by Sourcery

Improve local linting ergonomics when running flake8 from Emacs and ignore editor backup files in version control.

Enhancements:
- Make the lint target pass a pylint-style format option to flake8 when invoked from an Emacs compile buffer for better navigation of errors.

Chores:
- Add Emacs backup files to .gitignore so editor-generated artifacts are not tracked.