### PR TITLE
Add wait_for_server in chat.py and test_chat.py corresponding unit tests

### DIFF
--- a/ramalama/chat.py
+++ b/ramalama/chat.py
@@ -15,6 +15,8 @@ import urllib.request
 from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import timedelta
+from http.client import HTTPConnection
+from urllib.parse import urlparse
 
 from ramalama.arg_types import ChatArgsType
 from ramalama.chat_providers import ChatProvider, ChatRequestOptions
@@ -772,6 +774,38 @@ def _report_server_exit(monitor):
         perror("Check server logs for more details about why the service exited.")
 
 
+def wait_for_server(args, timeout: int = 30):
+    """Wait for the llama.cpp server to be ready before starting chat."""
+    parsed = urlparse(args.url)
+    host = parsed.hostname or "127.0.0.1"
+    port = parsed.port or 8080
+    start_time = time.time()
+    spinner = Spinner().start()
+    last_error: Exception | None = None
+    while time.time() - start_time < timeout:
+        conn = None
+        try:
+            conn = HTTPConnection(host, port, timeout=3)
+            conn.request("GET", "/health")
+            resp = conn.getresponse()
+            resp.read()
+            if resp.status == 200:
+                spinner.stop()
+                return
+        except Exception as exc:
+            last_error = exc
+        finally:
+            if conn:
+                conn.close()
+        time.sleep(1)
+    spinner.stop()
+
+    if last_error:
+        logger.debug(f"Error waiting for {args.url} /health: {last_error}")
+    else:
+        logger.debug(f"Time out waiting for {args.url} /health")
+
+
 def chat(
     args: ChatArgsType,
     operational_args: ChatOperationalArgs | None = None,
@@ -824,6 +858,9 @@ def chat(
 
     # Assign monitor to operational_args
     operational_args.monitor = monitor
+
+    # Wait until server reports healthy
+    wait_for_server(args)
 
     successful_exit = True
     try:

--- a/test/unit/test_chat.py
+++ b/test/unit/test_chat.py
@@ -1,0 +1,43 @@
+from argparse import Namespace
+from unittest.mock import Mock, patch
+
+import pytest
+
+from ramalama.chat import wait_for_server
+
+@patch("ramalama.chat.Spinner")
+@patch("ramalama.chat.HTTPConnection")
+def test_wait_for_server_success(mock_conn, mock_spinner):
+    mock_resp = Mock()
+    mock_resp.status = 200
+    mock_resp.read.return_value = b""
+    mock_conn.return_value.getresponse.return_value = mock_resp
+    args = Namespace(url="http://127.0.0.1:8080/v1")
+    wait_for_server(args, timeout=30)
+    assert mock_conn.return_value.request.called
+
+@patch("ramalama.chat.Spinner")
+@patch("ramalama.chat.time.sleep")
+@patch("ramalama.chat.HTTPConnection")
+def test_wait_for_server_timeout(mock_conn, mock_sleep, mock_spinner):
+    mock_resp = Mock()
+    mock_resp.status = 503
+    mock_resp.read.return_value = b""
+    mock_conn.return_value.getresponse.return_value = mock_resp
+    args = Namespace(url="http://127.0.0.1:8080/v1")
+    wait_for_server(args, timeout=0)
+
+@patch("ramalama.chat.Spinner")
+@patch("ramalama.chat.time.sleep")
+@patch("ramalama.chat.HTTPConnection")
+def test_wait_for_server_retry_success(mock_conn, mock_sleep, mock_spinner):
+    mock_resp_fail = Mock()
+    mock_resp_fail.status = 503
+    mock_resp_fail.read.return_value = b""
+    mock_resp_success = Mock()
+    mock_resp_success.status = 200
+    mock_resp_success.read.return_value = b""
+    mock_conn.return_value.getresponse.side_effect = [mock_resp_fail, mock_resp_success]
+    args = Namespace(url="http://127.0.0.1:8080/v1")
+    wait_for_server(args, timeout=30)
+    assert mock_conn.return_value.getresponse.call_count == 2    


### PR DESCRIPTION
Chat needs to wait for llama-server/model to finish loading before starting, but currently returns a 503 error while model is loading.

Solution: adds wait_for_server in chat.py to poll /health until the server is ready and log errors or timeouts. Unit tests in test/unit/test_chat.py for success, timeout, and retry cases.

Fixes: #2343

Signed-off-by: Shelby Coonce <s.coonce@ufl.edu>

## Summary by Sourcery

Ensure the chat client waits for the llama.cpp HTTP server to become healthy before starting an interactive session.

Bug Fixes:
- Prevent 503 errors at chat startup by polling the server /health endpoint until it reports ready or times out.

Tests:
- Add unit tests covering successful server readiness detection, timeout behavior, and retry logic when the server initially returns errors.