### PR TITLE
Enable more type checking and fix mypy type errors.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ endif
 
 .PHONY: type-check
 type-check:
-	mypy $(addprefix --exclude=,$(EXCLUDE_DIRS)) --exclude test $(PROJECT_DIR)
+	mypy $(addprefix --exclude=,$(EXCLUDE_DIRS)) --exclude test $(PROJECT_DIR) --check-untyped-defs
 
 .PHONY: validate
 validate: codespell lint check-format man-check type-check

--- a/ramalama/arg_types.py
+++ b/ramalama/arg_types.py
@@ -1,5 +1,6 @@
 from dataclasses import make_dataclass
-from typing import List, Protocol, get_type_hints
+from subprocess import Popen
+from typing import Any, List, Protocol, get_type_hints
 
 from ramalama.config_types import COLOR_OPTIONS, SUPPORTED_ENGINES, SUPPORTED_RUNTIMES, PathStr
 
@@ -49,6 +50,7 @@ class BaseEngineArgsType(Protocol):
     nocapdrop: bool | None
     device: list[str] | None
     podman_keep_groups: bool | None
+    rag: str | None
     # Optional attributes for labels
     MODEL: str | None
     runtime: str | None
@@ -91,6 +93,8 @@ ChatSubArgs = protocol_to_dataclass(ChatSubArgsType)
 
 class ChatArgsType(DefaultArgsType, ChatSubArgsType):
     ignore: bool | None  # runtime-only
+    server_process: Popen[Any] | None  # runtime-only
+    name: str | None  # runtime-only
 
 
 class ServeRunArgsType(DefaultArgsType, Protocol):

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -57,6 +57,7 @@ from ramalama.transports.base import (
     NoGGUFModelFileFound,
     NoRefFileFound,
     SafetensorModelNotSupported,
+    Transport,
     compute_serving_port,
     trim_model_name,
 )
@@ -1311,6 +1312,7 @@ def run_cli(args):
             raise ValueError("ramalama run --rag cannot be run with the --nocontainer option.")
         args = _rag_args(args)
 
+        assert isinstance(model, Transport), "RAG requires a Transport model, not APITransport"
         model = RagTransport(model, assemble_command_lazy(args.model_args), args)
         model.ensure_model_exists(args)
 

--- a/ramalama/daemon/daemon.py
+++ b/ramalama/daemon/daemon.py
@@ -16,7 +16,7 @@ from ramalama.log_levels import LogLevel
 class ShutdownHandler:
     def __init__(self, server: "RamalamaServer") -> None:
         self.server = server
-        self.idle_check_timer = None
+        self.idle_check_timer: threading.Timer | None = None
 
     def handle_kill(self, signum, frame):
         if self.idle_check_timer:
@@ -90,7 +90,7 @@ class RamalamaServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
     def check_model_expiration(self):
         curr_time = datetime.now()
         for name, m in self.model_runner.managed_models.items():
-            if m.expiration_date > curr_time:
+            if m.expiration_date is None or m.expiration_date > curr_time:
                 continue
 
             try:

--- a/ramalama/engine.py
+++ b/ramalama/engine.py
@@ -59,16 +59,16 @@ class BaseEngine(ABC):
                 run_cmd([str(self.args.engine), "pull", "-q", self.args.image], ignore_all=True)
             except Exception:  # Ignore errors, the run command will handle it.
                 pass
-        elif getattr(self.args, "pull", None):
-            self.add_pull(self.args.pull)
+        elif pull_value := getattr(self.args, "pull", None):
+            self.add_pull(pull_value)
 
     def add_network(self):
-        if getattr(self.args, "network", None):
-            self.exec_args += ["--network", self.args.network]
+        if network := getattr(self.args, "network", None):
+            self.exec_args += ["--network", network]
 
     def add_oci_runtime(self):
-        if getattr(self.args, "oci_runtime", None):
-            self.exec_args += ["--runtime", self.args.oci_runtime]
+        if oci_runtime := getattr(self.args, "oci_runtime", None):
+            self.exec_args += ["--runtime", oci_runtime]
             return
         if check_nvidia() == "cuda":
             if self.use_docker:
@@ -88,8 +88,8 @@ class BaseEngine(ABC):
         if request_no_device:
             return
 
-        if getattr(self.args, "device", None):
-            for device_arg in self.args.device:
+        if device_list := getattr(self.args, "device", None):
+            for device_arg in device_list:
                 self.exec_args += ["--device", device_arg]
 
         if ramalama.common.podman_machine_accel:

--- a/ramalama/hf_style_repo_base.py
+++ b/ramalama/hf_style_repo_base.py
@@ -76,11 +76,11 @@ class HFStyleRepository(ABC):
         self.organization = organization
         self.tag = tag
         self.headers: dict = {}
-        self.blob_url = None
-        self.model_filename = None
-        self.model_hash = None
-        self.mmproj_filename = None
-        self.mmproj_hash = None
+        self.blob_url: str | None = None
+        self.model_filename: str | None = None
+        self.model_hash: str | None = None
+        self.mmproj_filename: str | None = None
+        self.mmproj_hash: str | None = None
         self.other_files: list[dict] = []
         self.additional_safetensor_files: list[dict] = []
         self.safetensors_index_file: str | None = None
@@ -214,6 +214,8 @@ class HFStyleRepository(ABC):
     def mmproj_file(self) -> SnapshotFile:
         assert self.model_filename
         assert self.model_hash
+        assert self.mmproj_filename
+        assert self.mmproj_hash
         return SnapshotFile(
             url=f"{self.blob_url}/{self.mmproj_filename}",
             header=self.headers,

--- a/ramalama/http_client.py
+++ b/ramalama/http_client.py
@@ -25,7 +25,7 @@ class HttpClient:
         pass
 
     def init(self, url, headers, output_file, show_progress, response_bytes=None):
-        output_file_partial = None
+        output_file_partial: str | None = None
         if output_file:
             output_file_partial = output_file + ".partial"
 
@@ -49,7 +49,7 @@ class HttpClient:
             finally:
                 del out  # Ensure file is closed before rename
 
-        if output_file:
+        if output_file and output_file_partial:
             os.rename(output_file_partial, output_file)
 
     def urlopen(self, url, headers):

--- a/ramalama/mcp/mcp_agent.py
+++ b/ramalama/mcp/mcp_agent.py
@@ -5,7 +5,7 @@ import logging
 import time
 import urllib.error
 import urllib.request
-from typing import Any, Dict, List
+from typing import Any, Callable, Dict, List
 
 from ramalama.config import get_config
 from ramalama.logger import logger
@@ -33,7 +33,7 @@ class LLMAgent:
         self.args = args
         self.available_tools: List[Dict[str, Any]] = []
         self.tool_to_client: Dict[str, PureMCPClient] = {}
-        self._stream_callback = None
+        self._stream_callback: Callable[[str], None] | None = None
 
     def initialize(self):
         """Initialize the agent and get available tools from all clients."""

--- a/ramalama/rag.py
+++ b/ramalama/rag.py
@@ -131,6 +131,7 @@ class RagEngine(Engine):
         self.add_label(f"ai.ramalama.rag.{self.sourcetype}={self.args.rag}")
 
     def add_rag(self):
+        assert self.args.rag is not None
         if self.sourcetype is RagSource.DB:
             # Convert to container-friendly path format (handles Windows path conversion)
             rag = get_container_mount_path(self.args.rag)

--- a/ramalama/toml_parser.py
+++ b/ramalama/toml_parser.py
@@ -1,11 +1,12 @@
 import re
+from typing import Any
 
 from ramalama.logger import logger
 
 
 class TOMLParser:
     def __init__(self):
-        self.data = {}
+        self.data: dict[str, Any] = {}
 
     def parse(self, toml_string):
         current_section = self.data
@@ -61,9 +62,9 @@ class TOMLParser:
             return value.lower() == "true"
         raise ValueError(f"Unsupported value type: {value}")
 
-    def get(self, key, default=None):
+    def get(self, key: str, default: Any = None) -> Any:
         keys = key.split(".")
-        value = self.data
+        value: Any = self.data
         for k in keys:
             value = value.get(k)
             if value is None:

--- a/ramalama/transports/api.py
+++ b/ramalama/transports/api.py
@@ -79,7 +79,14 @@ class APITransport(TransportBase):
     def exists(self) -> bool:
         return True
 
-    def inspect(self, args):
+    def inspect(
+        self,
+        show_all: bool = False,
+        show_all_metadata: bool = False,
+        get_field: str = "",
+        as_json: bool = False,
+        dryrun: bool = False,
+    ):
         return {
             "provider": self.provider.provider,
             "model": self.model_name,

--- a/ramalama/transports/base.py
+++ b/ramalama/transports/base.py
@@ -138,8 +138,22 @@ class TransportBase(ABC):
         raise self.__not_implemented_error("exists")
 
     @abstractmethod
-    def inspect(self, args):
+    def inspect(
+        self,
+        show_all: bool = False,
+        show_all_metadata: bool = False,
+        get_field: str = "",
+        as_json: bool = False,
+        dryrun: bool = False,
+    ) -> Any:
         raise self.__not_implemented_error("inspect")
+
+    def inspect_metadata(self) -> dict[str, Any]:
+        """
+        Inspect metadata for the model.
+        Default implementation raises NotImplementedError.
+        """
+        raise self.__not_implemented_error("inspect_metadata")
 
 
 class Transport(TransportBase):
@@ -213,6 +227,20 @@ class Transport(TransportBase):
             name, _, orga = self.extract_model_identifiers()
             self._model_store = ModelStore(GlobalModelStore(self._model_store_path), name, self.model_type, orga)
         return self._model_store
+
+    def resolve_model(self) -> str:
+        """
+        Resolve the model name to a canonical form.
+        Only implemented by transports that need it (e.g., Ollama).
+        """
+        raise NotImplementedError(f"{self.__class__.__name__} does not implement resolve_model()")
+
+    def mount_cmd(self) -> str:
+        """
+        Generate the mount command for OCI models.
+        Only implemented by transports that need it (e.g., OCI).
+        """
+        raise NotImplementedError(f"{self.__class__.__name__} does not implement mount_cmd()")
 
     def _get_all_model_part_paths(
         self, use_container: bool, should_generate: bool, dry_run: bool

--- a/ramalama/transports/huggingface.py
+++ b/ramalama/transports/huggingface.py
@@ -3,7 +3,7 @@ import os
 import urllib.request
 from pathlib import Path
 
-from ramalama.common import run_cmd
+from ramalama.common import available, run_cmd
 from ramalama.hf_style_repo_base import (
     HFStyleRepoFile,
     HFStyleRepoModel,
@@ -178,7 +178,7 @@ class HuggingfaceRepository(HFStyleRepository):
             return False
 
         # Find all safetensors files, config files and index files
-        safetensors_files = []
+        safetensors_files: list[dict] = []
         self.other_files = []
         index_file = None
 
@@ -315,7 +315,7 @@ class Huggingface(HFStyleRepoModel):
         return False
 
     def push(self, _, args):
-        if not self.hf_cli_available:
+        if not available(self.get_cli_command()):
             raise NotImplementedError(self.get_missing_message())
         proc = run_cmd(
             [


### PR DESCRIPTION
Add missing type annotations for instance variables and function parameters in toml_parser, http_client, engine, chat, and daemon.

Add type hints to HFStyleRepository attributes (blob_url, model_filename, model_hash, etc.) to fix assignment errors in modelscope and huggingface transports.

Add stub methods to TransportBase class: resolve_model, mount_cmd, inspect_metadata.

Standardize inspect() method signature across all transport classes to accept optional parameters (show_all, show_all_metadata, get_field, as_json, dryrun).

Add missing attributes to Protocol types: ChatArgsType, name, rag.

Use walrus operator (:=) for type narrowing in engine.py to handle Optional types from getattr() calls.

Add assertions and None checks where needed to narrow types.

Fix _stream_callback type in LLMAgent.

Add mmproj_filename and mmproj_hash assertions in
HFStyleRepository.mmproj_file().

Replace hf_cli_available attribute with direct available() call in huggingface.py push method.

## Summary by Sourcery

Tighten type checking across the codebase and align transport interfaces to support stricter mypy validation.

New Features:
- Define default resolve_model and mount_cmd hooks on the base Transport class for transports that need model resolution or mount commands.
- Add an inspect_metadata hook on TransportBase to expose model metadata inspection in a structured way.

Bug Fixes:
- Prevent crashes in chat response parsing by narrowing types before accessing content fields.
- Avoid errors when checking model expiration by correctly handling models with no expiration date.
- Ensure HTTP downloads only rename partial files when they actually exist.
- Fix RAG run mode to assert a Transport-backed model and require a non-null rag argument before use.
- Require the Hugging Face CLI to be available at push time by probing via the CLI command instead of a cached attribute.

Enhancements:
- Standardize the inspect method signature across transports to accept optional filtering and formatting parameters.
- Add explicit type annotations and runtime assertions across parsers, transports, agents, daemon, and chat/engine logic to satisfy mypy and improve type safety.
- Refine engine and chat logic using walrus operator and more precise types to narrow Optionals and avoid getattr-based type ambiguity.
- Tighten HFStyleRepository state by typing core attributes and asserting mmproj-related fields before constructing snapshot files.
- Specify the stream callback type for LLMAgent and expand protocol types (e.g., rag, server_process, name) to match runtime usage.

Build:
- Run mypy with --check-untyped-defs to enforce type checking on previously untyped functions.