### PR TITLE
Upgrade to new license specifications.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools>=69.0.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -32,7 +32,6 @@ maintainers = [
    { name = "Mike Bonnet", email = "mikeb@redhat.com" },
 ]
 classifiers = [
-  "License :: OSI Approved :: MIT License",
   "Environment :: Console",
   "Intended Audience :: Developers",
   "Intended Audience :: Science/Research",
@@ -50,9 +49,8 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Artificial Intelligence",
   "Topic :: Utilities",
 ]
-
-[project.license]
-text = "MIT"
+license = "MIT"
+license-files = ["LICENSE"]
 
 [project.optional-dependencies]
 dev = [
@@ -102,7 +100,6 @@ ramalama = "ramalama.cli:main"
 
 [tool.setuptools]
 include-package-data = true
-license-files = ["LICENSE"]
 
 [tool.setuptools.package-data]
 "ramalama" = ["py.typed"]


### PR DESCRIPTION
As of setuptools version 77.0.0, project.license as a TOML table is deprecated. The new license representation is project.license, a valid SPDX license expression consisting of one or more license identifiers and project.license-files, a list of license files.  See: https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license.

Remove License classifier: License classifiers have been superseded by license expressions (see https://peps.python.org/pep-0639/). PyPI.org still recognizes license classifiers as search terms, but tools that enforce compliance with PEP-639 balk.

Remove [tool.setuptools] license-files. It is redundant.