### PR TITLE
CI: fix race in test_pull.py::test_pull_with_registry

### DIFF
--- a/test/e2e/test_pull.py
+++ b/test/e2e/test_pull.py
@@ -356,8 +356,8 @@ def test_pull_with_registry(container_registry, container_engine):
         ctx.check_call(ramalama_cli + ["pull"] + auth_flags + [fake_model_registry_url])
 
         # Check if the fake model was pulled correctly
-        model_list = json.loads(ctx.check_output(ramalama_cli + ["list", "--json", "--sort", "modified"]))
-        assert model_list[0]["name"] == fake_model_registry_url
+        model_list = json.loads(ctx.check_output(ramalama_cli + ["list", "--json"]))
+        assert fake_model_registry_url in [x["name"] for x in model_list]
 
         # Clean fake image
         ctx.check_call([container_engine, "rmi", fake_model_registry_url.replace("oci://", "")])


### PR DESCRIPTION
Previously this would sort the models on mtime and choose the first image as the oci image.
This was not correct, the oci image must be newer than the file:// used to create it.

However it works because the oci image mtime has seconds precision while file has ms.
If they are modified in the same second then the oci model will be "older" than the file model.
If not in the same second then oci model will be "newer".

The order isn't significant to the test assert, it just checks that oci model exists, so rewrite the test to avoid this issue completely.

## Summary by Sourcery

Tests:
- Change the pull-with-registry test to assert the presence of the fake model in the full model list rather than assuming it is the first entry.