### PR TITLE
packit: run no-rpm tests on V100 gpus

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -64,6 +64,7 @@ jobs:
       - fedora-latest-stable
     tmt_plan: "/plans/no-rpm"
     identifier: "no-rpm-fedora"
+    manual_trigger: true
 
   # Tests for CentOS Stream
   - job: tests

--- a/plans/no-rpm.fmf
+++ b/plans/no-rpm.fmf
@@ -12,7 +12,7 @@ provision:
     how: artemis
     hardware:
         gpu:
-            device-name: GK210 (Tesla K80)
+            device-name: GV100 (Tesla V100)
             vendor-name: NVIDIA
         disk:
             - size: ">= 512 GiB"


### PR DESCRIPTION
Testing Farm provides instances with K80 and V100 gpus, but recent cuda versions no longer support K80.

Only run the no-rpms tests manually, triggered by a "/packit test" comment on the PR. This avoids frequent failures/timeouts when gpus are not available in Testing Farm.