### PR TITLE
Resolves mlx regression identified in issue #2465

### DIFF
--- a/ramalama/chat_providers/base.py
+++ b/ramalama/chat_providers/base.py
@@ -2,7 +2,7 @@ import json
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, TypedDict
 from urllib import error as urllib_error
 from urllib import request as urllib_request
 
@@ -10,20 +10,41 @@ from ramalama.chat_utils import ChatMessageType
 from ramalama.config import get_config
 
 
+class RequiredChatRequestOptionsDict(TypedDict):
+    stream: bool
+
+
+class ChatRequestOptionsDict(RequiredChatRequestOptionsDict, total=False):
+    model: str
+    temperature: float
+    max_tokens: int
+
+
 @dataclass(slots=True)
 class ChatRequestOptions:
     """Normalized knobs for building a chat completion request."""
 
-    model: str | None = None
+    model: str | None
+    stream: bool = True
     temperature: float | None = None
     max_tokens: int | None = None
-    stream: bool = True
     extra: dict[str, Any] | None = None
 
-    def to_dict(self) -> dict[str, Any]:
-        keys = ["model", "temperature", "max_tokens", "stream"]
-        result = {k: v for k in keys if (v := getattr(self, k)) is not None}
-        result |= {} if self.extra is None else dict(self.extra)
+    def to_dict(self) -> ChatRequestOptionsDict:
+        result: ChatRequestOptionsDict = {'stream': self.stream}
+
+        if self.temperature is not None:
+            result['temperature'] = self.temperature
+        if self.max_tokens is not None:
+            result['max_tokens'] = self.max_tokens
+        if self.model is not None:
+            result['model'] = self.model
+
+        if self.extra is not None:
+            # Can't easily type this without access to open TypedDicts
+            # https://typing.python.org/en/latest/spec/glossary.html#term-closed
+            result |= self.extra  # type: ignore
+
         return result
 
 

--- a/ramalama/chat_providers/openai.py
+++ b/ramalama/chat_providers/openai.py
@@ -72,12 +72,15 @@ def _(message: AssistantMessage) -> dict[str, Any]:
     return {**message.metadata, 'content': message.text or "", 'role': message.role, 'tool_calls': tool_calls}
 
 
-class CompletionsPayload(TypedDict, total=False):
+class RequiredCompletionsPayload(TypedDict):
     messages: list[dict[str, Any]]
-    model: str | None
-    temperature: float | None
-    max_tokens: int | None
     stream: bool
+
+
+class CompletionsPayload(RequiredCompletionsPayload, total=False):
+    model: str
+    temperature: float
+    max_tokens: int
 
 
 class OpenAICompletionsChatProvider(ChatProvider):
@@ -91,10 +94,7 @@ class OpenAICompletionsChatProvider(ChatProvider):
     def build_payload(self, messages: Sequence[ChatMessageType], options: ChatRequestOptions) -> CompletionsPayload:
         payload: CompletionsPayload = {
             "messages": [message_to_completions_dict(m) for m in messages],
-            "model": options.model,
-            "temperature": options.temperature,
-            "max_tokens": options.max_tokens,
-            "stream": options.stream,
+            **options.to_dict(),
         }
         return payload
 

--- a/ramalama/shortnames.py
+++ b/ramalama/shortnames.py
@@ -33,8 +33,12 @@ class Shortnames:
             # Unix-specific paths using XDG conventions
             file_paths.extend(
                 [
-                    os.path.expanduser(os.path.join(os.getenv("XDG_CONFIG_HOME", "~/.config"), "ramalama/shortnames.conf")),
-                    os.path.expanduser(os.path.join(os.getenv("XDG_DATA_HOME", "~/.local/share"), "ramalama/shortnames.conf")),
+                    os.path.expanduser(
+                        os.path.join(os.getenv("XDG_CONFIG_HOME", "~/.config"), "ramalama/shortnames.conf")
+                    ),
+                    os.path.expanduser(
+                        os.path.join(os.getenv("XDG_DATA_HOME", "~/.local/share"), "ramalama/shortnames.conf")
+                    ),
                     os.path.expanduser("~/.local/pipx/venvs/ramalama/share/ramalama/shortnames.conf"),
                     "/etc/ramalama/shortnames.conf",
                     "/usr/share/ramalama/shortnames.conf",


### PR DESCRIPTION
MLX validates request arguments like `max_tokens` more strictly than standard openai completions endpoints. This drops optional values instead of passing null.

## Summary by Sourcery

Normalize chat completion request options so that only defined values are sent while always including the stream flag, and use this normalized options dict when building OpenAI chat completion payloads.

Bug Fixes:
- Avoid sending null-valued chat completion parameters like max_tokens by omitting unset optional fields from the request payload.

Enhancements:
- Introduce typed request option dictionaries for chat requests and OpenAI completions to better reflect required versus optional fields.
- Refine shortnames configuration path construction for readability without altering behavior.