### PR TITLE
Stop pinning setuptools version in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61"]
+requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
Pinning the setuptools version to >=61 breaks rpm builds on centos-stream9 where the setuptools version is older.
The rpm builds are using https://src.fedoraproject.org/rpms/pyproject-rpm-macros which should work with pyproject.yaml even when the setuptools version does not.

The setuptools/pyproject docs do not mention pinning the setuptools version, all of the example just show an unversioned dependence on 'setuptools'.