### PR TITLE
install ramalama python libraries in the ramalama and cuda images

### DIFF
--- a/container-images/cuda/Containerfile
+++ b/container-images/cuda/Containerfile
@@ -17,4 +17,18 @@ COPY --from=builder /tmp/install /usr
 # Workaround for CUDA libraries not in the ld path in base container
 RUN echo "/usr/local/cuda-12.8/compat" > /etc/ld.so.conf.d/99_cuda_compat.conf && ldconfig
 
+# Install python3.12 and ramalama to support a non-standard use-case
+RUN dnf -y install python3.12 && dnf -y clean all && ln -sf python3.12 /usr/bin/python3
+COPY . /src/ramalama
+WORKDIR /src/ramalama
+RUN python3 -m ensurepip && \
+    python3 -m pip \
+      --no-cache-dir \
+      --disable-pip-version-check \
+      install \
+        --compile \
+        --prefix=/usr \
+        .
+WORKDIR /
 ENTRYPOINT []
+CMD ["/bin/bash"]

--- a/container-images/ramalama/Containerfile
+++ b/container-images/ramalama/Containerfile
@@ -5,4 +5,15 @@ COPY container-images/scripts/build_llama_and_whisper.sh \
      /src/
 WORKDIR /src/
 RUN ./build_llama_and_whisper.sh ramalama
+# Install ramalama to support a non-standard use-case
+COPY . /src/ramalama
+WORKDIR /src/ramalama
+RUN python3 -m ensurepip && \
+    python3 -m pip \
+      --no-cache-dir \
+      --disable-pip-version-check \
+      install \
+        --compile \
+        --prefix=/usr \
+        .
 WORKDIR /


### PR DESCRIPTION
This allows "ramalama" to be run in "nocontainer" mode inside a running container, to support a non-standard use-case.

## Summary by Sourcery

Install the ramalama Python package into both the CUDA and ramalama container images to allow running ramalama in nocontainer mode from within these containers.

Build:
- Extend CUDA container image to include Python 3.12, install ramalama via pip, and switch the entrypoint to bash.
- Install the ramalama Python package into the ramalama container image via pip for in-container nocontainer usage.