### PR TITLE
Migrates type checker from mypy to ty

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           uv run -- make man-check
 
-      - name: Run type checking
+      - name: Run ty type checking
         run: |
           uv run -- make type-check
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ make validate                # Run all validation (codespell, lint, format check
 make lint                    # Run ruff + shellcheck
 make check-format            # Check ruff formatting + import sorting
 make format                  # Auto-format with ruff + import sorting
-make type-check              # Run mypy type checking
+make type-check              # Run ty type checking
 make codespell               # Check spelling
 ```
 
@@ -103,5 +103,5 @@ Manages local model storage:
 - Python 3.10+ required
 - Line length: 120 characters
 - Formatting: ruff format + ruff check (I rules)
-- Type hints encouraged (mypy checked)
+- Type hints encouraged (ty checked)
 - Commits require DCO sign-off (`git commit -s`)

--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ endif
 
 .PHONY: type-check
 type-check:
-	mypy $(addprefix --exclude=,$(EXCLUDE_DIRS)) --exclude test $(PROJECT_DIR)
+	ty check $(addprefix --exclude=,$(EXCLUDE_DIRS)) --exclude test
 
 .PHONY: validate
 validate: codespell lint man-check type-check
@@ -249,4 +249,3 @@ clean:
 	make -C docs clean
 	make -C docsite clean clean-generated
 	find . -depth -print0 | git check-ignore --stdin -z | xargs -0 rm -rf
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ dev = [
     "pytest~=9.0",
     "ruff>=0.14.14",
     "wheel~=0.46.3",
-    "mypy",
+    "ty",
     "types-PyYAML",
     "types-jsonschema",
     "tox",
@@ -254,5 +254,14 @@ dev = { features = ["dev"], solve-group = "default" }
 [tool.pixi.dependencies]
 tox = ">=4.30.2,<5"
 
-[tool.mypy]
-python_version = "3.10"
+[tool.ty.environment]
+python-version = "3.10"
+
+[tool.ty.rules]
+# invalid-argument-type = "warn"
+# invalid-method-override = "warn"
+# no-matching-overload = "warn"
+# not-iterable = "warn"
+# too-many-positional-arguments = "warn"
+# unresolved-attribute = "warn"
+# unsupported-operator = "warn"


### PR DESCRIPTION
## Summary by Sourcery

Migrate the project’s static type checking setup from mypy to ty across configuration, tooling, and documentation references.

Enhancements:
- Switch the Makefile type-check target to use ty check instead of mypy.

Build:
- Replace mypy with ty in development dependencies and configure ty settings in pyproject.toml.

CI:
- Update CI workflow step description to reflect ty-based type checking.

Documentation:
- Update contributor documentation to reference ty instead of mypy for type checking commands and expectations.