### PR TITLE
Redirect inference runtime std filehandles to null when nocontainer

### DIFF
--- a/ramalama/transports/base.py
+++ b/ramalama/transports/base.py
@@ -563,6 +563,9 @@ class Transport(TransportBase):
 
         process = subprocess.Popen(
             cmd,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
         )
         return process
 


### PR DESCRIPTION
Fixes: #2463

## Summary by Sourcery

Bug Fixes:
- Prevent non-container inference subprocesses from inheriting and using the parent process's standard input, output, and error streams.