### PR TITLE
fix macos podman machine detection when podman not installed

### DIFF
--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -102,7 +102,7 @@ def apple_vm(engine: SUPPORTED_ENGINES, config: Config | None = None) -> bool:
             result = handle_provider(machine, config)
             if result is not None:
                 return result
-    except (subprocess.CalledProcessError, json.JSONDecodeError) as e:
+    except (subprocess.CalledProcessError, json.JSONDecodeError, FileNotFoundError) as e:
         logger.warning(f"Failed to list and parse podman machines: {e}")
     return False
 

--- a/test/unit/test_common.py
+++ b/test/unit/test_common.py
@@ -183,6 +183,16 @@ def test_apple_vm_returns_result(mock_handle_provider, mock_run_cmd):
     mock_handle_provider.assert_called_once_with({"Name": "myvm"}, config)
 
 
+@patch("ramalama.common.run_cmd", side_effect=FileNotFoundError("podman: command not found"))
+def test_apple_vm_returns_false_when_podman_not_installed(mock_run_cmd):
+    from ramalama.common import apple_vm
+
+    result = apple_vm("podman", None)
+
+    assert result is False
+    mock_run_cmd.assert_called_once()
+
+
 class TestEnsureImage:
     """Tests for ensure_image()"""
 


### PR DESCRIPTION
apple_vm() was not handling the case where podman is not installed (FileNotFoundError raised)