### PR TITLE
Bump llama.cpp and whisper.cpp version

### DIFF
--- a/container-images/scripts/build_llama_and_whisper.sh
+++ b/container-images/scripts/build_llama_and_whisper.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-DEFAULT_LLAMA_CPP_COMMIT="968929528c6a05e10249366fbe5f0330ad9af678"
-DEFAULT_WHISPER_COMMIT="679bdb53dbcbfb3e42685f50c7ff367949fd4d48"
+DEFAULT_LLAMA_CPP_COMMIT="091a46cb8d43c0e662d04b80a3d11320d25b7d49" # b7815
+DEFAULT_WHISPER_COMMIT="2eeeba56e9edd762b4b38467bab96c2517163158" # v1.8.3
 
 dnf_install_intel_gpu() {
   local intel_rpms=("intel-oneapi-mkl-sycl-devel" "intel-oneapi-dnnl-devel"


### PR DESCRIPTION
Pull in @0cc4m's workaround for Intel vulkan issue https://github.com/ggml-org/llama.cpp/pull/18814

Note: ggml/whisper has not synced the change yet but has just released v1.8.3

Fixes #2308

## Summary by Sourcery

Build:
- Bump the pinned llama.cpp commit hash in the container image build script for llama and whisper.

## Summary by Sourcery

Update default pinned llama.cpp and whisper.cpp revisions used in container image builds to newer upstream versions.

Build:
- Bump default llama.cpp commit used in the llama/whisper container build script to a newer upstream revision.
- Bump default whisper.cpp commit used in the llama/whisper container build script to the v1.8.3 release commit.