### PR TITLE
[trivial] correctly omit test_serve_api

### DIFF
--- a/test/e2e/test_serve.py
+++ b/test/e2e/test_serve.py
@@ -705,6 +705,8 @@ def test_kube_generation_with_llama_api(test_model):
             assert re.search(r".*/llama-stack", content)
 
 
+@pytest.mark.skip(reason="pulls very large image")
+@pytest.mark.e2e
 @skip_if_docker
 @skip_if_no_container
 @skip_if_ppc64le


### PR DESCRIPTION
Restore the e2e mark, otherwise unit-tests will run it

## Summary by Sourcery

Tests:
- Ensure the serve API test that pulls a large image is skipped and only runs under the e2e test suite.