### PR TITLE
Fix install.sh on Debian and update PATH for uv

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -132,12 +132,21 @@ install_uv() {
   echo
 
   # Add uv bin dir to PATH if not present
-  if [ -x "$HOME"/.local/bin/uv ]; then
+  local uv_bin_dir=""
+  if [ -n "${XDG_BIN_HOME:-}" ] && [ -x "${XDG_BIN_HOME}/uv" ]; then
+    uv_bin_dir="${XDG_BIN_HOME}"
+  elif [ -n "${XDG_DATA_HOME:-}" ] && [ -x "${XDG_DATA_HOME}/../bin/uv" ]; then
+    uv_bin_dir="${XDG_DATA_HOME}/../bin"
+  elif [ -x "$HOME/.local/bin/uv" ]; then
+    uv_bin_dir="$HOME/.local/bin"
+  fi
+
+  if [ -n "$uv_bin_dir" ]; then
     case ":${PATH}:" in
-      *:${HOME}/.local/bin:*)
+      *:"$uv_bin_dir":*)
         ;;
       *)
-        export PATH="$HOME/.local/bin:$PATH"
+        export PATH="$uv_bin_dir:$PATH"
         ;;
     esac
   fi


### PR DESCRIPTION
Cannot call the apt_install function thru sudo, as it was trivial just remove.

Update path after installing uv.

Fixes: #2387

## Summary by Sourcery

Update Debian-based installation flow to call apt directly and ensure uv is available on the PATH after installation.

Bug Fixes:
- Fix Debian install script by avoiding calling the apt_install helper via sudo and instead invoking apt directly to install podman and docker.

Enhancements:
- Update the uv installation step to prepend the user's local bin directory to PATH when uv is installed there, avoiding missing-command issues.