### PR TITLE
disable "ollama pull" tests

### DIFF
--- a/test/e2e/test_pull.py
+++ b/test/e2e/test_pull.py
@@ -217,6 +217,9 @@ def test_pull_wrong_endian_model_error(model, expected):
         assert expected in exc_info.value.output.decode("utf-8")
 
 
+@pytest.mark.xfail(
+    reason="ollama pull is failing with \"Error: digest mismatch\", see https://github.com/ollama/ollama/issues/941"
+)
 @pytest.mark.e2e
 @pytest.mark.distro_integration
 @skip_if_no_ollama

--- a/test/system/050-pull.bats
+++ b/test/system/050-pull.bats
@@ -31,6 +31,7 @@ load setup_suite
 
 # bats test_tags=distro-integration
 @test "ramalama pull ollama cache" {
+    skip "ollama pull is failing with \"Error: digest mismatch\", see https://github.com/ollama/ollama/issues/941"
     skip_if_no_ollama
 
     ollama serve &


### PR DESCRIPTION
`ollama pull` commands are consistently failing with `Error: digest mismatch`. This appears to be a problem with ollama, and not related to ramalama. Disable the failing tests until the issue is resolved.

## Summary by Sourcery

Temporarily disable failing tests related to `ollama pull` commands that error with a digest mismatch.

Tests:
- Skip the e2e pull test that relies on `ollama pull` due to persistent digest mismatch errors.
- Skip the system BATS test for `ramalama pull ollama cache` while `ollama pull` is unstable.