### PR TITLE
Add: support ramalama --version flag

### DIFF
--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -305,6 +305,12 @@ The RAMALAMA_IN_CONTAINER environment variable modifies default behaviour.""",
         help="store AI Models in the specified directory",
     )
     parser.add_argument(
+        "--version",
+        "-V",
+        action="store_true",
+        help="display version of RamaLama",
+    )
+    parser.add_argument(
         "--noout",
         help=argparse.SUPPRESS,
     )
@@ -338,6 +344,11 @@ def configure_subcommands(parser):
 
 def post_parse_setup(args):
     """Perform additional setup after parsing arguments."""
+    # Handle --version flag early
+    if getattr(args, 'version', False):
+        print_version(args)
+        sys.exit(0)
+
     if getattr(args, "subcommand", None) == "benchmark":
         args.subcommand = "bench"
 

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -100,6 +100,30 @@ def test_help(args: list):
         help_cli(args)
 
 
+def test_version_flag(capsys):
+    """Test that --version flag displays version and exits."""
+    from ramalama.cli import parse_args_from_cmd
+
+    with pytest.raises(SystemExit) as exc_info:
+        parse_args_from_cmd(["--version"])
+
+    assert exc_info.value.code == 0
+    captured = capsys.readouterr()
+    assert "ramalama version" in captured.out or "0." in captured.out
+
+
+def test_version_short_flag(capsys):
+    """Test that -V is an alias for --version."""
+    from ramalama.cli import parse_args_from_cmd
+
+    with pytest.raises(SystemExit) as exc_info:
+        parse_args_from_cmd(["-V"])
+
+    assert exc_info.value.code == 0
+    captured = capsys.readouterr()
+    assert "ramalama version" in captured.out or "0." in captured.out
+
+
 # Test human readable size
 @pytest.mark.parametrize(
     "size, expected",


### PR DESCRIPTION
## Description
This PR adds support for the standard `--version` flag to the RamaLama CLI, complementing the existing `version` subcommand.

## Changes
- Adds `--version` and `-V` flags to global arguments
- Handles flag in `post_parse_setup()` to exit early with version output
- Adds unit tests for both flag variants

## Testing
Tests pass: `pytest test/unit/test_cli.py -k version`
Linting passes: `make validate`

Fixes #2537

## Summary by Sourcery

Add global CLI support for printing the RamaLama version via a standard flag and ensure it exits cleanly after output.

New Features:
- Introduce global --version and -V flags to display the RamaLama CLI version and exit immediately.

Tests:
- Add unit tests verifying that both --version and -V print a version string and terminate with exit code 0.