### PR TITLE
Trigger ci jobs on all branches for forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: ci
 
 on:
   pull_request:
-  push:
     branches:
       - main
+  push:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -12,6 +12,10 @@ concurrency:
 
 jobs:
   lint:
+    if: |
+      github.event_name == 'pull_request' ||
+      github.ref == 'refs/heads/main' ||
+      github.repository_owner != 'containers'
     name: Lint Code
     runs-on: ubuntu-24.04
     timeout-minutes: 20
@@ -57,6 +61,10 @@ jobs:
           uv run -- make type-check
 
   unit-test:
+    if: |
+      github.event_name == 'pull_request' ||
+      github.ref == 'refs/heads/main' ||
+      github.repository_owner != 'containers'
     strategy:
       fail-fast: false
       matrix:
@@ -80,6 +88,10 @@ jobs:
           uv run -- make unit-tests
 
   e2e-tests:
+    if: |
+      github.event_name == 'pull_request' ||
+      github.ref == 'refs/heads/main' ||
+      github.repository_owner != 'containers'
     needs:
       - lint
       - unit-test
@@ -138,6 +150,10 @@ jobs:
            make e2e-tests
 
   e2e-tests-nocontainer:
+    if: |
+      github.event_name == 'pull_request' ||
+      github.ref == 'refs/heads/main' ||
+      github.repository_owner != 'containers'
     needs:
       - lint
       - unit-test
@@ -194,6 +210,10 @@ jobs:
            make e2e-tests-nocontainer
 
   e2e-tests-docker:
+    if: |
+      github.event_name == 'pull_request' ||
+      github.ref == 'refs/heads/main' ||
+      github.repository_owner != 'containers'
     needs:
       - lint
       - unit-test
@@ -270,6 +290,10 @@ jobs:
            make e2e-tests-docker
 
   e2e-tests-macos:
+    if: |
+      github.event_name == 'pull_request' ||
+      github.ref == 'refs/heads/main' ||
+      github.repository_owner != 'containers'
     needs:
       - lint
       - unit-test
@@ -311,6 +335,10 @@ jobs:
           make e2e-tests-nocontainer
 
   e2e-tests-windows:
+    if: |
+      github.event_name == 'pull_request' ||
+      github.ref == 'refs/heads/main' ||
+      github.repository_owner != 'containers'
     needs:
       - lint
       - unit-test

--- a/.github/workflows/docsite-publish.yml
+++ b/.github/workflows/docsite-publish.yml
@@ -18,6 +18,8 @@ env:
   PUBLISH_TOKEN: ${{ secrets.DOCSITE_PUBLISH_TOKEN }}
 jobs:
   publish:
+    if: |
+      github.repository_owner == 'containers'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout RamaLama

--- a/.github/workflows/install_ramalama.yml
+++ b/.github/workflows/install_ramalama.yml
@@ -2,14 +2,16 @@ name: Install RamaLama
 
 on:
   push:
-    branches:
-      - main
   pull_request:
     branches:
       - main
 
 jobs:
   install_ramalama:
+    if: |
+      github.event_name == 'pull_request' ||
+      github.ref == 'refs/heads/main' ||
+      github.repository_owner != 'containers'
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]  # Runs on Ubuntu and macOS

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,6 +12,8 @@ permissions:
 
 jobs:
   stale:
+    if: |
+      github.repository_owner == 'containers'
 
     permissions:
       issues: write  # for actions/stale to close stale issues


### PR DESCRIPTION
When github actions are enabled on a fork, trigger CI for pushes to any branch on the fork to allow contributors to easily run CI and resolve issues before submitting a PR.

When it is not a fork (based on repo owner) continue to only run CI for pushes to main.

## Summary by Sourcery

Update GitHub Actions workflows to run CI on all branches for forked repositories while restricting certain workflows to the main repo owner.

CI:
- Run core CI workflows on all branches for forked repositories while keeping push-triggered CI on main for the upstream repo.
- Gate install_ramalama, docsite publish, and stale-issue workflows so they only run on the main branch or in the upstream containers repository as appropriate.