### PR TITLE
Revert #2455 "Use hardlink for local model files to save disk space"

### DIFF
--- a/ramalama/transports/url.py
+++ b/ramalama/transports/url.py
@@ -1,10 +1,11 @@
 import os
 import re
+import shutil
 from pathlib import Path
 
 from ramalama.common import SPLIT_MODEL_PATH_RE, generate_sha256, is_split_file_model
 from ramalama.model_store.snapshot_file import SnapshotFile, SnapshotFileType
-from ramalama.path_utils import create_file_link, normalize_host_path_for_container
+from ramalama.path_utils import normalize_host_path_for_container
 from ramalama.transports.base import Transport
 from ramalama.transports.huggingface import HuggingfaceRepository
 from ramalama.transports.modelscope import ModelScopeRepository
@@ -35,8 +36,8 @@ class LocalModelFile(SnapshotFile):
     def download(self, blob_file_path, snapshot_dir):
         if not os.path.exists(self.url):
             raise FileNotFoundError(f"No such file: '{self.url}'")
-        # Use hardlink first (space-efficient), fallback to symlink, then copy if needed
-        create_file_link(self.url, blob_file_path)
+        # moving from the local location to blob directory so the model store "owns" the data
+        shutil.copy(self.url, blob_file_path)
         return os.path.relpath(blob_file_path, start=snapshot_dir)
 
 

--- a/test/unit/test_url.py
+++ b/test/unit/test_url.py
@@ -1,10 +1,9 @@
-import os
 from dataclasses import dataclass, field
 
 import pytest
 
 from ramalama.model_store.snapshot_file import SnapshotFile
-from ramalama.transports.url import URL, LocalModelFile
+from ramalama.transports.url import URL
 
 
 @dataclass
@@ -57,29 +56,3 @@ def test__assemble_split_file_list(input: Input, expected: Expected):
     for i in range(file_count):
         assert files[i].url == expected.URLList[i]
         assert files[i].name == expected.Names[i]
-
-
-def test_local_model_file_uses_hardlink(tmp_path):
-    """Test that LocalModelFile.download() uses hardlink instead of copy to save disk space."""
-    # Create a test model file
-    src_file = tmp_path / "test_model.gguf"
-    src_file.write_text("test model content")
-
-    dest_file = tmp_path / "dest_model.gguf"
-
-    # Create LocalModelFile and download
-    lmf = LocalModelFile(
-        url=str(src_file),
-        header={},
-        model_file_hash="test_hash",
-        name="test_model.gguf",
-    )
-    lmf.download(str(dest_file), str(tmp_path))
-
-    # Verify files are hardlinked (same inode means no disk space duplication)
-    src_stat = os.stat(src_file)
-    dest_stat = os.stat(dest_file)
-
-    assert src_stat.st_ino == dest_stat.st_ino, "Files should be hardlinked (same inode)"
-    assert src_stat.st_nlink == 2, "Should have 2 links to the same inode"
-    assert dest_file.read_text() == "test model content", "Content should be accessible"


### PR DESCRIPTION
e2e ci has been failing on main since #2455 was merged.

This reverts commit 902ba6e67c46318ddd04a4c00f74b195a6e1676c.

## Summary by Sourcery

Revert the change that made local model file downloads use hardlinks and restore copying behavior, removing the associated hardlink-specific test.

Bug Fixes:
- Restore copy-based downloading for local model files to address CI failures caused by hardlink usage.

Tests:
- Remove the unit test that asserted LocalModelFile.download() used hardlinks instead of copying.