### PR TITLE
Add /clear command to reset conversation history

### DIFF
--- a/docs/ramalama-chat.1.md
+++ b/docs/ramalama-chat.1.md
@@ -60,6 +60,29 @@ Lower numbers are more deterministic, higher numbers are more creative.
 The host to send requests to (default: http://127.0.0.1:8080)
 
 
+## INTERACTIVE COMMANDS
+
+When running in interactive chat mode, the following commands are available.
+All commands are case-insensitive (e.g., `/CLEAR`, `/Clear`, and `/clear` all work).
+
+#### **/help**, **help**, **?**
+Display help information showing all available commands and their descriptions.
+
+#### **/clear**
+Clear the conversation history without exiting the chat session. This resets the context
+and allows starting a fresh conversation without restarting the container or connection.
+A confirmation message will be displayed when the history is cleared.
+
+#### **/bye**, **exit**
+Exit the chat session and close the connection.
+
+#### **/tool** [question]
+(Only available when using --mcp) Manually select which MCP tool to use for a question.
+Without this command, the AI automatically decides whether to use tools based on the question.
+
+#### **Ctrl + D**
+Exit the chat session (EOF signal).
+
 ## EXAMPLES
 
 Communicate with the default local OpenAI REST API. (http://127.0.0.1:8080)
@@ -67,16 +90,30 @@ With Podman containers.
 ```
 $ ramalama chat
 🦭 >
+```
 
 Communicate with an alternative OpenAI REST API URL. With Docker containers.
+```
 $ ramalama chat --url http://localhost:1234
 🐋 >
+```
 
 Send multiple lines at once
+```
 $ ramalama chat
 🦭 > Hi \
 🦭 > tell me a funny story \
 🦭 > please
+```
+
+Clear conversation history during a chat session (commands are case-insensitive)
+```
+$ ramalama chat
+🦭 > What is 2+2?
+4
+🦭 > /CLEAR
+Conversation history cleared.
+🦭 >
 ```
 
 ## SEE ALSO

--- a/docs/ramalama-run.1.md
+++ b/docs/ramalama-run.1.md
@@ -215,6 +215,29 @@ registry if it does not exist in local storage. By default a prompt for a chat
 bot is started. When arguments are specified, the arguments will be given
 to the AI Model and the output returned without entering the chatbot.
 
+## INTERACTIVE COMMANDS
+
+When running in interactive chat mode (without arguments), the following commands are available.
+All commands are case-insensitive (e.g., `/CLEAR`, `/Clear`, and `/clear` all work).
+
+#### **/help**, **help**, **?**
+Display help information showing all available commands and their descriptions.
+
+#### **/clear**
+Clear the conversation history without exiting the chat session. This resets the context
+and allows starting a fresh conversation without restarting the container or connection.
+A confirmation message will be displayed when the history is cleared.
+
+#### **/bye**, **exit**
+Exit the chat session and close the connection.
+
+#### **/tool** [question]
+(Only available when using --mcp) Manually select which MCP tool to use for a question.
+Without this command, the AI automatically decides whether to use tools based on the question.
+
+#### **Ctrl + D**
+Exit the chat session (EOF signal).
+
 ## EXAMPLES
 
 Run command without arguments starts a chatbot
@@ -250,10 +273,23 @@ This program is a Python script that allows the user to interact with a terminal
 
 Run command and send multiple lines at once to the chatbot by adding a backslash `\`
 at the end of the line
+```
 $ ramalama run granite
 🦭 > Hi \
 🦭 > tell me a funny story \
 🦭 > please
+```
+
+Clear conversation history during a chat session
+```
+$ ramalama run granite
+🦭 > What is the capital of France?
+Paris
+🦭 > /clear
+Conversation history cleared.
+🦭 > What is 2+2?
+4
+```
 
 ## Exit Codes:
 


### PR DESCRIPTION
Implement a /clear command in the chat interface that allows users to clear the conversation history without restarting the container. This addresses a common user need to reset context during long chat sessions.

Changes:
- Add /clear command handler in default() method
- Clear conversation_history when /clear is entered
- Display confirmation message when history is cleared
- Update help text to include /clear command in usage instructions
- Add /clear to both MCP usage instructions and general help messages

The command is checked after /bye and exit commands but before message processing, allowing users to quickly reset context without losing their session.

Fixes #2352

*This PR was created with the assistance of Cursor AI.*

## Summary by Sourcery

Document interactive chat commands and add a case-insensitive /clear command to reset conversation history without ending the session.

New Features:
- Add a /clear command in interactive chat to clear conversation history while keeping the session open.

Enhancements:
- Make chat control commands (/bye, exit, /tool) case-insensitive for more forgiving input handling.
- Improve interactive usage hints to mention /clear alongside existing exit instructions.

Documentation:
- Add INTERACTIVE COMMANDS sections to ramalama-run and ramalama-chat man pages, documenting /clear, /bye/exit, /tool, Ctrl+D, and multi-line input, with examples of clearing history during a session.