### PR TITLE
Fix remaining issues with Windows path handling and file URIs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -503,6 +503,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
+      - name: Enable long path support
+        shell: pwsh
+        run: |
+           New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1 -PropertyType DWORD -Force
+
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with: ${{ matrix.variant.uv-options }}

--- a/ramalama/command/context.py
+++ b/ramalama/command/context.py
@@ -105,7 +105,7 @@ class RamalamaModelContext:
 
     @property
     def alias(self) -> str:
-        return f"{self.model.model_organization}/{self.model.model_name}"
+        return self.model.model_alias
 
     @property
     def model_path(self) -> str:

--- a/ramalama/hf_style_repo_base.py
+++ b/ramalama/hf_style_repo_base.py
@@ -284,6 +284,8 @@ class HFStyleRepoModel(Transport, ABC):
             # No use pulling again
             raise
         except Exception as e:
+            if isinstance(e, OSError) and hasattr(e, "winerror") and e.winerror == 206:
+                raise  # Path too long on Windows
             if not available(self.get_cli_command()):
                 perror(f"URL pull failed and {self.get_cli_command()} not available")
                 raise KeyError(f"Failed to pull model: {str(e)}")

--- a/ramalama/transports/base.py
+++ b/ramalama/transports/base.py
@@ -182,6 +182,10 @@ class Transport(TransportBase):
         return self._model_name
 
     @property
+    def model_alias(self):
+        return f"{self.model_organization}/{self.model_name}"
+
+    @property
     def model_tag(self) -> str:
         return self._model_tag
 

--- a/test/e2e/test_convert.py
+++ b/test/e2e/test_convert.py
@@ -1,6 +1,5 @@
 import json
 import re
-import sys
 from pathlib import Path
 from subprocess import STDOUT, CalledProcessError
 from test.conftest import (
@@ -39,14 +38,12 @@ def test_convert_custom_gguf_config():
         pytest.param(
             Path("aimodel"), "foobar", None,
             "oci://localhost/foobar:latest",
-            id="file://{workspace_dir}/aimodel -> foobar",
-            marks=[pytest.mark.xfail(sys.platform.startswith("win"), reason="windows path formatting")]
+            id="{workspace_uri}/aimodel -> foobar",
         ),
         pytest.param(
             Path("aimodel"), "oci://foobar", None,
             "oci://localhost/foobar:latest",
-            id="file://{workspace_dir}/aimodel -> oci://foobar",
-            marks=[pytest.mark.xfail(sys.platform.startswith("win"), reason="windows path formatting")]
+            id="{workspace_uri}/aimodel -> oci://foobar",
         ),
         pytest.param(
             "tiny", "oci://quay.io/ramalama/tiny", None,
@@ -100,7 +97,7 @@ def test_convert(in_model, out_model, extra_params, expected):
             assert expected in model_name_list
         finally:
             # Clean images
-            ctx.check_call(ramalama_cli + ["rm", expected.replace("oci://", "")])
+            ctx.check_call(ramalama_cli + ["rm", "--ignore", expected.replace("oci://", "")])
 
 
 @pytest.mark.e2e

--- a/test/unit/command/test_context.py
+++ b/test/unit/command/test_context.py
@@ -75,6 +75,7 @@ def test_ramalama_model_context_properties(is_container, should_generate, dry_ru
     mock_model.model_name = "smollm"
     mock_model.model_tag = "135m"
     mock_model.model_organization = "mock-org"
+    mock_model.model_alias = "mock-org/smollm"
 
     mock_model._get_entry_model_path.return_value = "/path/to/model"
     mock_model._get_mmproj_path.return_value = "/path/to/mmproj"

--- a/test/unit/command/test_factory.py
+++ b/test/unit/command/test_factory.py
@@ -116,6 +116,7 @@ def test_command_factory(
     mock_model.model_name = model.model_name
     mock_model.model_tag = model.model_tag
     mock_model.model_organization = model.model_organization
+    mock_model.model_alias = f"{model.model_organization}/{model.model_name}"
 
     mock_model._get_entry_model_path.return_value = "/path/to/model"
     mock_model._get_mmproj_path.return_value = "/path/to/mmproj" if input.has_mmproj else ""

--- a/test/unit/test_engine.py
+++ b/test/unit/test_engine.py
@@ -117,7 +117,7 @@ class TestEngine(unittest.TestCase):
 @patch("ramalama.engine.HTTPConnection")
 def test_is_healthy_conn(mock_conn):
     args = Namespace(MODEL="themodel", name="thecontainer", port=8080, debug=False)
-    is_healthy(args)
+    is_healthy(args, model_name="themodel")
     mock_conn.assert_called_once_with("127.0.0.1", args.port, timeout=3)
 
 
@@ -152,7 +152,7 @@ def test_is_healthy_fail(mock_conn, mock_debug, health_status, models_status, mo
         responses.append(mock_models_resp)
     mock_conn.return_value.getresponse.side_effect = responses
     args = Namespace(MODEL="themodel", name="thecontainer", port=8080, debug=False)
-    assert not is_healthy(args)
+    assert not is_healthy(args, model_name="themodel")
     assert mock_conn.return_value.getresponse.call_count == len(responses)
     if len(responses) > 1:
         assert models_msg in mock_debug.call_args.args[0]
@@ -166,7 +166,7 @@ def test_is_healthy_unicode_fail(mock_conn):
     mock_conn.return_value.getresponse.side_effect = [mock_health_resp, mock_models_resp]
     args = Namespace(name="thecontainer", port=8080, debug=False)
     with pytest.raises(UnicodeDecodeError):
-        is_healthy(args)
+        is_healthy(args, model_name="themodel")
     assert mock_conn.return_value.getresponse.call_count == 2
 
 
@@ -185,7 +185,7 @@ def test_is_healthy_success(mock_conn, mock_debug, health_status):
     mock_models_resp.read.return_value = '{"models": [{"name": "themodel"}]}'
     mock_conn.return_value.getresponse.side_effect = [mock_health_resp, mock_models_resp]
     args = Namespace(MODEL="themodel", name="thecontainer", port=8080, debug=False)
-    assert is_healthy(args)
+    assert is_healthy(args, model_name="themodel")
     assert mock_conn.return_value.getresponse.call_count == 2
     assert mock_debug.call_args.args[0] == "Container thecontainer is healthy"
 


### PR DESCRIPTION
Update e2e tests and re-enable all that were marked xfail on windows.

Ensure the ramalama run client and backend agree on the model name.

Enable windows long path support in CI as it was hitting the default 256
char limit.

Fixes #2316

## Summary by Sourcery

Improve Windows support for file paths and file:// URIs across CLI, transports, and tests, and re-enable previously xfailed Windows e2e coverage.

New Features:
- Support parsing and normalization of file: URIs (including UNC paths) via a new file_uri_to_path helper and URL-based file transports.
- Expose a model_alias property on transports to provide a consistent, transport-aware model name for health checks and context aliasing.

Bug Fixes:
- Normalize host paths before mounting volumes and constructing container paths to fix Windows path handling in rag/run flows and volume bindings.
- Ensure the health check logic uses the same model alias as the transport/backend so model names match between client and server.
- Treat non-HTTP(S) CLI model arguments as local paths or file: URIs instead of generic URLs, fixing file-based model invocation on Windows and POSIX.
- Handle Windows path-too-long (ERROR_PATH_NOT_FOUND 206) errors with clearer messaging and error propagation during CLI execution and HF-style pulls.

Enhancements:
- Rework URL transport detection and pruning to handle generic file: URIs (not just file://) and to map them to normalized local paths.
- Make e2e workspace directories use real Windows paths and expose both path and URI forms for configuration-driven tests.
- Adjust convert and pull flows to use normalized container paths and explicit file:// POSIX-style URIs so behavior is consistent across platforms.

CI:
- Enable Windows long path support in GitHub Actions CI to avoid hitting the default MAX_PATH limit.