### PR TITLE
ramalama sandbox opencode: support running OpenCode in a sandbox

### DIFF
--- a/docs/ramalama-sandbox-opencode.1.md
+++ b/docs/ramalama-sandbox-opencode.1.md
@@ -1,0 +1,281 @@
+% ramalama-sandbox-opencode 1
+
+## NAME
+ramalama\-sandbox\-opencode - run OpenCode in a sandbox, backed by a local AI Model
+
+## SYNOPSIS
+**ramalama sandbox opencode** [*options*] *model* [arg ...]
+
+## DESCRIPTION
+Run OpenCode in a container, connected to a local model server also running
+in a container. OpenCode uses the model for reasoning and tool calling.
+
+When run with no arguments after the model, an interactive TUI session is
+launched. If one or more arguments are provided, they are passed to the agent
+as instructions to process non-interactively. Commands may also be passed via
+stdin.
+
+Two containers are started: a model server (llama-server) and the agent
+container. They communicate via container networking. When the agent session
+exits, the model server container is automatically stopped and removed.
+
+## OPTIONS
+
+#### **--authfile**=*password*
+Path of the authentication file for OCI registries
+
+#### **--backend**=*auto* | vulkan | rocm | cuda | sycl | openvino
+GPU backend to use for inference (default: auto).
+
+Available backends depend on the detected GPU hardware.
+
+**auto** (default): Automatically selects the preferred backend based on your GPU:
+- **AMD GPUs**: vulkan (Linux/macOS) or rocm (Windows)
+- **NVIDIA GPUs**: cuda
+- **Intel GPUs**: vulkan (Linux/macOS) or sycl (Windows); openvino available as explicit option
+- **No GPU**: vulkan (CPU fallback)
+
+**Platform-specific behavior**:
+- On **Linux/macOS**, Vulkan provides broad compatibility and is preferred for AMD and Intel GPUs
+- On **Windows**, vulkan is not supported on WSL2, so vendor-specific backends (rocm, sycl) are preferred
+
+**Explicit backend selection**:
+- **vulkan**: Use Vulkan-based inference (compatible with AMD, Intel, and CPU)
+- **rocm**: Use AMD ROCm backend (AMD GPUs only)
+- **cuda**: Use NVIDIA CUDA backend (NVIDIA GPUs only)
+- **sycl**: Use Intel SYCL/oneAPI backend (Intel GPUs only)
+- **openvino**: Use Intel OpenVINO backend (Intel GPUs only); uses `ghcr.io/ggml-org/llama.cpp:full-openvino`
+
+**Available choices**: The allowed values for `--backend` are dynamically determined based on
+your detected GPU hardware. For example, on a system with an AMD GPU, only `auto`, `vulkan`,
+and `rocm` are available.
+
+**Configuration**: The default can be overridden in the `ramalama.conf` file or via the
+RAMALAMA_BACKEND environment variable.
+
+Examples:
+```
+# Use auto-detection (default)
+ramalama serve granite
+
+# Force Vulkan backend
+ramalama serve --backend vulkan granite
+
+# Force ROCm backend on AMD GPU
+ramalama serve --backend rocm granite
+```
+
+#### **--cache-reuse**=256
+Min chunk size to attempt reusing from the cache via KV shifting
+
+#### **--ctx-size**, **-c**
+Size of the prompt context. This option is also available as **--max-model-len**. Applies to llama.cpp and vLLM regardless of alias (default: 0, 0 = loaded from model).
+
+#### **--device**
+Add a host device to the container. Optional permissions parameter can
+be used to specify device permissions by combining r for read, w for
+write, and m for mknod(2).
+
+Example: --device=/dev/dri/renderD128:/dev/xvdc:rwm
+
+The device specification is passed directly to the underlying container engine. See documentation of the supported container engine for more information.
+
+Pass '--device=none' to explicitly add no device to the container, e.g. for
+running a CPU-only performance comparison.
+
+#### **--env**=
+
+Set environment variables inside of the container.
+
+This option allows arbitrary environment variables that are available for the
+process to be launched inside of the container. If an environment variable is
+specified without a value, the container engine checks the host environment
+for a value and set the variable only if it is set on the host.
+
+#### **--help**, **-h**
+show this help message and exit
+
+#### **--host**="0.0.0.0"
+IP address for llama.cpp to listen on.
+
+#### **--image**=IMAGE
+OCI container image to run with specified AI model. RamaLama defaults to using
+images based on the accelerator it discovers. For example:
+`quay.io/ramalama/ramalama`. See the table below for all default images.
+The default image tag is based on the minor version of the RamaLama package.
+Version 0.18.0 of RamaLama pulls an image with a `:0.18` tag from the quay.io/ramalama OCI repository. The --image option overrides this default.
+
+The default can be overridden in the `ramalama.conf` file or via the
+RAMALAMA_IMAGE environment variable. `export RAMALAMA_IMAGE=quay.io/ramalama/aiimage:1.2` tells
+RamaLama to use the `quay.io/ramalama/aiimage:1.2` image.
+
+Accelerated images:
+
+| Accelerator             | Image                      |
+| ------------------------| -------------------------- |
+|  CPU, Apple             | quay.io/ramalama/ramalama  |
+|  HIP_VISIBLE_DEVICES    | quay.io/ramalama/rocm      |
+|  CUDA_VISIBLE_DEVICES   | quay.io/ramalama/cuda      |
+|  ASAHI_VISIBLE_DEVICES  | quay.io/ramalama/asahi     |
+|  INTEL_VISIBLE_DEVICES  | quay.io/ramalama/intel-gpu |
+|  ASCEND_VISIBLE_DEVICES | quay.io/ramalama/cann      |
+|  MUSA_VISIBLE_DEVICES   | quay.io/ramalama/musa      |
+
+Upstream llama.cpp "full" images from `ghcr.io/ggml-org/llama.cpp` are also supported.
+RamaLama automatically detects the image type and adjusts the container CLI accordingly.
+
+```
+ramalama serve --image ghcr.io/ggml-org/llama.cpp:full-vulkan MODEL
+```
+
+#### **--keep-groups**
+pass --group-add keep-groups to podman (default: False)
+If GPU device on host system is accessible to user via group access, this option leaks the groups into the container.
+
+#### **--logfile**=*path*
+Log output to a file
+
+#### **--max-tokens**=*integer*
+Maximum number of tokens to generate. Set to 0 for unlimited output (default: 0).
+This parameter is mapped to the appropriate runtime-specific parameter:
+- llama.cpp: `-n` parameter
+- MLX: `--max-tokens` parameter
+- vLLM: `--max-tokens` parameter
+
+#### **--model-draft**
+
+A draft model is a smaller, faster model that helps accelerate the decoding
+process of larger, more complex models, like Large Language Models (LLMs). It
+works by generating candidate sequences of tokens that the larger model then
+verifies and refines. This approach, often referred to as speculative decoding,
+can significantly improve the speed of inferencing by reducing the number of
+times the larger model needs to be invoked.
+
+Use --runtime-args to pass the other draft model related parameters.
+Make sure the sampling parameters like top_k on the web UI are set correctly.
+
+#### **--name**, **-n**
+Name of the container to run the Model in.
+
+#### **--network**=*""*
+set the network mode for the container
+
+#### **--ngl**
+number of GPU layers, 0 means CPU inferencing, 999 means use max layers (default: -1)
+The default, -1, means use whatever is automatically deemed appropriate (0 or 999)
+
+#### **--oci-runtime**
+
+Override the default OCI runtime used to launch the container. Container
+engines like Podman and Docker have their own default OCI runtime that they
+use. Using this option, RamaLama will override these defaults.
+
+On NVIDIA-based GPU systems, RamaLama defaults to using the
+`nvidia-container-runtime`. Use this option to override this selection.
+
+#### **--opencode-image**=*IMAGE*
+OpenCode container image
+
+#### **--port**, **-p**
+port for AI Model server to listen on. It must be available. If not specified,
+a free port in the 8080-8180 range is selected, starting with 8080.
+
+The default can be overridden in the `ramalama.conf` file.
+
+#### **--privileged**
+By default, RamaLama containers are unprivileged (=false) and cannot, for
+example, modify parts of the operating system. This is because by de‐
+fault a container is only allowed limited access to devices. A "privi‐
+leged" container is given the same access to devices as the user launch‐
+ing the container, with the exception of virtual consoles (/dev/tty\d+)
+when running in systemd mode (--systemd=always).
+
+A privileged container turns off the security features that isolate the
+container from the host. Dropped Capabilities, limited devices, read-
+only mount points, Apparmor/SELinux separation, and Seccomp filters are
+all disabled. Due to the disabled security features, the privileged
+field should almost never be set as containers can easily break out of
+confinement.
+
+Containers running in a user namespace (e.g., rootless containers) can‐
+not have more privileges than the user that launched them.
+
+#### **--pull**=*policy*
+
+- **always**: Always pull the image and throw an error if the pull fails.
+- **missing**: Only pull the image when it does not exist in the local containers storage. Throw an error if no image is found and the pull fails.
+- **never**: Never pull the image but use the one from the local containers storage. Throw an error when no image is found.
+- **newer**: Pull if the image on the registry is newer than the one in the local containers storage. An image is considered to be newer when the digests are different. Comparing the time stamps is prone to errors. Pull errors are suppressed if a local image was found.
+
+#### **--runtime-args**="*args*"
+Add *args* to the runtime (llama.cpp or vllm) invocation.
+
+#### **--seed**=
+Specify a seed rather than using a random seed.
+
+#### **--selinux**=*true*
+Enable SELinux container separation
+
+#### **--temp**="0.8"
+Temperature of the response from the AI Model.
+llama.cpp explains this as:
+
+    The lower the number is, the more deterministic the response.
+
+    The higher the number is the more creative the response is, but more likely to hallucinate when set too high.
+
+	Usage: Lower numbers are good for virtual assistants where we need deterministic responses. Higher numbers are good for roleplay or creative tasks like editing stories
+
+#### **--thinking**=*true*
+Enable or disable thinking mode in reasoning models
+
+#### **--threads**, **-t**
+Maximum number of CPU threads to use.
+The default is to use half the cores available on this system for the number of threads.
+
+#### **--tls-verify**=*true*
+require HTTPS and verify certificates when contacting OCI registries
+
+#### **--webui**=*on* | *off*
+Enable or disable the web UI for the served model (enabled by default). When set to "on" (the default), the web interface is properly initialized. When set to "off", the `--no-webui` option is passed to the llama-server command to disable the web interface.
+
+#### **--workdir**, **-w**
+Local directory to mount into the sandbox container at /work
+
+## EXAMPLES
+
+Run the OpenCode agent with default settings:
+```
+ramalama sandbox opencode qwen3:4b
+```
+
+Run the OpenCode agent with a custom image:
+```
+ramalama sandbox opencode --opencode-image ghcr.io/anomalyco/opencode:v1.3.0 qwen3:4b
+```
+
+Turn off thinking mode in the model the agent is connecting to (may result in faster responses):
+```
+ramalama sandbox opencode --thinking=off qwen3:4b
+```
+
+Start an interactive session with access to a local directory:
+```
+ramalama sandbox opencode -w ./src qwen3:4b
+```
+
+Request the agent to perform actions non-interactively:
+```
+ramalama sandbox opencode -w ./src qwen3:4b Please analyze the source code in the current directory
+```
+
+Send instructions to the agent via stdin:
+```
+echo "What is the speed of light in meters per second?" | ramalama sandbox opencode qwen3:4b
+```
+
+## SEE ALSO
+**[ramalama(1)](ramalama.1.md)**, **[ramalama-run(1)](ramalama-run.1.md)**, **[ramalama-serve(1)](ramalama-serve.1.md)**, **[ramalama-sandbox(1)](ramalama-sandbox.1.md)**
+
+## HISTORY
+Mar 2026, Originally compiled by Mike Bonnet <mikeb@redhat.com>

--- a/docs/ramalama-sandbox.1.md
+++ b/docs/ramalama-sandbox.1.md
@@ -13,6 +13,7 @@ in a container. The agent uses the model for reasoning and tool calling.
 The *agent* argument selects which AI agent to run. Currently supported agents:
 
 - **goose** - the Goose AI agent (https://github.com/block/goose)
+- **opencode** - the OpenCode AI agent (https://opencode.ai/)
 
 ## OPTIONS
 
@@ -24,6 +25,7 @@ show this help message and exit
 | Command  | Man Page                                                       | Description                                           |
 | -------- | -------------------------------------------------------------- | ----------------------------------------------------- |
 | goose    | [ramalama-sandbox-goose(1)](ramalama-sandbox-goose.1.md)       | run Goose in a sandbox, backed by a local AI Model    |
+| opencode | [ramalama-sandbox-opencode(1)](ramalama-sandbox-opencode.1.md) | run OpenCode in a sandbox, backed by a local AI Model |
 
 ## SEE ALSO
 **[ramalama(1)](ramalama.1.md)**, **[ramalama-run(1)](ramalama-run.1.md)**, **[ramalama-serve(1)](ramalama-serve.1.md)**

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -990,18 +990,8 @@ def sandbox_parser(subparsers):
 
     from ramalama.sandbox import add_sandbox_subparsers
 
-    for parser in add_sandbox_subparsers(sandbox_subparsers, local_images, local_models):
-        runtime_options(parser, "sandbox")
-        parser.set_defaults(func=sandbox_cli)
-
-
-def sandbox_cli(args):
-    if not args.container:
-        raise ValueError("ramalama sandbox requires a container engine")
-
-    from ramalama.sandbox import run_sandbox
-
-    run_sandbox(args)
+    for sub_parser in add_sandbox_subparsers(sandbox_subparsers, local_images, local_models):
+        runtime_options(sub_parser, "sandbox")
 
 
 def stop_parser(subparsers):

--- a/ramalama/sandbox.py
+++ b/ramalama/sandbox.py
@@ -1,6 +1,8 @@
 import argparse
+import json
 import platform
 from collections.abc import Callable
+from typing import cast
 
 from ramalama.arg_types import BaseEngineArgsType
 from ramalama.common import run_cmd
@@ -9,6 +11,20 @@ from ramalama.engine import Engine, stop_container
 from ramalama.plugins.loader import get_runtime
 from ramalama.transports.base import compute_serving_port
 from ramalama.transports.transport_factory import New
+
+
+def _add_common_sandbox_args(parser: argparse.ArgumentParser) -> None:
+    """Add --workdir and ARGS arguments shared by all sandbox subcommands."""
+    parser.add_argument(
+        "-w",
+        "--workdir",
+        help="local directory to mount into the sandbox container at /work",
+    )
+    parser.add_argument(
+        "ARGS",
+        nargs="*",
+        help="instructions for the sandbox to process non-interactively",
+    )
 
 
 def add_sandbox_subparsers(subparsers: argparse._SubParsersAction, img_comp: Callable, model_comp: Callable):
@@ -31,21 +47,28 @@ def add_sandbox_subparsers(subparsers: argparse._SubParsersAction, img_comp: Cal
         completer=img_comp,
         help="Goose container image",
     )
+    _add_common_sandbox_args(parser)
+    parser.set_defaults(func=run_sandbox_goose)
+    yield parser
+
+    parser = subparsers.add_parser("opencode", help="run OpenCode in a sandbox, backed by a local AI Model")
+    if getattr(runtime, "_add_inference_args", None):
+        runtime._add_inference_args(parser, "serve")  # type: ignore[attr-defined]
+    parser.add_argument("MODEL", completer=model_comp)
     parser.add_argument(
-        "-w",
-        "--workdir",
-        help="local directory to mount into the sandbox container at /work",
+        "--opencode-image",
+        default="ghcr.io/anomalyco/opencode:1.3.7",
+        completer=img_comp,
+        help="OpenCode container image",
     )
-    parser.add_argument(
-        "ARGS",
-        nargs="*",
-        help="instructions for the sandbox to process non-interactively",
-    )
+    _add_common_sandbox_args(parser)
+    parser.set_defaults(func=run_sandbox_opencode)
     yield parser
 
 
 class SandboxEngineArgsType(BaseEngineArgsType):
     ARGS: list[str]
+    workdir: str | None
 
 
 class SandboxEngine(Engine):
@@ -63,6 +86,11 @@ class SandboxEngine(Engine):
     def add_network(self) -> None:
         self.add_args(f"--network=container:{self.args.name}")  # type: ignore[attr-defined]
 
+    def add_workdir(self, args: SandboxEngineArgsType):
+        if args.workdir:
+            self.add_volume(args.workdir, "/work", opts="rw")
+            self.add_args("--workdir=/work")
+
     def add_port_option(self) -> None:
         pass
 
@@ -78,10 +106,22 @@ class SandboxEngine(Engine):
 
 class GooseArgsType(SandboxEngineArgsType):
     goose_image: str
-    workdir: str | None
 
 
-class Goose:
+class Agent:
+    """
+    Run an agent in a container.
+    """
+
+    def __init__(self, args: SandboxEngineArgsType, model_name: str):
+        self.engine = SandboxEngine(args)
+        self.model_name = model_name
+
+    def run(self) -> None:
+        run_cmd(self.engine.exec_args, stdout=None, stdin=None)
+
+
+class Goose(Agent):
     """
     Run Goose in a sandbox.
     Environment variables required by Goose will be set, and any workdir specified will be mounted into the container.
@@ -90,13 +130,13 @@ class Goose:
     """
 
     def __init__(self, args: GooseArgsType, model_name: str) -> None:
-        self.engine = SandboxEngine(args)
+        super().__init__(args, model_name)
         if self.engine.use_podman:
             if platform.system() != "Windows":
                 self.engine.add_args("--uidmap=+1000:0")
         self.engine.add_name(f"goose-{args.name}")  # type: ignore[attr-defined]
-        self.add_env_options(args, model_name)
-        self.add_workdir(args)
+        self.add_env_options(args)
+        self.engine.add_workdir(args)
         self.engine.add_args(args.goose_image)
         if args.ARGS:
             self.engine.add_args("run", "-t", " ".join(args.ARGS))
@@ -105,25 +145,74 @@ class Goose:
         else:
             self.engine.add_args("run", "-i", "-")
 
-    def add_env_options(self, args: GooseArgsType, model_name: str) -> None:
+    def add_env_options(self, args: GooseArgsType) -> None:
         self.engine.add_env_option("GOOSE_PROVIDER=openai")
         self.engine.add_env_option(f"OPENAI_HOST=http://localhost:{args.port}")
         self.engine.add_env_option("OPENAI_API_KEY=ramalama")
-        self.engine.add_env_option(f"GOOSE_MODEL={model_name}")
+        self.engine.add_env_option(f"GOOSE_MODEL={self.model_name}")
         self.engine.add_env_option("GOOSE_TELEMETRY_ENABLED=false")
         self.engine.add_env_option("GOOSE_CLI_SHOW_THINKING=true")
 
-    def add_workdir(self, args: GooseArgsType):
-        if args.workdir:
-            self.engine.add_volume(args.workdir, "/work", opts="rw")
-            self.engine.add_args("--workdir=/work")
 
-    def run(self) -> None:
-        run_cmd(self.engine.exec_args, stdout=None, stdin=None)
+class OpenCodeArgsType(SandboxEngineArgsType):
+    opencode_image: str
 
 
-def run_sandbox(args):
+class OpenCode(Agent):
+    """
+    Run OpenCode in a sandbox.
+    Environment variables required by OpenCode will be set, and any workdir specified will be mounted into the
+    container. If args are provided, they will be passed to OpenCode to process non-interactively. If there are
+    no arguments and stdin is a tty, an interactive TUI session will be started. Otherwise, instructions will be
+    read from stdin.
+    """
+
+    def __init__(self, args: OpenCodeArgsType, model_name: str) -> None:
+        super().__init__(args, model_name)
+        self.engine.add_name(f"opencode-{args.name}")  # type: ignore[attr-defined]
+        self.add_env_options(args)
+        self.engine.add_workdir(args)
+        self.engine.add_args(args.opencode_image)
+        if args.ARGS:
+            self.engine.add_args("run", " ".join(args.ARGS))
+        elif not self.engine.use_tty():
+            self.engine.add_args("run", "-")
+
+    def add_env_options(self, args: OpenCodeArgsType) -> None:
+        config = {
+            "$schema": "https://opencode.ai/config.json",
+            "provider": {
+                "ramalama": {
+                    "npm": "@ai-sdk/openai-compatible",
+                    "name": "RamaLama",
+                    "options": {
+                        "baseURL": f"http://localhost:{args.port}/v1",
+                        "apiKey": "ramalama",
+                    },
+                    "models": {
+                        self.model_name: {
+                            "name": self.model_name,
+                        },
+                    },
+                },
+            },
+        }
+        self.engine.add_env_option(f"OPENCODE_CONFIG_CONTENT={json.dumps(config)}")
+
+
+def run_sandbox_goose(args: GooseArgsType):
+    run_sandbox(args, Goose)
+
+
+def run_sandbox_opencode(args: OpenCodeArgsType):
+    run_sandbox(args, OpenCode)
+
+
+def run_sandbox(args: SandboxEngineArgsType, agent_cls: type[Agent]):
     """Orchestrate model server and sandbox containers."""
+
+    if not args.container:  # type: ignore[attr-defined]
+        raise ValueError("ramalama sandbox requires a container engine")
 
     args.port = compute_serving_port(args)
 
@@ -131,22 +220,22 @@ def run_sandbox(args):
     model.ensure_model_exists(args)
 
     runtime = get_runtime(ActiveConfig().runtime)
-    cmd = runtime.handle_subcommand("serve", args)
+    cmd = runtime.handle_subcommand("serve", cast(argparse.Namespace, args))
 
-    model.serve_nonblocking(args, cmd)
+    model.serve_nonblocking(args, cmd)  # type: ignore[union-attr]
 
-    goose = Goose(args, model.model_alias)
+    agent = agent_cls(args, model.model_alias)
 
     if args.dryrun:
-        goose.engine.dryrun()
+        agent.engine.dryrun()
         return
 
     try:
         # Wait for model server to be healthy
-        model.wait_for_healthy(args)
+        model.wait_for_healthy(args)  # type: ignore[union-attr]
 
-        # Launch Goose
-        goose.run()
+        # Launch agent
+        agent.run()
     finally:
-        args.ignore = True
-        stop_container(args, args.name, remove=True)
+        args.ignore = True  # type: ignore[attr-defined]
+        stop_container(args, args.name, remove=True)  # type: ignore[attr-defined]

--- a/test/e2e/test_sandbox.py
+++ b/test/e2e/test_sandbox.py
@@ -7,7 +7,13 @@ from test.conftest import skip_if_no_container, skip_if_not_windows, skip_if_ppc
 from test.e2e.utils import RamalamaExecWorkspace, check_output
 
 TEST_MODEL = "qwen3:1.7b"
-RAMALAMA_SANDBOX_DRY_RUN = ["ramalama", "-q", "--dryrun", "sandbox", "goose", TEST_MODEL]
+
+
+def _dryrun_cmd(agent):
+    return ["ramalama", "-q", "--dryrun", "sandbox", agent, TEST_MODEL]
+
+
+RAMALAMA_SANDBOX_DRY_RUN = _dryrun_cmd("goose")
 
 
 @pytest.fixture(scope="module")
@@ -21,13 +27,20 @@ def sandbox_ctx():
         yield ctx
 
 
+# --- Parametrized dryrun tests ---
+
+
 @pytest.mark.e2e
 @skip_if_no_container
 @skip_if_windows
-def test_sandbox_dryrun_default():
+@pytest.mark.parametrize("agent", ["goose", "opencode"])
+def test_sandbox_dryrun_default(agent):
     """Dryrun should print container commands including run."""
-    result = check_output(RAMALAMA_SANDBOX_DRY_RUN, stdin=subprocess.DEVNULL)
-    assert re.search(r"run -i -", result)
+    result = check_output(_dryrun_cmd(agent), stdin=subprocess.DEVNULL)
+    if agent == "goose":
+        assert re.search(r"run -i -", result)
+    else:
+        assert re.search(r"run -", result)
 
 
 @pytest.mark.e2e
@@ -42,7 +55,38 @@ def test_sandbox_dryrun_default_windows():
 
 @pytest.mark.e2e
 @skip_if_no_container
-def test_sandbox_dryrun_env_vars():
+@pytest.mark.parametrize("agent", ["goose", "opencode"])
+def test_sandbox_dryrun_network(agent):
+    """Dryrun output should include container networking."""
+    result = check_output(_dryrun_cmd(agent))
+    assert re.search(r"--network=container:", result)
+
+
+@pytest.mark.e2e
+@skip_if_no_container
+@pytest.mark.parametrize("agent", ["goose", "opencode"])
+def test_sandbox_dryrun_custom_model(agent):
+    """Custom model should appear in the model server dryrun output."""
+    result = check_output(_dryrun_cmd(agent)[:-1] + ["gpt-oss"])
+    assert "gpt-oss" in result
+
+
+@pytest.mark.e2e
+@skip_if_no_container
+@pytest.mark.parametrize("agent", ["goose", "opencode"])
+def test_sandbox_dryrun_custom_workdir(agent):
+    """--workdir should mount the directory and set --workdir=/work."""
+    result = check_output(_dryrun_cmd(agent) + ["-w", "/tmp"])
+    assert "/tmp:/work:rw" in result
+    assert "--workdir=/work" in result
+
+
+# --- Goose-specific dryrun tests ---
+
+
+@pytest.mark.e2e
+@skip_if_no_container
+def test_sandbox_dryrun_goose_env_vars():
     """Dryrun output should include Goose environment variables."""
     result = check_output(RAMALAMA_SANDBOX_DRY_RUN)
     assert "GOOSE_PROVIDER=openai" in result
@@ -52,15 +96,7 @@ def test_sandbox_dryrun_env_vars():
 
 @pytest.mark.e2e
 @skip_if_no_container
-def test_sandbox_dryrun_network():
-    """Dryrun output should include container networking."""
-    result = check_output(RAMALAMA_SANDBOX_DRY_RUN)
-    assert re.search(r"--network=container:", result)
-
-
-@pytest.mark.e2e
-@skip_if_no_container
-def test_sandbox_dryrun_thinking():
+def test_sandbox_dryrun_goose_thinking():
     """Dryrun output should include env var enabling thinking output."""
     result = check_output(RAMALAMA_SANDBOX_DRY_RUN)
     assert "GOOSE_CLI_SHOW_THINKING=true" in result
@@ -68,36 +104,57 @@ def test_sandbox_dryrun_thinking():
 
 @pytest.mark.e2e
 @skip_if_no_container
-def test_sandbox_dryrun_custom_model():
-    """Custom model should appear in the model server dryrun output."""
-    result = check_output(RAMALAMA_SANDBOX_DRY_RUN[:-1] + ["gpt-oss"])
-    assert "gpt-oss" in result
-
-
-@pytest.mark.e2e
-@skip_if_no_container
-def test_sandbox_dryrun_custom_image():
+def test_sandbox_dryrun_goose_custom_image():
     """Custom --goose-image should appear in the goose container command."""
     result = check_output(RAMALAMA_SANDBOX_DRY_RUN + ["--goose-image", "mygoose:v2"])
     assert "mygoose:v2" in result
 
 
+# --- OpenCode-specific dryrun tests ---
+
+
 @pytest.mark.e2e
 @skip_if_no_container
-def test_sandbox_dryrun_custom_workdir():
-    """--workdir should mount the directory and set --workdir=/work."""
-    result = check_output(RAMALAMA_SANDBOX_DRY_RUN + ["-w", "/tmp"])
-    assert "/tmp:/work:rw" in result
-    assert "--workdir=/work" in result
+def test_sandbox_dryrun_opencode_env_vars():
+    """Dryrun output should include OpenCode config env var."""
+    result = check_output(_dryrun_cmd("opencode"))
+    assert "OPENCODE_CONFIG_CONTENT=" in result
+    assert "@ai-sdk/openai-compatible" in result
+
+    # Validate that the generated OpenCode config wires baseURL and model correctly.
+    # We keep this regex-based so it remains robust to minor JSON formatting changes.
+    # Base URL must point at the local ramalama sandbox server
+    assert re.search(
+        r'baseURL"\s*:\s*"http://localhost:\d{4}/v1"',
+        result,
+    ), "Expected OpenCode config to include baseURL http://localhost:<port>/v1"
+
+    # Model alias must resolve to our ramalama model; keep this flexible but specific
+    assert re.search(
+        r'"models"\s*:\s*{"[a-zA-Z0-9._/-]+"',
+        result,
+    ), "Expected OpenCode config to include models section"
+
+
+@pytest.mark.e2e
+@skip_if_no_container
+def test_sandbox_dryrun_opencode_custom_image():
+    """Custom --opencode-image should appear in the opencode container command."""
+    result = check_output(_dryrun_cmd("opencode") + ["--opencode-image", "myopencode:v2"])
+    assert "myopencode:v2" in result
+
+
+# --- Live run tests ---
 
 
 @pytest.mark.e2e
 @skip_if_no_container
 @skip_if_ppc64le
 @skip_if_s390x
-def test_sandbox_run(sandbox_ctx):
+@pytest.mark.parametrize("agent", ["goose", "opencode"])
+def test_sandbox_run(sandbox_ctx, agent):
     """Agent should run successfully."""
-    result = sandbox_ctx.check_output(["ramalama", "sandbox", "goose", "--thinking=off", TEST_MODEL, "hi"])
+    result = sandbox_ctx.check_output(["ramalama", "sandbox", agent, "--thinking=off", TEST_MODEL, "hi"])
     assert result
 
 
@@ -105,7 +162,8 @@ def test_sandbox_run(sandbox_ctx):
 @skip_if_no_container
 @skip_if_ppc64le
 @skip_if_s390x
-def test_sandbox_run_cmdline(sandbox_ctx, tmp_path, container_engine):
+@pytest.mark.parametrize("agent", ["goose", "opencode"])
+def test_sandbox_run_cmdline(sandbox_ctx, tmp_path, container_engine, agent):
     """Agent should successfully execute instructions provided on the command-line."""
     # Not sure how to grant container user 1000 permissions to write to the
     # local user's directory under docker
@@ -114,9 +172,10 @@ def test_sandbox_run_cmdline(sandbox_ctx, tmp_path, container_engine):
     # fmt: off
     result = sandbox_ctx.check_output(
         [
-            "ramalama", "sandbox", "goose", "-w", tmp_path, "--seed=1", "--temp=0", TEST_MODEL,
+            "ramalama", "sandbox", agent, "-w", tmp_path, "--seed=1", "--temp=0", TEST_MODEL,
             "Please", "create", "a", "pyproject.toml", "for", "a", "project", "called",
-            "ramalama", "and", "write", "it", "to", "the", "current", "directory",
+            "ramalama", "and", "write", "it", "to", "the", "current", "directory.",
+            "Ensure", "it", "contains", "a", "project", "section.",
         ]
     )
     pyproject = tmp_path / "pyproject.toml"
@@ -131,11 +190,12 @@ def test_sandbox_run_cmdline(sandbox_ctx, tmp_path, container_engine):
 @skip_if_ppc64le
 @skip_if_s390x
 @skip_if_windows
-def test_sandbox_run_stdin(sandbox_ctx, tmp_path):
+@pytest.mark.parametrize("agent", ["goose", "opencode"])
+def test_sandbox_run_stdin(sandbox_ctx, tmp_path, agent):
     """Agent should successfully execute instructions provided on stdin"""
     fpath = tmp_path / "stdin.txt"
     fpath.write_text("What is the atomic number of molybdenum?")
     result = sandbox_ctx.check_output(
-        ["ramalama", "sandbox", "goose", "--thinking=off", "--seed=1", "--temp=0", TEST_MODEL], stdin=fpath.open()
+        ["ramalama", "sandbox", agent, "--thinking=off", "--seed=1", "--temp=0", TEST_MODEL], stdin=fpath.open()
     )
     assert "42" in result

--- a/test/unit/test_sandbox_cmd.py
+++ b/test/unit/test_sandbox_cmd.py
@@ -1,9 +1,10 @@
+import json
 from types import SimpleNamespace
 
 import pytest
 
-from ramalama.cli import parse_args_from_cmd, sandbox_cli
-from ramalama.sandbox import Goose
+from ramalama.cli import parse_args_from_cmd
+from ramalama.sandbox import Goose, OpenCode
 
 TEST_MODEL = "qwen3:4b"
 
@@ -24,24 +25,78 @@ def _make_args(engine="podman"):
     )
 
 
-def test_sandbox_model_positional():
+def _make_opencode_args(engine="podman"):
+    """Create minimal args for OpenCode tests."""
+    return SimpleNamespace(
+        engine=engine,
+        dryrun=False,
+        quiet=True,
+        opencode_image="ghcr.io/anomalyco/opencode:latest",
+        name="ramalama_model_abc",
+        port="8080",
+        thinking=False,
+        workdir=None,
+        subcommand="sandbox",
+        ARGS=[],
+    )
+
+
+# --- Parametrized tests shared by both agents ---
+
+
+@pytest.mark.parametrize("agent", ["goose", "opencode"])
+def test_sandbox_model_positional(agent):
     """Sandbox cli should accept a model as a positional argument"""
-    _, args = parse_args_from_cmd(["sandbox", "goose", TEST_MODEL])
+    _, args = parse_args_from_cmd(["sandbox", agent, TEST_MODEL])
     assert args.MODEL == "hf://Qwen/Qwen3-4B-GGUF/Qwen3-4B-Q4_K_M.gguf"
 
 
-def test_sandbox_requires_container_engine():
+@pytest.mark.parametrize("agent", ["goose", "opencode"])
+def test_sandbox_requires_container_engine(agent):
     """Sandbox cli should raise when no container engine is configured"""
-    _, args = parse_args_from_cmd(["sandbox", "goose", TEST_MODEL])
+    _, args = parse_args_from_cmd(["sandbox", agent, TEST_MODEL])
     args.container = False
     with pytest.raises(ValueError, match="ramalama sandbox requires a container engine"):
-        sandbox_cli(args)
+        args.func(args)
 
 
-def test_sandbox_subcommand():
+@pytest.mark.parametrize("agent", ["goose", "opencode"])
+def test_sandbox_subcommand(agent):
     """CLI should handle sandbox subcommand"""
-    _, args = parse_args_from_cmd(["sandbox", "goose", TEST_MODEL])
+    _, args = parse_args_from_cmd(["sandbox", agent, TEST_MODEL])
     assert args.subcommand == "sandbox"
+
+
+@pytest.mark.parametrize("agent", ["goose", "opencode"])
+def test_sandbox_agent_subcommand(agent):
+    """CLI should set sandbox_agent correctly"""
+    _, args = parse_args_from_cmd(["sandbox", agent, TEST_MODEL])
+    assert args.subcommand == "sandbox"
+    assert args.sandbox_agent == agent
+
+
+@pytest.mark.parametrize("agent", ["goose", "opencode"])
+def test_sandbox_thinking(agent):
+    """Inference-specific options like 'thinking' should be handled"""
+    _, args = parse_args_from_cmd(["sandbox", agent, "--thinking=off", TEST_MODEL])
+    assert not args.thinking
+
+
+@pytest.mark.parametrize("agent", ["goose", "opencode"])
+def test_sandbox_workdir_default_none(agent):
+    """Default workdir option should be None"""
+    _, args = parse_args_from_cmd(["sandbox", agent, TEST_MODEL])
+    assert args.workdir is None
+
+
+@pytest.mark.parametrize("agent", ["goose", "opencode"])
+def test_sandbox_workdir_option(agent):
+    """CLI should parse -w/--workdir."""
+    _, args = parse_args_from_cmd(["sandbox", agent, TEST_MODEL, "-w", "/tmp"])
+    assert args.workdir == "/tmp"
+
+    _, args = parse_args_from_cmd(["sandbox", agent, TEST_MODEL, "--workdir", "/tmp"])
+    assert args.workdir == "/tmp"
 
 
 def test_sandbox_no_subcommand(capsys):
@@ -51,19 +106,50 @@ def test_sandbox_no_subcommand(capsys):
     args.func(args)
     captured = capsys.readouterr()
     assert "goose" in captured.out
+    assert "opencode" in captured.out
 
 
-def test_sandbox_thinking():
-    """Inference-specific options like "thinking" should be handled"""
-    _, args = parse_args_from_cmd(["sandbox", "goose", "--thinking=off", TEST_MODEL])
-    assert not args.thinking
+# --- Parametrized agent construction tests ---
 
 
-def test_sandbox_goose_subcommand():
-    """CLI should set sandbox_agent to 'goose' and subcommand to 'sandbox'"""
-    _, args = parse_args_from_cmd(["sandbox", "goose", TEST_MODEL])
-    assert args.subcommand == "sandbox"
-    assert args.sandbox_agent == "goose"
+@pytest.mark.parametrize("agent", ["goose", "opencode"])
+def test_agent_network(agent):
+    """Agent should setup container networking"""
+    args = _make_args() if agent == "goose" else _make_opencode_args()
+    obj = Goose(args, "test-model") if agent == "goose" else OpenCode(args, "test-model")
+    assert "--network=container:ramalama_model_abc" in obj.engine.exec_args
+
+
+@pytest.mark.parametrize("agent", ["goose", "opencode"])
+def test_agent_interactive(agent):
+    """Agent should set the -i option"""
+    args = _make_args() if agent == "goose" else _make_opencode_args()
+    obj = Goose(args, "test-model") if agent == "goose" else OpenCode(args, "test-model")
+    assert "-i" in obj.engine.exec_args
+
+
+@pytest.mark.parametrize("agent", ["goose", "opencode"])
+def test_agent_workdir(agent):
+    """Agent should add -v and --workdir=/work when workdir is set."""
+    args = _make_args() if agent == "goose" else _make_opencode_args()
+    args.workdir = "/tmp/myproject"
+    obj = Goose(args, "test-model") if agent == "goose" else OpenCode(args, "test-model")
+    cmd = obj.engine.exec_args
+    assert "--workdir=/work" in cmd
+    assert "/tmp/myproject:/work:rw" in cmd
+
+
+@pytest.mark.parametrize("agent", ["goose", "opencode"])
+def test_agent_no_workdir(agent):
+    """Agent should not add volume or --workdir when workdir is not set."""
+    args = _make_args() if agent == "goose" else _make_opencode_args()
+    obj = Goose(args, "test-model") if agent == "goose" else OpenCode(args, "test-model")
+    cmd = obj.engine.exec_args
+    assert "--workdir=/work" not in cmd
+    assert "-v" not in cmd
+
+
+# --- Goose-specific tests ---
 
 
 def test_goose_default_image():
@@ -92,20 +178,6 @@ def test_goose_env_vars():
     assert "GOOSE_MODEL=Qwen3-4B-Q4_K_M" in cmd
 
 
-def test_goose_network():
-    """Goose should setup container networking"""
-    args = _make_args()
-    goose = Goose(args, "test-model")
-    assert "--network=container:ramalama_model_abc" in goose.engine.exec_args
-
-
-def test_goose_interactive():
-    """Goose should set the -i option"""
-    args = _make_args()
-    goose = Goose(args, "test-model")
-    assert "-i" in goose.engine.exec_args
-
-
 def test_goose_with_tty(monkeypatch):
     """Goose should run the session command when run with a tty"""
     monkeypatch.setattr("ramalama.engine.sys.stdin.isatty", lambda: True)
@@ -130,35 +202,63 @@ def test_goose_args():
     assert goose.engine.exec_args[-3:] == ["run", "-t", " ".join(args.ARGS)]
 
 
-def test_sandbox_workdir_default_none():
-    """Default workdir option should be None"""
-    _, args = parse_args_from_cmd(["sandbox", "goose", TEST_MODEL])
-    assert args.workdir is None
+# --- OpenCode-specific tests ---
 
 
-def test_sandbox_workdir_option():
-    """CLI should parse -w/--workdir."""
-    _, args = parse_args_from_cmd(["sandbox", "goose", TEST_MODEL, "-w", "/tmp"])
-    assert args.workdir == "/tmp"
-
-    _, args = parse_args_from_cmd(["sandbox", "goose", TEST_MODEL, "--workdir", "/tmp"])
-    assert args.workdir == "/tmp"
+def test_opencode_default_image():
+    """OpenCode subcommand should provide a default opencode image"""
+    _, args = parse_args_from_cmd(["sandbox", "opencode", TEST_MODEL])
+    assert args.opencode_image.startswith("ghcr.io/anomalyco/opencode:")
 
 
-def test_goose_workdir():
-    """Goose should add -v and --workdir=/work when workdir is set."""
-    args = _make_args()
-    args.workdir = "/tmp/myproject"
-    goose = Goose(args, "test-model")
-    cmd = goose.engine.exec_args
-    assert "--workdir=/work" in cmd
-    assert "/tmp/myproject:/work:rw" in cmd
+def test_opencode_custom_image():
+    """OpenCode subcommand should handle the --opencode-image option"""
+    _, args = parse_args_from_cmd(["sandbox", "opencode", TEST_MODEL, "--opencode-image", "myimage:v1"])
+    assert args.opencode_image == "myimage:v1"
 
 
-def test_goose_no_workdir():
-    """Goose should not add volume or --workdir when workdir is not set."""
-    args = _make_args()
-    goose = Goose(args, "test-model")
-    cmd = goose.engine.exec_args
-    assert "--workdir=/work" not in cmd
-    assert "-v" not in cmd
+def test_opencode_env_vars():
+    """OpenCode should set OPENCODE_CONFIG_CONTENT with proper JSON config"""
+    args = _make_opencode_args()
+    opencode = OpenCode(args, "Qwen3-4B-Q4_K_M")
+    cmd = opencode.engine.exec_args
+    assert "run" in cmd
+    assert "--rm" in cmd
+    # Find the OPENCODE_CONFIG_CONTENT env var
+    config_arg = None
+    for arg in cmd:
+        if arg.startswith("OPENCODE_CONFIG_CONTENT="):
+            config_arg = arg
+            break
+    assert config_arg is not None, "OPENCODE_CONFIG_CONTENT not found in command"
+    config_json = config_arg.split("=", 1)[1]
+    config = json.loads(config_json)
+    assert config["provider"]["ramalama"]["npm"] == "@ai-sdk/openai-compatible"
+    assert config["provider"]["ramalama"]["options"]["baseURL"] == "http://localhost:8080/v1"
+    assert config["provider"]["ramalama"]["options"]["apiKey"] == "ramalama"
+    assert "Qwen3-4B-Q4_K_M" in config["provider"]["ramalama"]["models"]
+
+
+def test_opencode_with_tty(monkeypatch):
+    """OpenCode should launch TUI (no extra args) when run with a tty"""
+    monkeypatch.setattr("ramalama.engine.sys.stdin.isatty", lambda: True)
+    args = _make_opencode_args()
+    opencode = OpenCode(args, "test-model")
+    # The last arg should be the image, no extra command
+    assert opencode.engine.exec_args[-1] == args.opencode_image
+
+
+def test_opencode_no_tty(monkeypatch):
+    """OpenCode should run "run -" when run without a tty, to read commands from stdin"""
+    monkeypatch.setattr("ramalama.engine.sys.stdin.isatty", lambda: False)
+    args = _make_opencode_args()
+    opencode = OpenCode(args, "test-model")
+    assert opencode.engine.exec_args[-2:] == ["run", "-"]
+
+
+def test_opencode_args():
+    """OpenCode should run "run <message>" when args are passed on the command-line"""
+    args = _make_opencode_args()
+    args.ARGS = ["hello", "ramalama"]
+    opencode = OpenCode(args, "test-model")
+    assert opencode.engine.exec_args[-2:] == ["run", "hello ramalama"]


### PR DESCRIPTION
The `ramalama sandbox opencode` command runs `OpenCode` from https://opencode.ai/ in a sandbox, connected to a local AI model via container networking. Instructions to the agent may be passed as command-line arguments or via stdin. If neither are provided, an interactive session is started.

The agent has no access to the local filesystem by default. A directory can be mounted into the agent image with the -w/--workdir option.

On completion of the agent session, the model server will be removed.

Fixes #2556

## Summary by Sourcery

Add support for running the OpenCode agent in a RamaLama sandbox alongside the existing Goose agent, including shared sandbox engine features and documentation.

New Features:
- Introduce an `opencode` sandbox subcommand that runs the OpenCode agent container connected to a local RamaLama model server.
- Add workdir mounting support to sandbox agents so a host directory can be exposed at `/work` inside the agent container.

Enhancements:
- Refactor sandbox CLI and engine logic so Goose and OpenCode share common container setup, including networking, TTY handling, and workdir configuration.
- Extend sandbox CLI help and man pages to document the new OpenCode agent and its usage.

Tests:
- Add and parameterize unit and end-to-end tests to cover the new OpenCode sandbox agent, shared sandbox behaviors, and workdir handling for both agents.