### PR TITLE
Fix #2524: improve user experience when trying to pull models from Hu...

### DIFF
--- a/ramalama/hf_style_repo_base.py
+++ b/ramalama/hf_style_repo_base.py
@@ -368,7 +368,10 @@ class HFStyleRepoModel(Transport, ABC):
             os.makedirs(self.model_store.base_path, exist_ok=True)
             with tempfile.TemporaryDirectory(prefix="tmp_hfcli_", dir=self.model_store.base_path) as tempdir:
                 model = f"{organization}/{name}"
-                conman_args = self.get_cli_download_args(tempdir, model)
+                try:
+                    conman_args = self.get_cli_download_args(tempdir, model)
+                except NotImplementedError:
+                    raise e from None
                 run_cmd(conman_args)
 
                 snapshot_hash, files = self._collect_cli_files(tempdir)

--- a/test/unit/test_transport_factory.py
+++ b/test/unit/test_transport_factory.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from typing import Union
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 
@@ -187,3 +188,30 @@ def test_transport_factory_passes_scheme_to_get_chat_provider(monkeypatch):
     assert captured["scheme"] == "openai"
     assert isinstance(transport, APITransport)
     assert transport.provider is provider
+
+
+def test_hf_pull_surfaces_http_error_not_notimplementederror():
+    """Regression test: HTTP errors (e.g. 404) from HF API must be surfaced to
+    the user rather than being masked by the generic 'huggingface cli download
+    not available' NotImplementedError raised by get_cli_download_args()."""
+    from argparse import Namespace
+
+    args = Namespace(quiet=True, verify=True)
+    model = Huggingface("huggingface://Qwen/Qwen2.5-7B-Instruct-GGUF/model.gguf", "/tmp/store")
+
+    http_error_key = "failed to pull https://huggingface.co/...: HTTP Error 404: Not Found"
+
+    mock_store = MagicMock()
+    mock_store.get_cached_files.return_value = ("tag", [], False)
+    mock_store.base_path = "/tmp/store"
+
+    with patch.object(type(model), "model_store", new_callable=PropertyMock, return_value=mock_store):
+        with patch.object(model, "create_repository", side_effect=KeyError(http_error_key)):
+            with patch("ramalama.hf_style_repo_base.available", return_value=True):
+                with patch("os.makedirs"), patch("tempfile.TemporaryDirectory") as mock_tmpdir:
+                    mock_tmpdir.return_value.__enter__ = lambda s: "/tmp/fake"
+                    mock_tmpdir.return_value.__exit__ = lambda s, *a: False
+                    with pytest.raises(KeyError) as exc_info:
+                        model.pull(args)
+
+    assert http_error_key in str(exc_info.value)


### PR DESCRIPTION
Closes #2524

Surfaces the original HTTP error (e.g. 404) when pulling from Hugging Face instead of masking it with a misleading `NotImplementedError`.

## Changes

**`ramalama/hf_style_repo_base.py` — `HFStyleRepoModel` pull path**

Wrapped the call to `self.get_cli_download_args(tempdir, model)` in a `try/except NotImplementedError` block. When `get_cli_download_args` raises `NotImplementedError` (the "huggingface cli download not available" path), the code now re-raises `e` — the original exception from the earlier `create_repository` attempt — via `raise e from None`, so the real failure reason reaches the user.

**`test/unit/test_transport_factory.py` — new regression test**

Added `test_hf_pull_surfaces_http_error_not_notimplementederror`, which patches `create_repository` to raise a `KeyError` containing a 404 message string, patches `available` to return `True` (simulating an installed CLI), and asserts that `model.pull()` propagates the `KeyError` rather than swallowing it. Imports `MagicMock`, `PropertyMock`, and `patch` from `unittest.mock` were added to support the new test.

## Motivation

When `create_repository` failed with an HTTP 404 (model file not found on HF), the exception was stored in `e` and control fell through to the CLI download path. There, `get_cli_download_args` raised `NotImplementedError` with the generic "huggingface cli download not available" message, which replaced the informative HTTP error. Users with `huggingface_hub` correctly installed still saw the misleading CLI-missing error with no indication that the model path itself was wrong.

## Testing

The new unit test covers the regression directly:

```
pytest test/unit/test_transport_factory.py::test_hf_pull_surfaces_http_error_not_notimplementederror
```

The test confirms that a `KeyError` containing `"HTTP Error 404: Not Found"` propagates out of `pull()` unchanged, and that `NotImplementedError` does not surface in its place.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*

## Summary by Sourcery

Surface original Hugging Face HTTP errors when model pulls fail instead of masking them with a generic NotImplementedError from the CLI download path.

Bug Fixes:
- Ensure HTTP errors (e.g. 404) from Hugging Face model pulls are propagated to the user rather than replaced by a misleading NotImplementedError.

Tests:
- Add a regression test verifying that Hugging Face pull propagates the original HTTP error (e.g. 404) and does not surface NotImplementedError instead.