### PR TITLE
Add --interactive flag to continue chat after stdin/args

### DIFF
--- a/docs/ramalama-chat.1.md
+++ b/docs/ramalama-chat.1.md
@@ -8,10 +8,13 @@ ramalama\-chat - OpenAI chat with the specified REST API URL
 
 positional arguments:
   ARGS                  overrides the default prompt, and the output is
-                        returned without entering the chatbot
+                        returned without entering the chatbot (unless
+                        --interactive is specified)
 
 ## DESCRIPTION
-Chat with an OpenAI Rest API
+Chat with an OpenAI REST API. By default, if arguments or stdin are provided,
+the response is displayed and the command exits. Use **--interactive** to
+continue to an interactive chat session after processing the initial prompt.
 
 ## OPTIONS
 
@@ -25,6 +28,11 @@ Possible values are "never", "always" and "auto". (default: auto)
 
 #### **--help**, **-h**
 Show this help message and exit
+
+#### **--interactive**, **-i**
+Continue to interactive chat mode after processing stdin or prompt arguments.
+By default, when arguments or piped input are provided, the command exits after
+displaying the response. This flag allows you to continue chatting interactively.
 
 #### **--list**
 List the available models at an endpoint
@@ -77,6 +85,13 @@ $ ramalama chat
 🦭 > Hi \
 🦭 > tell me a funny story \
 🦭 > please
+
+Send an initial prompt via stdin and continue chatting
+$ echo "What is 2+2?" | ramalama chat --interactive
+4
+🦭 > Now multiply that by 3
+12
+🦭 > /bye
 ```
 
 ## SEE ALSO

--- a/docs/ramalama-run.1.md
+++ b/docs/ramalama-run.1.md
@@ -95,6 +95,11 @@ Accelerated images:
 |  ASCEND_VISIBLE_DEVICES | quay.io/ramalama/cann      |
 |  MUSA_VISIBLE_DEVICES   | quay.io/ramalama/musa      |
 
+#### **--interactive**, **-i**
+Continue to interactive chat mode after processing stdin or prompt arguments.
+By default, when arguments or piped input are provided, the command exits after
+displaying the response. This flag allows you to continue chatting interactively.
+
 #### **--keep-groups**
 pass --group-add keep-groups to podman (default: False)
 If GPU device on host system is accessible to user via group access, this option leaks the groups into the container.
@@ -212,8 +217,10 @@ require HTTPS and verify certificates when contacting OCI registries
 ## DESCRIPTION
 Run specified AI Model as a chat bot. RamaLama pulls specified AI Model from
 registry if it does not exist in local storage. By default a prompt for a chat
-bot is started. When arguments are specified, the arguments will be given
-to the AI Model and the output returned without entering the chatbot.
+bot is started. When arguments or stdin are provided, they will be given
+to the AI Model and the output is returned. By default, the command exits after
+displaying the response, but you can use **--interactive** (**-i**) to continue
+to an interactive chat session after processing the initial prompt.
 
 ## EXAMPLES
 
@@ -233,6 +240,15 @@ Run command with a custom port to allow multiple models running simultaneously
 ```
 ramalama run --port 8081 granite
 >
+```
+
+Send an initial prompt via stdin and continue chatting interactively
+```
+$ echo "Explain quantum computing" | ramalama run -i granite
+[AI response...]
+> Can you give me an example?
+[AI response...]
+> /bye
 ```
 
 ```

--- a/ramalama/chat.py
+++ b/ramalama/chat.py
@@ -5,6 +5,7 @@ import cmd
 import copy
 import itertools
 import json
+import os
 import signal
 import subprocess
 import sys
@@ -400,9 +401,16 @@ class RamaLamaShell(cmd.Cmd):
             return None
 
     def handle_args(self, monitor):
+        """Process command-line arguments and/or stdin input.
+
+        Returns True if the program should exit, False if it should continue to interactive mode.
+        """
         prompt = " ".join(self.args.ARGS) if self.args.ARGS else None
+        stdin_was_pipe = False
+
         if not sys.stdin.isatty():
             stdin = sys.stdin.read()
+            stdin_was_pipe = True
             if prompt:
                 prompt += f"\n\n{stdin}"
             else:
@@ -410,6 +418,23 @@ class RamaLamaShell(cmd.Cmd):
 
         if prompt:
             self.default(prompt)
+            # Continue to interactive mode if --interactive flag is set
+            if getattr(self.args, 'interactive', False):
+                # If stdin was a pipe, we need to reopen the terminal for interactive input
+                if stdin_was_pipe:
+                    try:
+                        # Use platform-specific terminal device
+                        # Windows: 'CON', Unix/Linux: '/dev/tty'
+                        terminal_device = 'CON' if os.name == 'nt' else '/dev/tty'
+                        sys.stdin = open(terminal_device, 'r')
+                    except (OSError, FileNotFoundError) as e:
+                        perror(f"Cannot open terminal for interactive mode: {e}")
+                        monitor.stop()
+                        self.kills()
+                        return True
+                print("")
+                return False
+            # Default behavior: exit after displaying response
             monitor.stop()
             self.kills()
             return True

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -1201,6 +1201,12 @@ def chat_run_options(parser):
         metavar="N",
         help="automatically summarize conversation history after N messages to prevent context growth (0=disabled)",
     )
+    parser.add_argument(
+        "-i",
+        "--interactive",
+        action="store_true",
+        help="continue to interactive chat mode after processing stdin or prompt arguments",
+    )
 
 
 def _chat_cli(args):


### PR DESCRIPTION
Implement the ability to keep a stdin chat going after processing the initial prompt, addressing user feedback that the chat exits immediately after processing arguments or piped input.

Changes:
- Add --interactive/-i flag to chat and run commands
- When flag is set, continue to interactive mode after processing
- Default behavior unchanged (exit after response for scripts)
- Update both ramalama-chat and ramalama-run man pages
- Add comprehensive examples demonstrating the new functionality

The --interactive flag enables use cases like:
- Piping an initial question and continuing the conversation
- Starting with a prompt argument and exploring further
- Building on context from stdin in an interactive session

Fixes #2400

*This PR was created with the assistance of Cursor AI.*

## Summary by Sourcery

Add an interactive mode flag to chat and run commands so sessions can continue after processing initial stdin or prompt arguments.

New Features:
- Introduce an --interactive (-i) flag for ramalama-chat and ramalama-run to continue into interactive chat after handling stdin or prompt arguments.

Documentation:
- Document the --interactive flag semantics and default non-interactive behavior in ramalama-chat and ramalama-run man pages, including new usage examples for stdin and argument-based workflows.