### PR TITLE
Migrate to ruff and improve make command times

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,9 +49,9 @@ RAMALAMA=$(pwd)/bin/ramalama bats -T test/system/030-run.bats
 ### Code Quality
 ```bash
 make validate                # Run all validation (codespell, lint, format check, man-check, type check)
-make lint                    # Run flake8 + shellcheck
-make check-format            # Check black + isort formatting
-make format                  # Auto-format with black + isort
+make lint                    # Run ruff + shellcheck
+make check-format            # Check ruff formatting + import sorting
+make format                  # Auto-format with ruff + import sorting
 make type-check              # Run mypy type checking
 make codespell               # Check spelling
 ```
@@ -102,6 +102,6 @@ Manages local model storage:
 
 - Python 3.10+ required
 - Line length: 120 characters
-- Formatting: black + isort
+- Formatting: ruff format + ruff check (I rules)
 - Type hints encouraged (mypy checked)
 - Commits require DCO sign-off (`git commit -s`)

--- a/flake.nix
+++ b/flake.nix
@@ -35,8 +35,8 @@
                   (llama-cpp.override llamaCppOverrides)
                 ];
                 nativeBuildInputs =
-                  (with pkgs; [ codespell shellcheck isort bats jq apacheHttpd ]) ++
-                  (with pkgs.python3Packages; [ flake8 black pytest ]);
+                  (with pkgs; [ codespell shellcheck ruff bats jq apacheHttpd ]) ++
+                  (with pkgs.python3Packages; [ pytest ]);
               } // ramalamaOverrides)
           )
           { llamaCppOverrides.vulkanSupport = true; }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,16 +56,13 @@ text = "MIT"
 
 [project.optional-dependencies]
 dev = [
-    # "pytest>=7.0",
     "argcomplete~=3.0",
     "bcrypt",
-    "black~=26.1",
     "codespell~=2.0",
-    "flake8~=7.0",
-    "huggingface_hub~=1.4.0",
+    "huggingface_hub~=1.3.1",
     "hypothesis>=6.135.26",
-    "isort~=7.0",
     "pytest~=9.0",
+    "ruff>=0.14.14",
     "wheel~=0.46.3",
     "mypy",
     "types-PyYAML",
@@ -89,7 +86,7 @@ cov-detailed = [
 
 [dependency-groups]
 dev = [
-    "ramalama[cov-detailed]",
+    "ramalama[cov-detailed]"
 ]
 
 [project.urls]
@@ -113,17 +110,6 @@ license-files = ["LICENSE"]
 [tool.setuptools.dynamic]
 version = {attr = "ramalama.version.version"}
 
-[tool.black]
-line-length = 120
-skip-string-normalization = true
-target-version = ["py310", "py311", "py312", "py313", "py314"]
-extend-exclude = "(.history|build|dist|docs|hack)"
-
-[tool.isort]
-profile = "black"
-line_length = 120
-skip = [".venv", "venv", ".tox"]
-
 [tool.codespell]
 skip = ["build", "ramalama.egg-info", "logos", ".git", "venv", ".venv", ".tox", ".pixi"]
 dictionary = ".codespelldict"
@@ -141,8 +127,9 @@ check-hidden = true
 
 [tool.ruff]
 line-length = 120
-target-version = "py312"
+target-version = "py310"
 include = ["\\.pyi?$"]
+extend-include = ["bin/ramalama"]
 exclude = [
   "/\\.git",
   "/\\.tox",
@@ -155,6 +142,9 @@ exclude = [
   "/venv",
   "/.pixi"
 ]
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I"]
 
 [tool.ruff.format]
 preview = true

--- a/test/tmt/no-rpm.fmf
+++ b/test/tmt/no-rpm.fmf
@@ -7,10 +7,8 @@ adjust:
 
 require:
     - bats
-    - black
+    - ruff
     - codespell
-    - flake8
-    - isort
     - jq
     - make
     - perl-Clone


### PR DESCRIPTION
Make commands like `make lint` took more than 8 seconds to run on my machine. This migration reduces the load of multiple recursive grep commands, and replaces our black/isort/flake8 dependencies with ruff.

From my testing:

* `make lint` ~10x faster
* `make format` / `make check-format` ~280x to 650x faster
