### PR TITLE
cann: copy only required binaries to the output image

### DIFF
--- a/container-images/cann/Containerfile
+++ b/container-images/cann/Containerfile
@@ -10,8 +10,15 @@ WORKDIR /src/
 RUN ./build_llama_and_whisper.sh cann
 
 FROM quay.io/ascend/${ASCEND_VERSION}
-# Copy the entire installation directory from the builder
-COPY --from=builder /tmp/install /usr
+RUN --mount=type=bind,from=builder,source=/tmp/install,target=/tmp/install \
+    cp -a /tmp/install/bin/llama-bench \
+          /tmp/install/bin/llama-perplexity \
+          /tmp/install/bin/llama-quantize \
+          /tmp/install/bin/llama-server \
+          /tmp/install/bin/rpc-server \
+          /tmp/install/bin/whisper-server \
+          /usr/bin/ && \
+    cp -a /tmp/install/lib64/*.so* /usr/lib64/
 ENTRYPOINT [ \
     "/bin/bash", \
     "-c", \


### PR DESCRIPTION
Reduce the size of the image by only copying files that are used by ramalama, removing unnecessary compilation artifacts from the output image.

## Summary by Sourcery

Reduce the CANN runtime image footprint by only including required runtime binaries and libraries from the build stage.

Enhancements:
- Limit the runtime image contents to specific llama and whisper binaries and shared libraries instead of the full installation directory.

Build:
- Adjust the CANN Containerfile to copy only selected binaries and shared libraries from the builder image into the final image.