### PR TITLE
Fix test_help_command_flags on python 3.14.3

### DIFF
--- a/test/e2e/test_help.py
+++ b/test/e2e/test_help.py
@@ -57,7 +57,7 @@ def test_help_command_flags():
     # Test for regression of #7273 (spurious "--remote" help on output)
     for help_opt in ["help", "-h", "--help"]:
         result = check_output(["ramalama", help_opt])
-        assert re.search(r"^usage: ramalama \[-h] \[--debug] \[--dryrun] \[--engine {podman,docker}]", result)
+        assert re.search(r"^usage: ramalama \[-h] \[--debug.*] \[--dryrun] \[--engine {podman,docker}]", result)
 
 
 @pytest.mark.e2e


### PR DESCRIPTION
CLI output changes in python 3.14.3 due to an argparse bug fix (https://github.com/python/cpython/issues/75949). Update the test regex to match both.

## Summary by Sourcery

Bug Fixes:
- Relax the CLI usage regex in test_help_command_flags so it passes under both pre- and post-3.14.3 argparse formatting.