### PR TITLE
cuda: update compiler to gcc 14

### DIFF
--- a/container-images/scripts/build_llama_and_whisper.sh
+++ b/container-images/scripts/build_llama_and_whisper.sh
@@ -25,9 +25,10 @@ dnf_install_asahi() {
 }
 
 dnf_install_cuda() {
-  dnf install -y gcc-toolset-12
-  # shellcheck disable=SC1091
-  . /opt/rh/gcc-toolset-12/enable
+  local gcc_toolset_version=14
+  dnf install -y gcc-toolset-${gcc_toolset_version}
+  # shellcheck disable=SC1090
+  . /opt/rh/gcc-toolset-${gcc_toolset_version}/enable
 }
 
 dnf_install_cann() {


### PR DESCRIPTION
Turning on `GGML_CPU_ALL_VARIANTS` compiles backends for newer ARM cpu variants that gcc 12 doesn't support. Update to gcc 14 to support more modern cpu variants and compiler features.

## Summary by Sourcery

Build:
- Switch CUDA DNF installation to gcc-toolset-14 and generalize the toolset version handling in the build script.