### PR TITLE
ci: install coreutils on macos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,7 +255,7 @@ jobs:
       - name: install golang
         shell: bash
         run: |
-           brew install go bats bash jq llama.cpp shellcheck
+           brew install go bats bash jq llama.cpp shellcheck coreutils
            uv run -- make install-requirements
 
       - name: install ollama


### PR DESCRIPTION
the timeout command suddenly disappeared from the macos github runners this afternoon

## Summary by Sourcery

CI:
- Install coreutils via Homebrew in the macOS GitHub Actions workflow to restore availability of the timeout command.