### PR TITLE
Use "with pytest.raises" in tests checking for expected exceptions.

### DIFF
--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -181,14 +181,10 @@ def test_load_env_config_coerces_log_level():
     assert cfg["log_level"] == LogLevel.DEBUG
 
 
-@pytest.mark.xfail(raises=ValueError)
-def test_load_env_config_invalid_log_level_raises():
-    load_env_config({"RAMALAMA_LOG_LEVEL": "notalevel"})
-
-
-@pytest.mark.xfail(raises=ValueError)
-def test_load_env_config_invalid_log_level_case_raises():
-    load_env_config({"RAMALAMA_LOG_LEVEL": "InVaLiD"})
+@pytest.mark.parametrize("invalid_level", ["notalevel", "InVaLiD"])
+def test_load_env_config_invalid_log_level_raises(invalid_level):
+    with pytest.raises(ValueError):
+        load_env_config({"RAMALAMA_LOG_LEVEL": invalid_level})
 
 
 class TestGetDefaultEngine:


### PR DESCRIPTION
Using the "with pytest.raises" context manager explicitly guarantees that the test will fail unless the expected exception is raised. "pytest.mark.xfail" without the strict parameter will merely log the unexpected behavior but will not necessarily fail the test.

Collapse the two invalid_log_level tests into one parametrized test.

## Summary by Sourcery

Tests:
- Combine separate invalid log level configuration tests into a single parametrized test using pytest.raises for the expected ValueError.