### PR TITLE
Introduce ci-e2e tox environment for parallel testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
 
       - name: run e2e-tests
         run: |
-           make e2e-tests
+           make ci-e2e-tests
 
   e2e-tests-nocontainer:
     needs:
@@ -174,7 +174,7 @@ jobs:
 
       - name: run e2e-tests-nocontainer
         run: |
-           make e2e-tests-nocontainer
+           make ci-e2e-tests-nocontainer
 
   e2e-tests-docker:
     needs:
@@ -250,7 +250,7 @@ jobs:
       - name: run e2e-tests-docker
         run: |
            docker info
-           make e2e-tests-docker
+           make ci-e2e-tests-docker
 
   e2e-tests-macos:
     needs:
@@ -291,7 +291,7 @@ jobs:
       - name: run e2e-tests-nocontainer
         shell: bash
         run: |
-          make e2e-tests-nocontainer
+          make ci-e2e-tests-nocontainer
 
   e2e-tests-windows:
     needs:
@@ -403,7 +403,7 @@ jobs:
           $env:PATH = "$uvToolsPath;$env:PATH"
 
           # Run tests
-          uv run tox -e e2e -- -v
+          uv run tox -e ci-e2e
 
       - name: Debug - Show Podman logs on failure
         if: failure()

--- a/Makefile
+++ b/Makefile
@@ -240,6 +240,18 @@ end-to-end-tests: validate e2e-tests e2e-tests-nocontainer ci
 	make clean
 	hack/tree_status.sh
 
+.PHONY: ci-e2e-tests
+ci-e2e-tests: requires-tox
+	tox -q -e ci-e2e
+
+.PHONY: ci-e2e-tests-nocontainer
+ci-e2e-tests-nocontainer: requires-tox
+	tox -q -e ci-e2e -- --no-container
+
+.PHONY: ci-e2e-tests-docker
+ci-e2e-tests-docker: requires-tox
+	tox -q -e ci-e2e -- --container-engine=docker
+
 .PHONY: test
 test: tests
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ dev = [
     "hypothesis>=6.135.26",
     "isort~=7.0",
     "pytest~=9.0",
+    "pytest-xdist",
     "wheel~=0.46.3",
     "mypy",
     "types-PyYAML",
@@ -168,7 +169,7 @@ lcov.output = "coverage/coverage.lcov"
 
 [tool.pytest.ini_options]
 testpaths = ["test"]
-markers = ["e2e", "distro_integration"]
+markers = ["e2e", "distro_integration", "slow"]
 addopts = "-m 'not e2e' --color=yes --durations=10"
 
 [tool.setuptools.packages.find]
@@ -222,6 +223,20 @@ commands = [
     "--durations=10",
     "--basetemp={envtmpdir}",
     "--tb=short",
+    { replace = "posargs", extend = true },
+  ],
+]
+
+[tool.tox.env.ci-e2e]
+deps = [
+    "mlx-lm ; sys_platform == 'darwin' and platform_machine == 'arm64'"
+]
+commands = [
+  [
+    "pytest", "-v", "--tb=short",
+    "-n", "auto", "--dist", "loadfile",
+    "-m", "e2e",
+    "--basetemp={envtmpdir}",
     { replace = "posargs", extend = true },
   ],
 ]

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -58,6 +58,41 @@ We use `pytest` marks to categorize tests or skip them based on certain conditio
 
 For example, the `skip_if_no_container` mark will skip a test if the `--no-container` flag is enabled.
 
+### Filtering Tests with Marks
+
+We use marks to categorize tests. A common use case is to mark slow-running tests so they can be included or excluded from a test run.
+
+#### The `slow` Mark
+
+Some tests can be particularly time-consuming. We mark these with `@pytest.mark.slow`.
+
+This allows for flexible test execution:
+
+-   **Run only fast tests:** To speed up development, you can exclude slow tests.
+    ```bash
+    tox -e e2e -- -m "not slow"
+    ```
+
+-   **Run only slow tests:** To focus on the slow tests, for example in a dedicated CI job.
+    ```bash
+    tox -e e2e -- -m "slow"
+    ```
+
+-   **Run all tests:** By default, `tox -e e2e` runs all tests, including those marked as `slow`.
+
+Example of a slow test:
+```python
+import pytest
+from test.conftest import skip_if_no_container
+
+@pytest.mark.e2e
+@pytest.mark.slow
+@skip_if_no_container
+def test_something_slow_in_a_container():
+    # This test is marked as slow
+    assert True
+```
+
 ### How to Use Marks
 
 To use a mark, you apply it as a decorator to a test function.

--- a/test/e2e/test_convert.py
+++ b/test/e2e/test_convert.py
@@ -48,22 +48,26 @@ def test_convert_custom_gguf_config():
         pytest.param(
             "tiny", "oci://quay.io/ramalama/tiny", None,
             "oci://quay.io/ramalama/tiny:latest",
+            marks=pytest.mark.slow,
             id="tiny -> oci://quay.io/ramalama/tiny",
         ),
         pytest.param(
             "ollama://tinyllama", "oci://quay.io/ramalama/tinyllama", None,
             "oci://quay.io/ramalama/tinyllama:latest",
+            marks=pytest.mark.slow,
             id="ollama://tinyllama -> oci://quay.io/ramalama/tinyllama",
         ),
         pytest.param(
             "hf://TinyLlama/TinyLlama-1.1B-Chat-v1.0", "oci://quay.io/ramalama/tinyllama", None,
             "oci://quay.io/ramalama/tinyllama:latest",
+            marks=pytest.mark.slow,
             id="hf://TinyLlama/TinyLlama-1.1B-Chat-v1.0 -> oci://quay.io/ramalama/tinyllama",
         ),
         pytest.param(
             "hf://TinyLlama/TinyLlama-1.1B-Chat-v1.0", "oci://quay.io/ramalama/tiny-q4-0",
             ["--gguf", "Q4_0"],
             "oci://quay.io/ramalama/tiny-q4-0:latest",
+            marks=pytest.mark.slow,
             id="hf://TinyLlama/TinyLlama-1.1B-Chat-v1.0 -> oci://quay.io/ramalama/tiny-q4-0 (--gguf Q4_0)",
         ),
         # fmt: on

--- a/test/e2e/test_list.py
+++ b/test/e2e/test_list.py
@@ -56,10 +56,3 @@ def test_json_output(shared_ctx):
         assert re.search(r"[\w:/]+", image_data["name"])
         assert image_data["size"] > 0
         assert datetime.fromisoformat(image_data["modified"])
-
-
-@pytest.mark.e2e
-def test_all_images_removed(shared_ctx):
-    shared_ctx.check_call(["ramalama", "rm", "-a"])
-    result = shared_ctx.check_output(["ramalama", "list", "--noheading"])
-    assert result == ""

--- a/test/e2e/test_pull.py
+++ b/test/e2e/test_pull.py
@@ -53,47 +53,54 @@ def test_pull_non_existing_model():
         # fmt: off
         pytest.param(
             "ollama://tinyllama", None, "ollama://library/tinyllama:latest",
-            id="tinyllama model with ollama:// url"
+            id="tinyllama model with ollama:// url",
+            marks=pytest.mark.slow
         ),
         pytest.param(
             "smollm:360m", {"RAMALAMA_TRANSPORT": "ollama"}, "ollama://library/smollm:360m",
-            id="smollm:360m model with RAMALAMA_TRANSPORT=ollama"
+            id="smollm:360m model with RAMALAMA_TRANSPORT=ollama",
+            marks=pytest.mark.slow
         ),
         pytest.param(
             "ollama://smollm:360m", None, "ollama://library/smollm:360m",
-            id="smollm:360m model with ollama:// url"
+            id="smollm:360m model with ollama:// url",
+            marks=pytest.mark.slow
         ),
         pytest.param(
             "https://ollama.com/library/smollm:135m", None, "ollama://library/smollm:135m",
-            id="smollm:135m model with http url from ollama"
+            id="smollm:135m model with http url from ollama",
+            marks=pytest.mark.slow
         ),
         pytest.param(
             "hf://Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS.gguf",
             None,
             "hf://Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS.gguf",
-            id="hf://Felladrin/../smollm-360M-instruct-add-basics.IQ2_XXS.gguf model"
+            id="hf://Felladrin/../smollm-360M-instruct-add-basics.IQ2_XXS.gguf model",
+            marks=pytest.mark.slow
         ),
         pytest.param(
             "huggingface://Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS.gguf",
             None,
             "hf://Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS.gguf",
-            id="huggingface://Felladrin/../smollm-360M-instruct-add-basics.IQ2_XXS.gguf model"
+            id="huggingface://Felladrin/../smollm-360M-instruct-add-basics.IQ2_XXS.gguf model",
+            marks=pytest.mark.slow
         ),
         pytest.param(
             "Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS.gguf",
             {"RAMALAMA_TRANSPORT": "huggingface"},
             "hf://Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS.gguf",
-            id="Felladrin/../smollm-360M-instruct-add-basics.IQ2_XXS.gguf model with RAMALAMA_TRANSPORT=huggingface"
+            id="Felladrin/../smollm-360M-instruct-add-basics.IQ2_XXS.gguf model with RAMALAMA_TRANSPORT=huggingface",
+            marks=pytest.mark.slow
         ),
         pytest.param(
             "oci://quay.io/ramalama/smollm:135m", None, "oci://quay.io/ramalama/smollm:135m",
             id="smollm:135m model with oci:// url",
-            marks=skip_if_no_container
+            marks=[skip_if_no_container, pytest.mark.slow]
         ),
         pytest.param(
             "quay.io/ramalama/smollm:135m", {"RAMALAMA_TRANSPORT": "oci"}, "oci://quay.io/ramalama/smollm:135m",
             id="smollm:135m model with RAMALAMA_TRANSPORT=oci",
-            marks=skip_if_no_container
+            marks=[skip_if_no_container, pytest.mark.slow]
         ),
         pytest.param(
             Path("mymodel.gguf"), None, Path("mymodel.gguf"),
@@ -140,11 +147,13 @@ def test_pull(model, env_vars, expected):
         ctx.check_call(ramalama_cli + ["rm", model_name])
 
         # Check if the model pull is the expected
-        assert model_list[0]["name"] == expected_name
+        model_name_list = [model["name"] for model in model_list]
+        assert expected_name in model_name_list
 
 
 @pytest.mark.e2e
 @pytest.mark.distro_integration
+@pytest.mark.slow
 def test_pull_model_layers_download():
     with RamalamaExecWorkspace() as ctx:
         ramalama_cli = ["ramalama", "--store", str(ctx.storage_path)]
@@ -158,6 +167,7 @@ def test_pull_model_layers_download():
 
 @pytest.mark.e2e
 @pytest.mark.distro_integration
+@pytest.mark.slow
 def test_pull_huggingface_tag_multiple_references():
     with RamalamaExecWorkspace() as ctx:
         ramalama_cli = ["ramalama", "--store", str(ctx.storage_path)]
@@ -218,6 +228,7 @@ def test_pull_wrong_endian_model_error(model, expected):
             None,
             "ollama://library/tinyllama:latest",
             id="tinyllama model with ollama:// url",
+            marks=pytest.mark.slow,
         ),
         pytest.param(
             "smollm:135m",
@@ -225,6 +236,7 @@ def test_pull_wrong_endian_model_error(model, expected):
             None,
             "ollama://library/smollm:135m",
             id="smollm:135m model with http url from ollama",
+            marks=pytest.mark.slow,
         ),
         pytest.param(
             "smollm:360m",
@@ -232,6 +244,7 @@ def test_pull_wrong_endian_model_error(model, expected):
             {"RAMALAMA_TRANSPORT": "ollama"},
             "ollama://library/smollm:360m",
             id="smollm:360m model with RAMALAMA_TRANSPORT=ollama",
+            marks=pytest.mark.slow,
         ),
     ],
 )
@@ -253,13 +266,15 @@ def test_pull_using_ollama_cache(ollama_server, ollama_model, model, env_vars, e
 
         # Check if the model pull is the expected
         model_list = json.loads(ctx.check_output(ramalama_cli + ["list", "--json", "--sort", "modified"]))
-        assert model_list[0]["name"] == expected
+        model_name_list = [model["name"] for model in model_list]
+        assert expected in model_name_list
 
 
 @pytest.mark.e2e
 @pytest.mark.distro_integration
 @skip_if_no_container
 @pytest.mark.xfail("config.option.container_engine == 'docker'", reason="docker login does not support --tls-verify")
+@pytest.mark.slow
 def test_pull_with_registry(container_registry, container_engine):
     with RamalamaExecWorkspace() as ctx:
         ramalama_cli = ["ramalama", "--store", str(ctx.storage_path)]

--- a/test/e2e/test_rag.py
+++ b/test/e2e/test_rag.py
@@ -194,7 +194,7 @@ def test_rag_error_when_file_is_missing():
     [
         # fmt: off
         pytest.param(
-            OLLAMA_MODEL, ["--rag", RAG_MODEL], True, r".*llama-server --host [\w\.]+ --port 8081",
+            OLLAMA_MODEL, ["--rag", RAG_MODEL], True, r".*llama-server --host [\w\.]+ --port \d+ ",
             id="check llama-server"
         ),
         pytest.param(
@@ -202,7 +202,7 @@ def test_rag_error_when_file_is_missing():
             id="check rag image"
         ),
         pytest.param(
-            OLLAMA_MODEL, ["--rag", RAG_MODEL], True, ".*rag_framework serve --port 8080",
+            OLLAMA_MODEL, ["--rag", RAG_MODEL], True, r".*rag_framework serve --port \d+ ",
             id="check rag_framework"
         ),
         pytest.param(
@@ -268,6 +268,7 @@ def test_run_dry_run_pull_policy(container_engine):
 @skip_if_no_container
 @skip_if_ppc64le
 @skip_if_s390x
+@pytest.mark.slow
 def test_rag(container_engine):
     with RamalamaExecWorkspace() as ctx:
         (Path(ctx.workspace_dir) / "README.md").touch()

--- a/test/e2e/test_rm.py
+++ b/test/e2e/test_rm.py
@@ -28,6 +28,7 @@ def test_delete_non_existing_image_with_ignore_flag():
 
 
 @pytest.mark.e2e
+@pytest.mark.slow
 def test_delete_snapshot_with_multiple_references():
     with RamalamaExecWorkspace() as ctx:
         initial_inventory = set([x for x in Path(ctx.storage_dir).rglob('*') if x.is_file()])

--- a/test/e2e/test_run.py
+++ b/test/e2e/test_run.py
@@ -273,12 +273,14 @@ def test_params_errors(extra_params, pattern, config, env_vars, expected_exit_co
 
 
 @pytest.mark.e2e
+@pytest.mark.slow
+@skip_if_darwin  # test is broken on MAC --no-container right now
 def test_run_model_with_prompt(shared_ctx_with_models, test_model):
     import platform
 
     ctx = shared_ctx_with_models
 
-    run_cmd = ["ramalama", "run", "--temp", "0"]
+    run_cmd = ["ramalama", "run", "--temp", "0", "-p", "8180"]
     if platform.system() in ["Darwin", "Windows"]:
         # FIXME: continues rambling on Windows and macOS without --max-token
         run_cmd.extend(["--max-tokens", "100"])
@@ -295,12 +297,13 @@ _file_uri_id_relative = "relative_dir/file"
 @pytest.mark.parametrize(
     "scheme,relative_path",
     [
-        pytest.param("file:", True, id=f"file:{_file_uri_id_relative}"),
-        pytest.param("file:", False, id=f"file:{_file_uri_id_suffix}"),
-        pytest.param("file:/", False, id=f"file:/{_file_uri_id_suffix}", marks=skip_if_not_windows),
-        pytest.param("file://", False, id=f"file://{_file_uri_id_suffix}"),
+        pytest.param("file:", True, id=f"file:{_file_uri_id_relative}", marks=pytest.mark.slow),
+        pytest.param("file:", False, id=f"file:{_file_uri_id_suffix}", marks=pytest.mark.slow),
+        pytest.param("file:/", False, id=f"file:/{_file_uri_id_suffix}", marks=[skip_if_not_windows, pytest.mark.slow]),
+        pytest.param("file://", False, id=f"file://{_file_uri_id_suffix}", marks=pytest.mark.slow),
     ],
 )
+@pytest.mark.slow
 def test_run_with_file_uri(shared_ctx_with_models, test_model, scheme, relative_path):
     ctx = shared_ctx_with_models
 
@@ -331,6 +334,7 @@ def test_run_with_unc_file_uri(shared_ctx_with_models, test_model):
 
 
 @pytest.mark.e2e
+@pytest.mark.slow
 def test_run_keepalive(shared_ctx_with_models, test_model):
     ctx = shared_ctx_with_models
     ctx.check_call(["ramalama", "run", "--keepalive", "1s", test_model], stdin=DEVNULL)

--- a/test/e2e/test_serve.py
+++ b/test/e2e/test_serve.py
@@ -292,6 +292,7 @@ def test_full_model_name_expansion():
 
 @pytest.mark.e2e
 @skip_if_no_container
+@pytest.mark.slow
 def test_serve_and_stop(shared_ctx, test_model):
     ctx = shared_ctx
     container1_id = f"serve_and_stop_{''.join(random.choices(string.ascii_letters + string.digits, k=5))}"
@@ -323,7 +324,8 @@ def test_serve_and_stop(shared_ctx, test_model):
         ctx.check_call(["ramalama", "stop", container1_id])
 
     # Start Container2
-    c2_id = ctx.check_output(["ramalama", "serve", "--name", container2_id, "-d", test_model]).split("\n")[0]
+    c2_cmd = ["ramalama", "serve", "--name", container2_id, "-p", "8181", "-d", test_model]
+    c2_id = ctx.check_output(c2_cmd).split("\n")[0]
     try:
         containers_list = check_output(["ramalama", "containers", "-n"])
         assert re.search(f".*{c2_id[:10]}", containers_list)
@@ -341,6 +343,7 @@ def test_serve_and_stop(shared_ctx, test_model):
 
 @pytest.mark.e2e
 @skip_if_no_container
+@pytest.mark.slow
 def test_serve_multiple_models(shared_ctx, test_model):
     ctx = shared_ctx
     container1_id = f"serve_multiple_{''.join(random.choices(string.ascii_letters + string.digits, k=5))}"
@@ -469,6 +472,7 @@ def test_generation_with_bad_add_to_unit_flag_value(test_model):
 @pytest.mark.e2e
 @skip_if_no_container
 @pytest.mark.xfail("config.option.container_engine == 'docker'", reason="docker login does not support --tls-verify")
+@pytest.mark.slow
 def test_quadlet_and_kube_generation_with_container_registry(container_registry, is_container, test_model):
     with RamalamaExecWorkspace() as ctx:
         authfile = (Path(ctx.workspace_dir) / "authfile.json").as_posix()
@@ -705,10 +709,12 @@ def test_kube_generation_with_llama_api(test_model):
             assert re.search(r".*/llama-stack", content)
 
 
+@pytest.mark.e2e
 @skip_if_docker
 @skip_if_no_container
 @skip_if_ppc64le
 @skip_if_s390x
+@pytest.mark.slow
 def test_serve_api(caplog):
     # Configure logging for requests
     caplog.set_level(logging.CRITICAL, logger="requests")


### PR DESCRIPTION
Key changes:
- Add `pytest-xdist` to enable parallel test execution.
- Create a new `ci-e2e` tox environment that runs tests in parallel by default.
- Introduce a `slow` pytest marker to identify and manage slow-running tests.
- Update the CI workflow and Makefile to use the new `ci-e2e` environment.
- Mark several existing e2e tests as `slow` to allow for more flexible test selection.
