### PR TITLE
Nominating Oliver Walsh as a Maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # Default to all maintainers if nothing more specific matches
-* @rhatdan @bmahabirbu @maxamillion @dougsland @swarajpande5 @jhjaggars @cgruver @slp @engelmi
+* @rhatdan @bmahabirbu @maxamillion @dougsland @swarajpande5 @jhjaggars @cgruver @slp @engelmi @mikebonnet @olliewalsh

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -6,6 +6,7 @@
 | -------- | ------- | ------- |
 |  Dan Walsh | rhatdan | Red Hat |
 |  Mike Bonnet | mikebonnet | Red Hat |
+|  Oliver Walsh | olliewalsh | Red Hat |
 
 ## Reviewers
 


### PR DESCRIPTION
Oliver has been contributing to RamaLama since May 2025 and is currently doing much of the heavy lifting to keep the project running, including code review, feature development, and project roadmap and direction.

Also adding myself and Oliver to `CODEOWNERS` for notification of new PRs.

## Summary by Sourcery

Document Oliver Walsh as a project maintainer and update repository ownership metadata for pull request notifications.

Enhancements:
- Add Oliver Walsh to the MAINTAINERS list with affiliation details.

Chores:
- Update CODEOWNERS to include maintainers for notification and ownership of new pull requests.