### PR TITLE
Use /var/tmp for konflux tests

### DIFF
--- a/.tekton/integration/tasks/test-vm-cmd.yaml
+++ b/.tekton/integration/tasks/test-vm-cmd.yaml
@@ -116,7 +116,7 @@ spec:
       --security-opt label=disable \
       --security-opt unmask=/proc/* \
       --device /dev/net/tun \
-      -v /tmp \
+      -v /var/tmp:/tmp \
       \${EXTRA_ARGS[*]} \
       ${PODMAN_ENV[*]} \
       $TEST_IMAGE $TEST_CMD


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- Adjust konflux integration test container volume mount to use /var/tmp as the host directory for /tmp.