### PR TITLE
Fix selinux denial when building container images

### DIFF
--- a/container-images/asahi/Containerfile
+++ b/container-images/asahi/Containerfile
@@ -8,8 +8,8 @@ RUN ./build_llama.sh asahi
 
 FROM quay.io/fedora/fedora:43
 
-RUN --mount=type=bind,from=builder,source=/tmp/install,target=/tmp/install \
+RUN --mount=type=bind,from=builder,source=/tmp/install,target=/tmp/install,relabel=private \
     cp -a /tmp/install/bin/ /usr/ && \
     cp -a /tmp/install/lib64/*.so* /usr/lib64/
-RUN --mount=type=bind,target=/src \
+RUN --mount=type=bind,target=/src,relabel=private \
     /src/container-images/scripts/build_llama.sh asahi runtime

--- a/container-images/cann/Containerfile
+++ b/container-images/cann/Containerfile
@@ -10,7 +10,7 @@ WORKDIR /src/
 RUN ./build_llama.sh cann
 
 FROM quay.io/ascend/${ASCEND_VERSION}
-RUN --mount=type=bind,from=builder,source=/tmp/install,target=/tmp/install \
+RUN --mount=type=bind,from=builder,source=/tmp/install,target=/tmp/install,relabel=private \
     cp -a /tmp/install/bin/ /usr/ && \
     cp -a /tmp/install/lib64/*.so* /usr/lib64/
 ENTRYPOINT [ \

--- a/container-images/common/Containerfile.rag
+++ b/container-images/common/Containerfile.rag
@@ -19,5 +19,5 @@ COPY container-images/scripts/doc2rag \
 ADD --chmod=755 https://github.com/ggml-org/llama.cpp/raw/refs/tags/b7872/convert_hf_to_gguf.py \
     /usr/bin/
 
-RUN --mount=type=bind,target=/src\
+RUN --mount=type=bind,target=/src,relabel=private \
     /src/container-images/scripts/build_rag.sh $TORCH_BACKEND

--- a/container-images/cuda/Containerfile
+++ b/container-images/cuda/Containerfile
@@ -11,14 +11,14 @@ RUN ./build_llama.sh cuda
 # Final runtime image
 FROM docker.io/nvidia/cuda:${CUDA_VERSION}-runtime-ubi9
 
-RUN --mount=type=bind,from=builder,source=/tmp/install,target=/tmp/install \
+RUN --mount=type=bind,from=builder,source=/tmp/install,target=/tmp/install,relabel=private \
     cp -a /tmp/install/bin/ /usr/ && \
     cp -a /tmp/install/lib64/*.so* /usr/lib64/
-RUN --mount=type=bind,target=/src \
+RUN --mount=type=bind,target=/src,relabel=private \
     /src/container-images/scripts/build_llama.sh cuda runtime
 
 # Install ramalama to support a non-standard use-case
-RUN --mount=type=bind,target=/src \
+RUN --mount=type=bind,target=/src,relabel=private \
     cp -a /src /var/tmp/ramalama && \
     python3 -m pip \
       --no-cache-dir \

--- a/container-images/intel-gpu/Containerfile
+++ b/container-images/intel-gpu/Containerfile
@@ -9,11 +9,11 @@ RUN ./build_llama.sh intel-gpu
 
 FROM quay.io/fedora/fedora:43
 
-RUN --mount=type=bind,from=builder,source=/tmp/install,target=/tmp/install \
+RUN --mount=type=bind,from=builder,source=/tmp/install,target=/tmp/install,relabel=private \
     cp -a /tmp/install/bin/ /usr/ && \
     cp -a /tmp/install/lib64/*.so* /usr/lib64/
 COPY container-images/intel-gpu/oneAPI.repo /etc/yum.repos.d/
-RUN --mount=type=bind,target=/src \
+RUN --mount=type=bind,target=/src,relabel=private \
     /src/container-images/scripts/build_llama.sh intel-gpu runtime
 
 COPY --chmod=755 container-images/intel-gpu/entrypoint.sh /usr/bin/

--- a/container-images/ramalama/Containerfile
+++ b/container-images/ramalama/Containerfile
@@ -8,14 +8,14 @@ RUN ./build_llama.sh ramalama
 
 FROM quay.io/fedora/fedora:43
 
-RUN --mount=type=bind,from=builder,source=/tmp/install,target=/tmp/install \
+RUN --mount=type=bind,from=builder,source=/tmp/install,target=/tmp/install,relabel=private \
     cp -a /tmp/install/bin/ /usr/ && \
     cp -a /tmp/install/lib64/*.so* /usr/lib64/
-RUN --mount=type=bind,target=/src \
+RUN --mount=type=bind,target=/src,relabel=private \
     /src/container-images/scripts/build_llama.sh ramalama runtime
 
 # Install ramalama to support a non-standard use-case
-RUN --mount=type=bind,target=/src \
+RUN --mount=type=bind,target=/src,relabel=private \
     cp -a /src /var/tmp/ramalama && \
     python3 -m pip \
       --no-cache-dir \

--- a/container-images/rocm/Containerfile
+++ b/container-images/rocm/Containerfile
@@ -8,9 +8,9 @@ RUN ./build_llama.sh rocm
 
 FROM quay.io/fedora/fedora:43
 
-RUN --mount=type=bind,from=builder,source=/tmp/install,target=/tmp/install \
+RUN --mount=type=bind,from=builder,source=/tmp/install,target=/tmp/install,relabel=private \
     cp -a /tmp/install/bin/ /usr/ && \
     cp -a /tmp/install/lib64/*.so* /usr/lib64/
 
-RUN --mount=type=bind,target=/src \
+RUN --mount=type=bind,target=/src,relabel=private \
     /src/container-images/scripts/build_llama.sh rocm runtime


### PR DESCRIPTION
Relabel when using `RUN --mount=type=bind` to fix selinux denials.

## Summary by Sourcery

Bug Fixes:
- Add SELinux private relabeling to bind mounts used during container image builds to prevent access denials.