### PR TITLE
feat: add multi-model router mode for ramalama serve

### DIFF
--- a/docs/options/models-max.md
+++ b/docs/options/models-max.md
@@ -1,0 +1,7 @@
+####> This option file is used in:
+####>   ramalama serve
+####> If this file is edited, make sure the changes
+####> are applicable to all of those.
+#### **--models-max**=*integer*
+Maximum number of models to load concurrently in router mode (default: 4).
+Only used when `ramalama serve` is invoked in router mode (zero or multiple models).

--- a/docs/ramalama-serve.1.md
+++ b/docs/ramalama-serve.1.md
@@ -4,11 +4,17 @@
 ramalama\-serve - serve REST API on specified AI Model
 
 ## SYNOPSIS
-**ramalama serve** [*options*] _model_
+**ramalama serve** [*options*] [_model_]
 
 ## DESCRIPTION
 Serve specified AI Model as a chat bot. RamaLama pulls specified AI Model from
 registry if it does not exist in local storage.
+
+When invoked without a model argument, starts in **router mode**: all locally
+stored GGUF models are mounted into a container and served via llama.cpp's
+multi-model directory feature. Requests are routed to the appropriate model
+based on the model name in the API request. Router mode requires a container
+runtime.
 
 ## MODEL TRANSPORTS
 
@@ -211,6 +217,10 @@ times the larger model needs to be invoked.
 
 Use --runtime-arg to pass the other draft model related parameters.
 Make sure the sampling parameters like top_k on the web UI are set correctly.
+
+#### **--models-max**=*integer*
+Maximum number of models to load concurrently in router mode (default: 4).
+Only used when `ramalama serve` is invoked without a model argument.
 
 #### **--name**, **-n**
 Name of the container to run the Model in.

--- a/docs/ramalama-serve.1.md.in
+++ b/docs/ramalama-serve.1.md.in
@@ -4,11 +4,20 @@
 ramalama\-serve - serve REST API on specified AI Model
 
 ## SYNOPSIS
-**ramalama serve** [*options*] _model_
+**ramalama serve** [*options*] [_model_ ...]
 
 ## DESCRIPTION
 Serve specified AI Model as a chat bot. RamaLama pulls specified AI Model from
 registry if it does not exist in local storage.
+
+When invoked with two or more model arguments, or without any model argument,
+starts in **router mode**: models are mounted into a container and served via
+llama.cpp's multi-model directory feature. Requests are routed to the
+appropriate model based on the model name in the API request. Router mode
+requires a container runtime.
+
+With no model arguments, all locally stored GGUF models are served. With
+multiple model arguments, only the specified models are served.
 
 @@include options/model-transports.md
 
@@ -84,6 +93,8 @@ appending the path to the type, e.g. `--generate kube:/etc/containers/systemd`.
 @@option max-tokens
 
 @@option model-draft
+
+@@option models-max
 
 @@option name
 

--- a/ramalama/plugins/runtimes/inference/common.py
+++ b/ramalama/plugins/runtimes/inference/common.py
@@ -1,4 +1,6 @@
 import argparse
+import os
+import sys
 from abc import abstractmethod
 from typing import Any
 
@@ -12,9 +14,21 @@ from ramalama.cli import (
     runtime_options,
     suppressCompleter,
 )
-from ramalama.common import ContainerEntryPoint, accel_image, ensure_image, set_accel_env_vars
+from ramalama.common import (
+    ContainerEntryPoint,
+    accel_image,
+    ensure_image,
+    genname,
+    sanitize_filename,
+    set_accel_env_vars,
+)
 from ramalama.config import ActiveConfig
+from ramalama.engine import Engine
 from ramalama.logger import logger
+from ramalama.model_store.constants import DIRECTORY_NAME_BLOBS, DIRECTORY_NAME_REFS, DIRECTORY_NAME_SNAPSHOTS
+from ramalama.model_store.global_store import GlobalModelStore
+from ramalama.model_store.reffile import RefJSONFile, StoreFileType, migrate_reffile_to_refjsonfile
+from ramalama.path_utils import get_container_mount_path
 from ramalama.plugins.interface import InferenceRuntimePlugin
 from ramalama.plugins.loader import assemble_command
 from ramalama.stack import Stack
@@ -140,7 +154,7 @@ class BaseInferenceRuntime(InferenceRuntimePlugin):
         parser = subparsers.add_parser("serve", help="serve REST API on specified AI Model")
         runtime_options(parser, "serve")
         self._add_inference_args(parser, "serve")
-        parser.add_argument("MODEL", completer=local_models)  # positional argument
+        parser.add_argument("MODEL", nargs="?", default=None, completer=local_models)  # positional argument
         parser.set_defaults(func=self._serve_handler)
         return parser
 
@@ -202,6 +216,9 @@ class BaseInferenceRuntime(InferenceRuntimePlugin):
         if not args.container:
             args.detach = False
 
+        if args.MODEL is None:
+            return self._serve_router(args)
+
         if getattr(args, "api", None) == "llama-stack":
             if not args.container:
                 raise ValueError(
@@ -234,6 +251,88 @@ class BaseInferenceRuntime(InferenceRuntimePlugin):
             raise ValueError("ramalama serve is not supported for hosted API transports.")
 
         self._do_serve(args, model)
+
+    def _serve_router(self, args: argparse.Namespace) -> None:
+        """Serve all locally stored GGUF models using llama.cpp router mode (container-only)."""
+        if not args.container:
+            sys.exit("Error: router mode (ramalama serve with no model) requires a container runtime.")
+
+        set_accel_env_vars()
+        args.port = compute_serving_port(args)
+        args.router_mode = True
+
+        store = GlobalModelStore(args.store)
+        models = _enumerate_store_gguf_models(
+            store,
+            DIRECTORY_NAME_REFS,
+            DIRECTORY_NAME_SNAPSHOTS,
+            DIRECTORY_NAME_BLOBS,
+            RefJSONFile,
+            migrate_reffile_to_refjsonfile,
+        )
+
+        if not models:
+            sys.exit("Error: no GGUF models found in the model store. Pull a model first with: ramalama pull <model>")
+
+        if args.container and not args.dryrun:
+            config = ActiveConfig()
+            should_pull = config.pull in ["always", "missing", "newer"]
+            args.image = ensure_image(config.engine, accel_image(config), should_pull=should_pull)
+
+        cmd = assemble_command(args)
+        engine = Engine(args)
+        name = getattr(args, "name", None) or genname()
+        engine.add(["--label", "ai.ramalama", "--name", name, "--env=HOME=/tmp", "--init"])
+
+        for host_path, container_name in models:
+            mount_path = f"/mnt/models/{container_name}"
+            container_host_path = get_container_mount_path(host_path)
+            engine.add([f"--mount=type=bind,src={container_host_path},destination={mount_path},ro"])
+
+        engine.add([args.image] + cmd)
+
+        if args.dryrun:
+            engine.dryrun()
+            return
+        engine.exec()
+
+
+def _enumerate_store_gguf_models(store, refs_dir_name, snapshots_dir_name, blobs_dir_name, RefJSONFile, migrate_fn):
+    """Walk the model store and return (host_blob_path, readable_name.gguf) for each GGUF model."""
+    models = []
+    seen_names = set()
+
+    for root, subdirs, _ in os.walk(store.path):
+        if refs_dir_name not in subdirs:
+            continue
+
+        ref_dir = os.path.join(root, refs_dir_name)
+        for ref_file_name in os.listdir(ref_dir):
+            ref_file_path = os.path.join(ref_dir, ref_file_name)
+            ref_file = migrate_fn(ref_file_path, os.path.join(root, snapshots_dir_name))
+            if ref_file is None:
+                ref_file = RefJSONFile.from_path(ref_file_path)
+
+            tag, _ = os.path.splitext(ref_file_name)
+            model_rel = root.replace(store.path, "").lstrip(os.sep)
+            parts = model_rel.split(os.sep)
+            readable = "-".join(parts + [tag])
+
+            for model_file in ref_file.model_files:
+                if model_file.type != StoreFileType.GGUF_MODEL:
+                    continue
+
+                blob_path = os.path.join(root, blobs_dir_name, sanitize_filename(model_file.hash))
+                if not os.path.exists(blob_path):
+                    continue
+
+                name = f"{readable}.gguf"
+                if name in seen_names:
+                    name = f"{readable}-{model_file.hash[:8]}.gguf"
+                seen_names.add(name)
+                models.append((blob_path, name))
+
+    return models
 
 
 class ContainerizedInferenceRuntimePlugin(BaseInferenceRuntime):

--- a/ramalama/plugins/runtimes/inference/common.py
+++ b/ramalama/plugins/runtimes/inference/common.py
@@ -4,7 +4,6 @@ import argparse
 import copy
 import os
 from abc import abstractmethod
-from collections.abc import Callable
 from typing import Any
 
 from ramalama.cli import (
@@ -140,11 +139,15 @@ class BaseInferenceRuntime(InferenceRuntimePlugin):
         parser.set_defaults(func=self._run_handler)
         return parser
 
+    def _add_model_argument(self, parser: "argparse.ArgumentParser") -> None:
+        """Add the MODEL positional argument. Override to change nargs or defaults."""
+        parser.add_argument("MODEL", completer=local_models)
+
     def _register_serve_subcommand(self, subparsers: "argparse._SubParsersAction") -> "argparse.ArgumentParser":
         parser = subparsers.add_parser("serve", help="serve REST API on specified AI Model")
         runtime_options(parser, "serve")
         self._add_inference_args(parser, "serve")
-        parser.add_argument("MODEL", completer=local_models)
+        self._add_model_argument(parser)
         parser.set_defaults(func=self._serve_handler)
         return parser
 
@@ -254,13 +257,11 @@ class BaseInferenceRuntime(InferenceRuntimePlugin):
         self._do_serve(args, model)
 
 
-def _enumerate_store_gguf_models(
+def enumerate_store_gguf_models(
     store: Any,
     refs_dir_name: str,
-    snapshots_dir_name: str,
     blobs_dir_name: str,
     ref_json_cls: Any,
-    migrate_fn: Callable[[str, str], Any],
 ) -> list[tuple[str, str]]:
     """Walk the model store and return (host_blob_path, readable_name.gguf) for each GGUF model."""
     models: list[tuple[str, str]] = []
@@ -273,9 +274,7 @@ def _enumerate_store_gguf_models(
         ref_dir = os.path.join(root, refs_dir_name)
         for ref_file_name in os.listdir(ref_dir):
             ref_file_path = os.path.join(ref_dir, ref_file_name)
-            ref_file = migrate_fn(ref_file_path, os.path.join(root, snapshots_dir_name))
-            if ref_file is None:
-                ref_file = ref_json_cls.from_path(ref_file_path)
+            ref_file = ref_json_cls.from_path(ref_file_path)
 
             tag, _ = os.path.splitext(ref_file_name)
             model_rel = root.replace(store.path, "").lstrip(os.sep)

--- a/ramalama/plugins/runtimes/inference/common.py
+++ b/ramalama/plugins/runtimes/inference/common.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import argparse
 import copy
+import os
 from abc import abstractmethod
+from collections.abc import Callable
 from typing import Any
 
 from ramalama.cli import (
@@ -15,9 +17,16 @@ from ramalama.cli import (
     runtime_options,
     suppressCompleter,
 )
-from ramalama.common import ContainerEntryPoint, accel_image, ensure_image, set_accel_env_vars
+from ramalama.common import (
+    ContainerEntryPoint,
+    accel_image,
+    ensure_image,
+    sanitize_filename,
+    set_accel_env_vars,
+)
 from ramalama.config import ActiveConfig
 from ramalama.logger import logger
+from ramalama.model_store.reffile import StoreFileType
 from ramalama.plugins.interface import InferenceRuntimePlugin
 from ramalama.plugins.loader import assemble_command
 from ramalama.stack import Stack
@@ -135,7 +144,7 @@ class BaseInferenceRuntime(InferenceRuntimePlugin):
         parser = subparsers.add_parser("serve", help="serve REST API on specified AI Model")
         runtime_options(parser, "serve")
         self._add_inference_args(parser, "serve")
-        parser.add_argument("MODEL", completer=local_models)  # positional argument
+        parser.add_argument("MODEL", completer=local_models)
         parser.set_defaults(func=self._serve_handler)
         return parser
 
@@ -243,6 +252,51 @@ class BaseInferenceRuntime(InferenceRuntimePlugin):
             raise ValueError("ramalama serve is not supported for hosted API transports.")
 
         self._do_serve(args, model)
+
+
+def _enumerate_store_gguf_models(
+    store: Any,
+    refs_dir_name: str,
+    snapshots_dir_name: str,
+    blobs_dir_name: str,
+    ref_json_cls: Any,
+    migrate_fn: Callable[[str, str], Any],
+) -> list[tuple[str, str]]:
+    """Walk the model store and return (host_blob_path, readable_name.gguf) for each GGUF model."""
+    models: list[tuple[str, str]] = []
+    seen_names: set[str] = set()
+
+    for root, subdirs, _ in os.walk(store.path):
+        if refs_dir_name not in subdirs:
+            continue
+
+        ref_dir = os.path.join(root, refs_dir_name)
+        for ref_file_name in os.listdir(ref_dir):
+            ref_file_path = os.path.join(ref_dir, ref_file_name)
+            ref_file = migrate_fn(ref_file_path, os.path.join(root, snapshots_dir_name))
+            if ref_file is None:
+                ref_file = ref_json_cls.from_path(ref_file_path)
+
+            tag, _ = os.path.splitext(ref_file_name)
+            model_rel = root.replace(store.path, "").lstrip(os.sep)
+            parts = model_rel.split(os.sep)
+            readable = "-".join(parts + [tag])
+
+            for model_file in ref_file.model_files:
+                if model_file.type != StoreFileType.GGUF_MODEL:
+                    continue
+
+                blob_path = os.path.join(root, blobs_dir_name, sanitize_filename(model_file.hash))
+                if not os.path.exists(blob_path):
+                    continue
+
+                name = f"{readable}.gguf"
+                if name in seen_names:
+                    name = f"{readable}-{model_file.hash[:8]}.gguf"
+                seen_names.add(name)
+                models.append((blob_path, name))
+
+    return models
 
 
 class ContainerizedInferenceRuntimePlugin(BaseInferenceRuntime):

--- a/ramalama/plugins/runtimes/inference/llama_cpp.py
+++ b/ramalama/plugins/runtimes/inference/llama_cpp.py
@@ -222,7 +222,12 @@ class LlamaCppPlugin(LlamaCppCommands, ContainerizedInferenceRuntimePlugin):
 
         model_names = [m["name"] for m in body["models"]]
         if not model_name:
-            model_name = New(args.MODEL, args).model_alias
+            if hasattr(args, 'MODEL') and args.MODEL is not None:
+                model_name = New(args.MODEL, args).model_alias
+            else:
+                # Router mode: any model loaded means the server is ready
+                logger.debug(f"{self.name} {container_name} is ready (router mode)")
+                return True
 
         if not any(model_name in name for name in model_names):
             logger.debug(
@@ -394,6 +399,14 @@ class LlamaCppPlugin(LlamaCppCommands, ContainerizedInferenceRuntimePlugin):
     def _register_serve_subcommand(self, subparsers: "argparse._SubParsersAction") -> "argparse.ArgumentParser":
         parser = super()._register_serve_subcommand(subparsers)
         self._add_rag_args(parser)
+        parser.add_argument(
+            "--models-max",
+            dest="models_max",
+            type=int,
+            default=4,
+            help="maximum number of models to load concurrently in router mode (default: 4)",
+            completer=suppressCompleter,
+        )
         return parser
 
     def register_subcommands(self, subparsers: "argparse._SubParsersAction") -> None:

--- a/ramalama/plugins/runtimes/inference/llama_cpp.py
+++ b/ramalama/plugins/runtimes/inference/llama_cpp.py
@@ -50,7 +50,7 @@ from ramalama.model_store.global_store import GlobalModelStore
 from ramalama.model_store.reffile import RefJSONFile, migrate_reffile_to_refjsonfile
 from ramalama.path_utils import file_uri_to_path, get_container_mount_path
 from ramalama.plugins.loader import assemble_command
-from ramalama.plugins.runtimes.inference.common import ContainerizedInferenceRuntimePlugin, _enumerate_store_gguf_models
+from ramalama.plugins.runtimes.inference.common import ContainerizedInferenceRuntimePlugin, enumerate_store_gguf_models
 from ramalama.plugins.runtimes.inference.llama_cpp_commands import (
     LlamaCppCommands,
     _default_threads,
@@ -470,13 +470,12 @@ class LlamaCppPlugin(LlamaCppCommands, ContainerizedInferenceRuntimePlugin):
             models = self._resolve_specified_models(args)
         else:
             store = GlobalModelStore(args.store)
-            models = _enumerate_store_gguf_models(
+            self._migrate_store_ref_files(store)
+            models = enumerate_store_gguf_models(
                 store,
                 DIRECTORY_NAME_REFS,
-                DIRECTORY_NAME_SNAPSHOTS,
                 DIRECTORY_NAME_BLOBS,
                 RefJSONFile,
-                migrate_reffile_to_refjsonfile,
             )
 
         if not models:
@@ -503,6 +502,17 @@ class LlamaCppPlugin(LlamaCppCommands, ContainerizedInferenceRuntimePlugin):
             engine.dryrun()
             return
         engine.exec()
+
+    @staticmethod
+    def _migrate_store_ref_files(store: Any) -> None:
+        """Migrate any old-format ref files to JSON before enumeration."""
+        for root, subdirs, _ in os.walk(store.path):
+            if DIRECTORY_NAME_REFS not in subdirs:
+                continue
+            ref_dir = os.path.join(root, DIRECTORY_NAME_REFS)
+            for ref_file_name in os.listdir(ref_dir):
+                ref_file_path = os.path.join(ref_dir, ref_file_name)
+                migrate_reffile_to_refjsonfile(ref_file_path, os.path.join(root, DIRECTORY_NAME_SNAPSHOTS))
 
     @staticmethod
     def _resolve_specified_models(args: argparse.Namespace) -> list[tuple[str, str]]:
@@ -604,13 +614,11 @@ class LlamaCppPlugin(LlamaCppCommands, ContainerizedInferenceRuntimePlugin):
         self._add_rag_args(parser)
         return parser
 
+    def _add_model_argument(self, parser: "argparse.ArgumentParser") -> None:
+        parser.add_argument("MODEL", nargs="*", default=[], completer=local_models)
+
     def _register_serve_subcommand(self, subparsers: "argparse._SubParsersAction") -> "argparse.ArgumentParser":
         parser = super()._register_serve_subcommand(subparsers)
-        for action in parser._actions:
-            if hasattr(action, 'dest') and action.dest == 'MODEL':
-                action.nargs = '*'
-                action.default = []
-                break
         self._add_rag_args(parser)
         parser.add_argument(
             "--models-max",

--- a/ramalama/plugins/runtimes/inference/llama_cpp.py
+++ b/ramalama/plugins/runtimes/inference/llama_cpp.py
@@ -6,6 +6,7 @@ import json
 import os
 import platform
 import shutil
+import sys
 import tempfile
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
@@ -34,6 +35,7 @@ from ramalama.cli import (
 from ramalama.common import (
     accel_image,
     ensure_image,
+    genname,
     get_gpu_type_env_vars,
     run_cmd,
     set_accel_env_vars,
@@ -43,9 +45,12 @@ from ramalama.common import (
 from ramalama.config import ActiveConfig, DefaultConfig, coerce_to_bool
 from ramalama.engine import Engine, dry_run, image_inspect
 from ramalama.logger import logger
-from ramalama.path_utils import file_uri_to_path
+from ramalama.model_store.constants import DIRECTORY_NAME_BLOBS, DIRECTORY_NAME_REFS, DIRECTORY_NAME_SNAPSHOTS
+from ramalama.model_store.global_store import GlobalModelStore
+from ramalama.model_store.reffile import RefJSONFile, migrate_reffile_to_refjsonfile
+from ramalama.path_utils import file_uri_to_path, get_container_mount_path
 from ramalama.plugins.loader import assemble_command
-from ramalama.plugins.runtimes.inference.common import ContainerizedInferenceRuntimePlugin
+from ramalama.plugins.runtimes.inference.common import ContainerizedInferenceRuntimePlugin, _enumerate_store_gguf_models
 from ramalama.plugins.runtimes.inference.llama_cpp_commands import (
     LlamaCppCommands,
     _default_threads,
@@ -91,6 +96,13 @@ class LlamaCppConfig:
         self.threads = int(self.threads)
         if self.thinking is not None:
             self.thinking = coerce_to_bool(self.thinking)
+
+
+def _positive_int(value: str) -> int:
+    ivalue = int(value)
+    if ivalue < 1:
+        raise argparse.ArgumentTypeError(f"--models-max must be a positive integer, got {value}")
+    return ivalue
 
 
 class AddPathOrUrl(argparse.Action):
@@ -262,7 +274,14 @@ class LlamaCppPlugin(LlamaCppCommands, ContainerizedInferenceRuntimePlugin):
 
         model_names = [m["name"] for m in body["models"]]
         if not model_name:
-            model_name = New(args.MODEL, args).model_alias
+            if hasattr(args, 'MODEL') and isinstance(args.MODEL, str):
+                model_name = New(args.MODEL, args).model_alias
+            else:
+                if not model_names:
+                    logger.debug(f"{self.name} {container_name} /models returned no available models yet")
+                    return False
+                logger.debug(f"{self.name} {container_name} is ready (router mode)")
+                return True
 
         if model_name not in model_names:
             logger.debug(
@@ -425,6 +444,88 @@ class LlamaCppPlugin(LlamaCppCommands, ContainerizedInferenceRuntimePlugin):
             return
         super()._do_serve(args, model)
 
+    def _serve_handler(self, args: argparse.Namespace) -> None:
+        if not args.container:
+            args.detach = False
+
+        if len(args.MODEL) != 1:
+            return self._serve_router(args)
+
+        args.MODEL = args.MODEL[0]
+        if isinstance(getattr(args, "model", None), list):
+            args.model = args.MODEL
+
+        super()._serve_handler(args)
+
+    def _serve_router(self, args: argparse.Namespace) -> None:
+        """Serve multiple models using llama.cpp router mode (container-only)."""
+        if not args.container:
+            sys.exit("Error: multi-model router mode requires a container runtime.")
+
+        set_accel_env_vars()
+        args.port = compute_serving_port(args)
+        args.router_mode = True
+
+        if args.MODEL:
+            models = self._resolve_specified_models(args)
+        else:
+            store = GlobalModelStore(args.store)
+            models = _enumerate_store_gguf_models(
+                store,
+                DIRECTORY_NAME_REFS,
+                DIRECTORY_NAME_SNAPSHOTS,
+                DIRECTORY_NAME_BLOBS,
+                RefJSONFile,
+                migrate_reffile_to_refjsonfile,
+            )
+
+        if not models:
+            sys.exit("Error: no GGUF models found in the model store. Pull a model first with: ramalama pull <model>")
+
+        if args.container and not args.dryrun:
+            config = ActiveConfig()
+            should_pull = config.pull in ["always", "missing", "newer"]
+            args.image = ensure_image(config.engine, accel_image(config), should_pull=should_pull)
+
+        cmd = assemble_command(args)
+        engine = Engine(args)
+        name = getattr(args, "name", None) or genname()
+        engine.add(["--label", "ai.ramalama", "--name", name, "--env=HOME=/tmp", "--init"])
+
+        for host_path, container_name in models:
+            mount_path = f"/mnt/models/{container_name}"
+            container_host_path = get_container_mount_path(host_path)
+            engine.add([f"--mount=type=bind,src={container_host_path},destination={mount_path},ro"])
+
+        engine.add([args.image] + cmd)
+
+        if args.dryrun:
+            engine.dryrun()
+            return
+        engine.exec()
+
+    @staticmethod
+    def _resolve_specified_models(args: argparse.Namespace) -> list[tuple[str, str]]:
+        """Resolve user-specified model names to (host_blob_path, container_name.gguf) tuples."""
+        models: list[tuple[str, str]] = []
+        seen_names: set[str] = set()
+        for model_name in args.MODEL:
+            model = New(model_name, args)
+            model.ensure_model_exists(args)
+            host_path = model._get_entry_model_path(False, False, False)
+            alias = model.model_alias.replace("/", "-")
+            name = f"{alias}.gguf"
+            if name in seen_names:
+                i = 2
+                candidate = f"{alias}-{i}.gguf"
+                while candidate in seen_names:
+                    i += 1
+                    candidate = f"{alias}-{i}.gguf"
+                name = candidate
+            seen_names.add(name)
+            models.append((host_path, name))
+        return models
+
     def _add_rag_args(self, parser: "argparse.ArgumentParser") -> None:
         parser.add_argument(
             "--rag", help="RAG vector database or OCI Image to be served with the model", completer=local_models
@@ -505,7 +606,20 @@ class LlamaCppPlugin(LlamaCppCommands, ContainerizedInferenceRuntimePlugin):
 
     def _register_serve_subcommand(self, subparsers: "argparse._SubParsersAction") -> "argparse.ArgumentParser":
         parser = super()._register_serve_subcommand(subparsers)
+        for action in parser._actions:
+            if hasattr(action, 'dest') and action.dest == 'MODEL':
+                action.nargs = '*'
+                action.default = []
+                break
         self._add_rag_args(parser)
+        parser.add_argument(
+            "--models-max",
+            dest="models_max",
+            type=_positive_int,
+            default=4,
+            help="maximum number of models to load concurrently in router mode (default: 4)",
+            completer=suppressCompleter,
+        )
         return parser
 
     def register_subcommands(self, subparsers: "argparse._SubParsersAction") -> None:

--- a/ramalama/plugins/runtimes/inference/llama_cpp_commands.py
+++ b/ramalama/plugins/runtimes/inference/llama_cpp_commands.py
@@ -43,13 +43,16 @@ class LlamaCppCommands:
     def _cmd_run(self, args: argparse.Namespace) -> list[str]:
         if getattr(args, 'rag', None):
             return self._cmd_run_rag(args)
+
+        router_mode = getattr(args, 'router_mode', False)
+
         cmd = ["llama-server"] if not self._container_image_is_ggml(args) else ["--server"]  # type: ignore[attr-defined]
 
         is_container = args.container
         should_generate = getattr(args, 'generate', None) is not None
         dry_run = getattr(args, 'dryrun', False)
 
-        model = New(args.MODEL, args) if hasattr(args, 'MODEL') else None
+        model = New(args.MODEL, args) if hasattr(args, 'MODEL') and args.MODEL is not None else None
 
         # --host: use 0.0.0.0 in container, or the configured host otherwise
         host = '0.0.0.0' if is_container else getattr(args, 'host', None)
@@ -64,7 +67,11 @@ class LlamaCppCommands:
         if logfile:
             cmd += ["--log-file", str(logfile)]
 
-        if model is not None:
+        if router_mode:
+            cmd += ["--models-dir", "/mnt/models"]
+            models_max = getattr(args, 'models_max', 4)
+            cmd += ["--models-max", str(models_max)]
+        elif model is not None:
             model_path = model._get_entry_model_path(is_container, should_generate, dry_run)
             cmd += ["--model", model_path]
 
@@ -86,7 +93,7 @@ class LlamaCppCommands:
         if not getattr(args, 'thinking', None):
             cmd += ["--reasoning-budget", "0"]
 
-        if model is not None:
+        if not router_mode and model is not None:
             cmd += ["--alias", model.model_alias]
 
         ctx_size = getattr(args, 'ctx_size', None)
@@ -107,20 +114,21 @@ class LlamaCppCommands:
         if getattr(args, 'webui', None) == 'off':
             cmd.append("--no-webui")
 
-        ngl = getattr(args, 'ngl', 0)
-        ngl_val = 999 if ngl < 0 else ngl
-        cmd += ["-ngl", str(ngl_val)]
+        if not router_mode:
+            ngl = getattr(args, 'ngl', 0)
+            ngl_val = 999 if ngl < 0 else ngl
+            cmd += ["-ngl", str(ngl_val)]
 
-        model_draft = getattr(args, 'model_draft', None)
-        if model_draft:
-            draft_path = ""
-            if model is not None:
-                draft_model = getattr(model, 'draft_model', None)
-                if draft_model:
-                    draft_path = draft_model._get_entry_model_path(is_container, should_generate, dry_run)
-            if draft_path:
-                cmd += ["--model-draft", draft_path]
-            cmd += ["-ngld", str(ngl_val)]
+            model_draft = getattr(args, 'model_draft', None)
+            if model_draft:
+                draft_path = ""
+                if model is not None:
+                    draft_model = getattr(model, 'draft_model', None)
+                    if draft_model:
+                        draft_path = draft_model._get_entry_model_path(is_container, should_generate, dry_run)
+                if draft_path:
+                    cmd += ["--model-draft", draft_path]
+                cmd += ["-ngld", str(ngl_val)]
 
         threads = getattr(args, 'threads', None)
         if threads is not None:

--- a/ramalama/plugins/runtimes/inference/llama_cpp_commands.py
+++ b/ramalama/plugins/runtimes/inference/llama_cpp_commands.py
@@ -40,13 +40,16 @@ class LlamaCppCommands:
     def _cmd_run(self, args: argparse.Namespace) -> list[str]:
         if getattr(args, 'rag', None):
             return self._cmd_run_rag(args)
+
+        router_mode = getattr(args, 'router_mode', False)
+
         cmd = ["llama-server"] if not self._container_image_is_ggml(args) else ["--server"]  # type: ignore[attr-defined]
 
         is_container = args.container
         should_generate = getattr(args, 'generate', None) is not None
         dry_run = getattr(args, 'dryrun', False)
 
-        model = New(args.MODEL, args) if hasattr(args, 'MODEL') else None
+        model = New(args.MODEL, args) if hasattr(args, 'MODEL') and isinstance(args.MODEL, str) else None
 
         # --host: use :: in container, or the configured host otherwise
         host = '::' if is_container else getattr(args, 'host', None)
@@ -61,7 +64,11 @@ class LlamaCppCommands:
         if logfile:
             cmd += ["--log-file", str(logfile)]
 
-        if model is not None:
+        if router_mode:
+            cmd += ["--models-dir", "/mnt/models"]
+            models_max = getattr(args, 'models_max', 4)
+            cmd += ["--models-max", str(models_max)]
+        elif model is not None:
             model_path = model._get_entry_model_path(is_container, should_generate, dry_run)
             cmd += ["--model", model_path]
 
@@ -79,7 +86,7 @@ class LlamaCppCommands:
         if thinking is not None:
             cmd += ["--reasoning", "on" if thinking else "off"]
 
-        if model is not None:
+        if not router_mode and model is not None:
             cmd += ["--alias", model.model_alias]
 
         ctx_size = getattr(args, 'ctx_size', None)
@@ -100,22 +107,23 @@ class LlamaCppCommands:
         if getattr(args, 'webui', None) == 'off':
             cmd.append("--no-webui")
 
-        ngl = getattr(args, 'ngl', None)
-        if ngl is not None:
-            ngl_str = "all" if ngl == "-1" or ngl == -1 else str(ngl)
-            cmd += ["-ngl", ngl_str]
-
-        model_draft = getattr(args, 'model_draft', None)
-        if model_draft:
-            draft_path = ""
-            if model is not None:
-                draft_model = getattr(model, 'draft_model', None)
-                if draft_model:
-                    draft_path = draft_model._get_entry_model_path(is_container, should_generate, dry_run)
-            if draft_path:
-                cmd += ["--model-draft", draft_path]
+        if not router_mode:
+            ngl = getattr(args, 'ngl', None)
             if ngl is not None:
-                cmd += ["-ngld", ngl_str]
+                ngl_str = "all" if ngl == "-1" or ngl == -1 else str(ngl)
+                cmd += ["-ngl", ngl_str]
+
+            model_draft = getattr(args, 'model_draft', None)
+            if model_draft:
+                draft_path = ""
+                if model is not None:
+                    draft_model = getattr(model, 'draft_model', None)
+                    if draft_model:
+                        draft_path = draft_model._get_entry_model_path(is_container, should_generate, dry_run)
+                if draft_path:
+                    cmd += ["--model-draft", draft_path]
+                if ngl is not None:
+                    cmd += ["-ngld", ngl_str]
 
         threads = getattr(args, 'threads', None)
         if threads is not None:

--- a/test/e2e/test_serve.py
+++ b/test/e2e/test_serve.py
@@ -834,6 +834,35 @@ def test_serve_with_non_existing_images():
 
 @pytest.mark.e2e
 @skip_if_no_container
+def test_router_mode_dry_run(shared_ctx, test_model):
+    """ramalama serve (no model) in dryrun should produce a container command with --models-dir."""
+    ctx = shared_ctx
+    result = ctx.check_output(["ramalama", "-q", "--dryrun", "serve"])
+    assert re.search(r".*--models-dir /mnt/models", result)
+    assert re.search(r".*--mount=type=bind,src=.*,destination=/mnt/models/.*\.gguf,ro", result)
+
+
+@pytest.mark.e2e
+@skip_if_container
+def test_router_mode_nocontainer_fails():
+    """ramalama serve (no model) with --nocontainer should fail."""
+    with RamalamaExecWorkspace() as ctx:
+        with pytest.raises(CalledProcessError) as exc_info:
+            ctx.check_output(["ramalama", "--nocontainer", "serve"], stderr=STDOUT)
+        assert re.search(r".*router mode.*requires a container", exc_info.value.output.decode("utf-8"))
+
+
+@pytest.mark.e2e
+@skip_if_no_container
+def test_router_mode_models_max_dry_run(shared_ctx, test_model):
+    """--models-max flag is passed through to llama-server."""
+    ctx = shared_ctx
+    result = ctx.check_output(["ramalama", "-q", "--dryrun", "serve", "--models-max", "2"])
+    assert re.search(r".*--models-max 2", result)
+
+
+@pytest.mark.e2e
+@skip_if_no_container
 @skip_if_darwin
 @skip_if_docker
 def test_serve_with_rag():

--- a/test/e2e/test_serve.py
+++ b/test/e2e/test_serve.py
@@ -870,6 +870,35 @@ def test_serve_with_non_existing_images():
 
 @pytest.mark.e2e
 @skip_if_no_container
+def test_router_mode_dry_run(shared_ctx, test_model):
+    """ramalama serve (no model) in dryrun should produce a container command with --models-dir."""
+    ctx = shared_ctx
+    result = ctx.check_output(["ramalama", "-q", "--dryrun", "serve"])
+    assert re.search(r".*--models-dir /mnt/models", result)
+    assert re.search(r".*--mount=type=bind,src=.*,destination=/mnt/models/.*\.gguf,ro", result)
+
+
+@pytest.mark.e2e
+@skip_if_container
+def test_router_mode_nocontainer_fails():
+    """ramalama serve (no model) with --nocontainer should fail."""
+    with RamalamaExecWorkspace() as ctx:
+        with pytest.raises(CalledProcessError) as exc_info:
+            ctx.check_output(["ramalama", "--nocontainer", "serve"], stderr=STDOUT)
+        assert re.search(r".*router mode.*requires a container", exc_info.value.output.decode("utf-8"))
+
+
+@pytest.mark.e2e
+@skip_if_no_container
+def test_router_mode_models_max_dry_run(shared_ctx, test_model):
+    """--models-max flag is passed through to llama-server."""
+    ctx = shared_ctx
+    result = ctx.check_output(["ramalama", "-q", "--dryrun", "serve", "--models-max", "2"])
+    assert re.search(r".*--models-max 2", result)
+
+
+@pytest.mark.e2e
+@skip_if_no_container
 @skip_if_darwin
 @skip_if_docker
 def test_serve_with_rag():

--- a/test/unit/test_inference_engine_plugins.py
+++ b/test/unit/test_inference_engine_plugins.py
@@ -1,6 +1,7 @@
 """Unit tests for runtime plugins (llama.cpp, vllm, mlx)."""
 
 import argparse
+import json
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -15,8 +16,13 @@ from ramalama.common import ContainerEntryPoint, accel_image, version_tagged_ima
 from ramalama.compat import NamedTemporaryFile
 from ramalama.config import DEFAULT_IMAGE, load_config
 from ramalama.plugins.interface import InferenceRuntimePlugin
-from ramalama.plugins.runtimes.inference.common import ContainerizedInferenceRuntimePlugin
-from ramalama.plugins.runtimes.inference.llama_cpp import LlamaCppPlugin, get_available_backends
+from ramalama.plugins.runtimes.inference.common import ContainerizedInferenceRuntimePlugin, _enumerate_store_gguf_models
+from ramalama.plugins.runtimes.inference.llama_cpp import (
+    LlamaCppPlugin,
+    backend_to_gpu_env,
+    get_available_backends,
+    get_gpu_backend_preferences,
+)
 from ramalama.plugins.runtimes.inference.mlx import MlxPlugin
 from ramalama.plugins.runtimes.inference.vllm import VllmPlugin
 
@@ -1152,3 +1158,418 @@ def test_get_available_backends_windows(gpu_env: str | None, expected_backends: 
 
     with patch.dict("os.environ", env, clear=True):
         assert get_available_backends() == expected_backends
+
+
+# ---------------------------------------------------------------------------
+# _enumerate_store_gguf_models
+# ---------------------------------------------------------------------------
+
+
+def _make_ref_json_file(model_files):
+    """Create a mock RefJSONFile with the given model files."""
+    ref = MagicMock()
+    ref.model_files = model_files
+    return ref
+
+
+def _make_store_file(hash, file_type):
+    """Create a mock StoreFile."""
+    from ramalama.model_store.reffile import StoreFileType
+
+    sf = MagicMock()
+    sf.hash = hash
+    sf.type = file_type if isinstance(file_type, StoreFileType) else StoreFileType(file_type)
+    return sf
+
+
+class TestEnumerateStoreGgufModels:
+    """Tests for _enumerate_store_gguf_models."""
+
+    def test_finds_gguf_models(self, tmp_path):
+        """A ref file pointing to an existing GGUF blob is returned."""
+        from ramalama.model_store.reffile import StoreFileType
+
+        store = MagicMock()
+        store.path = str(tmp_path)
+
+        # Create store structure: <store>/huggingface/mymodel/refs/latest.json
+        model_dir = tmp_path / "huggingface" / "mymodel"
+        (model_dir / "refs").mkdir(parents=True)
+        (model_dir / "refs" / "latest.json").touch()
+        (model_dir / "blobs").mkdir()
+        (model_dir / "blobs" / "sha256-abc123").touch()
+
+        model_file = _make_store_file("sha256:abc123", StoreFileType.GGUF_MODEL)
+        ref = _make_ref_json_file([model_file])
+
+        models = _enumerate_store_gguf_models(
+            store,
+            "refs",
+            "snapshots",
+            "blobs",
+            MagicMock,
+            lambda path, snap_dir: ref,
+        )
+
+        assert len(models) == 1
+        assert models[0][0] == str(model_dir / "blobs" / "sha256-abc123")
+        assert models[0][1].endswith(".gguf")
+
+    def test_empty_store_returns_empty(self, tmp_path):
+        """An empty store returns no models."""
+        store = MagicMock()
+        store.path = str(tmp_path)
+        tmp_path.mkdir(exist_ok=True)
+
+        models = _enumerate_store_gguf_models(
+            store,
+            "refs",
+            "snapshots",
+            "blobs",
+            MagicMock,
+            lambda p, s: None,
+        )
+        assert models == []
+
+    def test_skips_non_gguf_files(self, tmp_path):
+        """Non-GGUF model files (e.g., safetensor) are skipped."""
+        from ramalama.model_store.reffile import StoreFileType
+
+        store = MagicMock()
+        store.path = str(tmp_path)
+
+        model_dir = tmp_path / "hf" / "model"
+        (model_dir / "refs").mkdir(parents=True)
+        (model_dir / "refs" / "latest.json").touch()
+        (model_dir / "blobs").mkdir()
+        (model_dir / "blobs" / "sha256-xyz").touch()
+
+        safetensor_file = _make_store_file("sha256:xyz", StoreFileType.SAFETENSOR_MODEL)
+        ref = _make_ref_json_file([safetensor_file])
+
+        models = _enumerate_store_gguf_models(
+            store,
+            "refs",
+            "snapshots",
+            "blobs",
+            MagicMock,
+            lambda p, s: ref,
+        )
+        assert models == []
+
+    def test_skips_missing_blobs(self, tmp_path):
+        """GGUF models whose blob files don't exist on disk are skipped."""
+        from ramalama.model_store.reffile import StoreFileType
+
+        store = MagicMock()
+        store.path = str(tmp_path)
+
+        model_dir = tmp_path / "hf" / "model"
+        (model_dir / "refs").mkdir(parents=True)
+        (model_dir / "refs" / "latest.json").touch()
+        (model_dir / "blobs").mkdir()
+        # Don't create the blob file
+
+        model_file = _make_store_file("sha256:missing", StoreFileType.GGUF_MODEL)
+        ref = _make_ref_json_file([model_file])
+
+        models = _enumerate_store_gguf_models(
+            store,
+            "refs",
+            "snapshots",
+            "blobs",
+            MagicMock,
+            lambda p, s: ref,
+        )
+        assert models == []
+
+    def test_deduplicates_names(self, tmp_path):
+        """When two models produce the same name, a hash suffix is added."""
+        from ramalama.model_store.reffile import StoreFileType
+
+        store = MagicMock()
+        store.path = str(tmp_path)
+
+        model_dir = tmp_path / "hf" / "model"
+        (model_dir / "refs").mkdir(parents=True)
+        (model_dir / "refs" / "latest.json").touch()
+        (model_dir / "blobs").mkdir()
+        (model_dir / "blobs" / "sha256-aaa").touch()
+        (model_dir / "blobs" / "sha256-bbb").touch()
+
+        file_a = _make_store_file("sha256:aaa", StoreFileType.GGUF_MODEL)
+        file_b = _make_store_file("sha256:bbb", StoreFileType.GGUF_MODEL)
+        ref = _make_ref_json_file([file_a, file_b])
+
+        models = _enumerate_store_gguf_models(
+            store,
+            "refs",
+            "snapshots",
+            "blobs",
+            MagicMock,
+            lambda p, s: ref,
+        )
+        assert len(models) == 2
+        names = {m[1] for m in models}
+        assert len(names) == 2  # names are unique
+
+
+# ---------------------------------------------------------------------------
+# Router mode in _cmd_run
+# ---------------------------------------------------------------------------
+
+
+class TestRouterModeCmdRun:
+    """Tests for llama.cpp _cmd_run in router mode."""
+
+    def setup_method(self):
+        self.plugin = LlamaCppPlugin()
+
+    @pytest.fixture(autouse=True)
+    def _patch_container_image_is_ggml(self):
+        with patch.object(self.plugin, "_container_image_is_ggml", return_value=False):
+            yield
+
+    @patch("ramalama.plugins.runtimes.inference.llama_cpp_commands.should_colorize", return_value=False)
+    def test_router_mode_has_models_dir(self, mock_colorize):
+        ns = make_ns(container=True)
+        ns.router_mode = True
+        ns.models_max = 4
+        cmd = self.plugin.handle_subcommand("serve", ns)
+
+        assert "--models-dir" in cmd
+        assert cmd[cmd.index("--models-dir") + 1] == "/mnt/models"
+
+    @patch("ramalama.plugins.runtimes.inference.llama_cpp_commands.should_colorize", return_value=False)
+    def test_router_mode_has_models_max(self, mock_colorize):
+        ns = make_ns(container=True)
+        ns.router_mode = True
+        ns.models_max = 8
+        cmd = self.plugin.handle_subcommand("serve", ns)
+
+        assert "--models-max" in cmd
+        assert cmd[cmd.index("--models-max") + 1] == "8"
+
+    @patch("ramalama.plugins.runtimes.inference.llama_cpp_commands.should_colorize", return_value=False)
+    def test_router_mode_skips_model_and_alias(self, mock_colorize):
+        ns = make_ns(container=True)
+        ns.router_mode = True
+        ns.models_max = 4
+        cmd = self.plugin.handle_subcommand("serve", ns)
+
+        assert "--model" not in cmd
+        assert "--alias" not in cmd
+
+    @patch("ramalama.plugins.runtimes.inference.llama_cpp_commands.should_colorize", return_value=False)
+    def test_router_mode_skips_ngl(self, mock_colorize):
+        ns = make_ns(container=True, ngl=-1)
+        ns.router_mode = True
+        ns.models_max = 4
+        cmd = self.plugin.handle_subcommand("serve", ns)
+
+        assert "-ngl" not in cmd
+
+
+# ---------------------------------------------------------------------------
+# _serve_router
+# ---------------------------------------------------------------------------
+
+
+class TestServeRouter:
+    """Tests for BaseInferenceRuntime._serve_router."""
+
+    def setup_method(self):
+        self.plugin = LlamaCppPlugin()
+
+    def test_nocontainer_exits(self):
+        """Router mode requires a container runtime."""
+        args = argparse.Namespace(container=False)
+        with pytest.raises(SystemExit):
+            self.plugin._serve_router(args)
+
+    @patch("ramalama.plugins.runtimes.inference.common._enumerate_store_gguf_models", return_value=[])
+    @patch("ramalama.plugins.runtimes.inference.common.set_accel_env_vars")
+    @patch("ramalama.plugins.runtimes.inference.common.compute_serving_port", return_value="8080")
+    def test_no_models_exits(self, mock_port, mock_accel, mock_enum):
+        """Router mode exits if no GGUF models are found."""
+        args = argparse.Namespace(
+            container=True,
+            store="/fake/store",
+            port="8080",
+        )
+        with pytest.raises(SystemExit):
+            self.plugin._serve_router(args)
+
+    @patch("ramalama.plugins.runtimes.inference.common.Engine")
+    @patch("ramalama.plugins.runtimes.inference.common.assemble_command", return_value=["llama-server"])
+    @patch("ramalama.plugins.runtimes.inference.common.ensure_image", return_value="test-image")
+    @patch("ramalama.plugins.runtimes.inference.common.accel_image", return_value="test-image")
+    @patch("ramalama.plugins.runtimes.inference.common.set_accel_env_vars")
+    @patch("ramalama.plugins.runtimes.inference.common.compute_serving_port", return_value="8080")
+    @patch("ramalama.plugins.runtimes.inference.common._enumerate_store_gguf_models")
+    def test_dryrun_does_not_exec(
+        self,
+        mock_enum,
+        mock_port,
+        mock_accel,
+        mock_accel_img,
+        mock_ensure,
+        mock_assemble,
+        mock_engine_cls,
+    ):
+        """Dryrun calls engine.dryrun() instead of engine.exec()."""
+        mock_enum.return_value = [("/path/to/blob", "model.gguf")]
+        mock_engine = MagicMock()
+        mock_engine_cls.return_value = mock_engine
+
+        args = argparse.Namespace(
+            container=True,
+            store="/fake/store",
+            port="8080",
+            dryrun=True,
+            name=None,
+            image="test-image",
+            runtime="llama.cpp",
+            subcommand="serve",
+        )
+        with patch("ramalama.plugins.runtimes.inference.common.ActiveConfig") as mock_cfg:
+            mock_cfg.return_value.pull = "missing"
+            mock_cfg.return_value.engine = "podman"
+            self.plugin._serve_router(args)
+
+        mock_engine.dryrun.assert_called_once()
+        mock_engine.exec.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# service_ready_check router mode
+# ---------------------------------------------------------------------------
+
+
+class TestServiceReadyCheckRouterMode:
+    """Tests for LlamaCppPlugin.service_ready_check in router mode."""
+
+    def setup_method(self):
+        self.plugin = LlamaCppPlugin()
+
+    def test_router_mode_ready_with_any_model(self):
+        """In router mode (no MODEL), any loaded model means the server is ready."""
+        conn = MagicMock()
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.read.return_value = json.dumps({"models": [{"name": "some-model"}]}).encode()
+        conn.getresponse.return_value = mock_response
+
+        args = argparse.Namespace()
+        # No MODEL attribute — simulates router mode
+        result = self.plugin.service_ready_check(conn, args)
+        assert result is True
+
+    def test_router_mode_not_ready_on_http_error(self):
+        """In router mode, a non-200 /health status means the server is not ready."""
+        conn = MagicMock()
+        mock_response = MagicMock()
+        mock_response.status = 503
+        mock_response.reason = "Service Unavailable"
+        mock_response.read.return_value = b""
+        conn.getresponse.return_value = mock_response
+
+        args = argparse.Namespace()
+        result = self.plugin.service_ready_check(conn, args)
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Subcommand arg registration for router mode
+# ---------------------------------------------------------------------------
+
+
+class TestRouterModeSubcommandArgs:
+    """Test that serve subparser has the right args for multi-model router mode."""
+
+    def _make_parser(self):
+        from ramalama.cli import ArgumentParserWithDefaults
+
+        return ArgumentParserWithDefaults()
+
+    def _subparser_option_strings(self, parser, subcommand):
+        name_map = next(a for a in parser._actions if hasattr(a, "_name_parser_map"))._name_parser_map
+        subparser = name_map[subcommand]
+        return {opt for action in subparser._actions for opt in action.option_strings}
+
+    def test_llama_cpp_serve_has_models_max(self, monkeypatch):
+        from ramalama.config import ActiveConfig
+
+        monkeypatch.setattr(ActiveConfig(), "runtime", "llama.cpp")
+        parser = self._make_parser()
+        configure_subcommands(parser)
+        opts = self._subparser_option_strings(parser, "serve")
+        assert "--models-max" in opts
+
+    def test_llama_cpp_serve_has_backend(self, monkeypatch):
+        from ramalama.config import ActiveConfig
+
+        monkeypatch.setattr(ActiveConfig(), "runtime", "llama.cpp")
+        parser = self._make_parser()
+        configure_subcommands(parser)
+        opts = self._subparser_option_strings(parser, "serve")
+        assert "--backend" in opts
+
+    def test_llama_cpp_serve_model_is_optional(self, monkeypatch):
+        """MODEL positional arg is optional for serve (nargs='?')."""
+        from ramalama.config import ActiveConfig
+
+        monkeypatch.setattr(ActiveConfig(), "runtime", "llama.cpp")
+        parser = self._make_parser()
+        configure_subcommands(parser)
+        name_map = next(a for a in parser._actions if hasattr(a, "_name_parser_map"))._name_parser_map
+        serve_parser = name_map["serve"]
+        model_action = next(a for a in serve_parser._actions if "MODEL" in getattr(a, "dest", ""))
+        assert model_action.nargs == "?"
+
+    def test_vllm_serve_no_models_max(self, monkeypatch):
+        from ramalama.config import ActiveConfig
+
+        monkeypatch.setattr(ActiveConfig(), "runtime", "vllm")
+        monkeypatch.setattr(ActiveConfig(), "container", True)
+        parser = self._make_parser()
+        configure_subcommands(parser)
+        opts = self._subparser_option_strings(parser, "serve")
+        assert "--models-max" not in opts
+
+
+# ---------------------------------------------------------------------------
+# backend_to_gpu_env and get_gpu_backend_preferences
+# ---------------------------------------------------------------------------
+
+
+class TestBackendHelpers:
+    """Direct tests for backend helper functions."""
+
+    @pytest.mark.parametrize(
+        "backend,expected",
+        [
+            ("vulkan", "GGML_VK_VISIBLE_DEVICES"),
+            ("rocm", "HIP_VISIBLE_DEVICES"),
+            ("cuda", "CUDA_VISIBLE_DEVICES"),
+            ("sycl", "INTEL_VISIBLE_DEVICES"),
+            ("cann", "ASCEND_VISIBLE_DEVICES"),
+            ("musa", "MUSA_VISIBLE_DEVICES"),
+            ("nonexistent", ""),
+        ],
+    )
+    def test_backend_to_gpu_env(self, backend, expected):
+        assert backend_to_gpu_env(backend) == expected
+
+    def test_gpu_backend_preferences_nvidia(self):
+        prefs = get_gpu_backend_preferences("CUDA_VISIBLE_DEVICES")
+        assert prefs == ["cuda"]
+
+    def test_gpu_backend_preferences_amd(self):
+        prefs = get_gpu_backend_preferences("HIP_VISIBLE_DEVICES")
+        assert "vulkan" in prefs
+        assert "rocm" in prefs
+
+    def test_gpu_backend_preferences_unknown(self):
+        prefs = get_gpu_backend_preferences("UNKNOWN_DEVICES")
+        assert prefs == []

--- a/test/unit/test_inference_engine_plugins.py
+++ b/test/unit/test_inference_engine_plugins.py
@@ -18,7 +18,13 @@ from ramalama.compat import NamedTemporaryFile
 from ramalama.config import DEFAULT_IMAGE, load_config
 from ramalama.plugins.interface import InferenceRuntimePlugin
 from ramalama.plugins.runtimes.inference.common import ContainerizedInferenceRuntimePlugin
-from ramalama.plugins.runtimes.inference.llama_cpp import LlamaCppConfig, LlamaCppPlugin, get_available_backends
+from ramalama.plugins.runtimes.inference.llama_cpp import (
+    LlamaCppConfig,
+    LlamaCppPlugin,
+    backend_to_gpu_env,
+    get_available_backends,
+    get_gpu_backend_preferences,
+)
 from ramalama.plugins.runtimes.inference.mlx import MlxConfig, MlxPlugin
 from ramalama.plugins.runtimes.inference.vllm import VllmPlugin
 
@@ -1273,3 +1279,40 @@ def test_get_available_backends_windows(gpu_env: Optional[str], expected_backend
 
     with patch.dict("os.environ", env, clear=True):
         assert get_available_backends() == expected_backends
+
+
+# ---------------------------------------------------------------------------
+# backend_to_gpu_env and get_gpu_backend_preferences
+# ---------------------------------------------------------------------------
+
+
+class TestBackendHelpers:
+    """Direct tests for backend helper functions."""
+
+    @pytest.mark.parametrize(
+        "backend,expected",
+        [
+            ("vulkan", "GGML_VK_VISIBLE_DEVICES"),
+            ("rocm", "HIP_VISIBLE_DEVICES"),
+            ("cuda", "CUDA_VISIBLE_DEVICES"),
+            ("sycl", "INTEL_VISIBLE_DEVICES"),
+            ("cann", "ASCEND_VISIBLE_DEVICES"),
+            ("musa", "MUSA_VISIBLE_DEVICES"),
+            ("nonexistent", ""),
+        ],
+    )
+    def test_backend_to_gpu_env(self, backend, expected):
+        assert backend_to_gpu_env(backend) == expected
+
+    def test_gpu_backend_preferences_nvidia(self):
+        prefs = get_gpu_backend_preferences("CUDA_VISIBLE_DEVICES")
+        assert prefs == ["cuda"]
+
+    def test_gpu_backend_preferences_amd(self):
+        prefs = get_gpu_backend_preferences("HIP_VISIBLE_DEVICES")
+        assert "vulkan" in prefs
+        assert "rocm" in prefs
+
+    def test_gpu_backend_preferences_unknown(self):
+        prefs = get_gpu_backend_preferences("UNKNOWN_DEVICES")
+        assert prefs == []

--- a/test/unit/test_router_mode.py
+++ b/test/unit/test_router_mode.py
@@ -1,0 +1,186 @@
+"""Unit tests for llama.cpp multi-model router mode."""
+
+import argparse
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from test_inference_engine_plugins import make_ns
+
+from ramalama.cli import configure_subcommands
+from ramalama.plugins.runtimes.inference.common import _enumerate_store_gguf_models
+from ramalama.plugins.runtimes.inference.llama_cpp import LlamaCppPlugin
+
+# ---------------------------------------------------------------------------
+# _enumerate_store_gguf_models
+# ---------------------------------------------------------------------------
+
+
+class TestEnumerateStoreGgufModels:
+    def test_finds_gguf_models(self, tmp_path):
+        from ramalama.model_store.reffile import StoreFileType
+
+        store = MagicMock()
+        store.path = str(tmp_path)
+
+        model_dir = tmp_path / "huggingface" / "mymodel"
+        (model_dir / "refs").mkdir(parents=True)
+        (model_dir / "refs" / "latest.json").touch()
+        (model_dir / "blobs").mkdir()
+        (model_dir / "blobs" / "sha256-abc123").touch()
+
+        sf = MagicMock()
+        sf.hash = "sha256:abc123"
+        sf.type = StoreFileType.GGUF_MODEL
+        ref = MagicMock()
+        ref.model_files = [sf]
+
+        models = _enumerate_store_gguf_models(
+            store,
+            "refs",
+            "snapshots",
+            "blobs",
+            MagicMock,
+            lambda path, snap_dir: ref,
+        )
+
+        assert len(models) == 1
+        assert models[0][0] == str(model_dir / "blobs" / "sha256-abc123")
+        assert models[0][1].endswith(".gguf")
+
+    def test_empty_store_returns_empty(self, tmp_path):
+        store = MagicMock()
+        store.path = str(tmp_path)
+        tmp_path.mkdir(exist_ok=True)
+
+        models = _enumerate_store_gguf_models(
+            store,
+            "refs",
+            "snapshots",
+            "blobs",
+            MagicMock,
+            lambda p, s: None,
+        )
+        assert models == []
+
+
+# ---------------------------------------------------------------------------
+# Router mode in _cmd_run
+# ---------------------------------------------------------------------------
+
+
+class TestRouterModeCmdRun:
+    def setup_method(self):
+        self.plugin = LlamaCppPlugin()
+
+    @pytest.fixture(autouse=True)
+    def _patch_container_image_is_ggml(self):
+        with patch.object(self.plugin, "_container_image_is_ggml", return_value=False):
+            yield
+
+    @patch("ramalama.plugins.runtimes.inference.llama_cpp_commands.should_colorize", return_value=False)
+    def test_router_mode_has_models_dir_and_max(self, mock_colorize):
+        ns = make_ns(container=True)
+        ns.router_mode = True
+        ns.models_max = 8
+        cmd = self.plugin.handle_subcommand("serve", ns)
+
+        assert "--models-dir" in cmd
+        assert cmd[cmd.index("--models-dir") + 1] == "/mnt/models"
+        assert "--models-max" in cmd
+        assert cmd[cmd.index("--models-max") + 1] == "8"
+
+    @patch("ramalama.plugins.runtimes.inference.llama_cpp_commands.should_colorize", return_value=False)
+    def test_router_mode_skips_single_model_flags(self, mock_colorize):
+        ns = make_ns(container=True, ngl=-1)
+        ns.router_mode = True
+        ns.models_max = 4
+        cmd = self.plugin.handle_subcommand("serve", ns)
+
+        assert "--model" not in cmd
+        assert "--alias" not in cmd
+        assert "-ngl" not in cmd
+
+
+# ---------------------------------------------------------------------------
+# _serve_router guard rails
+# ---------------------------------------------------------------------------
+
+
+class TestServeRouter:
+    def setup_method(self):
+        self.plugin = LlamaCppPlugin()
+
+    def test_nocontainer_exits(self):
+        args = argparse.Namespace(container=False)
+        with pytest.raises(SystemExit):
+            self.plugin._serve_router(args)
+
+    @patch("ramalama.plugins.runtimes.inference.llama_cpp._enumerate_store_gguf_models", return_value=[])
+    @patch("ramalama.plugins.runtimes.inference.llama_cpp.set_accel_env_vars")
+    @patch("ramalama.plugins.runtimes.inference.llama_cpp.compute_serving_port", return_value="8080")
+    def test_no_models_exits(self, mock_port, mock_accel, mock_enum):
+        args = argparse.Namespace(container=True, store="/fake/store", port="8080", MODEL=[])
+        with pytest.raises(SystemExit):
+            self.plugin._serve_router(args)
+
+
+# ---------------------------------------------------------------------------
+# service_ready_check router mode
+# ---------------------------------------------------------------------------
+
+
+class TestServiceReadyCheckRouterMode:
+    def setup_method(self):
+        self.plugin = LlamaCppPlugin()
+
+    def test_router_mode_ready_with_any_model(self):
+        conn = MagicMock()
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.read.return_value = json.dumps({"models": [{"name": "some-model"}]}).encode()
+        conn.getresponse.return_value = mock_response
+
+        result = self.plugin.service_ready_check(conn, argparse.Namespace(MODEL=[]))
+        assert result is True
+
+    def test_router_mode_not_ready_with_no_models(self):
+        conn = MagicMock()
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.read.return_value = json.dumps({"models": []}).encode()
+        conn.getresponse.return_value = mock_response
+
+        result = self.plugin.service_ready_check(conn, argparse.Namespace(MODEL=[]))
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Subcommand arg registration for router mode
+# ---------------------------------------------------------------------------
+
+
+class TestRouterModeSubcommandArgs:
+    def test_llama_cpp_serve_has_models_max(self, monkeypatch):
+        from ramalama.cli import ArgumentParserWithDefaults
+        from ramalama.config import ActiveConfig
+
+        monkeypatch.setattr(ActiveConfig(), "runtime", "llama.cpp")
+        parser = ArgumentParserWithDefaults()
+        configure_subcommands(parser)
+        name_map = next(a for a in parser._actions if hasattr(a, "_name_parser_map"))._name_parser_map
+        serve_parser = name_map["serve"]
+        opts = {opt for action in serve_parser._actions for opt in action.option_strings}
+        assert "--models-max" in opts
+
+    def test_llama_cpp_serve_model_accepts_multiple(self, monkeypatch):
+        from ramalama.cli import ArgumentParserWithDefaults
+        from ramalama.config import ActiveConfig
+
+        monkeypatch.setattr(ActiveConfig(), "runtime", "llama.cpp")
+        parser = ArgumentParserWithDefaults()
+        configure_subcommands(parser)
+        name_map = next(a for a in parser._actions if hasattr(a, "_name_parser_map"))._name_parser_map
+        serve_parser = name_map["serve"]
+        model_action = next(a for a in serve_parser._actions if "MODEL" in getattr(a, "dest", ""))
+        assert model_action.nargs == "*"

--- a/test/unit/test_router_mode.py
+++ b/test/unit/test_router_mode.py
@@ -8,11 +8,11 @@ import pytest
 from test_inference_engine_plugins import make_ns
 
 from ramalama.cli import configure_subcommands
-from ramalama.plugins.runtimes.inference.common import _enumerate_store_gguf_models
+from ramalama.plugins.runtimes.inference.common import enumerate_store_gguf_models
 from ramalama.plugins.runtimes.inference.llama_cpp import LlamaCppPlugin
 
 # ---------------------------------------------------------------------------
-# _enumerate_store_gguf_models
+# enumerate_store_gguf_models
 # ---------------------------------------------------------------------------
 
 
@@ -35,13 +35,13 @@ class TestEnumerateStoreGgufModels:
         ref = MagicMock()
         ref.model_files = [sf]
 
-        models = _enumerate_store_gguf_models(
+        ref_cls = MagicMock()
+        ref_cls.from_path = MagicMock(return_value=ref)
+        models = enumerate_store_gguf_models(
             store,
             "refs",
-            "snapshots",
             "blobs",
-            MagicMock,
-            lambda path, snap_dir: ref,
+            ref_cls,
         )
 
         assert len(models) == 1
@@ -53,13 +53,11 @@ class TestEnumerateStoreGgufModels:
         store.path = str(tmp_path)
         tmp_path.mkdir(exist_ok=True)
 
-        models = _enumerate_store_gguf_models(
+        models = enumerate_store_gguf_models(
             store,
             "refs",
-            "snapshots",
             "blobs",
             MagicMock,
-            lambda p, s: None,
         )
         assert models == []
 
@@ -116,10 +114,11 @@ class TestServeRouter:
         with pytest.raises(SystemExit):
             self.plugin._serve_router(args)
 
-    @patch("ramalama.plugins.runtimes.inference.llama_cpp._enumerate_store_gguf_models", return_value=[])
+    @patch("ramalama.plugins.runtimes.inference.llama_cpp.enumerate_store_gguf_models", return_value=[])
+    @patch.object(LlamaCppPlugin, "_migrate_store_ref_files")
     @patch("ramalama.plugins.runtimes.inference.llama_cpp.set_accel_env_vars")
     @patch("ramalama.plugins.runtimes.inference.llama_cpp.compute_serving_port", return_value="8080")
-    def test_no_models_exits(self, mock_port, mock_accel, mock_enum):
+    def test_no_models_exits(self, mock_port, mock_accel, mock_migrate, mock_enum):
         args = argparse.Namespace(container=True, store="/fake/store", port="8080", MODEL=[])
         with pytest.raises(SystemExit):
             self.plugin._serve_router(args)


### PR DESCRIPTION
## Summary
- When `ramalama serve` is invoked without a MODEL argument, it starts llama.cpp in router mode
- Automatically discovers and mounts all locally stored GGUF models into a container, serving them via llama.cpp's `--models-dir` feature
- Adds `--models-max` flag to control how many models can be loaded concurrently (default: 4)
- Router mode requires a container runtime; raises `NotImplementedError` with `--nocontainer`

## Details
This enables users to serve multiple models through a single endpoint with automatic model swapping, leveraging llama.cpp's built-in router/model-directory support. The server will load models on demand as requests come in, up to the configured `--models-max` limit.

### Files changed
- `ramalama/plugins/runtimes/inference/common.py` — Made MODEL optional in serve registration, added `_serve_router()` handler and `_enumerate_store_gguf_models()` helper
- `ramalama/plugins/runtimes/inference/llama_cpp_commands.py` — Updated `_cmd_run` to emit `--models-dir`/`--models-max` instead of single-model flags when in router mode
- `ramalama/plugins/runtimes/inference/llama_cpp.py` — Added `--models-max` CLI argument, updated `service_ready_check` for router mode

## Test plan
- [ ] `ramalama serve` with no model argument (container mode) starts llama.cpp with `--models-dir`
- [ ] `ramalama serve` with no model and `--nocontainer` raises a clear error
- [ ] `ramalama serve <model>` continues to work as before (single model mode)
- [ ] `ramalama serve --models-max 2` limits concurrent models
- [ ] `ramalama serve --dryrun` shows the full container command with model mounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enable container-only multi-model router mode for `ramalama serve` using llama.cpp’s models directory support.

New Features:
- Allow `ramalama serve` to run in router mode when invoked without a MODEL argument, serving multiple GGUF models from the local model store through a single endpoint.
- Add a `--models-max` CLI option to limit the number of models that can be loaded concurrently in router mode.

Enhancements:
- Automatically discover GGUF models in the global model store and mount them into the inference container for llama.cpp router mode.
- Update llama.cpp command construction to use `--models-dir`/`--models-max` in router mode instead of single-model flags and to skip per-model GPU/draft settings when routing.
- Treat router-mode servers as ready as soon as any model is available, adjusting the readiness check accordingly.
- Disallow router mode without a container runtime by raising a clear `NotImplementedError` when `ramalama serve` is run without a model and `--nocontainer` is set.