### PR TITLE
Fix kube resource label for llama-stack

### DIFF
--- a/ramalama/stack.py
+++ b/ramalama/stack.py
@@ -38,7 +38,7 @@ class Stack:
             return """
         resources:
           limits:
-             nvidia.com/gpu=all: 1"""
+             'nvidia.com/gpu=all': 1"""
         return ""
 
     def _gen_volume_mounts(self):


### PR DESCRIPTION
GPU resource label was not correct.

This reverts commit a1f0440f997658aab74cff29298e79dc9af62b8f.

## Summary by Sourcery

Fix GPU resource labeling for llama-stack Kubernetes resources and simplify container runtime handling when serving.

Bug Fixes:
- Correct the Kubernetes GPU resource label used for llama-stack pods.

Enhancements:
- Remove custom OCI runtime override logic and invoke the container engine directly when serving.