### PR TITLE
cuda: update compiler to gcc 15

### DIFF
--- a/container-images/scripts/build_llama_and_whisper.sh
+++ b/container-images/scripts/build_llama_and_whisper.sh
@@ -25,9 +25,9 @@ dnf_install_asahi() {
 }
 
 dnf_install_cuda() {
-  dnf install -y gcc-toolset-12
+  dnf install -y gcc-toolset-15
   # shellcheck disable=SC1091
-  . /opt/rh/gcc-toolset-12/enable
+  . /opt/rh/gcc-toolset-15/enable
 }
 
 dnf_install_cann() {


### PR DESCRIPTION
Turning on `GGML_CPU_ALL_VARIANTS` compiles backends for newer ARM cpu variants that gcc 12 doesn't support. Update to gcc 15 to support more modern cpu variants and compiler features.

## Summary by Sourcery

Build:
- Switch CUDA DNF installation from gcc-toolset-12 to gcc-toolset-15 in the container build script.