### PR TITLE
Download safetensors models from huggingface.co with https.

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -96,8 +96,6 @@ skip_if_gh_actions_darwin = pytest.mark.skipif(
 skip_if_windows = pytest.mark.skipif(platform.system() == "Windows", reason="Windows operating system")
 skip_if_not_windows = pytest.mark.skipif(platform.system() != "Windows", reason="not Windows operating system")
 
-skip_if_no_huggingface_cli = pytest.mark.skipif(shutil.which("hf") is None, reason="hf cli not installed")
-
 skip_if_no_llama_bench = pytest.mark.skipif(shutil.which("llama-bench") is None, reason="llama-bench not installed")
 
 skip_if_no_mlx = pytest.mark.skipif(

--- a/test/system/050-pull.bats
+++ b/test/system/050-pull.bats
@@ -77,7 +77,6 @@ load setup_suite
     is "$output" ".*Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS" "image was actually pulled locally"
     run_ramalama rm huggingface://Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS.gguf
 
-    skip_if_no_hf_cli
     run_ramalama pull hf://HuggingFaceTB/SmolLM-135M
     run_ramalama list
     is "$output" ".*HuggingFaceTB/SmolLM-135M" "image was actually pulled locally"
@@ -94,9 +93,6 @@ load setup_suite
     run_ramalama rm huggingface://ggml-org/SmolVLM-256M-Instruct-GGUF:Q8_0
 
     run_ramalama pull hf://owalsh/SmolLM2-135M-Instruct-GGUF-Split:Q4_0
-    for i in $(seq 1 3); do
-        is "$output" ".*Downloading Q4_0/SmolLM2-135M-Instruct-Q4_0-0000${i}-of-00003.gguf" "model part ${i} downloaded"
-    done
     run_ramalama list
     is "$output" ".*owalsh/SmolLM2-135M-Instruct-GGUF-Split:Q4_0" "image was actually pulled locally"
     run_ramalama rm hf://owalsh/SmolLM2-135M-Instruct-GGUF-Split:Q4_0
@@ -115,29 +111,6 @@ load setup_suite
     is "$output" ".*Not removing snapshot" "snapshot with remaining reference was not deleted"
     run_ramalama --debug rm huggingface://ggml-org/SmolVLM-256M-Instruct-GGUF:Q8_0
     is "$output" ".*Snapshot removed" "snapshot with no remaining references was deleted"
-}
-
-# bats test_tags=distro-integration
-@test "ramalama pull hf cli cache" {
-    skip_if_no_hf_cli
-    hf download Felladrin/gguf-smollm-360M-instruct-add-basics smollm-360M-instruct-add-basics.IQ2_XXS.gguf
-
-    run_ramalama pull hf://Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS.gguf
-    run_ramalama list
-    is "$output" ".*Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS" "image was actually pulled locally from hf-cli cache"
-    run_ramalama rm hf://Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS.gguf
-
-    run_ramalama pull huggingface://Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS.gguf
-    run_ramalama list
-    is "$output" ".*Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS" "image was actually pulled locally from hf-cli cache"
-    run_ramalama rm huggingface://Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS.gguf
-
-    RAMALAMA_TRANSPORT=huggingface run_ramalama pull Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS.gguf
-    run_ramalama list
-    is "$output" ".*Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS" "image was actually pulled locally from hf-cli cache"
-    run_ramalama rm huggingface://Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS.gguf
-
-    rm -rf ~/.cache/huggingface/hub/models--Felladrin--gguf-smollm-360M-instruct-add-basics
 }
 
 # bats test_tags=distro-integration


### PR DESCRIPTION
Refactor the fetch_metadata method to attempt to fetch GGUF metadata from a manifest, and then to attempt to fetch safetensors metadata from the repo files.

To fetch a safetensors model, download the set of files from the repo with https requests. Add an "other_files" category for safetensors files that are neither JSON config files nor .safetensors model files, such as the tokenizer.model file.

Remove code to download models from huggingface.co with the huggingface cli. It didn't work correctly anyway. Stub out the _collect_cli_files and in_existing_cache methods for the huggingface transport.

Enable bats test of downloading safetensors models from huggingface. Remove bats test of downloading models with the huggingface cli.

Fixes: #1493

## Summary by Sourcery

Support downloading Hugging Face safetensors and associated files over HTTPS while deprecating CLI-based downloads and extending repository metadata handling.

New Features:
- Discover safetensors model, index, and auxiliary files from Hugging Face repositories using the Files API and download them via HTTPS.
- Treat non-model, non-config artifacts (such as tokenizer and related files) as an explicit "other_files" category in snapshot generation.

Bug Fixes:
- Remove broken support for downloading models via the Hugging Face CLI and stub related cache and collection pathways to avoid incorrect behavior.

Enhancements:
- Fallback to safetensors-based metadata when a GGUF manifest is unavailable, and infer model type from file extensions when building snapshot entries.
- Extend HF-style repository metadata and file list generation to track additional safetensor shards and index files, including appropriate checksum handling.

Tests:
- Adjust system tests to cover safetensors downloads from Hugging Face and drop tests that relied on the Hugging Face CLI.