### PR TITLE
Use correct merge repo in konflux PR pipeline

### DIFF
--- a/.tekton/pipelines/pull-request-pipeline.yaml
+++ b/.tekton/pipelines/pull-request-pipeline.yaml
@@ -142,6 +142,8 @@ spec:
       value: "50"
     - name: mergeTargetBranch
       value: "true"
+    - name: mergeSourceRepoUrl:
+      value: https://github.com/containers/ramalama
     runAfter:
     - init
     taskRef:


### PR DESCRIPTION
IIUC setting mergeSourceRepoUrl to https://github.com/containers/ramalama should merge upstream main into the PR branch instead of main from the PR source branch repo.

From: https://github.com/konflux-ci/build-definitions/tree/main/pipelines/docker-build-multi-platform-oci-ta#git-clone-oci-ta01-task-parameters

## Summary by Sourcery

New Features:
- Add configuration to specify the upstream containers/ramalama repository as the merge source in the PR pipeline.