### PR TITLE
Resolves tighter mlx message validation for multiturn discussions

### DIFF
--- a/ramalama/chat_providers/openai.py
+++ b/ramalama/chat_providers/openai.py
@@ -58,18 +58,22 @@ def _(message: AssistantMessage) -> dict[str, Any]:
     if message.attachments:
         raise ValueError("Attachments are not supported by this provider.")
 
-    tool_calls = [
-        {
-            "id": call.id,
-            "type": "function",
-            "function": {
-                "name": call.name,
-                "arguments": json.dumps(call.arguments, ensure_ascii=False),
-            },
-        }
-        for call in message.tool_calls
-    ]
-    return {**message.metadata, 'content': message.text or "", 'role': message.role, 'tool_calls': tool_calls}
+    payload = {**message.metadata, 'content': message.text or "", 'role': message.role}
+
+    if message.tool_calls:
+        payload['tool_calls'] = [
+            {
+                "id": call.id,
+                "type": "function",
+                "function": {
+                    "name": call.name,
+                    "arguments": json.dumps(call.arguments, ensure_ascii=False),
+                },
+            }
+            for call in message.tool_calls
+        ]
+
+    return payload
 
 
 class RequiredCompletionsPayload(TypedDict):


### PR DESCRIPTION
This resolves a bug with multi-turn conversations running on the MLX engine. Currently, on the conversations path assistant messages are passed with an empty list of tool_calls but mlx expects that field to instead be omitted.

## Summary by Sourcery

Bug Fixes:
- Fix multi-turn MLX conversations failing due to assistant messages including an empty tool_calls field instead of omitting it when no tool calls are present.