### PR TITLE
Docsite navbar: link logo to ramalama.ai and add docs landing link

### DIFF
--- a/docsite/docusaurus.config.ts
+++ b/docsite/docusaurus.config.ts
@@ -4,6 +4,9 @@ import type * as Preset from '@docusaurus/preset-classic';
 
 // This runs in Node.js - Don't use client-side code here (browser APIs, JSX...)
 
+// Define baseUrl as a constant to reuse in activeBaseRegex
+const siteBaseUrl = '/docs/';
+
 const config: Config = {
   title: 'RamaLama',
   tagline: 'Working with AI made simple, straightforward, and familiar',
@@ -18,7 +21,7 @@ const config: Config = {
   url: 'https://ramalama.ai',
   // Set the /<baseUrl>/ pathname under which your site is served
   // The docs live at https://ramalama.ai/docs
-  baseUrl: '/docs/',
+  baseUrl: siteBaseUrl,
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.
@@ -83,7 +86,7 @@ const config: Config = {
           to: '/',
           label: 'Home',
           position: 'left',
-          activeBaseRegex: '^/docs/?$',
+          activeBaseRegex: `^${siteBaseUrl}?$`,
         },
         {
           type: 'docSidebar',


### PR DESCRIPTION
Fixes #2312

From the docs site, it was not obvious how to navigate back to the main ramalama.ai homepage.

Changes:
- Make the navbar logo link to https://ramalama.ai (same tab) so users can return to the main site.
- Add a link to the docs landing page and ensure its active state only matches `/docs` or `/docs/` (not subpages).

Testing:
- Verified logo navigation back to the main site and correct active highlighting on the docs landing page.

## Summary by Sourcery

Update docs navbar to improve navigation between the main ramalama.ai site and the docs.

New Features:
- Make the docs navbar logo link back to the main ramalama.ai homepage in the same tab.
- Add a dedicated Home item in the docs navbar that points to the docs landing page with correct active-state matching.