### PR TITLE
Add e2e pytest test for info command

### DIFF
--- a/test/e2e/test_info.py
+++ b/test/e2e/test_info.py
@@ -1,0 +1,62 @@
+import json
+import tempfile
+from pathlib import Path
+from test.conftest import skip_if_gh_actions_darwin
+from test.e2e.utils import RamalamaExecWorkspace, check_output
+
+import pytest
+
+from ramalama.version import version
+
+
+@pytest.mark.e2e
+@pytest.mark.distro_integration
+@skip_if_gh_actions_darwin
+def test_info(container_engine):
+    info = json.loads(check_output(["ramalama", "info"]))
+
+    assert info["Image"].startswith("quay.io/ramalama/")
+    assert info["Version"] == version()
+    assert info["Store"] in [str(Path.home() / ".local" / "share" / "ramalama"), "/var/lib/ramalama"]
+    assert info["Engine"]["Name"] == container_engine
+
+
+@pytest.mark.e2e
+@pytest.mark.distro_integration
+@skip_if_gh_actions_darwin
+@pytest.mark.parametrize(
+    "params, key, expected_value",
+    [
+        pytest.param(
+            ["--store", str(Path(tempfile.gettempdir()) / "test_store")],
+            ["Store"],
+            str(Path(tempfile.gettempdir()) / "test_store"),
+            id="with --store",
+        ),
+        pytest.param(["--runtime", "vllm"], ["Inference", "Default"], "vllm", id="with --runtime"),
+    ],
+)
+def test_info_with_params(params, key, expected_value):
+    info = json.loads(check_output(["ramalama"] + params + ["info"]))
+    value = info
+    for k in key:
+        value = value[k]
+    assert value == str(expected_value)
+
+
+@pytest.mark.e2e
+@pytest.mark.distro_integration
+@skip_if_gh_actions_darwin
+def test_info_selinux_state():
+    # Verify selinux defaults to disabled
+    info_default = json.loads(check_output(["ramalama", "info"]))
+    assert info_default["Selinux"] is False
+
+    # Verify selinux setting from ramalama.conf
+    config = """
+    [ramalama]
+    selinux=True
+    """
+    with RamalamaExecWorkspace(config=config) as ctx:
+        info = json.loads(ctx.check_output(["ramalama", "info"]))
+        assert info["Selinux"] is True


### PR DESCRIPTION
- Migrate to e2e pytest the `test/system/050-info.bats` bat test.

## Summary by Sourcery

Add end-to-end pytest coverage for the `ramalama info` command, including default behavior, parameter handling, and SELinux configuration.

Tests:
- Add e2e pytest for `ramalama info` covering image, version, store path, and container engine metadata.
- Add parameterized e2e tests verifying `--store` and `--runtime` options influence the info output as expected.
- Add SELinux-focused e2e test ensuring default disabled state and honoring configuration from `ramalama.conf`.