### PR TITLE
Use hardlink for local model files to save disk space

### DIFF
--- a/ramalama/transports/url.py
+++ b/ramalama/transports/url.py
@@ -1,11 +1,10 @@
 import os
 import re
-import shutil
 from pathlib import Path
 
 from ramalama.common import SPLIT_MODEL_PATH_RE, generate_sha256, is_split_file_model
 from ramalama.model_store.snapshot_file import SnapshotFile, SnapshotFileType
-from ramalama.path_utils import normalize_host_path_for_container
+from ramalama.path_utils import create_file_link, normalize_host_path_for_container
 from ramalama.transports.base import Transport
 from ramalama.transports.huggingface import HuggingfaceRepository
 from ramalama.transports.modelscope import ModelScopeRepository
@@ -36,8 +35,8 @@ class LocalModelFile(SnapshotFile):
     def download(self, blob_file_path, snapshot_dir):
         if not os.path.exists(self.url):
             raise FileNotFoundError(f"No such file: '{self.url}'")
-        # moving from the local location to blob directory so the model store "owns" the data
-        shutil.copy(self.url, blob_file_path)
+        # Use hardlink first (space-efficient), fallback to symlink, then copy if needed
+        create_file_link(self.url, blob_file_path)
         return os.path.relpath(blob_file_path, start=snapshot_dir)
 
 

--- a/test/unit/test_url.py
+++ b/test/unit/test_url.py
@@ -1,9 +1,10 @@
+import os
 from dataclasses import dataclass, field
 
 import pytest
 
 from ramalama.model_store.snapshot_file import SnapshotFile
-from ramalama.transports.url import URL
+from ramalama.transports.url import URL, LocalModelFile
 
 
 @dataclass
@@ -56,3 +57,29 @@ def test__assemble_split_file_list(input: Input, expected: Expected):
     for i in range(file_count):
         assert files[i].url == expected.URLList[i]
         assert files[i].name == expected.Names[i]
+
+
+def test_local_model_file_uses_hardlink(tmp_path):
+    """Test that LocalModelFile.download() uses hardlink instead of copy to save disk space."""
+    # Create a test model file
+    src_file = tmp_path / "test_model.gguf"
+    src_file.write_text("test model content")
+
+    dest_file = tmp_path / "dest_model.gguf"
+
+    # Create LocalModelFile and download
+    lmf = LocalModelFile(
+        url=str(src_file),
+        header={},
+        model_file_hash="test_hash",
+        name="test_model.gguf",
+    )
+    lmf.download(str(dest_file), str(tmp_path))
+
+    # Verify files are hardlinked (same inode means no disk space duplication)
+    src_stat = os.stat(src_file)
+    dest_stat = os.stat(dest_file)
+
+    assert src_stat.st_ino == dest_stat.st_ino, "Files should be hardlinked (same inode)"
+    assert src_stat.st_nlink == 2, "Should have 2 links to the same inode"
+    assert dest_file.read_text() == "test model content", "Content should be accessible"


### PR DESCRIPTION
When pulling local model files (file://), use hardlinks instead of copying the file to avoid duplicating large model files on disk. This addresses issue #2098 where users want to use models from external tools without duplicating multi-GB files.

The implementation uses the existing create_file_link() utility which:
1. First attempts to create a hardlink (most efficient, no extra disk space)
2. Falls back to symlink if hardlink fails (e.g., cross-filesystem)
3. Falls back to copy as last resort (e.g., filesystem doesn't support links)

Benefits:
- No disk space duplication for local models
- Works across all platforms (Linux, macOS, Windows)
- Maintains backward compatibility (copy as fallback)
- Handles edge cases like cross-filesystem scenarios

Changes:
- Updated LocalModelFile.download() to use create_file_link() instead of shutil.copy()
- Added test to verify hardlink behavior
- Updated comment to reflect new hardlink-first approach

Fixes #2098

*This PR was created with the assistance of Cursor AI.*

## Summary by Sourcery

Use file linking instead of copying for local model downloads to avoid duplicating large files on disk.

Bug Fixes:
- Prevent unnecessary duplication of local model files by replacing copies with hardlinks or symlinks when downloading.

Enhancements:
- Update LocalModelFile downloads to use a link-creation utility that prefers hardlinks, then symlinks, and falls back to copying if needed.

Tests:
- Add a unit test verifying that LocalModelFile.download() creates a hardlink for local model files and preserves file contents.