### PR TITLE
Fix removing blobs when hardlink/copy is used

### DIFF
--- a/test/e2e/test_rm.py
+++ b/test/e2e/test_rm.py
@@ -1,7 +1,8 @@
 import random
 import re
+from pathlib import Path
 from subprocess import STDOUT, CalledProcessError
-from test.e2e.utils import check_output
+from test.e2e.utils import RamalamaExecWorkspace, check_output
 
 import pytest
 
@@ -24,3 +25,22 @@ def test_delete_non_existing_image_with_ignore_flag():
     image_name = f"rm_random_image_{random.randint(0, 9999)}"
     result = check_output(["ramalama", "rm", "--ignore", image_name])
     assert result == ""
+
+
+@pytest.mark.e2e
+def test_delete_snapshot_with_multiple_references():
+    with RamalamaExecWorkspace() as ctx:
+        initial_inventory = set([x for x in Path(ctx.storage_dir).rglob('*') if x.is_file()])
+        ctx.check_call(["ramalama", "--store", ctx.storage_dir, "pull", "hf://ggml-org/SmolVLM-256M-Instruct-GGUF"])
+        inventory_a = set([x for x in Path(ctx.storage_dir).rglob('*') if x.is_file()])
+        ctx.check_call(
+            ["ramalama", "--store", ctx.storage_dir, "pull", "hf://ggml-org/SmolVLM-256M-Instruct-GGUF:Q8_0"]
+        )
+        inventory_b = set([x for x in Path(ctx.storage_dir).rglob('*') if x.is_file()])
+        ctx.check_call(["ramalama", "--store", ctx.storage_dir, "rm", "hf://ggml-org/SmolVLM-256M-Instruct-GGUF:Q8_0"])
+        inventory_c = set([x for x in Path(ctx.storage_dir).rglob('*') if x.is_file()])
+        ctx.check_call(["ramalama", "--store", ctx.storage_dir, "rm", "hf://ggml-org/SmolVLM-256M-Instruct-GGUF"])
+        final_inventory = set([x for x in Path(ctx.storage_dir).rglob('*') if x.is_file()])
+        assert final_inventory == initial_inventory
+        assert inventory_c == inventory_a
+        assert inventory_b != inventory_a


### PR DESCRIPTION
Removing binary blob files previously relied on following the symlink from a snapshot file to the binary blob file.
This no longer works now that hardlinks are used by default.

## Summary by Sourcery

Ensure blob files are correctly removed when deleting snapshots regardless of whether symlinks, hardlinks, or copies are used, and add coverage for snapshot deletion with multiple references.

Bug Fixes:
- Fix blob removal logic to work when snapshot files are hardlinked or copied instead of symlinked.
- Correct cleanup of partial blob files when snapshot reference counts reach zero.

Tests:
- Add an end-to-end test verifying that removing snapshots with multiple references cleans up blobs and restores storage contents correctly.