### PR TITLE
Fix llama-stack oci runtime on CUDA

### DIFF
--- a/ramalama/stack.py
+++ b/ramalama/stack.py
@@ -245,9 +245,9 @@ spec:
         if not oci_runtime:
             return exec_cmd(exec_args)
 
-        oci_runtime_name = (
-            run_cmd([self.args.engine, "info", "--format", "{{.Host.OCIRuntime.Name}}"]).stdout.decode("utf-8").strip()
-        )
+        oci_runtime_name = run_cmd(
+            [self.args.engine, "info", "--format", "{{.Host.OCIRuntime.Name}}"], encoding="utf-8"
+        ).stdout.strip()
 
         with NamedTemporaryFile(
             mode="w", prefix="RamaLama_", suffix=".conf", delete=not self.args.debug, delete_on_close=False
@@ -267,7 +267,8 @@ spec:
                 if old_containers_conf:
                     os.environ["CONTAINERS_CONF_OVERRIDE"] = old_containers_conf
                 else:
-                    del os.environ["CONTAINERS_CONF_OVERRIDE"]
+                    if "CONTAINERS_CONF_OVERRIDE" in os.environ:
+                        del os.environ["CONTAINERS_CONF_OVERRIDE"]
 
     def stop(self):
         with NamedTemporaryFile(


### PR DESCRIPTION
Typically the container runtime for CUDA is specified using the `podman --runtime` arg.
However lama-stack uses `podman kube play` which has no way to override the runtime. Use a temporary containers.conf file to do this instead.

## Summary by Sourcery

Ensure llamma-stack Podman integration supports configurable OCI runtimes, including CUDA setups, when using `podman kube play`.

Enhancements:
- Allow non-default Podman engine binaries whose names start with `podman` instead of requiring an exact `podman` basename.
- Introduce runtime selection via a temporary `containers.conf` override so CUDA/NVIDIA runtimes can be used with `podman kube play`.