### PR TITLE
Enable verbose logging in konflux git-clone

### DIFF
--- a/.tekton/pipelines/pull-request-pipeline.yaml
+++ b/.tekton/pipelines/pull-request-pipeline.yaml
@@ -144,6 +144,8 @@ spec:
       value: "true"
     - name: mergeSourceRepoUrl
       value: https://github.com/containers/ramalama
+    - name: verbose
+      value: "true"
     runAfter:
     - init
     taskRef:

--- a/.tekton/pipelines/push-pipeline.yaml
+++ b/.tekton/pipelines/push-pipeline.yaml
@@ -132,6 +132,8 @@ spec:
       value: $(params.output-image).git
     - name: ociArtifactExpiresAfter
       value: $(params.image-expires-after)
+    - name: verbose
+      value: "true"
     runAfter:
     - init
     taskRef:


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Pass a verbose=true parameter to the git-clone task in the pull-request and push Tekton pipelines to increase logging output.