### PR TITLE
ci: fix the ollama installer

### DIFF
--- a/.github/scripts/install-ollama.sh
+++ b/.github/scripts/install-ollama.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -eux -o pipefail
+
 os_name=$(uname)
 
 if [[ "$os_name" == "Darwin" ]]; then
@@ -7,10 +9,22 @@ if [[ "$os_name" == "Darwin" ]]; then
   brew update
   brew services start ollama
 elif [[ "$os_name" == "Linux" ]]; then
-  curl -L https://ollama.com/download/ollama-linux-amd64.tgz -o ollama-linux-amd64.tgz
-  sudo tar -C /usr -xzf ollama-linux-amd64.tgz
+  ARCH=$(uname -m)
+  case "$ARCH" in
+    x86_64)
+      ARCH=amd64
+      ;;
+    aarch64)
+      ARCH=arm64
+      ;;
+  esac
+  TARBALL=ollama-linux-$ARCH.tar.zst
+  curl -fsSLO "https://ollama.com/download/$TARBALL"
+  sudo tar -C /usr -xf "$TARBALL"
   sudo useradd -r -s /bin/false -U -m -d /usr/share/ollama ollama
-  sudo usermod -a -G ollama $(whoami)
+  sudo usermod -a -G ollama "$(whoami)"
+  rm "$TARBALL"
 else
   echo "Operating system is neither macOS nor Linux"
+  exit 1
 fi


### PR DESCRIPTION
ollama tarballs are now provided as `.tar.zst`, use the updated URL.

Add error handling and cleanup to the installation script.

## Summary by Sourcery

Update the Ollama installation script to support the new Linux tarball format and improve robustness.

Bug Fixes:
- Fix Linux Ollama installation by using the updated .tar.zst download URL and matching extraction flags.
- Ensure the script fails fast and reports errors when installation steps encounter issues.
- Avoid leaving the downloaded tarball on disk after installation by cleaning it up.

Enhancements:
- Add architecture detection for Linux to install the correct Ollama binary for x86_64 and aarch64.
- Improve script safety by enabling strict bash options and quoting user-related commands.