### PR TITLE
Use "git check-ignore" to generate the cleanup list in the Makefile.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-ramalama/__pycache__
 docsite/docs/**/*.mdx
 docs/*.1
 docs/*.5
@@ -7,7 +6,8 @@ build
 *.egg-info
 *.dist
 *.patch
-ramalama/*.patch
+*.rej
+*.orig
 dist
 .#*
 venv/
@@ -28,4 +28,4 @@ uv.lock
 .pixi/*
 !.pixi/config.toml
 *~
-\#*#
+*#

--- a/Makefile
+++ b/Makefile
@@ -249,10 +249,7 @@ rag-requirements:
 
 .PHONY: clean
 clean:
-	@find . -name \*~ -delete
-	@find . -name \*# -delete
-	@find . -name \*.rej -delete
-	@find . -name \*.orig -delete
 	make -C docs clean
 	make -C docsite clean clean-generated
-	rm -rf $$(<.gitignore)
+	find . -depth -print0 | git check-ignore --stdin -z | xargs -0 rm -rf
+


### PR DESCRIPTION
Use git check-ignore to generate the list of files and directories to be cleaned up rather than trying to use the contents of .gitignore directly. The .gitignore file contains double asterisk wildcard and exclamation point negation constructs that are not compatible with shell glob expansion, which can lead to too many or too few files and directories being cleaned up.

Add some patterns to .gitignore and remove some redundancy.

## Summary by Sourcery

Use git’s ignore logic to drive the clean target and refresh ignore patterns.

Build:
- Update the Makefile clean target to remove files based on git check-ignore results rather than manual find and .gitignore expansion.

Chores:
- Adjust .gitignore patterns to better align with automated cleanup and remove redundant entries.