### PR TITLE
056-artifact.bats: fix the expected return code for OSErrors

### DIFF
--- a/test/system/056-artifact.bats
+++ b/test/system/056-artifact.bats
@@ -389,7 +389,7 @@ EOF
 
     # Test with directory instead of file
     mkdir -p $RAMALAMA_TMPDIR/testdir
-    run_ramalama 22 convert --type artifact file://$RAMALAMA_TMPDIR/testdir test-artifact
+    run_ramalama 5 convert --type artifact file://$RAMALAMA_TMPDIR/testdir test-artifact
     is "$output" ".*Error.*" "directory as source is handled gracefully"
 }
 


### PR DESCRIPTION
Passing a directory instead of a file to `ramalama convert` results in a `IsADirectoryError` which is a subclass of `OSError` (synonym of `IOError`). `IOErrors` result in a return code of 5 (`EIO`).

## Summary by Sourcery

Bug Fixes:
- Update the expected exit code in the artifact conversion test to match the actual OSError-derived return code when a directory is used as input.