### PR TITLE
README: fix description of "version" sub-command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1167,7 +1167,7 @@ $ cat /usr/share/ramalama/shortnames.conf
 </details>
 
 ### [`ramalama-version`](https://github.com/containers/ramalama/blob/main/docs/ramalama-version.1.md)
-#### Display version of the AI Model.
+#### Display version of RamaLama.
 - <details>
     <summary>
         Print the version of RamaLama.


### PR DESCRIPTION
This subcommand prints the version of the ramalama software, not the
model version.

Signed-off-by: Ken Dreyer <kdreyer@redhat.com>

## Summary by Sourcery

Documentation:
- Update `ramalama-version` README section to correctly describe the subcommand as displaying the RamaLama software program version.