### PR TITLE
fix env config of kube and stack (kube case)

### DIFF
--- a/ramalama/kube.py
+++ b/ramalama/kube.py
@@ -166,9 +166,12 @@ class Kube:
 
         return ports
 
-    @staticmethod
-    def __gen_env_vars():
+    def __gen_env_vars(self):
         env_vars = get_accel_env_vars()
+
+        if hasattr(self.args, "env"):
+            extra_env = dict(i.split("=", 1) for i in self.args.env)
+            env_vars |= extra_env
 
         if not env_vars:
             return ""
@@ -176,7 +179,7 @@ class Kube:
         env_spec = """\
         env:"""
 
-        for k, v in env_vars.items():
+        for k, v in sorted(env_vars.items()):
             env_spec += f"""
         - name: {k}
           value: \"{v}\""""

--- a/ramalama/stack.py
+++ b/ramalama/stack.py
@@ -78,20 +78,32 @@ class Stack:
         name: {name}"""
         return volumes
 
-    def _gen_server_env(self):
-        server_env = ""
+    def _get_env_vars(self):
+        env_vars = {}
         if hasattr(self.args, "env"):
-            for env in self.args.env:
-                server_env += f"\n{env}"
+            for e in self.args.env:
+                env = e.split("=", 1)
+                env_vars[env[0]] = env[1]
+        return env_vars
 
-        for k, v in get_accel_env_vars().items():
-            # Special case for Cuda
-            if k == "MUSA_VISIBLE_DEVICES":
-                server_env += "\nMTHREADS_VISIBLE_DEVICES=all"
-                continue
-            server_env += f"""\n        - name: {k}
+    def _gen_compose_env(self, env_vars):
+        compose_env = ""
+        for k, v in env_vars.items():
+            compose_env += f"""\n      - {k}={v}"""
+        return compose_env
+
+    def _gen_kube_env(self, env_vars):
+        kube_env = ""
+        for k, v in env_vars.items():
+            kube_env += f"""\n        - name: {k}
           value: {v}"""
-        return server_env
+        return kube_env
+
+    def _gen_server_env(self):
+        accel_env_vars = get_accel_env_vars()
+        if "MUSA_VISIBLE_DEVICES" in accel_env_vars:
+            accel_env_vars["MTHREADS_VISIBLE_DEVICES"] = "all"
+        return self._gen_kube_env(accel_env_vars)
 
     def _gen_security_context(self):
         return """
@@ -144,6 +156,8 @@ class Stack:
         llama_args = self._gen_llama_args()
         resources = self._gen_resources()
         security = self._gen_security_context()
+        env_vars = self._get_env_vars()
+        common_env = self._gen_kube_env(env_vars)
         server_env = self._gen_server_env()
         volume_mounts = self._gen_volume_mounts()
         volumes = self._gen_volumes()
@@ -171,7 +185,7 @@ spec:
         command:
         - {llama_args}\
         {security}
-        env:{server_env}\
+        env:{common_env}{server_env}\
         {resources}
         volumeMounts:{volume_mounts}
       - name: llama-stack
@@ -183,7 +197,7 @@ spec:
         - --image-type
         - venv
         - /etc/ramalama/ramalama-run.yaml
-        env:
+        env:{common_env}
         - name: RAMALAMA_URL
           value: http://127.0.0.1:{self.model_port}
         - name: INFERENCE_MODEL
@@ -240,15 +254,16 @@ spec:
                     exec_args,
                 )
                 file = compose.generate()
+                compose_env = self._gen_compose_env(self._get_env_vars())
                 file.content += f"""
   {self.model.model_name}-stack:
     image: {self.stack_image}
     container_name: {self.name}-stack
     ports:
       - "{stack_port}:8123"
-    environment:
-      RAMALAMA_URL: http://{self.name}:{self.model_port}
-      INFERENCE_MODEL: "{self.model.model_alias}"
+    environment:{compose_env}
+      - RAMALAMA_URL=http://{self.name}:{self.model_port}
+      - INFERENCE_MODEL={self.model.model_alias}
     depends_on:
       - {self.model.model_name}
     restart: unless-stopped"""

--- a/test/e2e/test_serve.py
+++ b/test/e2e/test_serve.py
@@ -596,7 +596,7 @@ def test_quadlet_and_kube_generation_with_container_registry(container_registry,
         )
     ],
 )
-def test_serve_kube_generation(test_model, generate, env_vars):
+def test_serve_generation(test_model, generate, env_vars):
     with RamalamaExecWorkspace(env_vars=env_vars) as ctx:
         # Pull model
         ctx.check_call(["ramalama", "pull", test_model])
@@ -672,12 +672,25 @@ def test_serve_kube_generation(test_model, generate, env_vars):
 
 @pytest.mark.e2e
 @skip_if_no_container
-@skip_if_docker
-def test_kube_generation_with_llama_api(test_model):
+@pytest.mark.parametrize(
+    "generate, env_vars",
+    [
+        pytest.param(
+            *item,
+            id=f"generate={item[0]}{' + env_vars' if item[1] else ''}",
+        )
+        for item in itertools.product(
+            ["kube", "compose"],
+            [None, "SEARCH_API_KEY=9999"]
+        )
+    ],
+)
+def test_serve_generation_with_llama_api(test_model, generate, env_vars):
     with RamalamaExecWorkspace() as ctx:
         # Pull model
         ctx.check_call(["ramalama", "pull", test_model])
 
+        extra_args = ["--env", env_vars] if env_vars else []
         # Exec ramalama serve
         result = ctx.check_output(
             [
@@ -688,61 +701,47 @@ def test_kube_generation_with_llama_api(test_model):
                 "--port",
                 "1234",
                 "--generate",
-                "kube",
+                generate,
                 "--api",
                 "llama-stack",
                 "--dri",
                 "off",
                 test_model,
-            ]
+            ] + extra_args
         )
 
-        # Test the expected output of the command execution
-        assert re.search(r".*Generating Kubernetes YAML file: test.yaml", result)
+        if generate == 'kube':
+            # Test the expected output of the command execution
+            assert re.search(r".*Generating Kubernetes YAML file: test.yaml", result)
+            # Check "test.yaml" contents
+            with (Path(ctx.workspace_dir) / "test.yaml").open("r") as f:
+                content = f.read()
+                assert re.search(r".*llama-server", content)
+                assert re.search(r".*hostPort: 1234", content)
+                assert re.search(r".*/llama-stack", content)
 
-        # Check "test.yaml" contents
-        with (Path(ctx.workspace_dir) / "test.yaml").open("r") as f:
-            content = f.read()
-            assert re.search(r".*llama-server", content)
-            assert re.search(r".*hostPort: 1234", content)
-            assert re.search(r".*/llama-stack", content)
+                if env_vars:
+                    assert len(re.findall(r"name: SEARCH_API_KEY", content)) == 2
+                    assert len(re.findall(r"value: 9999", content)) == 2
+                else:
+                    assert not re.search(r".*name: SEARCH_API_KEY", content)
+                    assert not re.search(r".*value: 9999", content)
 
+        elif generate == 'compose':
+            # Test the expected output of the command execution
+            assert re.search(r".*Generating Compose YAML file: docker-compose.yaml", result)
 
-@pytest.mark.e2e
-@skip_if_no_container
-def test_compose_generation_with_llama_api(test_model):
-    with RamalamaExecWorkspace() as ctx:
-        # Pull model
-        ctx.check_call(["ramalama", "pull", test_model])
+            # Check "docker-compose.yaml" contents
+            with (Path(ctx.workspace_dir) / "docker-compose.yaml").open("r") as f:
+                content = f.read()
+                assert re.search(r".*llama-server", content)
+                assert re.search(r".*\"1234:8123\"", content)
+                assert re.search(r".*/llama-stack", content)
 
-        # Exec ramalama serve
-        result = ctx.check_output(
-            [
-                "ramalama",
-                "serve",
-                "--name",
-                "test",
-                "--port",
-                "1234",
-                "--generate",
-                "compose",
-                "--api",
-                "llama-stack",
-                "--dri",
-                "off",
-                test_model,
-            ]
-        )
-
-        # Test the expected output of the command execution
-        assert re.search(r".*Generating Compose YAML file: docker-compose.yaml", result)
-
-        # Check "docker-compose.yaml" contents
-        with (Path(ctx.workspace_dir) / "docker-compose.yaml").open("r") as f:
-            content = f.read()
-            assert re.search(r".*llama-server", content)
-            assert re.search(r".*\"1234:8123\"", content)
-            assert re.search(r".*/llama-stack", content)
+                if env_vars:
+                    assert len(re.findall(r"- SEARCH_API_KEY=9999", content)) == 2
+                else:
+                    assert not re.search(r".*- SEARCH_API_KEY=9999", content)
 
 
 @pytest.mark.skip(reason="pulls very large image")

--- a/test/unit/data/test_kube/with_env.yaml
+++ b/test/unit/data/test_kube/with_env.yaml
@@ -1,0 +1,53 @@
+# Save the output of this file and use kubectl create -f to import
+# it into Kubernetes.
+#
+# Created with ramalama-test-version
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ramalama
+  labels:
+    app: ramalama
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ramalama
+  template:
+    metadata:
+      labels:
+        app: ramalama
+    spec:
+      containers:
+      - name: ramalama
+        image: testimage
+        command: ["llama-server"]
+        args: ['--model', '/mnt/models/model.file']
+        env:
+        - name: API_KEY
+          value: "123456789"
+        - name: TEST_ENV
+          value: "test_value"
+
+        volumeMounts:
+        - mountPath: /mnt/models/model.file
+          name: model
+        - mountPath: /dev/accel
+          name: accel
+        - mountPath: /dev/dri
+          name: dri
+        - mountPath: /dev/kfd
+          name: kfd
+      volumes:
+      - hostPath:
+          path: /path/to/model.file
+        name: model
+      - hostPath:
+          path: /dev/accel
+        name: accel
+      - hostPath:
+          path: /dev/dri
+        name: dri
+      - hostPath:
+          path: /dev/kfd
+        name: kfd

--- a/test/unit/test_kube.py
+++ b/test/unit/test_kube.py
@@ -143,6 +143,18 @@ DATA_PATH = Path(__file__).parent / "data" / "test_kube"
             ),
             "with_mmproj.yaml",
         ),
+        (
+            Input(
+                model_name="tinyllama",
+                model_src_path="/path/to/model.file",
+                model_dest_path="/mnt/models/model.file",
+                model_file_exists=True,
+                args=Args(env=["API_KEY=123456789"]),
+                exec_args=["llama-server", "--model", "/mnt/models/model.file"],
+                artifact=False,
+            ),
+            "with_env.yaml",
+        ),
     ],
 )
 def test_kube_generate(input: Input, expected_file_name: str, monkeypatch):


### PR DESCRIPTION
This fixes following problem on generating kube/docker-compose config

- env variables via the cli like `-env SOME=thing` will generate a respective entry in the kube.yml without llama-stack
- the env variables from cli with generating kube.yml with llama-stack is fixed
- generated files with llama-stack now duplicates the env variables for both the model server as well the llama-stack server. This allows now to configure ENV for the ramalama-stack part like API-keys for the search tools like brave, tavily or wolfram-alpha, while generating the files.

## Summary by Sourcery

Allow CLI-provided environment variables to be propagated correctly into generated Kubernetes and Docker Compose configurations when using the llama-stack API, and ensure they are applied to both the model and stack services.

New Features:
- Support passing arbitrary CLI environment variables into generated Kubernetes manifests alongside accelerator-related env vars.
- Support passing arbitrary CLI environment variables into generated Docker Compose configurations for both the model service and the llama-stack service.

Bug Fixes:
- Fix omission of CLI-provided environment variables in Kubernetes YAML generation when using llama-stack.
- Fix inconsistent env var handling between Kubernetes and Docker Compose generation paths.

Enhancements:
- Unify and parameterize serve-generation tests across Kubernetes and Compose outputs with and without extra environment variables.
- Extend kube unit tests with coverage for env var generation and add a golden manifest including user-defined env vars.