### PR TITLE
convert: remove unnecessary fallback

### DIFF
--- a/ramalama/transports/oci.py
+++ b/ramalama/transports/oci.py
@@ -292,16 +292,7 @@ class OCI(Transport):
         imageid = self.build(source_model, args)
         if args.dryrun:
             imageid = "a1b2c3d4e5f6"
-        try:
-            self._create_manifest(self.model, imageid, args)
-        except subprocess.CalledProcessError as e:
-            perror(
-                f"""\
-Failed to create manifest for OCI {self.model} : {e}
-Tagging build instead
-                """
-            )
-            self.tag(imageid, self.model, args)
+        self._create_manifest(self.model, imageid, args)
 
     def convert(self, source_model, args):
         self._convert(source_model, args)


### PR DESCRIPTION
Use the `--ignore` option to `podman manifest rm` to remove the need to catch a `subprocess` error.

When creating a manifest, don't fall back to tagging the image instead, they are not the same.

## Summary by Sourcery

Simplify OCI conversion by relying on podman’s built-in ignore behavior for manifest removal and by always creating an OCI manifest instead of silently falling back to tagging the image.

Bug Fixes:
- Remove incorrect fallback that tagged the built image when manifest creation failed, ensuring conversion produces a proper OCI manifest or fails visibly.

Enhancements:
- Use the podman `manifest rm --ignore` option instead of catching subprocess errors to streamline manifest cleanup before conversion.