### PR TITLE
Set GGML_CPU_ALL_VARIANTS for llama-cpp builds

### DIFF
--- a/container-images/scripts/build_llama_and_whisper.sh
+++ b/container-images/scripts/build_llama_and_whisper.sh
@@ -218,7 +218,7 @@ configure_common_flags() {
     common_flags+=("-DGGML_CANN=ON" "-DSOC_TYPE=Ascend910B3")
     ;;
   musa)
-    common_flags+=("-DGGML_MUSA=ON")
+    common_flags+=("-DGGML_MUSA=ON" "-DCMAKE_EXE_LINKER_FLAGS=-Wl,--allow-shlib-undefined")
     ;;
   esac
 }
@@ -262,6 +262,9 @@ cleanup() {
 
 add_common_flags() {
   common_flags+=("-DLLAMA_CURL=ON" "-DGGML_RPC=ON")
+  if [ "$containerfile" != "cann" ]; then
+      common_flags+=("-DGGML_NATIVE=OFF" "-DGGML_BACKEND_DL=ON" "-DGGML_CPU_ALL_VARIANTS=ON")
+  fi
   case "$containerfile" in
   ramalama)
     if [ "$uname_m" = "x86_64" ] || [ "$uname_m" = "aarch64" ]; then


### PR DESCRIPTION
Builds shared library backends for multiple CPU variants and loads the appropriate variant at runtime.

## Summary by Sourcery

Configure llama.cpp container image builds to produce CPU backend shared libraries for all supported CPU variants and load the appropriate one at runtime.

Build:
- Enable GGML_CPU_ALL_VARIANTS and GGML_BACKEND_DL with GGML_NATIVE disabled in common build flags for llama.cpp.
- Restrict the linker flag --allow-shlib-undefined to x86_64 and aarch64 builds while removing it from the CUDA-specific configuration.