### PR TITLE
Add missing XDG environment variable checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,20 +130,20 @@ sudo rm /usr/local/share/zsh/site-functions/_ramalama
 See the [macOS Installation Guide](docs/MACOS_INSTALL.md) for more details.
 
 ### Remove User Data and Configuration
-After uninstalling RamaLama using any method above, you may want to remove downloaded models and configuration files from your home directory:
+After uninstalling RamaLama using any method above, you may want to remove downloaded models and configuration files:
 
 ```bash
 # Remove downloaded models and data (can be large)
-rm -rf ~/.local/share/ramalama
+rm -rf -- "${XDG_DATA_HOME:-~/.local/share}/ramalama"
 
 # Remove configuration files
-rm -rf ~/.config/ramalama
+rm -rf -- "${XDG_CONFIG_HOME:-~/.config}/ramalama"
 
 # If you ran RamaLama as root, also remove:
 sudo rm -rf /var/lib/ramalama
 ```
 
-**Note:** The model data directory (`~/.local/share/ramalama`) can be quite large depending on how many models you've downloaded. Make sure you want to remove these files before running the commands above.
+**Note:** The model data directory (by default `~/.local/share/ramalama`) can be quite large depending on how many models you've downloaded. Make sure you want to remove these files before running the commands above.
 
 ## Accelerated images
 
@@ -295,8 +295,8 @@ RamaLama reads shortnames.conf files if they exist. These files contain a list o
 | Shortnames type    | Path                                                       |
 | :----------------  | :-------------------------------------------               |
 | Development        | ./shortnames.conf                                          |
-| User (Config)      | $HOME/.config/ramalama/shortnames.conf                     |
-| User (Local Share) | $HOME/.local/share/ramalama/shortnames.conf                |
+| User (Config)      | $XDG\_CONFIG\_HOME/ramalama/shortnames.conf                |
+| User (Data)        | $XDG\_DATA\_HOME/ramalama/shortnames.conf                  |
 | Administrators     | /etc/ramalama/shortnames.conf                              |
 | Distribution       | /usr/share/ramalama/shortnames.conf                        |
 | Local Distribution | /usr/local/share/ramalama/shortnames.conf                  |

--- a/docs/MACOS_INSTALL.md
+++ b/docs/MACOS_INSTALL.md
@@ -128,8 +128,8 @@ sudo rm /usr/local/bin/ramalama
 sudo rm -rf /Applications/ramalama.app
 
 # Remove configuration and data files (optional)
-rm -rf ~/.local/share/ramalama
-rm -rf ~/.config/ramalama
+rm -rf -- "${XDG_DATA_HOME:-~/.local/share}/ramalama"
+rm -rf -- "${XDG_CONFIG_HOME:-~/.config}/ramalama"
 
 # Remove man pages (optional)
 sudo rm /usr/local/share/man/man1/ramalama*.1

--- a/ramalama/config.py
+++ b/ramalama/config.py
@@ -83,7 +83,7 @@ def get_default_store() -> str:
     if hasattr(os, 'geteuid') and os.geteuid() == 0:
         return "/var/lib/ramalama"
 
-    return os.path.expanduser("~/.local/share/ramalama")
+    return os.path.expanduser(os.path.join(os.getenv("XDG_DATA_HOME", "~/.local/share"), "ramalama"))
 
 
 def get_all_inference_spec_dirs(subdir: str) -> list[Path]:

--- a/ramalama/shortnames.py
+++ b/ramalama/shortnames.py
@@ -30,8 +30,8 @@ class Shortnames:
             # Unix-specific paths using XDG conventions
             file_paths.extend(
                 [
-                    os.path.expanduser("~/.config/ramalama/shortnames.conf"),
-                    os.path.expanduser("~/.local/share/ramalama/shortnames.conf"),
+                    os.path.expanduser(os.path.join(os.getenv("XDG_CONFIG_HOME", "~/.config"), "ramalama/shortnames.conf")),
+                    os.path.expanduser(os.path.join(os.getenv("XDG_DATA_HOME", "~/.local/share"), "ramalama/shortnames.conf")),
                     os.path.expanduser("~/.local/pipx/venvs/ramalama/share/ramalama/shortnames.conf"),
                     "/etc/ramalama/shortnames.conf",
                     "/usr/share/ramalama/shortnames.conf",


### PR DESCRIPTION
Just like was already done elsewhere in ramalama/config.py. Otherwise, ramalama would do the wrong thing when XDG_CONFIG_HOME or XDG_DATA_HOME is set to a non-default location.

## Summary by Sourcery

Respect XDG base directory environment variables for Ramalama configuration and data file discovery.

Bug Fixes:
- Use XDG_CONFIG_HOME and XDG_DATA_HOME when resolving the shortnames configuration file path.
- Use XDG_DATA_HOME when determining the default Ramalama data store directory for non-root users.