### PR TITLE
Fixes API Transport regression resulting from eager call to _get_entry_model_path

### DIFF
--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -679,13 +679,11 @@ def _list_models_from_store(args):
             size_sum += file.size
             last_modified = max(file.modified, last_modified)
 
-        ret.append(
-            {
-                "name": f"{model} (partial)" if is_partially_downloaded else model,
-                "modified": datetime.fromtimestamp(last_modified, tz=local_timezone).isoformat(),
-                "size": size_sum,
-            }
-        )
+        ret.append({
+            "name": f"{model} (partial)" if is_partially_downloaded else model,
+            "modified": datetime.fromtimestamp(last_modified, tz=local_timezone).isoformat(),
+            "size": size_sum,
+        })
 
     # sort the listed models according to the desired order
     ret.sort(key=lambda entry: entry[args.sort], reverse=args.order == "desc")

--- a/ramalama/command/factory.py
+++ b/ramalama/command/factory.py
@@ -88,13 +88,11 @@ class CommandFactory:
         if not ("{{" in stmt and "}}" in stmt):
             return stmt
 
-        return jinja2.Template(stmt).render(
-            {
-                "args": ctx.args,
-                "model": ctx.model,
-                "host": ctx.host,
-            }
-        )
+        return jinja2.Template(stmt).render({
+            "args": ctx.args,
+            "model": ctx.model,
+            "host": ctx.host,
+        })
 
     @staticmethod
     def validate_spec(spec_data: dict, schema: dict):

--- a/ramalama/rag.py
+++ b/ramalama/rag.py
@@ -197,6 +197,7 @@ class RagTransport(OCI):
                 stop_container(args.model_args, args.model_args.name, remove=True)
 
     def run(self, args: RagArgsType, cmd: list[str]):
+
         args.model_args.name = self.imodel.get_container_name(args.model_args)
         process = self.imodel.serve_nonblocking(args.model_args, self.model_cmd)
         rag_process = self.serve_nonblocking(args, cmd)

--- a/ramalama/transports/api.py
+++ b/ramalama/transports/api.py
@@ -40,9 +40,7 @@ class APITransport(TransportBase):
         return f"{self.model_organization}/{self.model_name}"
 
     def _get_entry_model_path(self, use_container: bool, should_generate: bool, dry_run: bool) -> str:
-        raise NotImplementedError(
-            f"{self.model} is provided over a hosted API preventing direct pulling of the model file."
-        )
+        return ''
 
     def _get_mmproj_path(self, use_container: bool, should_generate: bool, dry_run: bool):
         return None


### PR DESCRIPTION
## Summary by Sourcery

Prevent API-based transports from failing due to eager model path resolution and ensure CLI runs them without attempting a pull.

Bug Fixes:
- Avoid raising an error for hosted API models during entry model path resolution by returning an empty path.
- Ensure running the CLI with an API transport invokes only the run operation and does not trigger a model pull.

Tests:
- Add a regression test verifying that CLI usage with an API transport does not call pull but does call run.