### PR TITLE
Fix konflux git-clone merge issue for renovate

### DIFF
--- a/.tekton/pipelines/pull-request-pipeline.yaml
+++ b/.tekton/pipelines/pull-request-pipeline.yaml
@@ -151,7 +151,7 @@ spec:
       - name: name
         value: git-clone-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:56f65a16d3d0485c64ad85af2c1f3e9b0bb4d02d63f2fd0ebb9498d219ca723d
+        value: quay.io/olliewalsh/tekton-catalog/task-git-clone-oci-ta:fix_3158
       - name: kind
         value: task
       resolver: bundles

--- a/.tekton/pipelines/push-pipeline.yaml
+++ b/.tekton/pipelines/push-pipeline.yaml
@@ -139,7 +139,7 @@ spec:
       - name: name
         value: git-clone-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:56f65a16d3d0485c64ad85af2c1f3e9b0bb4d02d63f2fd0ebb9498d219ca723d
+        value: quay.io/olliewalsh/tekton-catalog/task-git-clone-oci-ta:fix_3158
       - name: kind
         value: task
       resolver: bundles


### PR DESCRIPTION
Switch to custom task with fix for https://github.com/konflux-ci/build-definitions/issues/3158

## Summary by Sourcery

Build:
- Point pull-request and push Tekton pipelines at the custom git-clone-oci-ta task bundle containing the merge fix.