### PR TITLE
Fix quadlet generation for multi-part models

### DIFF
--- a/test/unit/data/test_quadlet/multipart/gpt-oss-120b.container
+++ b/test/unit/data/test_quadlet/multipart/gpt-oss-120b.container
@@ -1,0 +1,23 @@
+[Unit]
+Description=RamaLama gpt-oss-120b AI Model Service
+After=local-fs.target
+
+[Container]
+AddDevice=-/dev/accel
+AddDevice=-/dev/dri
+AddDevice=-/dev/kfd
+AddDevice=nvidia.com/gpu=all
+Image=testimage
+RunInit=true
+Environment=HOME=/tmp
+Exec=
+SecurityLabelDisable=true
+DropCapability=all
+NoNewPrivileges=true
+Mount=type=bind,src=sha256-e2865eb6c1df7b2ffbebf305cd5d9074d5ccc0fe3b862f98d343a46dad1606f9,target=/mnt/models/gpt-oss-120b-mxfp4-00001-of-00003.gguf,ro,Z
+Mount=type=bind,src=sha256-81856b5b996da9c9fd68397d49671264ead380a8355b3c83284eae5e21e998ed,target=/mnt/models/gpt-oss-120b-mxfp4-00002-of-00003.gguf,ro,Z
+Mount=type=bind,src=sha256-38b087fffe4b5ba5d62fa7761ed7278a07fef7a6145b9744b11205b851021dce,target=/mnt/models/gpt-oss-120b-mxfp4-00003-of-00003.gguf,ro,Z
+
+[Install]
+WantedBy=multi-user.target default.target
+


### PR DESCRIPTION
Add support for generating multiple Mount= declarations in quadlet files for multi-part models (e.g., models split into multiple GGUF files).

Changes:
- Add _get_all_model_part_paths() method to Transport class to retrieve all parts of a multi-part model from the ref file
- Update Quadlet class to accept and store model_parts list
- Modify _gen_model_volume() to generate Mount= entries for each part
- Update generate_container_config() to pass model parts to quadlet
- Add test case for multi-part model quadlet generation

The fix ensures that when generating quadlet files for models like gpt-oss-120b that are split across multiple files, all parts are properly mounted into the container with correct src/dest paths.

Fixes #2017

## Summary by Sourcery

Ensure quadlet generation correctly mounts all parts of multi-part models instead of only a single model file.

Bug Fixes:
- Fix quadlet model volume generation so all GGUF parts of a multi-part model are mounted into the container, not just the entry file.
- Handle safetensor and OCI models consistently when determining model mount paths for quadlet and kube generation.

Tests:
- Add unit coverage for quadlet generation with a multi-part GGUF model, including expected container file output.