### PR TITLE
[draft_model] Fix OCI mount options for draft_model

### DIFF
--- a/ramalama/transports/base.py
+++ b/ramalama/transports/base.py
@@ -29,7 +29,6 @@ if TYPE_CHECKING:
 
 from ramalama.common import (
     MNT_DIR,
-    MNT_FILE_DRAFT,
     exec_cmd,
     genname,
     is_split_file_model,
@@ -152,8 +151,10 @@ class Transport(TransportBase):
 
         self.draft_model: Transport | None = None
 
-    def extract_model_identifiers(self):
-        model_name = self.model
+    def extract_model_identifiers(self, model=None):
+        if model is None:
+            model = self.model
+        model_name = model
         model_tag = "latest"
         model_organization = ""
 
@@ -446,12 +447,20 @@ class Transport(TransportBase):
             )
 
         if self.draft_model:
-            draft_model = self.draft_model._get_entry_model_path(args.container, args.generate, args.dryrun)
-            # Convert path to container-friendly format (handles Windows path conversion)
-            container_draft_model = get_container_mount_path(draft_model)
-            mount_opts = f"--mount=type=bind,src={container_draft_model},destination={MNT_FILE_DRAFT}"
-            mount_opts += f",ro{self.engine.relabel()}"
-            self.engine.add([mount_opts])
+            # Get the model tag for draft model
+            _, draft_tag, _ = self.extract_model_identifiers(model=self.draft_model.model)
+            ref_file_draft = self.draft_model.model_store.get_ref_file(draft_tag)
+            if ref_file_draft is None:
+                raise NoRefFileFound(self.draft_model.model)
+
+            # Mount the draft model files
+            for file in ref_file_draft.files:
+                blob_path = self.draft_model.model_store.get_blob_file_path(file.hash)
+                container_blob_path = get_container_mount_path(blob_path)
+                mount_path = f"{MNT_DIR}/drafts/{file.name}"
+                self.engine.add(
+                    [f"--mount=type=bind,src={container_blob_path},destination={mount_path},ro{self.engine.relabel()}"]
+                )
 
     def serve_nonblocking(self, args, cmd: list[str]) -> subprocess.Popen | None:
         if args.container:

--- a/ramalama/transports/huggingface.py
+++ b/ramalama/transports/huggingface.py
@@ -293,8 +293,8 @@ class Huggingface(HFStyleRepoModel):
     def get_cli_download_args(self, directory_path, model):
         raise NotImplementedError("huggingface cli download not available")
 
-    def extract_model_identifiers(self):
-        model_name, model_tag, model_organization = super().extract_model_identifiers()
+    def extract_model_identifiers(self, model=None):
+        model_name, model_tag, model_organization = super().extract_model_identifiers(model)
         if '/' not in model_organization:
             # if it is a repo then normalize the case insensitive quantization tag
             if model_tag != "latest":

--- a/ramalama/transports/ollama.py
+++ b/ramalama/transports/ollama.py
@@ -146,8 +146,8 @@ class Ollama(Transport):
 
         self.type = "Ollama"
 
-    def extract_model_identifiers(self) -> tuple[str, str, str]:
-        model_name, model_tag, model_organization = super().extract_model_identifiers()
+    def extract_model_identifiers(self, model=None) -> tuple[str, str, str]:
+        model_name, model_tag, model_organization = super().extract_model_identifiers(model)
 
         # use the ollama default namespace if no model organization has been identified
         if not model_organization:

--- a/ramalama/transports/url.py
+++ b/ramalama/transports/url.py
@@ -59,7 +59,7 @@ class URL(Transport):
             return self.model
         return super().model_alias()
 
-    def extract_model_identifiers(self):
+    def extract_model_identifiers(self, model=None):
         if self.type == "file":
             return (
                 Path(self.model).name,
@@ -67,7 +67,7 @@ class URL(Transport):
                 normalize_host_path_for_container(str(Path(self.model).parent)).removeprefix("/"),
             )
 
-        model_name, model_tag, model_organization = super().extract_model_identifiers()
+        model_name, model_tag, model_organization = super().extract_model_identifiers(model)
 
         parts = model_organization.split("/")
         if len(parts) > 2 and parts[-2] == "blob":


### PR DESCRIPTION
When supplying draft model the old code pretty much tried to bindmount model with both src and destination in the end translating to same location. Also there was no support for mulitple file models so when one tried to use 440B as main model and 30B as draft model it would not be possible.

Lastly mmproj and chat_template would translate to the same location as main model so we ignore them. As of now draft_models won't work with multimodal models but we can still do speculative decoding when disabling vision by passing --no-mmproj.

## Summary by Sourcery

Support correct identification and mounting of draft models, including multi-file models, while reusing the existing model identifier parsing across transports.

Bug Fixes:
- Fix draft model OCI mounts to bind individual model files instead of incorrectly mounting the same path as both source and destination.
- Skip multimodal-specific files (e.g., mmproj and chat_template) when mounting draft models to avoid conflicts with the main model.

Enhancements:
- Allow extract_model_identifiers to accept an explicit model parameter so it can be reused for draft and alternate models across base, Hugging Face, Ollama, and URL transports.