### PR TITLE
Add --quiet/-q flag to silence warnings

### DIFF
--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -261,7 +261,13 @@ The RAMALAMA_CONTAINER_ENGINE environment variable modifies default behaviour.""
         help="""do not run RamaLama in the default container.
 The RAMALAMA_IN_CONTAINER environment variable modifies default behaviour.""",
     )
-    verbosity_group.add_argument("--quiet", "-q", dest="quiet", action="store_true", help="reduce output.")
+    verbosity_group.add_argument(
+        "--quiet",
+        "-q",
+        dest="quiet",
+        action="store_true",
+        help="Reduce output verbosity (silences warnings, simplifies list output)",
+    )
     parser.add_argument(
         "--runtime",
         default=CONFIG.runtime,
@@ -372,7 +378,13 @@ def post_parse_setup(args):
     if hasattr(args, 'pull'):
         args.pull = normalize_pull_arg(args.pull, getattr(args, 'engine', None))
 
-    log_level = LogLevel.DEBUG if args.debug else (CONFIG.log_level or LogLevel.WARNING)
+    # Determine log level: debug > quiet > config > default
+    if args.debug:
+        log_level = LogLevel.DEBUG
+    elif getattr(args, 'quiet', False):
+        log_level = LogLevel.ERROR
+    else:
+        log_level = CONFIG.log_level or LogLevel.WARNING
     configure_logger(log_level)
 
 


### PR DESCRIPTION
Implement support for silencing CUDA version warnings and other warnings by using the existing --quiet/-q flag. When specified, the log level is set to ERROR, which suppresses WARNING level messages.

The flag was already defined but not properly connected to the logging system. This change updates post_parse_setup() to respect the quiet flag and set the appropriate log level.

Log level priority: --debug > --quiet > config > default

This addresses user feedback in issue #2151 where CUDA version warnings were being displayed even when the user wanted to suppress them.

Fixes #2151

*This PR was created with the assistance of Cursor AI.*

## Summary by Sourcery

Respect the existing --quiet/-q CLI flag when configuring logging so that it suppresses warnings and only shows errors, while keeping debug output precedence over quiet mode.

Bug Fixes:
- Ensure the quiet flag correctly silences CUDA version and other warning-level messages by setting the log level to ERROR when enabled.

Enhancements:
- Clarify the CLI help text for the --quiet/-q flag to indicate that it silences warnings rather than generically reducing output.