### PR TITLE
Adding mikebonnet as ramalama maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,7 +4,8 @@
 
 | Maintainer| GitHub ID| Affiliation|
 | -------- | ------- | ------- |
-|  TODO| TODO | TODO |
+|  Dan Walsh | rhatdan | Red Hat |
+|  Mike Bonnet | mikebonnet | Red Hat |
 
 ## Reviewers
 


### PR DESCRIPTION
View #2113

## Summary by Sourcery

Documentation:
- Document Dan Walsh and Mike Bonnet as maintainers for ramalama in MAINTAINERS.md.