### PR TITLE
container-images: update mesa version

### DIFF
--- a/container-images/scripts/build_llama.sh
+++ b/container-images/scripts/build_llama.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 DEFAULT_LLAMA_CPP_COMMIT="f76565db92272d98976d5b8b1809ebe1e079f8cd" # b8256
-MESA_VULKAN_VERSION=25.2.3-101.fc43
+MESA_VULKAN_VERSION=25.3.6-102.fc43
 
 dnf_install_intel_gpu() {
   local intel_rpms=("intel-oneapi-mkl-sycl-devel" "intel-oneapi-dnnl-devel"


### PR DESCRIPTION
Update the patched mesa version to one based on the latest vesrion packaged in Fedora 43.

## Summary by Sourcery

Update the Mesa Vulkan package version used in the llama container image build script to the latest Fedora 43-based release.

Enhancements:
- Align the llama build script with a newer patched Mesa Vulkan version from Fedora 43 for updated graphics stack support.

Build:
- Bump Mesa Vulkan RPM version reference in the llama container image build script.