### PR TITLE
Fix windows model store names

### DIFF
--- a/ramalama/model_store/global_store.py
+++ b/ramalama/model_store/global_store.py
@@ -44,9 +44,9 @@ class GlobalModelStore:
 
                     model_path = root.replace(self.path, "").replace(os.sep, "", 1)
 
-                    parts = model_path.split("/")
+                    parts = model_path.split(os.sep)
                     model_source = parts[0]
-                    model_path_without_source = f"{os.sep}".join(parts[1:])
+                    model_path_without_source = "/".join(parts[1:])
 
                     separator = ":///" if model_source == "file" else "://"  # Use ':///' for file URLs, '://' otherwise
                     tag = ref_file_name.replace(".json", "")


### PR DESCRIPTION
Logic to generate the name for models from the store had the logic reversed on windows

## Summary by Sourcery

Bug Fixes:
- Correct model store path parsing on Windows by using the OS directory separator when splitting model paths while preserving forward slashes in stored model subpaths.