### PR TITLE
Refactor code base to use pathlib.Path

### DIFF
--- a/ramalama/command/context.py
+++ b/ramalama/command/context.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+from pathlib import Path
 from typing import Optional
 
 from ramalama.common import check_metal, check_nvidia
@@ -112,19 +113,19 @@ class RamalamaModelContext:
         return self.model._get_entry_model_path(self.is_container, self.should_generate, self.dry_run)
 
     @property
-    def mmproj_path(self) -> Optional[str]:
+    def mmproj_path(self) -> Optional[Path]:
         return self.model._get_mmproj_path(self.is_container, self.should_generate, self.dry_run)
 
     @property
-    def chat_template_path(self) -> Optional[str]:
+    def chat_template_path(self) -> Optional[Path]:
         return self.model._get_chat_template_path(self.is_container, self.should_generate, self.dry_run)
 
     @property
-    def draft_model_path(self) -> str:
+    def draft_model_path(self) -> Optional[str]:
         if getattr(self.model, "draft_model", None):
             assert self.model.draft_model
             return self.model.draft_model._get_entry_model_path(self.is_container, self.should_generate, self.dry_run)
-        return ""
+        return None
 
 
 class RamalamaHostContext:

--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -13,6 +13,7 @@ import subprocess
 import sys
 from collections.abc import Callable, Sequence
 from functools import lru_cache
+from pathlib import Path
 from typing import IO, TYPE_CHECKING, Any, Literal, Optional, Protocol, TypeAlias, TypedDict, cast, get_args
 
 import yaml
@@ -115,7 +116,7 @@ def available(cmd: str) -> bool:
 
 def quoted(arr) -> str:
     """Return string with quotes around elements containing spaces."""
-    return " ".join(['"' + element + '"' if ' ' in element else element for element in arr])
+    return " ".join(['"' + s + '"' if ' ' in s else s for element in arr for s in [str(element)]])
 
 
 def exec_cmd(args, stdout2null: bool = False, stderr2null: bool = False):
@@ -249,25 +250,25 @@ def generate_sha256(to_hash: str, with_sha_prefix: bool = True) -> str:
     return generate_sha256_binary(to_hash.encode("utf-8"), with_sha_prefix)
 
 
-def verify_checksum(filename: str) -> bool:
+def verify_checksum(filepath: Path) -> bool:
     """
     Verifies if the SHA-256 checksum of a file matches the checksum provided in
-    the filename.
+    the file path.
 
     Args:
-    filename (str): The filename containing the checksum prefix
+    filepath (Path): The filen path containing the checksum prefix
                     (e.g., "sha256:<checksum>")
 
     Returns:
     bool: True if the checksum matches, False otherwise.
     """
 
-    if not os.path.exists(filename):
+    if not filepath.exists():
         return False
 
     # Check if the filename starts with "sha256:" or "sha256-" and extract the checksum from filename
     expected_checksum = ""
-    fn_base = os.path.basename(filename)
+    fn_base = filepath.name if filepath.is_file() else ""
     if fn_base.startswith("sha256:"):
         expected_checksum = fn_base.split(":")[1]
     elif fn_base.startswith("sha256-"):
@@ -280,7 +281,7 @@ def verify_checksum(filename: str) -> bool:
 
     # Calculate the SHA-256 checksum of the file contents
     sha256_hash = hashlib.sha256()
-    with open(filename, "rb") as f:
+    with open(filepath, "rb") as f:
         for byte_block in iter(lambda: f.read(4096), b""):
             sha256_hash.update(byte_block)
 

--- a/ramalama/engine.py
+++ b/ramalama/engine.py
@@ -4,6 +4,7 @@ import os
 import subprocess
 import sys
 import time
+import pathlib
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Sequence
 from http.client import HTTPConnection, HTTPException
@@ -123,7 +124,7 @@ class BaseEngine(ABC):
         self.add(args)
 
     def add_volume(self, src: str, dest: str, *, opts="ro"):
-        self.add_args("-v", f"{normalize_host_path_for_container(src)}:{dest}:{opts}{self.relabel()}")
+        self.add_args("-v", f"{normalize_host_path_for_container(pathlib.Path(src))}:{dest}:{opts}{self.relabel()}")
 
     def dryrun(self):
         dry_run(self.exec_args)

--- a/ramalama/http_client.py
+++ b/ramalama/http_client.py
@@ -5,6 +5,7 @@ import shutil
 import sys
 import time
 import urllib.request
+from pathlib import Path
 
 import ramalama.console as console
 from ramalama.common import perror
@@ -24,10 +25,10 @@ class HttpClient:
     def __init__(self):
         pass
 
-    def init(self, url, headers, output_file, show_progress, response_bytes=None):
-        output_file_partial = None
-        if output_file:
-            output_file_partial = output_file + ".partial"
+    def init(
+        self, url: str, headers: dict[str, str] | None, output_file: Path, show_progress: bool, response_bytes=None
+    ):
+        output_file_partial = Path(f"{output_file}.partial")
 
         self.file_size = self.set_resume_point(output_file_partial)
         self.urlopen(url, headers)
@@ -49,8 +50,7 @@ class HttpClient:
             finally:
                 del out  # Ensure file is closed before rename
 
-        if output_file:
-            os.rename(output_file_partial, output_file)
+        os.rename(output_file_partial, output_file)
 
     def urlopen(self, url, headers):
         headers["Range"] = f"bytes={self.file_size}-"
@@ -162,13 +162,13 @@ class HttpClient:
         return now_downloaded / elapsed_seconds
 
 
-def download_file(url: str, dest_path: str, headers: dict[str, str] | None = None, show_progress: bool = True):
+def download_file(url: str, dest_path: Path, headers: dict[str, str] | None = None, show_progress: bool = True):
     """
     Downloads a file from a given URL to a specified destination path.
 
     Args:
         url (str): The URL to download from.
-        dest_path (str): The path to save the downloaded file.
+        dest_path (Path): The path to save the downloaded file.
         headers (dict): Optional headers to include in the request.
         show_progress (bool): Whether to show a progress bar during download.
 

--- a/ramalama/kube.py
+++ b/ramalama/kube.py
@@ -1,5 +1,6 @@
 import os
 import platform
+import pathlib
 from typing import Optional, Tuple
 
 from ramalama.common import MNT_DIR, RAG_DIR, ContainerEntryPoint, get_accel_env_vars
@@ -92,10 +93,10 @@ class Kube:
         return mounts, volumes
 
     def _gen_path_volume(self):
-        host_model_path = normalize_host_path_for_container(self.src_model_path)
+        host_model_path = normalize_host_path_for_container(pathlib.Path(self.src_model_path))
         if platform.system() == "Windows":
             #  Workaround https://github.com/containers/podman/issues/16704
-            host_model_path = '/mnt' + host_model_path
+            host_model_path = f"/mnt{host_model_path}"
         mount = f"""
         - mountPath: {self.dest_model_path}
           name: model"""
@@ -126,10 +127,10 @@ class Kube:
         return mounts, volumes
 
     def _gen_chat_template_volume(self):
-        host_chat_template_path = normalize_host_path_for_container(self.src_chat_template_path)
+        host_chat_template_path = normalize_host_path_for_container(pathlib.Path(self.src_chat_template_path))
         if platform.system() == "Windows":
             #  Workaround https://github.com/containers/podman/issues/16704
-            host_chat_template_path = '/mnt' + host_chat_template_path
+            host_chat_template_path = f"/mnt{host_chat_template_path}"
         mount = f"""
         - mountPath: {self.dest_chat_template_path}
           name: chat_template"""
@@ -140,10 +141,10 @@ class Kube:
         return mount, volume
 
     def _gen_mmproj_volume(self):
-        host_mmproj_path = normalize_host_path_for_container(self.src_mmproj_path)
+        host_mmproj_path = normalize_host_path_for_container(pathlib.Path(self.src_mmproj_path))
         if platform.system() == "Windows":
             #  Workaround https://github.com/containers/podman/issues/16704
-            host_mmproj_path = '/mnt' + host_mmproj_path
+            host_mmproj_path = f"/mnt{host_mmproj_path}"
         mount = f"""
         - mountPath: {self.dest_mmproj_path}
           name: mmproj"""

--- a/ramalama/model_inspect/gguf_parser.py
+++ b/ramalama/model_inspect/gguf_parser.py
@@ -1,6 +1,7 @@
 import io
 import struct
 from enum import IntEnum
+from pathlib import Path
 from typing import Any, Dict, cast
 
 from ramalama.endian import GGUFEndian
@@ -112,7 +113,7 @@ GGUF_NUMBER_FORMATS: list[GGUFValueType] = [
 
 class GGUFInfoParser:
     @staticmethod
-    def is_model_gguf(model_path: str) -> bool:
+    def is_model_gguf(model_path: Path) -> bool:
         try:
             with open(model_path, "rb") as model_file:
                 magic_number = GGUFInfoParser.read_string(model_file, GGUFEndian.LITTLE, 4)
@@ -178,7 +179,7 @@ class GGUFInfoParser:
         return value
 
     @staticmethod
-    def get_model_endianness(model_path: str) -> GGUFEndian:
+    def get_model_endianness(model_path: Path) -> GGUFEndian:
         # Pin model endianness to Little Endian by default.
         # Models downloaded via HuggingFace are majority Little Endian.
         model_endianness = GGUFEndian.LITTLE
@@ -205,7 +206,7 @@ class GGUFInfoParser:
         return metadata
 
     @staticmethod
-    def parse_metadata(model_path: str) -> GGUFModelMetadata:
+    def parse_metadata(model_path: Path) -> GGUFModelMetadata:
         model_endianness = GGUFInfoParser.get_model_endianness(model_path)
 
         with open(model_path, "rb") as model:
@@ -220,7 +221,7 @@ class GGUFInfoParser:
             return GGUFModelMetadata(GGUFInfoParser._parse_metadata(model, model_endianness))
 
     @staticmethod
-    def parse(model_name: str, model_registry: str, model_path: str) -> GGUFModelInfo:
+    def parse(model_name: str, model_registry: str, model_path: Path) -> GGUFModelInfo:
         model_endianness = GGUFInfoParser.get_model_endianness(model_path)
 
         with open(model_path, "rb") as model:
@@ -249,5 +250,5 @@ class GGUFInfoParser:
                 tensors.append(Tensor(name, n_dimensions, dimensions, tensor_type.name, offset))
 
             return GGUFModelInfo(
-                model_name, model_registry, model_path, gguf_version, metadata, tensors, model_endianness
+                model_name, model_registry, str(model_path), gguf_version, metadata, tensors, model_endianness
             )

--- a/ramalama/model_inspect/safetensor_parser.py
+++ b/ramalama/model_inspect/safetensor_parser.py
@@ -1,5 +1,6 @@
 import json
 import struct
+from pathlib import Path
 
 import ramalama.console as console
 from ramalama.model_inspect.error import ParseError
@@ -18,7 +19,7 @@ class SafetensorInfoParser:
         return model_name.endswith(".safetensor") or model_name.endswith(".safetensors")
 
     @staticmethod
-    def parse(model_name: str, model_registry: str, model_path: str) -> SafetensorModelInfo:
+    def parse(model_name: str, model_registry: str, model_path: Path) -> SafetensorModelInfo:
         try:
             with open(model_path, "rb") as model_file:
                 prefix = '<'
@@ -27,7 +28,7 @@ class SafetensorInfoParser:
                 header_size = struct.unpack(typestring, model_file.read(8))[0]
                 header = json.loads(model_file.read(header_size))
 
-                return SafetensorModelInfo(model_name, model_registry, model_path, header)
+                return SafetensorModelInfo(model_name, model_registry, str(model_path), header)
 
         except Exception as ex:
             msg = f"Failed to parse safetensor model '{model_path}': {ex}"

--- a/ramalama/model_store/global_store.py
+++ b/ramalama/model_store/global_store.py
@@ -1,5 +1,6 @@
 import os
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Dict, List
 
 from ramalama import oci_tools
@@ -21,10 +22,10 @@ class GlobalModelStore:
         self,
         base_path: str,
     ):
-        self._store_base_path = os.path.join(base_path, "store")
+        self._store_base_path = Path(os.path.join(base_path, "store"))
 
     @property
-    def path(self) -> str:
+    def path(self) -> Path:
         return self._store_base_path
 
     def list_models(self, engine: str, show_container: bool) -> Dict[str, List[ModelFile]]:
@@ -32,16 +33,16 @@ class GlobalModelStore:
 
         for root, subdirs, _ in os.walk(self.path):
             if DIRECTORY_NAME_REFS in subdirs:
-                ref_dir = os.path.join(root, DIRECTORY_NAME_REFS)
+                ref_dir = Path(root).joinpath(DIRECTORY_NAME_REFS)
                 for ref_file_name in os.listdir(ref_dir):
-                    ref_file_path = os.path.join(ref_dir, ref_file_name)
+                    ref_file_path = ref_dir.joinpath(ref_file_name)
                     ref_file = migrate_reffile_to_refjsonfile(
-                        ref_file_path, os.path.join(root, DIRECTORY_NAME_SNAPSHOTS)
+                        ref_file_path, Path(root).joinpath(DIRECTORY_NAME_SNAPSHOTS)
                     )
                     if ref_file is None:
                         ref_file = RefJSONFile.from_path(ref_file_path)
 
-                    model_path = root.replace(self.path, "").replace(os.sep, "", 1)
+                    model_path = root.replace(f"{self.path}", "").replace(os.sep, "", 1)
 
                     parts = model_path.split(os.sep)
                     model_source = parts[0]
@@ -54,14 +55,14 @@ class GlobalModelStore:
                     collected_files = []
                     for snapshot_file in ref_file.files:
                         is_partially_downloaded = False
-                        snapshot_file_path = os.path.join(
-                            root, DIRECTORY_NAME_SNAPSHOTS, ref_file.hash, snapshot_file.name
+                        snapshot_file_path = Path(root).joinpath(
+                            DIRECTORY_NAME_SNAPSHOTS, ref_file.hash, snapshot_file.name
                         )
-                        if not os.path.exists(snapshot_file_path):
-                            blobs_partial_file_path = os.path.join(
-                                root, DIRECTORY_NAME_BLOBS, ref_file.hash + ".partial"
+                        if not snapshot_file_path.exists():
+                            blobs_partial_file_path = Path(root).joinpath(
+                                DIRECTORY_NAME_BLOBS, ref_file.hash + ".partial"
                             )
-                            if not os.path.exists(blobs_partial_file_path):
+                            if not blobs_partial_file_path.exists():
                                 continue
 
                             snapshot_file_path = blobs_partial_file_path

--- a/ramalama/model_store/snapshot_file.py
+++ b/ramalama/model_store/snapshot_file.py
@@ -1,5 +1,6 @@
 import os
 from enum import IntEnum
+from pathlib import Path
 from typing import Dict, Sequence
 
 from ramalama.common import generate_sha256_binary, perror
@@ -36,8 +37,8 @@ class SnapshotFile:
         self.should_verify_checksum: bool = should_verify_checksum
         self.required: bool = required
 
-    def download(self, blob_file_path: str, snapshot_dir: str) -> str:
-        if not os.path.exists(blob_file_path):
+    def download(self, blob_file_path: Path, snapshot_dir: Path) -> str:
+        if not blob_file_path.exists():
             if self.should_show_progress:
                 perror(f"Downloading {self.name}")
             download_file(
@@ -50,7 +51,7 @@ class SnapshotFile:
             logger.debug(f"Using cached blob for {self.name} ({os.path.basename(blob_file_path)})")
         prefix = os.path.dirname(self.name)
         if prefix:
-            snapshot_dir = os.path.join(snapshot_dir, prefix)
+            snapshot_dir = snapshot_dir.joinpath(prefix)
         return os.path.relpath(blob_file_path, start=snapshot_dir)
 
 

--- a/ramalama/path_utils.py
+++ b/ramalama/path_utils.py
@@ -7,7 +7,7 @@ from pathlib import Path, PureWindowsPath
 from urllib.parse import unquote_to_bytes
 
 
-def normalize_host_path_for_container(host_path: str) -> str:
+def normalize_host_path_for_container(host_path: Path) -> Path:
     """
     Convert a host filesystem path to a format suitable for container volume mounts.
 
@@ -37,22 +37,22 @@ def normalize_host_path_for_container(host_path: str) -> str:
     # Docker Desktop for Windows expects paths in the format /c/Users/... instead of C:\Users\...
 
     # First, resolve symlinks and make the path absolute.
-    path = Path(host_path).resolve()
+    path = host_path.resolve()
 
     # Handle UNC paths to container filesystem
     # e.g if the model store is placed on the podman machine VM to reduce copying
     # \\wsl.localhost\podman-machine-default\home\user\.local\share\ramalama\store
     # NOTE: UNC paths cannot be accessed implicitly from the container, would need to smb mount
     if path.drive.startswith("\\\\"):
-        return '/' + path.relative_to(path.drive).as_posix()
+        return Path('/' + path.relative_to(path.drive).as_posix())
 
     if not path.drive:
-        return path.as_posix()
+        return Path(path.as_posix())
 
     # Handle paths with drive letters
     drive_letter = path.drive[0].lower()
     # path.as_posix() on Windows is 'C:/Users/...', so we partition on ':' and take the rest.
-    return f"/{drive_letter}{path.as_posix().partition(':')[2]}"
+    return Path(f"/{drive_letter}{path.as_posix().partition(':')[2]}")
 
 
 def is_windows_absolute_path(path: str) -> bool:
@@ -71,7 +71,7 @@ def is_windows_absolute_path(path: str) -> bool:
     return PureWindowsPath(path).is_absolute()
 
 
-def resolve_real_path(path: str) -> str:
+def resolve_real_path(path: Path) -> Path:
     """
     Resolve a path to its real absolute path, handling symlinks.
 
@@ -84,10 +84,10 @@ def resolve_real_path(path: str) -> str:
     Returns:
         Absolute path with symlinks resolved
     """
-    return os.path.realpath(path)
+    return Path(os.path.realpath(path))
 
 
-def get_container_mount_path(host_path: str) -> str:
+def get_container_mount_path(host_path: Path) -> Path:
     """
     Get the properly formatted path for use in container mount arguments.
 
@@ -112,7 +112,7 @@ def get_container_mount_path(host_path: str) -> str:
     return normalize_host_path_for_container(real_path)
 
 
-def create_file_link(src: str, dst: str) -> None:
+def create_file_link(src: Path, dst: Path) -> None:
     """
     Create a link from dst to src using the best available method for the platform.
 
@@ -136,15 +136,15 @@ def create_file_link(src: str, dst: str) -> None:
         - Hardlinks share the same inode, so deleting one doesn't affect the other
         - On Windows, hardlinks are preferred over symlinks for file operations
     """
-    if not os.path.exists(src):
+    if not src.exists():
         raise FileNotFoundError(f"Source file does not exist: {src}")
 
     # Ensure destination directory exists
-    os.makedirs(os.path.dirname(dst), exist_ok=True)
+    dst.parent.mkdir(exist_ok=True, parents=True)
 
     # Remove existing destination if it exists
-    if os.path.exists(dst) or os.path.islink(dst):
-        os.unlink(dst)
+    if dst.exists() or dst.is_symlink():
+        dst.unlink()
 
     # Strategy 1: Try hardlink first (best for Windows, works without admin)
     try:

--- a/ramalama/stack.py
+++ b/ramalama/stack.py
@@ -1,5 +1,6 @@
 import os
 import platform
+from pathlib import Path
 
 import ramalama.kube as kube
 import ramalama.quadlet as quadlet
@@ -60,10 +61,10 @@ class Stack:
         return volume_mounts
 
     def _gen_volumes(self):
-        host_model_path = normalize_host_path_for_container(self.model._get_entry_model_path(False, False, False))
+        host_model_path = normalize_host_path_for_container(Path(self.model._get_entry_model_path(False, False, False)))
         if platform.system() == "Windows":
             #  Workaround https://github.com/containers/podman/issues/16704
-            host_model_path = '/mnt' + host_model_path
+            host_model_path = f"/mnt{host_model_path}"
         volumes = f"""
       - hostPath:
           path: {host_model_path}

--- a/ramalama/transports/base.py
+++ b/ramalama/transports/base.py
@@ -9,6 +9,7 @@ import sys
 import time
 from abc import ABC, abstractmethod
 from functools import cached_property
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional
 
 from ramalama import chat
@@ -239,7 +240,7 @@ class Transport(TransportBase):
         safetensor_files = ref_file.safetensor_model_files
         if safetensor_files:
             # Safetensor models use directory mounts, not individual files
-            src_path = self.model_store.get_snapshot_directory_from_tag(self.model_tag)
+            src_path = str(self.model_store.get_snapshot_directory_from_tag(self.model_tag))
             if use_container or should_generate:
                 dest_path = MNT_DIR
             else:
@@ -253,16 +254,20 @@ class Transport(TransportBase):
             if use_container or should_generate:
                 dest_path = f"{MNT_DIR}/{model_file.name}"
             else:
-                dest_path = self.model_store.get_blob_file_path(model_file.hash)
-            src_path = self.model_store.get_blob_file_path(model_file.hash)
+                dest_path = str(self.model_store.get_blob_file_path(model_file.hash))
+            src_path = str(self.model_store.get_blob_file_path(model_file.hash))
             model_parts.append((src_path, dest_path))
 
         # Sort multi-part models by filename to ensure correct order
-        if len(model_parts) > 1 and any("-00001-of-" in name for _, name in model_parts):
+        if len(model_parts) > 1 and any("-00001-of-" in str(name) for _, name in model_parts):
             model_parts.sort(key=lambda x: x[1])
 
         return model_parts
 
+    #
+    # Keep returning str here due to the possible return value of oci:// which would be
+    # reduced to oci:/ by pathlib.Path.
+    #
     def _get_entry_model_path(self, use_container: bool, should_generate: bool, dry_run: bool) -> str:
         """
         Returns the path to the model blob on the host if use_container and should_generate are both False.
@@ -293,7 +298,7 @@ class Transport(TransportBase):
         if safetensor_files:
             if use_container or should_generate:
                 return MNT_DIR
-            return self.model_store.get_snapshot_directory_from_tag(self.model_tag)
+            return str(self.model_store.get_snapshot_directory_from_tag(self.model_tag))
         elif not gguf_files:
             raise NoGGUFModelFileFound()
 
@@ -308,7 +313,7 @@ class Transport(TransportBase):
 
         if use_container or should_generate:
             return f"{MNT_DIR}/{model_file.name}"
-        return self.model_store.get_blob_file_path(model_file.hash)
+        return str(self.model_store.get_blob_file_path(model_file.hash))
 
     def _get_inspect_model_path(self, dry_run: bool) -> str:
         """Return a concrete file path for inspection.
@@ -318,16 +323,17 @@ class Transport(TransportBase):
             return "/path/to/model"
         if self.model_type == 'oci':
             return self._get_entry_model_path(False, False, dry_run)
-        safetensor_blob = self.model_store.get_safetensor_blob_path(self.model_tag, self.filename)
+        safetensor_blob_path = self.model_store.get_safetensor_blob_path(self.model_tag, self.filename)
+        safetensor_blob = None if safetensor_blob_path is None else str(safetensor_blob_path)
         return safetensor_blob or self._get_entry_model_path(False, False, dry_run)
 
-    def _get_mmproj_path(self, use_container: bool, should_generate: bool, dry_run: bool) -> Optional[str]:
+    def _get_mmproj_path(self, use_container: bool, should_generate: bool, dry_run: bool) -> Optional[Path]:
         """
         Returns the path to the mmproj blob on the host if use_container and should_generate are both False.
         Or returns the path to the mounted file inside a container.
         """
         if dry_run:
-            return ""
+            return Path("")
 
         if self.model_type == 'oci':
             return None
@@ -342,16 +348,16 @@ class Transport(TransportBase):
         # Use the first mmproj file
         mmproj_file = ref_file.mmproj_files[0]
         if use_container or should_generate:
-            return f"{MNT_DIR}/{mmproj_file.name}"
+            return Path(f"{MNT_DIR}/{mmproj_file.name}")
         return self.model_store.get_blob_file_path(mmproj_file.hash)
 
-    def _get_chat_template_path(self, use_container: bool, should_generate: bool, dry_run: bool) -> Optional[str]:
+    def _get_chat_template_path(self, use_container: bool, should_generate: bool, dry_run: bool) -> Optional[Path]:
         """
         Returns the path to the chat template blob on the host if use_container and should_generate are both False.
         Or returns the path to the mounted file inside a container.
         """
         if dry_run:
-            return ""
+            return Path("")
 
         if self.model_type == 'oci':
             return None
@@ -366,7 +372,7 @@ class Transport(TransportBase):
         # Use the last chat template file (may have been go template converted to jinja)
         chat_template_file = ref_file.chat_templates[-1]
         if use_container or should_generate:
-            return f"{MNT_DIR}/{chat_template_file.name}"
+            return Path(f"{MNT_DIR}/{chat_template_file.name}")
         return self.model_store.get_blob_file_path(chat_template_file.hash)
 
     def remove(self, args) -> bool:
@@ -463,7 +469,7 @@ class Transport(TransportBase):
         if self.draft_model:
             draft_model = self.draft_model._get_entry_model_path(args.container, args.generate, args.dryrun)
             # Convert path to container-friendly format (handles Windows path conversion)
-            container_draft_model = get_container_mount_path(draft_model)
+            container_draft_model = get_container_mount_path(Path(draft_model))
             mount_opts = f"--mount=type=bind,src={container_draft_model},destination={MNT_FILE_DRAFT}"
             mount_opts += f",ro{self.engine.relabel()}"
             self.engine.add([mount_opts])
@@ -819,7 +825,7 @@ class Transport(TransportBase):
         compose.generate().write(output_dir)
 
     def inspect_metadata(self) -> dict[str, Any]:
-        model_path = self._get_entry_model_path(False, False, False)
+        model_path = Path(self._get_entry_model_path(False, False, False))
 
         if GGUFInfoParser.is_model_gguf(model_path):
             return GGUFInfoParser.parse_metadata(model_path).data
@@ -835,7 +841,10 @@ class Transport(TransportBase):
     ) -> Any:
         model_name = self.filename
         model_registry = self.type.lower()
-        model_path = self._get_inspect_model_path(dryrun)
+        model_path = Path(self._get_inspect_model_path(dryrun))
+        if not model_path.exists():
+            raise NoRefFileFound(model_name)
+
         if GGUFInfoParser.is_model_gguf(model_path):
             if not show_all_metadata and get_field == "":
                 gguf_info: GGUFModelInfo = GGUFInfoParser.parse(model_name, model_registry, model_path)
@@ -854,7 +863,7 @@ class Transport(TransportBase):
             safetensor_info: SafetensorModelInfo = SafetensorInfoParser.parse(model_name, model_registry, model_path)
             return safetensor_info.serialize(json=as_json, all=show_all)
 
-        return ModelInfoBase(model_name, model_registry, model_path).serialize(json=as_json)
+        return ModelInfoBase(model_name, model_registry, str(model_path)).serialize(json=as_json)
 
     def print_pull_message(self, model_name) -> None:
         model_name = trim_model_name(model_name)

--- a/ramalama/transports/ollama.py
+++ b/ramalama/transports/ollama.py
@@ -2,6 +2,7 @@ import json
 import os
 import shutil
 import urllib.error
+import pathlib
 from typing import Optional
 
 from ramalama.common import available, perror
@@ -11,7 +12,7 @@ from ramalama.path_utils import create_file_link
 from ramalama.transports.base import Transport
 
 
-def in_existing_cache(organization, model_name, model_tag):
+def in_existing_cache(organization, model_name, model_tag) -> Optional[pathlib.Path]:
     if not available("ollama"):
         return None
     default_ollama_caches = [
@@ -30,8 +31,9 @@ def in_existing_cache(organization, model_name, model_tag):
                     if layer["mediaType"] == "application/vnd.ollama.image.model":
                         layer_digest = layer["digest"]
                         ollama_digest_path = os.path.join(cache_dir, 'blobs', layer_digest)
-                        if os.path.exists(str(ollama_digest_path).replace(':', '-')):
-                            return str(ollama_digest_path).replace(':', '-')
+                        sanitized_digest = pathlib.Path(ollama_digest_path.replace(':', '-'))
+                        if sanitized_digest.exists():
+                            return sanitized_digest
     return None
 
 
@@ -183,8 +185,7 @@ class Ollama(Transport):
         ollama_repo = OllamaRepository(name, organization)
         manifest = ollama_repo.fetch_manifest(tag)
         ollama_cache_path = in_existing_cache(organization, self.model_name, tag)
-        is_model_in_ollama_cache = ollama_cache_path is not None
-        files: list[SnapshotFile] = ollama_repo.get_file_list(tag, cached_files, is_model_in_ollama_cache)
+        files: list[SnapshotFile] = ollama_repo.get_file_list(tag, cached_files, ollama_cache_path is not None)
 
         if not args.quiet:
             self.print_pull_message(f"ollama://{organization}/{name}:{tag}")
@@ -193,7 +194,7 @@ class Ollama(Transport):
         self.model_store.new_snapshot(tag, model_hash, files, verify=getattr(args, "verify", True))
 
         # If a model has been downloaded via ollama cli, only create link in the snapshots directory
-        if is_model_in_ollama_cache:
+        if ollama_cache_path is not None:
             if not args.quiet:
                 perror(f"Using cached ollama://{name}{tag} ...")
             snapshot_model_path = self.model_store.get_snapshot_file_path(model_hash, self.model_store.model_name)

--- a/ramalama/transports/url.py
+++ b/ramalama/transports/url.py
@@ -61,10 +61,11 @@ class URL(Transport):
 
     def extract_model_identifiers(self):
         if self.type == "file":
+            normalized_host_path = normalize_host_path_for_container(Path(self.model).parent)
             return (
                 Path(self.model).name,
                 "latest",
-                normalize_host_path_for_container(str(Path(self.model).parent)).removeprefix("/"),
+                str(normalized_host_path).removeprefix("/"),
             )
 
         model_name, model_tag, model_organization = super().extract_model_identifiers()

--- a/test/e2e/test_pull.py
+++ b/test/e2e/test_pull.py
@@ -123,7 +123,7 @@ def test_pull(model, env_vars, expected):
         elif isinstance(expected, Path):
             expected_name = (
                 "file://"
-                + PurePosixPath(normalize_host_path_for_container(str(ctx.workspace_path)))
+                + PurePosixPath(normalize_host_path_for_container(ctx.workspace_path))
                 .joinpath(PurePosixPath(expected))
                 .as_posix()
             )

--- a/test/e2e/test_rag.py
+++ b/test/e2e/test_rag.py
@@ -77,7 +77,7 @@ def test_rag_dry_run(file, params, expected, expected_regex):
         assert (
             bool(
                 re.search(
-                    expected_regex.format(workspace_dir=normalize_host_path_for_container(ctx.workspace_dir)), result
+                    expected_regex.format(workspace_dir=normalize_host_path_for_container(Path(ctx.workspace_dir))), result
                 )
             )
             is expected

--- a/test/unit/command/test_context.py
+++ b/test/unit/command/test_context.py
@@ -117,4 +117,4 @@ def test_ramalama_model_context_without_draft_model():
         dry_run=True,
     )
 
-    assert ctx.draft_model_path == ""
+    assert ctx.draft_model_path is None

--- a/test/unit/test_common.py
+++ b/test/unit/test_common.py
@@ -1,4 +1,3 @@
-import os
 import shutil
 import subprocess
 from contextlib import ExitStack
@@ -81,11 +80,11 @@ def test_verify_checksum(
     if ":" in input_file_name and platform == "win32":
         return
 
-    full_dir_path = os.path.join(Path(__file__).parent, "verify_checksum")
-    file_path = os.path.join(full_dir_path, input_file_name)
+    full_dir_path = Path(__file__).parent / "verify_checksum"
+    file_path = full_dir_path / input_file_name
 
     try:
-        os.makedirs(full_dir_path, exist_ok=True)
+        full_dir_path.mkdir(exist_ok=True, parents=True)
         with open(file_path, "w") as f:
             f.write(content)
 


### PR DESCRIPTION
Refactor code base to use pathlib.Path

## Summary by Sourcery

Refactor path handling across model storage, transport, inspection, and orchestration code to consistently use pathlib.Path objects instead of string paths.

Enhancements:
- Update model store, transport, and command context APIs to return and consume pathlib.Path instances for filesystem locations.
- Adjust path utility helpers, HTTP download handling, and checksum verification to operate on pathlib.Path for improved safety and cross-platform behavior.
- Adapt quadlet, kube, and stack volume generation logic to work with Path-based model, template, and auxiliary file paths.
- Migrate ref file representations and snapshot download logic to store and process path information using pathlib.Path.