### PR TITLE
doc2rag: if not using cuda, explicitly set the accelerator to cpu

### DIFF
--- a/container-images/scripts/doc2rag
+++ b/container-images/scripts/doc2rag
@@ -18,6 +18,7 @@ from pathlib import Path
 import docling
 import qdrant_client
 from docling.chunking import HybridChunker
+from docling.datamodel.accelerator_options import AcceleratorDevice, AcceleratorOptions
 from docling.datamodel.base_models import InputFormat
 from docling.datamodel.pipeline_options import PdfPipelineOptions
 from docling.document_converter import DocumentConverter, PdfFormatOption
@@ -40,8 +41,14 @@ class Converter:
 
     def __init__(self, args):
         # Docling Setup (Turn off OCR (image processing) for drastically reduced RAM usage and big speed increase)
-        pipeline_options = PdfPipelineOptions()
-        pipeline_options.do_ocr = args.ocr
+        if os.environ.get("CUDA_VISIBLE_DEVICES", "").lower() in ["", "none", "-1"]:
+            dev = AcceleratorDevice.CPU
+        else:
+            dev = AcceleratorDevice.CUDA
+        pipeline_options = PdfPipelineOptions(
+            accelerator_options=AcceleratorOptions(device=dev),
+            do_ocr=args.ocr,
+        )
         self.sources = []
         for source in args.sources:
             self.add(source)


### PR DESCRIPTION
docling doesn't support intel or rocm accelerators, and is incorrectly selecting cuda in some cases. Only enable cuda if ramalama has already detected it.

Fixes: #2089

## Summary by Sourcery

Adjust accelerator selection for doc2rag to explicitly use CPU when CUDA is not detected, avoiding incorrect CUDA selection by docling.

Bug Fixes:
- Prevent docling from incorrectly selecting CUDA accelerators on unsupported hardware by only enabling CUDA when it has been pre-detected.

Build:
- Update doc2rag container script configuration to default to CPU accelerator when CUDA is unavailable.