### PR TITLE
Nominating Michael Engel and Brian Mahabir as Reviewers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -10,6 +10,7 @@
 
 ## Reviewers
 
-| Reviewer| GitHub ID| Affiliation|
-| -------- | ------- | ------- |
-| TODO | TODO | TODO |
+| Reviewer | GitHub ID | Affiliation |
+| -------- | --------- | ----------- |
+| Michael Engel | engelmi | Red Hat |
+| Brian Mahabir | bmahabirbu | Red Hat |


### PR DESCRIPTION
Both have already contributed significant functionality, and are actively participating in code review and project planning. They are already listed in CODEOWNERS.

## Summary by Sourcery

Documentation:
- Document Michael Engel and Brian Mahabir as project reviewers in MAINTAINERS.md.