### PR TITLE
version is a subcommand

### DIFF
--- a/docs/MACOS_INSTALL.md
+++ b/docs/MACOS_INSTALL.md
@@ -40,7 +40,7 @@ The installer places files in:
 
 ```bash
 # Check version
-ramalama --version
+ramalama version
 
 # Get help
 ramalama --help
@@ -182,7 +182,7 @@ Once installed, try these commands:
 
 ```bash
 # Check version
-ramalama --version
+ramalama version
 
 # Pull a model
 ramalama pull tinyllama

--- a/scripts/build_macos_pkg.sh
+++ b/scripts/build_macos_pkg.sh
@@ -157,7 +157,7 @@ echo "Location: /usr/local/bin/ramalama"
 echo ""
 echo "Next steps:"
 echo "  1. Restart your terminal or run: source ~/.zshrc"
-echo "  2. Verify installation: ramalama --version"
+echo "  2. Verify installation: ramalama version"
 echo "  3. Get help: ramalama --help"
 echo ""
 

--- a/scripts/macos-installer/conclusion.html
+++ b/scripts/macos-installer/conclusion.html
@@ -7,7 +7,7 @@
 <h2>Next Steps:</h2>
 <ol>
     <li>Restart your terminal or run: <code>source ~/.zshrc</code></li>
-    <li>Verify installation: <code>ramalama --version</code></li>
+    <li>Verify installation: <code>ramalama version</code></li>
     <li>Get help: <code>ramalama --help</code></li>
     <li>Pull a model: <code>ramalama pull tinyllama</code></li>
     <li>Run a chatbot: <code>ramalama run tinyllama</code></li>


### PR DESCRIPTION
See https://ramalama.ai/docs/commands/ramalama/version

## Summary by Sourcery

Update version check instructions to use the `version` subcommand instead of the `--version` flag across macOS docs and installer assets.

Build:
- Update macOS package build script messaging to reference `ramalama version` for installation verification.

Deployment:
- Adjust macOS installer conclusion screen to show `ramalama version` as the version verification command.

Documentation:
- Change macOS installation docs to instruct users to run `ramalama version` for version checks.