### PR TITLE
Include store disk usage stats in info output

### DIFF
--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -9,6 +9,7 @@ import sys
 import urllib.error
 from datetime import datetime, timezone
 from functools import lru_cache
+from pathlib import Path
 from typing import Any, get_args
 from urllib.parse import urlparse
 
@@ -20,7 +21,7 @@ try:
 except Exception:
     suppressCompleter = None
 
-from ramalama import engine
+from ramalama import common, engine
 from ramalama.arg_types import DefaultArgsType
 from ramalama.cli_arg_normalization import normalize_pull_arg
 from ramalama.common import accel_image, exec_cmd, get_accel, perror
@@ -653,6 +654,7 @@ def info_cli(args: DefaultArgsType) -> None:
             "Sources": list(set(shortnames.config_sources.values())),
         },
         "Store": args.store,
+        "StoreUsage": common.store_disk_stats(Path(args.store)),
         "UseContainer": args.container,
         "Version": version(),
     }

--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -800,3 +800,27 @@ class SemVer:
     @classmethod
     def parse(cls, s: str) -> "SemVer":
         return parse_semver(s)
+
+
+def store_disk_stats(store_path: Path) -> dict[str, Optional[int]] | None:
+    """Get disk usage statistics for the store path.
+
+    Walks up the directory tree if the path does not exist until an existing
+    parent is found.
+
+    Args:
+        store_path: Path to the model store directory.
+
+    Returns:
+        A dictionary with disk usage stats  - None for all stats if no path is found.
+    """
+    current_path = store_path
+    while True:
+        try:
+            total, used, free = shutil.disk_usage(current_path)
+            return {"total": total, "used": used, "free": free}
+        except OSError:
+            if current_path == current_path.parent:
+                # Reached the root of the filesystem.
+                return {"total": None, "used": None, "free": None}
+            current_path = current_path.parent

--- a/test/unit/test_common.py
+++ b/test/unit/test_common.py
@@ -24,6 +24,7 @@ from ramalama.common import (
     load_cdi_config,
     populate_volume_from_image,
     rm_until_substring,
+    store_disk_stats,
     verify_checksum,
 )
 from ramalama.compat import NamedTemporaryFile
@@ -685,3 +686,25 @@ class TestPopulateVolumeFromImage:
 
             result = populate_volume_from_image(mock_model, Mock(engine="docker"), "test.gguf")
             assert result == expected_volume
+
+
+class TestStoreDiskStats:
+    @patch("ramalama.common.shutil.disk_usage")
+    def test_store_disk_stats(self, mock_disk_usage):
+        mock_disk_usage.return_value = (1000, 200, 800)
+        assert store_disk_stats(Path("/tmp/store")) == {"total": 1000, "used": 200, "free": 800}
+
+    @patch("ramalama.common.shutil.disk_usage")
+    def test_store_disk_stats_no_store_dir(self, mock_disk_usage):
+        mock_disk_usage.side_effect = [FileNotFoundError, FileNotFoundError, (1000, 200, 800)]
+        assert store_disk_stats(Path("/tmp/store")) == {"total": 1000, "used": 200, "free": 800}
+
+    @patch("ramalama.common.shutil.disk_usage")
+    def test_store_disk_stats_root_not_found(self, mock_disk_usage):
+        mock_disk_usage.side_effect = [FileNotFoundError, FileNotFoundError, FileNotFoundError]
+        assert store_disk_stats(Path("/tmp/store")) == {"total": None, "used": None, "free": None}
+
+    @patch("ramalama.common.shutil.disk_usage")
+    def test_store_disk_stats_permission_error(self, mock_disk_usage):
+        mock_disk_usage.side_effect = [PermissionError, (1000, 200, 800)]
+        assert store_disk_stats(Path("/tmp/store")) == {"total": 1000, "used": 200, "free": 800}


### PR DESCRIPTION
## Summary by Sourcery

Add reporting of disk usage statistics for the store path to the CLI info output.

New Features:
- Expose store disk usage statistics (total, used, free) in the info CLI command output.

Tests:
- Add unit tests covering store disk usage retrieval, including non-existent store paths and missing root directory scenarios.