### PR TITLE
feat: Implement support for the OpenClaw in ramalama

### DIFF
--- a/docs/ramalama-sandbox-openclaw.1.md
+++ b/docs/ramalama-sandbox-openclaw.1.md
@@ -1,0 +1,288 @@
+% ramalama-sandbox-openclaw 1
+
+## NAME
+ramalama\-sandbox\-openclaw - run OpenClaw in a sandbox, backed by a local AI Model
+
+## SYNOPSIS
+**ramalama sandbox openclaw** [*options*] *model* [arg ...]
+
+## DESCRIPTION
+Run OpenClaw in a container, connected to a local model server also running
+in a container. OpenClaw uses the model for reasoning and tool calling.
+
+When run with no arguments after the model, an interactive TUI session is
+launched. If one or more arguments are provided, they are passed to the agent
+as instructions to process non-interactively. Commands may also be passed via
+stdin.
+
+Three containers are started: a model server (llama-server), an OpenClaw
+gateway container, and a client container. They communicate via container
+networking. When the client session exits, the gateway and model server
+containers are automatically stopped and removed.
+
+## OPTIONS
+
+#### **--authfile**=*password*
+Path of the authentication file for OCI registries
+
+#### **--backend**=*auto* | vulkan | rocm | cuda | sycl | openvino
+GPU backend to use for inference (default: auto).
+
+Available backends depend on the detected GPU hardware.
+
+**auto** (default): Automatically selects the preferred backend based on your GPU:
+- **AMD GPUs**: vulkan (Linux/macOS) or rocm (Windows)
+- **NVIDIA GPUs**: cuda
+- **Intel GPUs**: vulkan (Linux/macOS) or sycl (Windows); openvino available as explicit option
+- **No GPU**: vulkan (CPU fallback)
+
+**Platform-specific behavior**:
+- On **Linux/macOS**, Vulkan provides broad compatibility and is preferred for AMD and Intel GPUs
+- On **Windows**, vulkan is not supported on WSL2, so vendor-specific backends (rocm, sycl) are preferred
+
+**Explicit backend selection**:
+- **vulkan**: Use Vulkan-based inference (compatible with AMD, Intel, and CPU)
+- **rocm**: Use AMD ROCm backend (AMD GPUs only)
+- **cuda**: Use NVIDIA CUDA backend (NVIDIA GPUs only)
+- **sycl**: Use Intel SYCL/oneAPI backend (Intel GPUs only)
+- **openvino**: Use Intel OpenVINO backend (Intel GPUs only); uses `ghcr.io/ggml-org/llama.cpp:full-openvino`
+
+**Available choices**: The allowed values for `--backend` are dynamically determined based on
+your detected GPU hardware. For example, on a system with an AMD GPU, only `auto`, `vulkan`,
+and `rocm` are available.
+
+**Configuration**: The default can be overridden in the `ramalama.conf` file or via the
+RAMALAMA_BACKEND environment variable.
+
+Examples:
+```sh
+# Use auto-detection (default)
+ramalama serve granite
+
+# Force Vulkan backend
+ramalama serve --backend vulkan granite
+
+# Force ROCm backend on AMD GPU
+ramalama serve --backend rocm granite
+```
+
+#### **--cache-reuse**=256
+Min chunk size to attempt reusing from the cache via KV shifting
+
+#### **--ctx-size**, **-c**
+Size of the prompt context. This option is also available as **--max-model-len**. Applies to llama.cpp and vLLM regardless of alias (default: 0, 0 = loaded from model).
+
+#### **--device**
+Add a host device to the container. Optional permissions parameter can
+be used to specify device permissions by combining r for read, w for
+write, and m for mknod(2).
+
+Example: --device=/dev/dri/renderD128:/dev/xvdc:rwm
+
+The device specification is passed directly to the underlying container engine. See documentation of the supported container engine for more information.
+
+Pass '--device=none' to explicitly add no device to the container, e.g. for
+running a CPU-only performance comparison.
+
+#### **--env**=
+
+Set environment variables inside of the container.
+
+This option allows arbitrary environment variables that are available for the
+process to be launched inside of the container. If an environment variable is
+specified without a value, the container engine checks the host environment
+for a value and set the variable only if it is set on the host.
+
+#### **--help**, **-h**
+show this help message and exit
+
+#### **--host**="0.0.0.0"
+IP address for llama.cpp to listen on.
+
+#### **--image**=IMAGE
+OCI container image to run with specified AI model. RamaLama defaults to using
+images based on the accelerator it discovers. For example:
+`quay.io/ramalama/ramalama`. See the table below for all default images.
+The default image tag is based on the minor version of the RamaLama package.
+Version 0.18.0 of RamaLama pulls an image with a `:0.18` tag from the quay.io/ramalama OCI repository. The --image option overrides this default.
+
+The default can be overridden in the `ramalama.conf` file or via the
+RAMALAMA_IMAGE environment variable. `export RAMALAMA_IMAGE=quay.io/ramalama/aiimage:1.2` tells
+RamaLama to use the `quay.io/ramalama/aiimage:1.2` image.
+
+Accelerated images:
+
+| Accelerator             | Image                      |
+| ------------------------| -------------------------- |
+|  CPU, Apple             | quay.io/ramalama/ramalama  |
+|  HIP_VISIBLE_DEVICES    | quay.io/ramalama/rocm      |
+|  CUDA_VISIBLE_DEVICES   | quay.io/ramalama/cuda      |
+|  ASAHI_VISIBLE_DEVICES  | quay.io/ramalama/asahi     |
+|  INTEL_VISIBLE_DEVICES  | quay.io/ramalama/intel-gpu |
+|  ASCEND_VISIBLE_DEVICES | quay.io/ramalama/cann      |
+|  MUSA_VISIBLE_DEVICES   | quay.io/ramalama/musa      |
+
+Upstream llama.cpp "full" images from `ghcr.io/ggml-org/llama.cpp` are also supported.
+RamaLama automatically detects the image type and adjusts the container CLI accordingly.
+
+```sh
+ramalama serve --image ghcr.io/ggml-org/llama.cpp:full-vulkan MODEL
+```
+
+#### **--keep-groups**
+pass --group-add keep-groups to podman (default: False)
+If GPU device on host system is accessible to user via group access, this option leaks the groups into the container.
+
+#### **--logfile**=*path*
+Log output to a file
+
+#### **--max-tokens**=*integer*
+Maximum number of tokens to generate. Set to 0 for unlimited output (default: 0).
+This parameter is mapped to the appropriate runtime-specific parameter:
+- llama.cpp: `-n` parameter
+- MLX: `--max-tokens` parameter
+- vLLM: `--max-tokens` parameter
+
+#### **--model-draft**
+
+A draft model is a smaller, faster model that helps accelerate the decoding
+process of larger, more complex models, like Large Language Models (LLMs). It
+works by generating candidate sequences of tokens that the larger model then
+verifies and refines. This approach, often referred to as speculative decoding,
+can significantly improve the speed of inferencing by reducing the number of
+times the larger model needs to be invoked.
+
+Use --runtime-args to pass the other draft model related parameters.
+Make sure the sampling parameters like top_k on the web UI are set correctly.
+
+#### **--name**, **-n**
+Name of the container to run the Model in.
+
+#### **--network**=*""*
+set the network mode for the container
+
+#### **--ngl**
+number of GPU layers, 0 means CPU inferencing, 999 means use max layers (default: -1)
+The default, -1, means use whatever is automatically deemed appropriate (0 or 999)
+
+#### **--oci-runtime**
+
+Override the default OCI runtime used to launch the container. Container
+engines like Podman and Docker have their own default OCI runtime that they
+use. Using this option, RamaLama will override these defaults.
+
+On NVIDIA-based GPU systems, RamaLama defaults to using the
+`nvidia-container-runtime`. Use this option to override this selection.
+
+#### **--openclaw-image**=*IMAGE*
+OpenClaw container image
+
+#### **--openclaw-port**=*PORT*
+OpenClaw gateway port (default: 18789)
+
+#### **--port**, **-p**
+port for AI Model server to listen on. It must be available. If not specified,
+a free port in the 8080-8180 range is selected, starting with 8080.
+
+The default can be overridden in the `ramalama.conf` file.
+
+#### **--privileged**
+By default, RamaLama containers are unprivileged (=false) and cannot, for
+example, modify parts of the operating system. This is because by de‐
+fault a container is only allowed limited access to devices. A "privi‐
+leged" container is given the same access to devices as the user launch‐
+ing the container, with the exception of virtual consoles (/dev/tty\d+)
+when running in systemd mode (--systemd=always).
+
+A privileged container turns off the security features that isolate the
+container from the host. Dropped Capabilities, limited devices, read-
+only mount points, Apparmor/SELinux separation, and Seccomp filters are
+all disabled. Due to the disabled security features, the privileged
+field should almost never be set as containers can easily break out of
+confinement.
+
+Containers running in a user namespace (e.g., rootless containers) can‐
+not have more privileges than the user that launched them.
+
+#### **--pull**=*policy*
+
+- **always**: Always pull the image and throw an error if the pull fails.
+- **missing**: Only pull the image when it does not exist in the local container storage. Throw an error if no image is found and the pull fails.
+- **never**: Never pull the image but use the one from the local container storage. Throw an error when no image is found.
+- **newer**: Pull if the image on the registry is newer than the one in the local container storage. An image is considered to be newer when the digests are different. Comparing the time stamps is prone to errors. Pull errors are suppressed if a local image was found.
+
+#### **--runtime-args**="*args*"
+Add *args* to the runtime (llama.cpp or vllm) invocation.
+
+#### **--seed**=
+Specify a seed rather than using a random seed.
+
+#### **--selinux**=*true*
+Enable SELinux container separation
+
+#### **--state-dir**
+Local directory to mount into the OpenClaw gateway container for persistent state
+
+#### **--temp**="0.8"
+Temperature of the response from the AI Model.
+llama.cpp explains this as:
+
+    The lower the number is, the more deterministic the response.
+
+    The higher the number is the more creative the response is, but more likely to hallucinate when set too high.
+
+	Usage: Lower numbers are good for virtual assistants where we need deterministic responses. Higher numbers are good for roleplay or creative tasks like editing stories
+
+#### **--thinking**=*true*
+Enable or disable thinking mode in reasoning models
+
+#### **--threads**, **-t**
+Maximum number of CPU threads to use.
+The default is to use half the cores available on this system for the number of threads.
+
+#### **--tls-verify**=*true*
+requires HTTPS and verifies certificates when contacting OCI registries
+
+#### **--webui**=*on* | *off*
+Enable or disable the web UI for the served model (enabled by default). When set to "on" (the default), the web interface is properly initialized. When set to "off", the `--no-webui` option is passed to the llama-server command to disable the web interface.
+
+#### **--workdir**, **-w**
+Local directory to mount into the sandbox container at /work
+
+## EXAMPLES
+
+Run the OpenClaw agent with default settings:
+```sh
+ramalama sandbox openclaw qwen3:4b
+```
+
+Run the OpenClaw agent with a custom image:
+```sh
+ramalama sandbox openclaw --openclaw-image ghcr.io/openclaw/openclaw:2026.4.5 qwen3:4b
+```
+
+Turn off thinking mode in the model the agent is connecting to (may result in faster responses):
+```sh
+ramalama sandbox openclaw --thinking=off qwen3:4b
+```
+
+Start an interactive session with access to a local directory:
+```sh
+ramalama sandbox openclaw -w ./src qwen3:4b
+```
+
+Request the agent to perform actions non-interactively:
+```sh
+ramalama sandbox openclaw -w ./src qwen3:4b Please analyze the source code in the current directory
+```
+
+Send instructions to the agent via stdin:
+```sh
+echo "What is the speed of light in meters per second?" | ramalama sandbox openclaw qwen3:4b
+```
+
+## SEE ALSO
+**[ramalama(1)](ramalama.1.md)**, **[ramalama-run(1)](ramalama-run.1.md)**, **[ramalama-serve(1)](ramalama-serve.1.md)**, **[ramalama-sandbox(1)](ramalama-sandbox.1.md)**
+
+## HISTORY
+Mar 2026, Originally compiled by Mike Bonnet <mikeb@redhat.com>

--- a/docs/ramalama-sandbox.1.md
+++ b/docs/ramalama-sandbox.1.md
@@ -14,6 +14,8 @@ The *agent* argument selects which AI agent to run. Currently supported agents:
 
 - **goose** - the Goose AI agent (https://github.com/aaif-goose/goose)
 - **opencode** - the OpenCode AI agent (https://opencode.ai/)
+- **openclaw** - the OpenClaw AI agent (https://openclaw.ai/)
+
 
 ## OPTIONS
 
@@ -25,7 +27,9 @@ show this help message and exit
 | Command  | Man Page                                                       | Description                                           |
 | -------- | -------------------------------------------------------------- | ----------------------------------------------------- |
 | goose    | [ramalama-sandbox-goose(1)](ramalama-sandbox-goose.1.md)       | run Goose in a sandbox, backed by a local AI Model    |
+| openclaw | [ramalama-sandbox-openclaw(1)](ramalama-sandbox-openclaw.1.md) | run OpenClaw in a sandbox, backed by a local AI Model |
 | opencode | [ramalama-sandbox-opencode(1)](ramalama-sandbox-opencode.1.md) | run OpenCode in a sandbox, backed by a local AI Model |
+
 
 ## SEE ALSO
 **[ramalama(1)](ramalama.1.md)**, **[ramalama-run(1)](ramalama-run.1.md)**, **[ramalama-serve(1)](ramalama-serve.1.md)**

--- a/ramalama/sandbox.py
+++ b/ramalama/sandbox.py
@@ -2,14 +2,17 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import platform
+import tempfile
 from collections.abc import Callable
-from typing import Optional, cast
+from types import SimpleNamespace
+from typing import Any, Optional, cast
 
 from ramalama.arg_types import BaseEngineArgsType
 from ramalama.common import run_cmd
 from ramalama.config import ActiveConfig
-from ramalama.engine import Engine, stop_container
+from ramalama.engine import Engine, inspect, logs, stop_container, wait_for_healthy
 from ramalama.plugins.loader import get_runtime
 from ramalama.transports.base import compute_serving_port
 from ramalama.transports.transport_factory import New
@@ -67,6 +70,30 @@ def add_sandbox_subparsers(subparsers: argparse._SubParsersAction, img_comp: Cal
     parser.set_defaults(func=run_sandbox_opencode)
     yield parser
 
+    parser = subparsers.add_parser("openclaw", help="run OpenClaw in a sandbox, backed by a local AI Model")
+    if getattr(runtime, "_add_inference_args", None):
+        runtime._add_inference_args(parser, "serve")  # type: ignore[attr-defined]
+    parser.add_argument("MODEL", completer=model_comp)
+    parser.add_argument(
+        "--openclaw-image",
+        default="ghcr.io/openclaw/openclaw:2026.4.5",
+        completer=img_comp,
+        help="OpenClaw container image",
+    )
+    parser.add_argument(
+        "--openclaw-port",
+        type=int,
+        default=18789,
+        help="OpenClaw gateway port (default: 18789)",
+    )
+    parser.add_argument(
+        "--state-dir",
+        help="local directory to mount into the OpenClaw gateway container for persistent state",
+    )
+    _add_common_sandbox_args(parser)
+    parser.set_defaults(func=run_sandbox_openclaw)
+    yield parser
+
 
 class SandboxEngineArgsType(BaseEngineArgsType):
     ARGS: list[str]
@@ -76,13 +103,20 @@ class SandboxEngineArgsType(BaseEngineArgsType):
 class SandboxEngine(Engine):
     """Engine for running sandbox containers."""
 
-    def __init__(self, args: SandboxEngineArgsType) -> None:
+    def __init__(self, args: SandboxEngineArgsType, *, background: bool = False) -> None:
+        self.background = background
         super().__init__(args)
 
     def base_args(self) -> None:
-        self.add_args("run", "--rm", "-i")
+        super().base_args()
+        if self.background:
+            self.add_args("-d")
+        else:
+            self.add_args("-i")
 
     def is_tty_cmd(self) -> bool:
+        if self.background:
+            return False
         return getattr(self.args, "subcommand", "") == "sandbox"
 
     def add_network(self) -> None:
@@ -118,6 +152,9 @@ class Agent:
     def __init__(self, args: SandboxEngineArgsType, model_name: str):
         self.engine = SandboxEngine(args)
         self.model_name = model_name
+
+    def dryrun(self) -> None:
+        self.engine.dryrun()
 
     def run(self) -> None:
         run_cmd(self.engine.exec_args, stdout=None, stdin=None)
@@ -204,6 +241,162 @@ class OpenCode(Agent):
         self.engine.add_env_option(f"OPENCODE_CONFIG_CONTENT={json.dumps(config)}")
 
 
+class OpenClawArgsType(SandboxEngineArgsType):
+    openclaw_image: str
+    openclaw_port: int
+    state_dir: str | None
+    debug: bool
+
+
+class OpenClaw(Agent):
+    """
+    Run OpenClaw in a sandbox using a gateway+client architecture.
+    A gateway container runs in the background, configured to communicate with the local model
+    server. A client container runs the TUI or agent, connecting to the gateway via websocket.
+    A JSON config file is written to a temporary file and mounted into both containers via
+    OPENCLAW_CONFIG_PATH.
+    """
+
+    def __init__(self, args: OpenClawArgsType, model_name: str) -> None:
+        super().__init__(args, model_name)
+        self.args = args
+        self.config_file_path = self._write_config(args)
+        self._gateway_name = f"openclaw-gateway-{args.name}"  # type: ignore[attr-defined]
+        self._gateway_started = False
+
+        #  Gateway Engine (detached background container)
+        self.gateway_engine = SandboxEngine(args, background=True)
+        self.gateway_engine.add_name(self._gateway_name)
+        self._add_env_to_engine(self.gateway_engine, args)
+        self._add_state_dir_to_engine(self.gateway_engine, args)
+        self.gateway_engine.add_workdir(args)
+        self.gateway_engine.add_volume(self.config_file_path, "/etc/openclaw/ramalama.json")
+        self.gateway_engine.add_args(args.openclaw_image)
+        self.gateway_engine.add_args("openclaw", "gateway", "run")
+
+        # Client Engine (foreground interactive container)
+        self.engine.add_name(f"openclaw-{args.name}")  # type: ignore[attr-defined]
+        self._add_env_to_engine(self.engine, args)
+        self.engine.add_volume(self.config_file_path, "/etc/openclaw/ramalama.json")
+        self.engine.add_args(args.openclaw_image)
+        if args.ARGS:
+            message = " ".join(args.ARGS)
+            agent_verbose_args = ["--verbose"] if args.debug else []
+            self.engine.add_args(
+                "openclaw",
+                "agent",
+                *agent_verbose_args,
+                "--session-id",
+                "ramalama",
+                "--message",
+                message,
+            )
+        elif self.engine.use_tty():
+            self.engine.add_args("openclaw", "tui", "--session", "main")
+        else:
+            verbose_flag = " --verbose" if args.debug else ""
+            self.engine.add_args(
+                "bash",
+                "-c",
+                f'msg="$(cat)"; exec openclaw agent{verbose_flag} --session-id ramalama --message "$msg"',
+            )
+
+    def _write_config(self, args: OpenClawArgsType) -> str:
+        config: dict[str, Any] = {
+            "models": {
+                "providers": {
+                    "openai": {
+                        "api": "openai-completions",
+                        "apiKey": "ramalama",
+                        "baseUrl": f"http://localhost:{args.port}/v1",
+                        "models": [],
+                    },
+                },
+            },
+            "agents": {
+                "defaults": {
+                    "model": {
+                        "primary": f"openai/{self.model_name}",
+                    },
+                },
+            },
+            "gateway": {
+                "mode": "local",
+                "bind": "loopback",
+                "port": args.openclaw_port,
+            },
+        }
+        if args.workdir:
+            config["agents"]["defaults"]["workspace"] = "/work"
+        tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False)
+        json.dump(config, tmp)
+        tmp.close()
+        return tmp.name
+
+    def start_gateway(self) -> None:
+        """Start the gateway container in detached mode."""
+        run_cmd(self.gateway_engine.exec_args, stdout=None, stdin=None)
+        self._gateway_started = True
+
+    def _gateway_ready(self) -> bool:
+        """Check whether the OpenClaw gateway container is running and listening on the configured port."""
+        try:
+            running = inspect(self.engine.args, self._gateway_name, format="{{ .State.Running }}", ignore_stderr=True)
+            if running.lower() != "true":
+                return False
+
+            gateway_logs = logs(self.engine.args, self._gateway_name, ignore_stderr=True)
+            port = str(self.args.openclaw_port)
+            return any(token in gateway_logs for token in (f"127.0.0.1:{port}", f"localhost:{port}", f":{port}"))
+        except Exception:
+            return False
+
+    def _wait_for_gateway_ready(self, timeout: int = 30) -> None:
+        gateway_args = SimpleNamespace(**vars(self.engine.args))
+        gateway_args.name = self._gateway_name
+        wait_for_healthy(gateway_args, lambda _args: self._gateway_ready(), timeout=timeout)
+
+    def run(self) -> None:
+        """Start gateway, wait for it to become ready, then run the OpenClaw client."""
+        try:
+            self.start_gateway()
+            self._wait_for_gateway_ready()
+            super().run()
+        finally:
+            self.cleanup()
+
+    def cleanup(self) -> None:
+        """Remove temporary config file and stop gateway container."""
+        try:
+            os.unlink(self.config_file_path)
+        except FileNotFoundError:
+            pass
+        if self._gateway_started:
+            self.engine.args.ignore = True  # type: ignore[attr-defined]
+            stop_container(self.engine.args, self._gateway_name, remove=True)
+
+    def _add_state_dir_to_engine(self, engine: SandboxEngine, args: OpenClawArgsType) -> None:
+        state_dir = getattr(args, "state_dir", None)
+        if state_dir:
+            engine.add_volume(state_dir, "/var/lib/openclaw", opts="rw")
+            engine.add_env_option("OPENCLAW_STATE_DIR=/var/lib/openclaw")
+
+    def _add_env_to_engine(self, engine: SandboxEngine, args: OpenClawArgsType) -> None:
+        engine.add_env_option(f"OPENAI_BASE_URL=http://localhost:{args.port}/v1")
+        engine.add_env_option("OPENAI_API_KEY=ramalama")
+        engine.add_env_option("OPENCLAW_CONFIG_PATH=/etc/openclaw/ramalama.json")
+        engine.add_env_option("OPENCLAW_SKIP_CHANNELS=1")
+        engine.add_env_option("OPENCLAW_SKIP_GMAIL_WATCHER=1")
+        engine.add_env_option("OPENCLAW_SKIP_CRON=1")
+        engine.add_env_option("OPENCLAW_SKIP_CANVAS_HOST=1")
+        if getattr(args, "debug", False):
+            engine.add_env_option("OPENCLAW_LOG_LEVEL=debug")
+
+    def dryrun(self) -> None:
+        self.gateway_engine.dryrun()
+        super().dryrun()
+
+
 def run_sandbox_goose(args: GooseArgsType):
     run_sandbox(args, Goose)
 
@@ -212,13 +405,17 @@ def run_sandbox_opencode(args: OpenCodeArgsType):
     run_sandbox(args, OpenCode)
 
 
+def run_sandbox_openclaw(args: OpenClawArgsType):
+    run_sandbox(args, OpenClaw)
+
+
 def run_sandbox(args: SandboxEngineArgsType, agent_cls: type[Agent]):
     """Orchestrate model server and sandbox containers."""
 
     if not args.container:  # type: ignore[attr-defined]
         raise ValueError("ramalama sandbox requires a container engine")
 
-    args.port = compute_serving_port(args)
+    args.port = compute_serving_port(args)  # type: ignore[attr-defined]
 
     model = New(args.MODEL, args)
     model.ensure_model_exists(args)
@@ -231,7 +428,7 @@ def run_sandbox(args: SandboxEngineArgsType, agent_cls: type[Agent]):
     agent = agent_cls(args, model.model_alias)
 
     if args.dryrun:
-        agent.engine.dryrun()
+        agent.dryrun()
         return
 
     try:

--- a/test/e2e/test_sandbox.py
+++ b/test/e2e/test_sandbox.py
@@ -38,6 +38,7 @@ def sandbox_ctx():
     [
         ["goose", r"run -i -\s*$"],
         ["opencode", r"run --thinking=true\s*$"],
+        ["openclaw", r"openclaw gateway run"],
     ],
 )
 def test_sandbox_dryrun_default(agent, cmd):
@@ -58,7 +59,7 @@ def test_sandbox_dryrun_default_windows():
 
 @pytest.mark.e2e
 @skip_if_no_container
-@pytest.mark.parametrize("agent", ["goose", "opencode"])
+@pytest.mark.parametrize("agent", ["goose", "opencode", "openclaw"])
 def test_sandbox_dryrun_network(agent):
     """Dryrun output should include container networking."""
     result = check_output(_dryrun_cmd(agent))
@@ -67,7 +68,7 @@ def test_sandbox_dryrun_network(agent):
 
 @pytest.mark.e2e
 @skip_if_no_container
-@pytest.mark.parametrize("agent", ["goose", "opencode"])
+@pytest.mark.parametrize("agent", ["goose", "opencode", "openclaw"])
 def test_sandbox_dryrun_custom_model(agent):
     """Custom model should appear in the model server dryrun output."""
     result = check_output(_dryrun_cmd(agent)[:-1] + ["gpt-oss"])
@@ -76,7 +77,7 @@ def test_sandbox_dryrun_custom_model(agent):
 
 @pytest.mark.e2e
 @skip_if_no_container
-@pytest.mark.parametrize("agent", ["goose", "opencode"])
+@pytest.mark.parametrize("agent", ["goose", "opencode", "openclaw"])
 def test_sandbox_dryrun_custom_workdir(agent):
     """--workdir should mount the directory and set --workdir=/work."""
     result = check_output(_dryrun_cmd(agent) + ["-w", "/tmp"])
@@ -147,6 +148,44 @@ def test_sandbox_dryrun_opencode_custom_image():
     assert "myopencode:v2" in result
 
 
+# --- OpenClaw-specific dryrun tests ---
+
+
+@pytest.mark.e2e
+@skip_if_no_container
+def test_sandbox_dryrun_openclaw_env_vars():
+    """Dryrun output should include OpenClaw environment variables."""
+    result = check_output(_dryrun_cmd("openclaw"))
+    assert "OPENAI_API_KEY=ramalama" in result
+    assert re.search(r"OPENAI_BASE_URL=http://localhost:\d+/v1", result)
+    assert "OPENCLAW_SKIP_CHANNELS=1" in result
+
+
+@pytest.mark.e2e
+@skip_if_no_container
+def test_sandbox_dryrun_openclaw_custom_image():
+    """Custom --openclaw-image should appear in the OpenClaw container command."""
+    result = check_output(_dryrun_cmd("openclaw") + ["--openclaw-image", "myopenclaw:v2"])
+    assert "myopenclaw:v2" in result
+
+
+@pytest.mark.e2e
+@skip_if_no_container
+def test_sandbox_dryrun_openclaw_no_url_flag():
+    """OpenClaw client command should rely on config gateway.port instead of --url."""
+    result = check_output(_dryrun_cmd("openclaw") + ["hello"])
+    assert "openclaw agent" in result
+    assert "--url" not in result
+
+
+@pytest.mark.e2e
+@skip_if_no_container
+def test_sandbox_dryrun_openclaw_debug_verbose():
+    """OpenClaw debug mode should pass --verbose to the agent command."""
+    result = check_output(["ramalama", "--debug", "--dryrun", "sandbox", "openclaw", TEST_MODEL, "hello"])
+    assert "openclaw agent --verbose" in result
+
+
 # --- Live run tests ---
 
 
@@ -155,7 +194,7 @@ def test_sandbox_dryrun_opencode_custom_image():
 @skip_if_no_container
 @skip_if_ppc64le
 @skip_if_s390x
-@pytest.mark.parametrize("agent", ["goose", "opencode"])
+@pytest.mark.parametrize("agent", ["goose", "opencode", "openclaw"])
 def test_sandbox_run(sandbox_ctx, agent):
     """Agent should run successfully."""
     result = sandbox_ctx.check_output(["ramalama", "sandbox", agent, "--thinking=off", TEST_MODEL, "hi"])

--- a/test/unit/test_sandbox_cmd.py
+++ b/test/unit/test_sandbox_cmd.py
@@ -1,10 +1,11 @@
 import json
+import os
 from types import SimpleNamespace
 
 import pytest
 
 from ramalama.cli import parse_args_from_cmd
-from ramalama.sandbox import Goose, OpenCode
+from ramalama.sandbox import Agent, Goose, OpenClaw, OpenCode
 
 TEST_MODEL = "qwen3:4b"
 
@@ -41,17 +42,42 @@ def _make_opencode_args(engine="podman"):
     )
 
 
+def _make_openclaw_args(engine="podman"):
+    """Create minimal args for OpenClaw tests."""
+    return SimpleNamespace(
+        engine=engine,
+        dryrun=False,
+        quiet=True,
+        openclaw_image="ghcr.io/openclaw/openclaw:latest",
+        openclaw_port=18789,
+        state_dir=None,
+        name="ramalama_model_abc",
+        port="8080",
+        thinking=False,
+        workdir=None,
+        subcommand="sandbox",
+        debug=False,
+        ARGS=[],
+    )
+
+
+def _build_agent(agent: str, model: str = "test-model"):
+    args = _make_args() if agent == "goose" else _make_opencode_args() if agent == "opencode" else _make_openclaw_args()
+    cls = Goose if agent == "goose" else OpenCode if agent == "opencode" else OpenClaw
+    return args, cls(args, model)
+
+
 # --- Parametrized tests shared by both agents ---
 
 
-@pytest.mark.parametrize("agent", ["goose", "opencode"])
+@pytest.mark.parametrize("agent", ["goose", "opencode", "openclaw"])
 def test_sandbox_model_positional(agent):
     """Sandbox cli should accept a model as a positional argument"""
     _, args = parse_args_from_cmd(["sandbox", agent, TEST_MODEL])
     assert args.MODEL == "hf://Qwen/Qwen3-4B-GGUF/Qwen3-4B-Q4_K_M.gguf"
 
 
-@pytest.mark.parametrize("agent", ["goose", "opencode"])
+@pytest.mark.parametrize("agent", ["goose", "opencode", "openclaw"])
 def test_sandbox_requires_container_engine(agent):
     """Sandbox cli should raise when no container engine is configured"""
     _, args = parse_args_from_cmd(["sandbox", agent, TEST_MODEL])
@@ -60,14 +86,14 @@ def test_sandbox_requires_container_engine(agent):
         args.func(args)
 
 
-@pytest.mark.parametrize("agent", ["goose", "opencode"])
+@pytest.mark.parametrize("agent", ["goose", "opencode", "openclaw"])
 def test_sandbox_subcommand(agent):
     """CLI should handle sandbox subcommand"""
     _, args = parse_args_from_cmd(["sandbox", agent, TEST_MODEL])
     assert args.subcommand == "sandbox"
 
 
-@pytest.mark.parametrize("agent", ["goose", "opencode"])
+@pytest.mark.parametrize("agent", ["goose", "opencode", "openclaw"])
 def test_sandbox_agent_subcommand(agent):
     """CLI should set sandbox_agent correctly"""
     _, args = parse_args_from_cmd(["sandbox", agent, TEST_MODEL])
@@ -75,21 +101,21 @@ def test_sandbox_agent_subcommand(agent):
     assert args.sandbox_agent == agent
 
 
-@pytest.mark.parametrize("agent", ["goose", "opencode"])
+@pytest.mark.parametrize("agent", ["goose", "opencode", "openclaw"])
 def test_sandbox_thinking(agent):
     """Inference-specific options like 'thinking' should be handled"""
     _, args = parse_args_from_cmd(["sandbox", agent, "--thinking=off", TEST_MODEL])
     assert not args.thinking
 
 
-@pytest.mark.parametrize("agent", ["goose", "opencode"])
+@pytest.mark.parametrize("agent", ["goose", "opencode", "openclaw"])
 def test_sandbox_workdir_default_none(agent):
     """Default workdir option should be None"""
     _, args = parse_args_from_cmd(["sandbox", agent, TEST_MODEL])
     assert args.workdir is None
 
 
-@pytest.mark.parametrize("agent", ["goose", "opencode"])
+@pytest.mark.parametrize("agent", ["goose", "opencode", "openclaw"])
 def test_sandbox_workdir_option(agent):
     """CLI should parse -w/--workdir."""
     _, args = parse_args_from_cmd(["sandbox", agent, TEST_MODEL, "-w", "/tmp"])
@@ -107,46 +133,63 @@ def test_sandbox_no_subcommand(capsys):
     captured = capsys.readouterr()
     assert "goose" in captured.out
     assert "opencode" in captured.out
+    assert "openclaw" in captured.out
 
 
 # --- Parametrized agent construction tests ---
 
 
-@pytest.mark.parametrize("agent", ["goose", "opencode"])
+@pytest.mark.parametrize("agent", ["goose", "opencode", "openclaw"])
 def test_agent_network(agent):
     """Agent should setup container networking"""
-    args = _make_args() if agent == "goose" else _make_opencode_args()
-    obj = Goose(args, "test-model") if agent == "goose" else OpenCode(args, "test-model")
-    assert "--network=container:ramalama_model_abc" in obj.engine.exec_args
+    _, obj = _build_agent(agent)
+    try:
+        assert "--network=container:ramalama_model_abc" in obj.engine.exec_args
+    finally:
+        getattr(obj, "cleanup", lambda: None)()
 
 
-@pytest.mark.parametrize("agent", ["goose", "opencode"])
+@pytest.mark.parametrize("agent", ["goose", "opencode", "openclaw"])
 def test_agent_interactive(agent):
     """Agent should set the -i option"""
-    args = _make_args() if agent == "goose" else _make_opencode_args()
-    obj = Goose(args, "test-model") if agent == "goose" else OpenCode(args, "test-model")
-    assert "-i" in obj.engine.exec_args
+    _, obj = _build_agent(agent)
+    try:
+        assert "-i" in obj.engine.exec_args
+    finally:
+        getattr(obj, "cleanup", lambda: None)()
 
 
-@pytest.mark.parametrize("agent", ["goose", "opencode"])
+@pytest.mark.parametrize("agent", ["goose", "opencode", "openclaw"])
 def test_agent_workdir(agent):
     """Agent should add -v and --workdir=/work when workdir is set."""
-    args = _make_args() if agent == "goose" else _make_opencode_args()
+    args = _make_args() if agent == "goose" else _make_opencode_args() if agent == "opencode" else _make_openclaw_args()
+    cls = Goose if agent == "goose" else OpenCode if agent == "opencode" else OpenClaw
     args.workdir = "/tmp/myproject"
-    obj = Goose(args, "test-model") if agent == "goose" else OpenCode(args, "test-model")
-    cmd = obj.engine.exec_args
-    assert "--workdir=/work" in cmd
-    assert "/tmp/myproject:/work:rw" in cmd
+    obj = cls(args, "test-model")
+    try:
+        # OpenClaw mounts workdir on the gateway container, not the client
+        cmd = obj.gateway_engine.exec_args if agent == "openclaw" else obj.engine.exec_args
+        assert "--workdir=/work" in cmd
+        assert "/tmp/myproject:/work:rw" in cmd
+        if agent == "openclaw":
+            # Client engine should NOT have workdir
+            assert "--workdir=/work" not in obj.engine.exec_args
+    finally:
+        getattr(obj, "cleanup", lambda: None)()
 
 
-@pytest.mark.parametrize("agent", ["goose", "opencode"])
+@pytest.mark.parametrize("agent", ["goose", "opencode", "openclaw"])
 def test_agent_no_workdir(agent):
     """Agent should not add volume or --workdir when workdir is not set."""
-    args = _make_args() if agent == "goose" else _make_opencode_args()
-    obj = Goose(args, "test-model") if agent == "goose" else OpenCode(args, "test-model")
-    cmd = obj.engine.exec_args
-    assert "--workdir=/work" not in cmd
-    assert "-v" not in cmd
+    _, obj = _build_agent(agent)
+    try:
+        cmd = obj.engine.exec_args
+        assert "--workdir=/work" not in cmd
+        # Check no workdir volume is mounted (OpenClaw mounts a config volume, which is fine)
+        workdir_volumes = [arg for arg in cmd if ":/work:" in arg]
+        assert len(workdir_volumes) == 0
+    finally:
+        getattr(obj, "cleanup", lambda: None)()
 
 
 # --- Goose-specific tests ---
@@ -263,3 +306,295 @@ def test_opencode_args():
     args.ARGS = ["hello", "ramalama"]
     opencode = OpenCode(args, "test-model")
     assert opencode.engine.exec_args[-4:] == ["run", "--thinking=true", "hello", "ramalama"]
+
+
+# --- OpenClaw-specific tests ---
+
+
+def test_openclaw_default_image():
+    """OpenClaw subcommand should provide a default OpenClaw image"""
+    _, args = parse_args_from_cmd(["sandbox", "openclaw", TEST_MODEL])
+    assert args.openclaw_image.startswith("ghcr.io/openclaw/openclaw:")
+
+
+def test_openclaw_custom_image():
+    """OpenClaw subcommand should handle the --openclaw-image option"""
+    _, args = parse_args_from_cmd(["sandbox", "openclaw", TEST_MODEL, "--openclaw-image", "myimage:v1"])
+    assert args.openclaw_image == "myimage:v1"
+
+
+def test_openclaw_env_vars():
+    """OpenClaw should set environment for local OpenAI-compatible provider on both engines"""
+    args = _make_openclaw_args()
+    openclaw = OpenClaw(args, "Qwen3-4B-Q4_K_M")
+    try:
+        # Client engine env vars
+        cmd = openclaw.engine.exec_args
+        assert "OPENAI_BASE_URL=http://localhost:8080/v1" in cmd
+        assert "OPENAI_API_KEY=ramalama" in cmd
+        assert "OPENCLAW_CONFIG_PATH=/etc/openclaw/ramalama.json" in cmd
+        assert "OPENCLAW_SKIP_CHANNELS=1" in cmd
+        assert "OPENCLAW_SKIP_GMAIL_WATCHER=1" in cmd
+        assert "OPENCLAW_SKIP_CRON=1" in cmd
+        assert "OPENCLAW_SKIP_CANVAS_HOST=1" in cmd
+        # Gateway engine env vars
+        gw_cmd = openclaw.gateway_engine.exec_args
+        assert "OPENAI_BASE_URL=http://localhost:8080/v1" in gw_cmd
+        assert "OPENAI_API_KEY=ramalama" in gw_cmd
+        assert "OPENCLAW_CONFIG_PATH=/etc/openclaw/ramalama.json" in gw_cmd
+    finally:
+        openclaw.cleanup()
+
+
+def test_openclaw_env_custom_port():
+    """OpenClaw should honour a non-default port in env and launch config"""
+    args = _make_openclaw_args()
+    args.port = "9999"
+    openclaw = OpenClaw(args, "Qwen3-4B-Q4_K_M")
+    try:
+        cmd = openclaw.engine.exec_args
+        assert "OPENAI_BASE_URL=http://localhost:9999/v1" in cmd
+        # Config file should also use the overridden port
+        with open(openclaw.config_file_path) as f:
+            config = json.load(f)
+        assert config["models"]["providers"]["openai"]["baseUrl"] == "http://localhost:9999/v1"
+    finally:
+        openclaw.cleanup()
+
+
+def test_openclaw_config_file():
+    """OpenClaw should write a correct JSON config file"""
+    args = _make_openclaw_args()
+    model_name = "test-model"
+    openclaw = OpenClaw(args, model_name)
+    try:
+        assert os.path.exists(openclaw.config_file_path)
+        with open(openclaw.config_file_path) as f:
+            config = json.load(f)
+        # Validate provider configuration
+        assert config["models"]["providers"]["openai"]["api"] == "openai-completions"
+        assert config["models"]["providers"]["openai"]["apiKey"] == "ramalama"
+        assert "8080" in config["models"]["providers"]["openai"]["baseUrl"]
+        # Validate default agent model
+        assert config["agents"]["defaults"]["model"]["primary"] == f"openai/{model_name}"
+        # Validate gateway configuration
+        assert config["gateway"]["mode"] == "local"
+        assert config["gateway"]["bind"] == "loopback"
+        assert config["gateway"]["port"] == 18789
+    finally:
+        openclaw.cleanup()
+
+
+def test_openclaw_config_workspace_when_workdir_set():
+    """OpenClaw should set agents.defaults.workspace when workdir is provided."""
+    args = _make_openclaw_args()
+    args.workdir = "/tmp/myproject"
+    openclaw = OpenClaw(args, "test-model")
+    try:
+        with open(openclaw.config_file_path) as f:
+            config = json.load(f)
+        assert config["agents"]["defaults"]["workspace"] == "/work"
+    finally:
+        openclaw.cleanup()
+
+
+def test_openclaw_cleanup():
+    """OpenClaw cleanup should remove the temporary config file"""
+    args = _make_openclaw_args()
+    openclaw = OpenClaw(args, "test-model")
+    config_path = openclaw.config_file_path
+    assert os.path.exists(config_path)
+    openclaw.cleanup()
+    assert not os.path.exists(config_path)
+    # cleanup should be idempotent
+    openclaw.cleanup()
+
+
+def test_openclaw_with_tty(monkeypatch):
+    """OpenClaw client should launch TUI connecting to gateway when run with a tty"""
+    monkeypatch.setattr("ramalama.engine.sys.stdin.isatty", lambda: True)
+    args = _make_openclaw_args()
+    openclaw = OpenClaw(args, "test-model")
+    try:
+        assert openclaw.engine.exec_args[-4:] == ["openclaw", "tui", "--session", "main"]
+    finally:
+        openclaw.cleanup()
+
+
+def test_openclaw_no_tty(monkeypatch):
+    """OpenClaw client should read stdin as message when run without a tty"""
+    monkeypatch.setattr("ramalama.engine.sys.stdin.isatty", lambda: False)
+    args = _make_openclaw_args()
+    openclaw = OpenClaw(args, "test-model")
+    try:
+        assert openclaw.engine.exec_args[-2:] == [
+            "-c",
+            'msg="$(cat)"; exec openclaw agent --session-id ramalama --message "$msg"',
+        ]
+    finally:
+        openclaw.cleanup()
+
+
+def test_openclaw_args():
+    """OpenClaw client should run a one-shot agent call connecting to gateway"""
+    args = _make_openclaw_args()
+    args.ARGS = ["hello", "ramalama"]
+    openclaw = OpenClaw(args, "test-model")
+    try:
+        assert openclaw.engine.exec_args[-6:] == [
+            "openclaw",
+            "agent",
+            "--session-id",
+            "ramalama",
+            "--message",
+            "hello ramalama",
+        ]
+    finally:
+        openclaw.cleanup()
+
+
+def test_openclaw_gateway_engine():
+    """OpenClaw should create a detached gateway engine running openclaw gateway run"""
+    args = _make_openclaw_args()
+    openclaw = OpenClaw(args, "test-model")
+    try:
+        gw = openclaw.gateway_engine.exec_args
+        # Gateway should be detached
+        assert "-d" in gw
+        # Gateway should NOT be interactive
+        assert "-i" not in gw
+        # Gateway should share network with model server
+        assert "--network=container:ramalama_model_abc" in gw
+        # Gateway command should be openclaw gateway run
+        assert gw[-3:] == ["openclaw", "gateway", "run"]
+    finally:
+        openclaw.cleanup()
+
+
+def test_openclaw_gateway_config_mounted():
+    """Both gateway and client engines should mount the same config file"""
+    args = _make_openclaw_args()
+    openclaw = OpenClaw(args, "test-model")
+    try:
+        config_path = openclaw.config_file_path
+        # Both should contain a volume mount for the config file
+        gw_volumes = [a for a in openclaw.gateway_engine.exec_args if config_path in a]
+        client_volumes = [a for a in openclaw.engine.exec_args if config_path in a]
+        assert len(gw_volumes) > 0, "Gateway should mount the config file"
+        assert len(client_volumes) > 0, "Client should mount the config file"
+        # Both should mount to the same container path
+        assert "/etc/openclaw/ramalama.json" in gw_volumes[0]
+        assert "/etc/openclaw/ramalama.json" in client_volumes[0]
+    finally:
+        openclaw.cleanup()
+
+
+def test_openclaw_debug_log_level():
+    """OpenClaw should set OPENCLAW_LOG_LEVEL=debug on both engines when debug is True"""
+    args = _make_openclaw_args()
+    args.debug = True
+    openclaw = OpenClaw(args, "test-model")
+    try:
+        assert "OPENCLAW_LOG_LEVEL=debug" in openclaw.engine.exec_args
+        assert "OPENCLAW_LOG_LEVEL=debug" in openclaw.gateway_engine.exec_args
+    finally:
+        openclaw.cleanup()
+
+
+def test_openclaw_debug_verbose_in_agent_args():
+    """OpenClaw should pass --verbose to agent command when debug is True."""
+    args = _make_openclaw_args()
+    args.debug = True
+    args.ARGS = ["hello"]
+    openclaw = OpenClaw(args, "test-model")
+    try:
+        cmd = openclaw.engine.exec_args
+        assert "openclaw" in cmd
+        assert "agent" in cmd
+        assert "--verbose" in cmd
+    finally:
+        openclaw.cleanup()
+
+
+def test_openclaw_debug_verbose_in_stdin_path(monkeypatch):
+    """OpenClaw should include --verbose in stdin agent command when debug is True."""
+    monkeypatch.setattr("ramalama.engine.sys.stdin.isatty", lambda: False)
+    args = _make_openclaw_args()
+    args.debug = True
+    openclaw = OpenClaw(args, "test-model")
+    try:
+        assert openclaw.engine.exec_args[-2:] == [
+            "-c",
+            'msg="$(cat)"; exec openclaw agent --verbose --session-id ramalama --message "$msg"',
+        ]
+    finally:
+        openclaw.cleanup()
+
+
+def test_openclaw_run_handles_start_wait_and_cleanup(monkeypatch):
+    """OpenClaw.run should start gateway, wait for readiness, run client, and cleanup in finally."""
+    calls = []
+
+    def _record_run_cmd(cmd, stdout=None, stdin=None):
+        calls.append(cmd)
+
+    monkeypatch.setattr("ramalama.sandbox.run_cmd", _record_run_cmd)
+    monkeypatch.setattr(
+        "ramalama.sandbox.stop_container", lambda args, name, remove=False: calls.append(["stop", name])
+    )
+    monkeypatch.setattr(OpenClaw, "_wait_for_gateway_ready", lambda self, timeout=30: calls.append(["wait"]))
+
+    args = _make_openclaw_args()
+    args.ARGS = ["hello"]
+    openclaw = OpenClaw(args, "test-model")
+    config_path = openclaw.config_file_path
+    openclaw.run()
+
+    assert calls[0] == openclaw.gateway_engine.exec_args
+    assert calls[1] == ["wait"]
+    assert calls[2] == openclaw.engine.exec_args
+    assert calls[3] == ["stop", openclaw._gateway_name]
+    assert not os.path.exists(config_path)
+
+
+def test_openclaw_run_cleans_up_on_failure(monkeypatch):
+    """OpenClaw.run should cleanup even if client launch fails."""
+    cleaned = {"value": False}
+
+    monkeypatch.setattr(OpenClaw, "start_gateway", lambda self: None)
+    monkeypatch.setattr(OpenClaw, "_wait_for_gateway_ready", lambda self, timeout=30: None)
+    monkeypatch.setattr(Agent, "run", lambda self: (_ for _ in ()).throw(RuntimeError("boom")))
+    monkeypatch.setattr(OpenClaw, "cleanup", lambda self: cleaned.__setitem__("value", True))
+
+    args = _make_openclaw_args()
+    openclaw = OpenClaw(args, "test-model")
+    with pytest.raises(RuntimeError, match="boom"):
+        openclaw.run()
+    assert cleaned["value"]
+
+
+def test_openclaw_no_debug_log_level():
+    """OpenClaw should not set OPENCLAW_LOG_LEVEL when debug is False"""
+    args = _make_openclaw_args()
+    args.debug = False
+    openclaw = OpenClaw(args, "test-model")
+    try:
+        assert "OPENCLAW_LOG_LEVEL=debug" not in openclaw.engine.exec_args
+        assert "OPENCLAW_LOG_LEVEL=debug" not in openclaw.gateway_engine.exec_args
+    finally:
+        openclaw.cleanup()
+
+
+def test_openclaw_state_dir():
+    """OpenClaw should mount state-dir on gateway engine"""
+    args = _make_openclaw_args()
+    args.state_dir = "/tmp/openclaw-state"
+    openclaw = OpenClaw(args, "test-model")
+    try:
+        gw = openclaw.gateway_engine.exec_args
+        assert "OPENCLAW_STATE_DIR=/var/lib/openclaw" in gw
+        volume_args = [arg for arg in gw if "/tmp/openclaw-state:" in arg]
+        assert len(volume_args) > 0, "Expected a volume mount for state_dir on gateway"
+        assert "/var/lib/openclaw:rw" in volume_args[0]
+    finally:
+        openclaw.cleanup()


### PR DESCRIPTION
Introduce an ```openclaw``` subcommand to ```ramalama``` sandbox that launches OpenClaw using the official container image (```ghcr.io/openclaw/openclaw:2026.3.24```). The implementation follows the existing ```sandbox goose``` pattern as mentioned in the #2557

Closes :- #2557

## Summary by Sourcery

Add OpenClaw as a new sandbox agent in ramalama, wired into the CLI, runtime, and documentation, with full test coverage and support for local model server integration.

New Features:
- Introduce an `openclaw` sandbox subcommand that runs the OpenClaw agent in a container backed by a local model server.
- Add an `OpenClaw` agent implementation that configures OpenClaw to use a local OpenAI-compatible endpoint and supports interactive, stdin-driven, and one-shot invocation modes.
- Support selection and override of the OpenClaw container image via a dedicated `--openclaw-image` option.

Enhancements:
- Extend existing sandbox CLI and runtime plumbing to treat OpenClaw alongside Goose and OpenCode, including shared networking and workdir behavior.

Documentation:
- Document the new `ramalama sandbox openclaw` subcommand, its options, and usage examples, and list OpenClaw as a supported sandbox agent in the main sandbox man page.

Tests:
- Expand unit and end-to-end sandbox tests to cover OpenClaw behavior, including environment configuration, launch modes, image overrides, and dry-run output.