### PR TITLE
Fix reading from a pipe on windows

### DIFF
--- a/docs/ramalama-chat.1.md
+++ b/docs/ramalama-chat.1.md
@@ -8,10 +8,13 @@ ramalama\-chat - OpenAI chat with the specified REST API URL
 
 positional arguments:
   ARGS                  overrides the default prompt, and the output is
-                        returned without entering the chatbot
+                        returned without entering the chatbot (unless
+                        --interactive is specified)
 
 ## DESCRIPTION
-Chat with an OpenAI Rest API
+Chat with an OpenAI REST API. By default, if arguments or stdin are provided,
+the response is displayed and the command exits. Use **--interactive** to
+continue to an interactive chat session after processing the initial prompt.
 
 ## OPTIONS
 
@@ -25,6 +28,11 @@ Possible values are "never", "always" and "auto". (default: auto)
 
 #### **--help**, **-h**
 Show this help message and exit
+
+#### **--interactive**, **-i**
+Continue to interactive chat mode after processing stdin or prompt arguments.
+By default, when arguments or piped input are provided, the command exits after
+displaying the response. This flag allows you to continue chatting interactively.
 
 #### **--list**
 List the available models at an endpoint
@@ -104,6 +112,13 @@ $ ramalama chat
 🦭 > Hi \
 🦭 > tell me a funny story \
 🦭 > please
+
+Send an initial prompt via stdin and continue chatting
+$ echo "What is 2+2?" | ramalama chat --interactive
+4
+🦭 > Now multiply that by 3
+12
+🦭 > /bye
 ```
 
 Clear conversation history during a chat session (commands are case-insensitive)

--- a/docs/ramalama-run.1.md
+++ b/docs/ramalama-run.1.md
@@ -95,6 +95,11 @@ Accelerated images:
 |  ASCEND_VISIBLE_DEVICES | quay.io/ramalama/cann      |
 |  MUSA_VISIBLE_DEVICES   | quay.io/ramalama/musa      |
 
+#### **--interactive**, **-i**
+Continue to interactive chat mode after processing stdin or prompt arguments.
+By default, when arguments or piped input are provided, the command exits after
+displaying the response. This flag allows you to continue chatting interactively.
+
 #### **--keep-groups**
 pass --group-add keep-groups to podman (default: False)
 If GPU device on host system is accessible to user via group access, this option leaks the groups into the container.
@@ -212,8 +217,10 @@ require HTTPS and verify certificates when contacting OCI registries
 ## DESCRIPTION
 Run specified AI Model as a chat bot. RamaLama pulls specified AI Model from
 registry if it does not exist in local storage. By default a prompt for a chat
-bot is started. When arguments are specified, the arguments will be given
-to the AI Model and the output returned without entering the chatbot.
+bot is started. When arguments or stdin are provided, they will be given
+to the AI Model and the output is returned. By default, the command exits after
+displaying the response, but you can use **--interactive** (**-i**) to continue
+to an interactive chat session after processing the initial prompt.
 
 ## INTERACTIVE COMMANDS
 
@@ -256,6 +263,15 @@ Run command with a custom port to allow multiple models running simultaneously
 ```
 ramalama run --port 8081 granite
 >
+```
+
+Send an initial prompt via stdin and continue chatting interactively
+```
+$ echo "Explain quantum computing" | ramalama run -i granite
+[AI response...]
+> Can you give me an example?
+[AI response...]
+> /bye
 ```
 
 ```

--- a/ramalama/chat.py
+++ b/ramalama/chat.py
@@ -5,6 +5,7 @@ import cmd
 import copy
 import itertools
 import json
+import os
 import signal
 import subprocess
 import sys
@@ -409,9 +410,16 @@ class RamaLamaShell(cmd.Cmd):
             return None
 
     def handle_args(self, monitor):
+        """Process command-line arguments and/or stdin input.
+
+        Returns True if the program should exit, False if it should continue to interactive mode.
+        """
         prompt = " ".join(self.args.ARGS) if self.args.ARGS else None
+        stdin_was_pipe = False
+
         if not sys.stdin.isatty():
             stdin = sys.stdin.read()
+            stdin_was_pipe = True
             if prompt:
                 prompt += f"\n\n{stdin}"
             else:
@@ -419,6 +427,23 @@ class RamaLamaShell(cmd.Cmd):
 
         if prompt:
             self.default(prompt)
+            # Continue to interactive mode if --interactive flag is set
+            if getattr(self.args, 'interactive', False):
+                # If stdin was a pipe, we need to reopen the terminal for interactive input
+                if stdin_was_pipe:
+                    try:
+                        # Use platform-specific terminal device
+                        # Windows: 'CON', Unix/Linux: '/dev/tty'
+                        terminal_device = 'CON' if os.name == 'nt' else '/dev/tty'
+                        sys.stdin = open(terminal_device, 'r')
+                    except (OSError, FileNotFoundError) as e:
+                        perror(f"Cannot open terminal for interactive mode: {e}")
+                        monitor.stop()
+                        self.kills()
+                        return True
+                print("")
+                return False
+            # Default behavior: exit after displaying response
             monitor.stop()
             self.kills()
             return True

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -1219,6 +1219,12 @@ def chat_run_options(parser):
         metavar="N",
         help="automatically summarize conversation history after N messages to prevent context growth (0=disabled)",
     )
+    parser.add_argument(
+        "-i",
+        "--interactive",
+        action="store_true",
+        help="continue to interactive chat mode after processing stdin or prompt arguments",
+    )
 
 
 def _chat_cli(args):

--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -168,7 +168,9 @@ def run_cmd(
     if env:
         env = os.environ | env
 
-    result = subprocess.run(args, check=True, cwd=cwd, stdout=sout, stderr=serr, stdin=subprocess.DEVNULL, encoding=encoding, env=env)
+    result = subprocess.run(
+        args, check=True, cwd=cwd, stdout=sout, stderr=serr, stdin=subprocess.DEVNULL, encoding=encoding, env=env
+    )
     logger.debug(f"Command finished with return code: {result.returncode}")
 
     return result

--- a/ramalama/engine.py
+++ b/ramalama/engine.py
@@ -487,7 +487,6 @@ def is_healthy(args, timeout: int = 3, model_name: str | None = None):
 
 def wait_for_healthy(args, health_func: Callable[[Any], bool], timeout=None):
     """Waits for a container to become healthy by polling its endpoint."""
-    config = get_config()
     if timeout is None:
         timeout = 180
     logger.debug(f"Waiting for container {args.name} to become healthy (timeout: {timeout}s)...")


### PR DESCRIPTION
Ensure any subprocesses spawned via run_cmd do not inherit stdin as they can read from our pipe.

Also make the wait_for_healthy logic more robust on windows.

## Summary by Sourcery

Prevent subprocesses from inheriting stdin and improve container health check robustness and timeout handling.

Bug Fixes:
- Prevent subprocesses spawned via run_cmd from reading from the parent process stdin pipe by explicitly redirecting stdin to /dev/null.
- Handle TimeoutError in wait_for_healthy health checks so transient timeouts do not break the readiness loop and use a consistent default timeout across runtimes.