### PR TITLE
Set TORCHINDUCTOR_CACHE_DIR for doc2rag on docker

### DIFF
--- a/container-images/common/Containerfile.rag
+++ b/container-images/common/Containerfile.rag
@@ -9,7 +9,8 @@ ENV VIRTUAL_ENV="/opt/venv" \
     UV_NO_MANAGED_PYTHON=1 \
     UV_TORCH_BACKEND=$TORCH_BACKEND \
     HF_HOME=/var/cache/huggingface \
-    FASTEMBED_CACHE_PATH=/var/cache/fastembed
+    FASTEMBED_CACHE_PATH=/var/cache/fastembed \
+    TORCHINDUCTOR_CACHE_DIR=/var/cache/torchinductor
 
 COPY container-images/scripts/doc2rag \
      container-images/scripts/rag_framework \


### PR DESCRIPTION
The defaulting logic in pytorch fails when the uid does not map to a user. Workaround this by explicitly setting the cache dir when setting the uid.

Fixes: #2401

## Summary by Sourcery

Bug Fixes:
- Work around PyTorch cache directory resolution failing when the container UID does not map to a user by explicitly setting TORCHINDUCTOR_CACHE_DIR.