### PR TITLE
Adds compose generator for llama-stack

### DIFF
--- a/ramalama/stack.py
+++ b/ramalama/stack.py
@@ -4,13 +4,13 @@ import platform
 
 import ramalama.kube as kube
 import ramalama.quadlet as quadlet
-from ramalama.command.factory import assemble_command
 from ramalama.common import check_nvidia, exec_cmd, genname, get_accel_env_vars, tagged_image
 from ramalama.compat import NamedTemporaryFile
 from ramalama.compose import Compose
 from ramalama.config import get_config
 from ramalama.engine import add_labels
 from ramalama.path_utils import normalize_host_path_for_container
+from ramalama.plugins.loader import assemble_command
 from ramalama.transports.base import compute_serving_port
 from ramalama.transports.transport_factory import New
 
@@ -253,7 +253,7 @@ spec:
                 file.write(self.args.generate.output_dir)
                 return
 
-        if not os.path.basename(args.engine).startswith("podman"):
+        if not os.path.basename(self.args.engine).startswith("podman"):
             raise ValueError("llama-stack requires use of the Podman container engine")
         with NamedTemporaryFile(
             mode='w', prefix='RamaLama_', delete=not self.args.debug, delete_on_close=False
@@ -274,7 +274,7 @@ spec:
             exec_cmd(exec_args)
 
     def stop(self):
-        if not os.path.basename(args.engine).startswith("podman"):
+        if not os.path.basename(self.args.engine).startswith("podman"):
             raise ValueError("llama-stack requires use of the Podman container engine")
         with NamedTemporaryFile(
             mode='w', prefix='RamaLama_', delete=not self.args.debug, delete_on_close=False

--- a/test/e2e/test_serve.py
+++ b/test/e2e/test_serve.py
@@ -708,6 +708,43 @@ def test_kube_generation_with_llama_api(test_model):
             assert re.search(r".*/llama-stack", content)
 
 
+@pytest.mark.e2e
+@skip_if_no_container
+def test_compose_generation_with_llama_api(test_model):
+    with RamalamaExecWorkspace() as ctx:
+        # Pull model
+        ctx.check_call(["ramalama", "pull", test_model])
+
+        # Exec ramalama serve
+        result = ctx.check_output(
+            [
+                "ramalama",
+                "serve",
+                "--name",
+                "test",
+                "--port",
+                "1234",
+                "--generate",
+                "compose",
+                "--api",
+                "llama-stack",
+                "--dri",
+                "off",
+                test_model,
+            ]
+        )
+
+        # Test the expected output of the command execution
+        assert re.search(r".*Generating Compose YAML file: docker-compose.yaml", result)
+
+        # Check "docker-compose.yaml" contents
+        with (Path(ctx.workspace_dir) / "docker-compose.yaml").open("r") as f:
+            content = f.read()
+            assert re.search(r".*llama-server", content)
+            assert re.search(r".*\"1234:8123\"", content)
+            assert re.search(r".*/llama-stack", content)
+
+
 @pytest.mark.skip(reason="pulls very large image")
 @pytest.mark.e2e
 @skip_if_docker


### PR DESCRIPTION
resolves #2446

## Summary by Sourcery

Add support for generating Docker Compose configuration for llama-stack alongside existing generation options.

New Features:
- Introduce a new `compose` generate type that outputs a Docker Compose file wiring the model service with a llama-stack sidecar service.

Enhancements:
- Allow the `quadlet` generate type as an alias for `quadlet/kube` and update generated Kubernetes metadata and comments to use the model alias instead of the full model object.