### PR TITLE
Bump to v0.16.0

### DIFF
--- a/docs/ramalama-bench.1.md
+++ b/docs/ramalama-bench.1.md
@@ -59,7 +59,7 @@ OCI container image to run with specified AI model. RamaLama defaults to using
 images based on the accelerator it discovers. For example:
 `quay.io/ramalama/ramalama`. See the table below for all default images.
 The default image tag is based on the minor version of the RamaLama package.
-Version 0.15.0 of RamaLama pulls an image with a `:0.15` tag from the quay.io/ramalama OCI repository. The --image option overrides this default.
+Version 0.16.0 of RamaLama pulls an image with a `:0.16` tag from the quay.io/ramalama OCI repository. The --image option overrides this default.
 
 The default can be overridden in the ramalama.conf file or via the
 RAMALAMA_IMAGE environment variable. `export RAMALAMA_IMAGE=quay.io/ramalama/aiimage:1.2` tells

--- a/docs/ramalama-perplexity.1.md
+++ b/docs/ramalama-perplexity.1.md
@@ -62,7 +62,7 @@ OCI container image to run with specified AI model. RamaLama defaults to using
 images based on the accelerator it discovers. For example:
 `quay.io/ramalama/ramalama`. See the table below for all default images.
 The default image tag is based on the minor version of the RamaLama package.
-Version 0.15.0 of RamaLama pulls an image with a `:0.15` tag from the quay.io/ramalama OCI repository. The --image option overrides this default.
+Version 0.16.0 of RamaLama pulls an image with a `:0.16` tag from the quay.io/ramalama OCI repository. The --image option overrides this default.
 
 The default can be overridden in the ramalama.conf file or via the
 RAMALAMA_IMAGE environment variable. `export RAMALAMA_IMAGE=quay.io/ramalama/aiimage:1.2` tells

--- a/docs/ramalama-rag.1.md
+++ b/docs/ramalama-rag.1.md
@@ -50,7 +50,7 @@ OCI container image to run with specified AI model. RamaLama defaults to using
 images based on the accelerator it discovers. For example:
 `quay.io/ramalama/ramalama-rag`. See the table below for all default images.
 The default image tag is based on the minor version of the RamaLama package.
-Version 0.15.0 of RamaLama pulls an image with a `:0.15` tag from the quay.io/ramalama OCI repository. The --image option overrides this default.
+Version 0.16.0 of RamaLama pulls an image with a `:0.16` tag from the quay.io/ramalama OCI repository. The --image option overrides this default.
 
 The default can be overridden in the ramalama.conf file or via the
 RAMALAMA_IMAGE environment variable. `export RAMALAMA_IMAGE=quay.io/ramalama/aiimage:1.2` tells

--- a/docs/ramalama-run.1.md
+++ b/docs/ramalama-run.1.md
@@ -73,7 +73,7 @@ OCI container image to run with specified AI model. RamaLama defaults to using
 images based on the accelerator it discovers. For example:
 `quay.io/ramalama/ramalama`. See the table below for all default images.
 The default image tag is based on the minor version of the RamaLama package.
-Version 0.15.0 of RamaLama pulls an image with a `:0.15` tag from the quay.io/ramalama OCI repository. The --image option overrides this default.
+Version 0.16.0 of RamaLama pulls an image with a `:0.16` tag from the quay.io/ramalama OCI repository. The --image option overrides this default.
 
 The default can be overridden in the `ramalama.conf` file or via the
 RAMALAMA_IMAGE environment variable. `export RAMALAMA_IMAGE=quay.io/ramalama/aiimage:1.2` tells

--- a/docs/ramalama-serve.1.md
+++ b/docs/ramalama-serve.1.md
@@ -120,7 +120,7 @@ OCI container image to run with specified AI model. RamaLama defaults to using
 images based on the accelerator it discovers. For example:
 `quay.io/ramalama/ramalama`. See the table above for all default images.
 The default image tag is based on the minor version of the RamaLama package.
-Version 0.15.0 of RamaLama pulls an image with a `:0.15` tag from the quay.io/ramalama OCI repository. The --image option overrides this default.
+Version 0.16.0 of RamaLama pulls an image with a `:0.16` tag from the quay.io/ramalama OCI repository. The --image option overrides this default.
 
 The default can be overridden in the `ramalama.conf` file or via the
 RAMALAMA_IMAGE environment variable. `export RAMALAMA_IMAGE=quay.io/ramalama/aiimage:1.2` tells

--- a/docs/ramalama-version.1.md
+++ b/docs/ramalama-version.1.md
@@ -18,9 +18,9 @@ Print usage message
 
 ```
 $ ramalama version
-ramalama version 0.15.0
+ramalama version 0.16.0
 $ ramalama -q version
-0.15.0
+0.16.0
 >
 ```
 ## SEE ALSO

--- a/docs/ramalama.conf.5.md
+++ b/docs/ramalama.conf.5.md
@@ -144,7 +144,7 @@ In some cases this is needed to access the gpu from a rootless container
 **log_level**=warning
 Set the logging level of RamaLama application.
 Valid Values:
-    debug, info, warning, error critical
+    debug, info, warning, error, critical
 Note: --debug option overrides this field and forces the system to debug
 
 **max_tokens**=0

--- a/docsite/docs/commands/ramalama/bench.mdx
+++ b/docsite/docs/commands/ramalama/bench.mdx
@@ -63,7 +63,7 @@ OCI container image to run with specified AI model. RamaLama defaults to using
 images based on the accelerator it discovers. For example:
 `quay.io/ramalama/ramalama`. See the table below for all default images.
 The default image tag is based on the minor version of the RamaLama package.
-Version 0.15.0 of RamaLama pulls an image with a `:0.15` tag from the quay.io/ramalama OCI repository. The --image option overrides this default.
+Version 0.16.0 of RamaLama pulls an image with a `:0.16` tag from the quay.io/ramalama OCI repository. The --image option overrides this default.
 
 The default can be overridden in the ramalama.conf file or via the
 RAMALAMA_IMAGE environment variable. `export RAMALAMA_IMAGE=quay.io/ramalama/aiimage:1.2` tells

--- a/docsite/docs/commands/ramalama/convert.mdx
+++ b/docsite/docs/commands/ramalama/convert.mdx
@@ -45,14 +45,15 @@ Image to use when converting to GGUF format (when then `--gguf` option has been 
 executable and available in the `PATH`. The script is available from the `llama.cpp` GitHub repo. Defaults to the current
 `quay.io/ramalama/ramalama-rag` image.
 
-#### **--type**=*raw* | *car*
+#### **--type**="artifact" | *raw* | *car*
 
-type of OCI Model Image to convert.
+Convert the MODEL to the specified OCI Object
 
-| Type | Description                                                   |
-| ---- | ------------------------------------------------------------- |
-| car  | Includes base image with the model stored in a /models subdir |
-| raw  | Only the model and a link file model.file to it stored at /   |
+| Type     | Description                                                   |
+| -------- | ------------------------------------------------------------- |
+| artifact | Store AI Models as artifacts                                  |
+| car      | Traditional OCI image including base image with the model stored in a /models subdir |
+| raw      | Traditional OCI image including only the model and a link file `model.file` pointed at it stored at /   |
 
 ## EXAMPLE
 

--- a/docsite/docs/commands/ramalama/list.mdx
+++ b/docsite/docs/commands/ramalama/list.mdx
@@ -29,6 +29,12 @@ print Model list in json format
 #### **--noheading**, **-n**
 do not print heading
 
+#### **--order**
+order used to sort the AI Models. Valid options are 'asc' and 'desc'
+
+#### **--sort**
+field used to sort the AI Models. Valid options are 'name', 'size', and 'modified'.
+
 ## Examples
 
 List all Models downloaded to users homedir

--- a/docsite/docs/commands/ramalama/perplexity.mdx
+++ b/docsite/docs/commands/ramalama/perplexity.mdx
@@ -66,7 +66,7 @@ OCI container image to run with specified AI model. RamaLama defaults to using
 images based on the accelerator it discovers. For example:
 `quay.io/ramalama/ramalama`. See the table below for all default images.
 The default image tag is based on the minor version of the RamaLama package.
-Version 0.15.0 of RamaLama pulls an image with a `:0.15` tag from the quay.io/ramalama OCI repository. The --image option overrides this default.
+Version 0.16.0 of RamaLama pulls an image with a `:0.16` tag from the quay.io/ramalama OCI repository. The --image option overrides this default.
 
 The default can be overridden in the ramalama.conf file or via the
 RAMALAMA_IMAGE environment variable. `export RAMALAMA_IMAGE=quay.io/ramalama/aiimage:1.2` tells

--- a/docsite/docs/commands/ramalama/rag.mdx
+++ b/docsite/docs/commands/ramalama/rag.mdx
@@ -56,7 +56,7 @@ OCI container image to run with specified AI model. RamaLama defaults to using
 images based on the accelerator it discovers. For example:
 `quay.io/ramalama/ramalama-rag`. See the table below for all default images.
 The default image tag is based on the minor version of the RamaLama package.
-Version 0.15.0 of RamaLama pulls an image with a `:0.15` tag from the quay.io/ramalama OCI repository. The --image option overrides this default.
+Version 0.16.0 of RamaLama pulls an image with a `:0.16` tag from the quay.io/ramalama OCI repository. The --image option overrides this default.
 
 The default can be overridden in the ramalama.conf file or via the
 RAMALAMA_IMAGE environment variable. `export RAMALAMA_IMAGE=quay.io/ramalama/aiimage:1.2` tells

--- a/docsite/docs/commands/ramalama/run.mdx
+++ b/docsite/docs/commands/ramalama/run.mdx
@@ -77,7 +77,7 @@ OCI container image to run with specified AI model. RamaLama defaults to using
 images based on the accelerator it discovers. For example:
 `quay.io/ramalama/ramalama`. See the table below for all default images.
 The default image tag is based on the minor version of the RamaLama package.
-Version 0.15.0 of RamaLama pulls an image with a `:0.15` tag from the quay.io/ramalama OCI repository. The --image option overrides this default.
+Version 0.16.0 of RamaLama pulls an image with a `:0.16` tag from the quay.io/ramalama OCI repository. The --image option overrides this default.
 
 The default can be overridden in the `ramalama.conf` file or via the
 RAMALAMA_IMAGE environment variable. `export RAMALAMA_IMAGE=quay.io/ramalama/aiimage:1.2` tells

--- a/docsite/docs/commands/ramalama/serve.mdx
+++ b/docsite/docs/commands/ramalama/serve.mdx
@@ -122,7 +122,7 @@ OCI container image to run with specified AI model. RamaLama defaults to using
 images based on the accelerator it discovers. For example:
 `quay.io/ramalama/ramalama`. See the table above for all default images.
 The default image tag is based on the minor version of the RamaLama package.
-Version 0.15.0 of RamaLama pulls an image with a `:0.15` tag from the quay.io/ramalama OCI repository. The --image option overrides this default.
+Version 0.16.0 of RamaLama pulls an image with a `:0.16` tag from the quay.io/ramalama OCI repository. The --image option overrides this default.
 
 The default can be overridden in the `ramalama.conf` file or via the
 RAMALAMA_IMAGE environment variable. `export RAMALAMA_IMAGE=quay.io/ramalama/aiimage:1.2` tells

--- a/docsite/docs/commands/ramalama/version.mdx
+++ b/docsite/docs/commands/ramalama/version.mdx
@@ -22,9 +22,9 @@ Print usage message
 
 ```bash
 $ ramalama version
-ramalama version 0.15.0
+ramalama version 0.16.0
 $ ramalama -q version
-0.15.0
+0.16.0
 >
 ```
 ## See Also

--- a/docsite/docs/configuration/conf.mdx
+++ b/docsite/docs/configuration/conf.mdx
@@ -86,6 +86,17 @@ Min chunk size to attempt reusing from the cache via KV shifting
 Run RamaLama in the default container.
 RAMALAMA_IN_CONTAINER environment variable overrides this field.
 
+**convert_type**="raw"
+
+Convert the MODEL to the specified OCI Object
+Options: artifact, car, raw
+
+| Type     | Description                                                   |
+| -------- | ------------------------------------------------------------- |
+| artifact | Store AI Models as artifacts                                  |
+| car      | Traditional OCI image including base image with the model stored in a /models subdir |
+| raw      | Traditional OCI image including only the model and a link file `model.file` pointed at it stored at /   |
+
 **ctx_size**=0
 
 Size of the prompt context (0 = loaded from model)

--- a/ramalama/version.py
+++ b/ramalama/version.py
@@ -2,7 +2,7 @@
 
 
 def version():
-    return "0.15.0"
+    return "0.16.0"
 
 
 def print_version(args):

--- a/rpm/ramalama.spec
+++ b/rpm/ramalama.spec
@@ -1,7 +1,7 @@
 %global pypi_name ramalama
 %global forgeurl  https://github.com/containers/%{pypi_name}
 # see ramalama/version.py
-%global version0  0.15.0
+%global version0  0.16.0
 %forgemeta
 
 %global summary   Command line tool for working with AI LLM models


### PR DESCRIPTION
## Summary by Sourcery

Bump RamaLama to version 0.16.0 and update related configuration and documentation.

Build:
- Update Python package version constant and RPM spec to 0.16.0 for packaging alignment.

Documentation:
- Document the new `artifact` convert type alongside existing `raw` and `car` types in both CLI and configuration docs.
- Describe new `--order` and `--sort` options for `ramalama list` to control model listing.
- Refresh CLI and manpage documentation to reference version 0.16.0 and correct the `log_level` valid values list.