### PR TITLE
Further fix for unreliable oci convert logic

### DIFF
--- a/ramalama/transports/oci/oci.py
+++ b/ramalama/transports/oci/oci.py
@@ -292,16 +292,15 @@ class OCI(Transport):
         imageid = self.build(source_model, args)
         if args.dryrun:
             imageid = "a1b2c3d4e5f6"
-        if not imageid.startswith("sha256:"):
-            imageid = f"sha256:{imageid}"
+        local_ref = f"containers-storage:{imageid}"
         try:
-            self._create_manifest(self.model, imageid, args)
+            self._create_manifest(self.model, local_ref, args)
         except subprocess.CalledProcessError as e:
             perror(f"""\
 Failed to create manifest for OCI {self.model} : {e}
 Tagging build instead
                 """)
-            self.tag(imageid, self.model, args)
+            self.tag(local_ref, self.model, args)
 
     def convert(self, source_model, args):
         self._convert(source_model, args)


### PR DESCRIPTION
test_quadlet_and_kube_generation_with_container_registry is failing intermittently.

The image_id is not the sha256 digest, remove it as it was trying to pull
the sha256 image.

Also adds the containers-storage prefix to ensure the reference is considered
local.

Follow-up to #2536

Assisted-by: Claude [noreply@anthropic.com](mailto:noreply@anthropic.com)

## Summary by Sourcery

Bug Fixes:
- Prevent OCI conversion from incorrectly treating image IDs as sha256 digests by using a containers-storage-prefixed local reference for manifest creation and tagging.