### PR TITLE
docs: fix docsite build by escaping angle bracket and curly bracket

### DIFF
--- a/docs/ramalama-benchmarks.1.md
+++ b/docs/ramalama-benchmarks.1.md
@@ -30,7 +30,7 @@ limit number of results to display
 #### **--offset**=OFFSET
 offset for pagination (default: 0)
 
-#### **--format**={table,json}
+#### **--format**=\{table,json\}
 output format (table or json) (default: table)
 
 ## EXAMPLES

--- a/docs/ramalama.conf.5.md
+++ b/docs/ramalama.conf.5.md
@@ -272,7 +272,7 @@ The ramalama.benchmarks table contains benchmark related settings.
 
 `[[ramalama.benchmarks]]`
 
-**storage_folder**="<default store>/benchmarks"
+**storage_folder**="\<default store>/benchmarks"
 
 Manually specify where to save benchmark results.
 By default, this will be stored in the default model store directory under `benchmarks/`.


### PR DESCRIPTION
Required for successful mdx processing.

## Summary by Sourcery

Escape special characters in documentation to ensure correct processing by the MDX docsite build.

Documentation:
- Escape curly braces in the CLI --format option documentation to avoid MDX parsing issues.
- Escape angle brackets in the configuration storage_folder example path so it renders correctly in the generated docs.