### PR TITLE
e2e: install git-core

### DIFF
--- a/container-images/e2e/Containerfile
+++ b/container-images/e2e/Containerfile
@@ -8,7 +8,7 @@ WORKDIR /src
 ENTRYPOINT ["/usr/bin/entrypoint.sh"]
 
 RUN dnf -y --setopt=install_weak_deps=false install \
-    make podman openssl \
+    make podman openssl git-core \
     # for building python dependencies on ppc64le and s390x
     gcc rust cargo \
     $([ $(uname -m) == "x86_64" ] && echo ollama) \


### PR DESCRIPTION
`git` is now required by the `make clean` command.

## Summary by Sourcery

Build:
- Add git-core to the e2e container image dependencies to support commands that now require git.