### PR TITLE
feat(container): rewrite of openvino container

### DIFF
--- a/container-images/openvino/Containerfile
+++ b/container-images/openvino/Containerfile
@@ -1,19 +1,50 @@
-FROM registry.access.redhat.com/ubi9/ubi:9.7-1775624009
+# OpenVINO container build
+#
+# Uses Fedora 44 as the base image with OpenVINO installed from the upstream
+# tarball release. Fedora 44 provides intel-opencl 26.x and ocl-icd natively,
+# avoiding the need to pull packages from Rawhide (which would drag in a
+# development glibc upgrade).
+#
+# TODO: Once openvino 2026.x is packaged in Fedora (RHBZ#2392862), switch
+# from the upstream tarball to `dnf install openvino openvino-devel` and
+# remove the tarball download and manual library copies below.
+#
+# The upstream llama.cpp OpenVINO Dockerfile installs OpenVINO the same way:
+# download tarball, extract to /opt/intel/openvino, source setupvars.sh.
 
-# Install Python development dependencies
-RUN dnf install -y python3-devel wget compat-openssl11 python3-jinja2 python3-markupsafe
-# RUN pip3 install "Jinja2==3.1.6" "MarkupSafe==3.0.2"
+ARG OPENVINO_VERSION_MAJOR=2026.0
+ARG OPENVINO_VERSION_FULL=2026.0.0.20965.c6d6a13a886
 
-# Download and extract the Red Hat OpenVINO Model Server binary release
-RUN wget https://github.com/openvinotoolkit/model_server/releases/download/v2025.3/ovms_redhat_python_on.tar.gz && \
-    tar -xzvf ovms_redhat_python_on.tar.gz && \
-    rm ovms_redhat_python_on.tar.gz
+FROM quay.io/fedora/fedora:44 AS builder
 
-# Set environment variables for OpenVINO libraries and OVMS executable
-ENV LD_LIBRARY_PATH=/ovms/lib:/ovms/third-party:/usr/lib64:$LD_LIBRARY_PATH
-ENV PATH=/ovms/bin:/usr/local/bin:$PATH
-ENV PYTHONPATH=/ovms/lib/python
+ARG OPENVINO_VERSION_MAJOR
+ARG OPENVINO_VERSION_FULL
 
-WORKDIR /ovms
+# Install OpenVINO from upstream tarball
+RUN dnf install -y wget tar gzip && \
+    mkdir -p /opt/intel && \
+    wget -q https://storage.openvinotoolkit.org/repositories/openvino/packages/${OPENVINO_VERSION_MAJOR}/linux/openvino_toolkit_rhel8_${OPENVINO_VERSION_FULL}_x86_64.tgz && \
+    tar -xf openvino_toolkit_rhel8_${OPENVINO_VERSION_FULL}_x86_64.tgz && \
+    mv openvino_toolkit_rhel8_${OPENVINO_VERSION_FULL}_x86_64 /opt/intel/openvino && \
+    rm -f openvino_toolkit_rhel8_${OPENVINO_VERSION_FULL}_x86_64.tgz && \
+    dnf -y clean all
 
-CMD ["ovms"]
+ENV OpenVINO_DIR=/opt/intel/openvino
+
+COPY container-images/scripts/build_llama.sh \
+     container-images/scripts/lib.sh \
+     /src/
+WORKDIR /src/
+RUN ./build_llama.sh openvino
+
+FROM quay.io/fedora/fedora:44
+
+# Copy OpenVINO runtime libraries and bundled TBB from builder
+COPY --from=builder /opt/intel/openvino/runtime/lib/intel64/ /usr/lib64/
+COPY --from=builder /opt/intel/openvino/runtime/3rdparty/tbb/lib/ /usr/lib64/
+
+RUN --mount=type=bind,from=builder,source=/tmp/install,target=/tmp/install,relabel=private \
+    cp -a /tmp/install/bin/ /usr/ && \
+    cp -a /tmp/install/lib64/*.so* /usr/lib64/
+RUN --mount=type=bind,target=/src,relabel=private \
+    /src/container-images/scripts/build_llama.sh openvino runtime

--- a/container-images/scripts/build_llama.sh
+++ b/container-images/scripts/build_llama.sh
@@ -52,6 +52,10 @@ dnf_install_s390_ppc64le() {
   dnf install -y "openblas-devel"
 }
 
+dnf_install_openvino() {
+  dnf install -y ocl-icd-devel opencl-headers
+}
+
 dnf_install_mesa() {
   if [ "${ID}" = "fedora" ]; then
     dnf copr enable -y slp/mesa-libkrun-vulkan
@@ -96,6 +100,8 @@ dnf_install() {
     dnf_install_intel_gpu
   elif [ "$containerfile" = "cann" ]; then
     dnf_install_cann
+  elif [ "$containerfile" = "openvino" ]; then
+    dnf_install_openvino
   fi
 
   if [[ "${RAMALAMA_IMAGE_BUILD_DEBUG_MODE:-}" == y ]]; then
@@ -134,8 +140,14 @@ dnf_install_runtime_deps() {
       intel-oneapi-mkl-core intel-oneapi-mkl-sycl-blas intel-oneapi-mkl-sycl-dft
       oneapi-level-zero
     )
+  elif [ "$containerfile" = "openvino" ]; then
+    runtime_pkgs+=(ocl-icd intel-opencl intel-npu-driver)
   fi
-  dnf install -y --setopt=install_weak_deps=false "${runtime_pkgs[@]}"
+  if [ ${#runtime_pkgs[@]} -gt 0 ]; then
+    local enablerepo_flag=""
+    [ "$containerfile" = "openvino" ] && enablerepo_flag="--enablerepo=updates-testing"
+    dnf install -y $enablerepo_flag --setopt=install_weak_deps=false "${runtime_pkgs[@]}"
+  fi
   dnf -y clean all
 }
 
@@ -167,6 +179,9 @@ setup_build_env() {
   elif [ "$containerfile" = "intel-gpu" ]; then
     # shellcheck disable=SC1091
     source /opt/intel/oneapi/setvars.sh
+  elif [ "$containerfile" = "openvino" ]; then
+    # shellcheck disable=SC1091
+    source /opt/intel/openvino/setupvars.sh
   fi
   set -ux
 }
@@ -192,7 +207,14 @@ configure_common_flags() {
       "-DGGML_CCACHE=OFF" "-DGGML_RPC=ON" "-DCMAKE_INSTALL_PREFIX=/tmp/install"
       "-DLLAMA_BUILD_TESTS=OFF" "-DLLAMA_BUILD_EXAMPLES=OFF" "-DGGML_BUILD_TESTS=OFF" "-DGGML_BUILD_EXAMPLES=OFF"
   )
-  if [ "$containerfile" != "cann" ]; then
+  if [ "$containerfile" = "cann" ]; then
+      :
+  elif [ "$containerfile" = "openvino" ]; then
+      # openvino backend doesn't support GGML_BACKEND_DL — upstream is missing
+      # GGML_BACKEND_DL_IMPL(ggml_backend_openvino_reg) in ggml-openvino.cpp.
+      # Until that's added, we also can't use GGML_CPU_ALL_VARIANTS.
+      common_flags+=("-DGGML_NATIVE=OFF")
+  else
       common_flags+=("-DGGML_NATIVE=OFF" "-DGGML_BACKEND_DL=ON" "-DGGML_CPU_ALL_VARIANTS=ON")
   fi
   if [[ "${RAMALAMA_IMAGE_BUILD_DEBUG_MODE:-}" == y ]]; then
@@ -233,6 +255,9 @@ configure_common_flags() {
     ;;
   musa)
     common_flags+=("-DGGML_MUSA=ON" "-DCMAKE_EXE_LINKER_FLAGS=-Wl,--allow-shlib-undefined")
+    ;;
+  openvino)
+    common_flags+=("-DGGML_OPENVINO=ON")
     ;;
   esac
 }


### PR DESCRIPTION
this totally rewrites the openvino container to support the new llama.cpp backend instead of using the prebuild binary for openvino which has no integration support in ramalama as a runtime. Now openvino is a backend for llama.cpp

Fixes: https://github.com/containers/ramalama/issues/2528

## Summary by Sourcery

Rewrite the OpenVINO container image to build and run llama.cpp with the OpenVINO backend instead of the legacy OpenVINO model server binary.

New Features:
- Add a Fedora-based multi-stage OpenVINO image that builds and installs llama.cpp with OpenVINO backend support.

Enhancements:
- Extend the shared llama build script to install OpenVINO development and runtime dependencies and enable the GGML OpenVINO build flag for the OpenVINO container.