### PR TITLE
Add support for python 3.9 and EL9 rpm builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,10 +80,10 @@ jobs:
           - title: ""
             runs-on: ubuntu-24.04
             uv-options: {}
-          - title: " (python 3.10)"
+          - title: " (python 3.9)"
             runs-on: ubuntu-24.04
             uv-options:
-              python-version: '3.10'
+              python-version: '3.9'
           - title: " (MacOS)"
             runs-on: macos-26
             uv-options: {}
@@ -115,9 +115,9 @@ jobs:
           - title: ""
             uv-options:
               activate-environment: true
-          - title: " (python 3.10)"
+          - title: " (python 3.9)"
             uv-options:
-              python-version: '3.10'
+              python-version: '3.9'
               activate-environment: true
     name: E2E Tests${{ matrix.variant.title }}
     runs-on: ubuntu-24.04
@@ -177,9 +177,9 @@ jobs:
           - title: ""
             uv-options:
               activate-environment: true
-          - title: " (python 3.10)"
+          - title: " (python 3.9)"
             uv-options:
-              python-version: '3.10'
+              python-version: '3.9'
               activate-environment: true
     name: E2E Tests (--no-container)${{ matrix.variant.title }}
     runs-on: ubuntu-24.04
@@ -237,9 +237,9 @@ jobs:
           - title: ""
             uv-options:
               activate-environment: true
-          - title: " (python 3.10)"
+          - title: " (python 3.9)"
             uv-options:
-              python-version: '3.10'
+              python-version: '3.9'
               activate-environment: true
     name: E2E Tests (docker)${{ matrix.variant.title }}
     runs-on: ubuntu-24.04
@@ -317,9 +317,9 @@ jobs:
           - title: ""
             uv-options:
               activate-environment: true
-          - title: " (python 3.10)"
+          - title: " (python 3.9)"
             uv-options:
-              python-version: '3.10'
+              python-version: '3.9'
               activate-environment: true
     name: E2E Tests (MacOS)${{ matrix.variant.title }}
     runs-on: macos-15
@@ -362,9 +362,9 @@ jobs:
           - title: ""
             uv-options:
               activate-environment: true
-          - title: " (python 3.10)"
+          - title: " (python 3.9)"
             uv-options:
-              python-version: '3.10'
+              python-version: '3.9'
               activate-environment: true
     name: E2E Tests (Windows)${{ matrix.variant.title }}
     runs-on: windows-latest

--- a/.packit-copr-rpm.sh
+++ b/.packit-copr-rpm.sh
@@ -6,11 +6,7 @@
 
 set -exo pipefail
 
-# Extract version from Python module since pyproject.toml uses dynamic versioning
-# Note: 
-# cd into ramalama directory so that the version module can be imported individually
-# and additional dependencies such as pyyaml or jsonschema are not required
-VERSION=$(cd ramalama && python3 -c "import version; print(version.version())")
+VERSION=$(python3 "ramalama/version.py")
 
 SPEC_FILE=rpm/ramalama.spec
 

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -36,6 +36,7 @@ jobs:
     packages: [ramalama-centos]
     targets: &centos_copr_targets
       - centos-stream-10
+      - centos-stream-9
 
   # Run on commit to main branch
   - job: copr_build
@@ -81,6 +82,7 @@ jobs:
       - fedora-all
       - epel10
       - epel10.0
+      - epel9
 
   - job: koji_build
     trigger: commit
@@ -94,3 +96,4 @@ jobs:
       - fedora-branched # rawhide updates are created automatically
       - epel10
       - epel10.0
+      - epel9

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,7 +107,7 @@ supported subcommands.
 
 ## Code Style
 
-- Python 3.10+ required
+- Python 3.9+ required
 - Line length: 120 characters
 - Formatting: ruff format + ruff check (I rules)
 - Type hints encouraged (mypy checked)

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ pip install ramalama
 ```
 
 **Requirements:**
-- Python 3.10 or later
+- Python 3.9 or later
 - Docker Desktop or Podman Desktop with WSL2 backend
 - For GPU support, see [NVIDIA GPU Setup for WSL2](docs/readme/wsl2-docker-cuda.md)
 

--- a/docs/MACOS_INSTALL.md
+++ b/docs/MACOS_INSTALL.md
@@ -51,7 +51,7 @@ ramalama --help
 If you prefer to use Python package management:
 
 ```bash
-# Install Python 3.10 or later (if not already installed)
+# Install Python 3.9 or later (if not already installed)
 brew install python@3.11
 
 # Install ramalama

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,6 @@
                 dependencies = with python3Packages; [
                   argcomplete
                   pyyaml
-                  jsonschema
                   jinja2
                   (llama-cpp.override llamaCppOverrides)
                 ];

--- a/hack/xref-helpmsgs-manpages
+++ b/hack/xref-helpmsgs-manpages
@@ -405,8 +405,8 @@ sub ramalama_help {
                 $section = 'options';
             }
         }
-        elsif ($line =~ /^(options):/) {
-            $section = lc $1;
+        elsif ($line =~ /^(options|optional\s+arguments):/) {
+            $section = 'options';
         }
 
         # ...then track commands and options. For subcommands, recurse.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "ramalama"
 dynamic = ["version"]
 description = "RamaLama is a command line tool for working with AI LLM models."
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.9"
 keywords = [
   "ramalama",
   "llama",
@@ -24,7 +24,6 @@ keywords = [
 dependencies = [
   "argcomplete",
   "pyyaml",
-  "jsonschema",
   "jinja2",
   "wmi ; sys_platform == 'win32'",
 ]
@@ -43,6 +42,7 @@ classifiers = [
   "Operating System :: POSIX :: Linux",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -60,9 +60,10 @@ dev = [
     "argcomplete~=3.0",
     "bcrypt",
     "codespell~=2.0",
-    "huggingface_hub~=1.11.0",
+    "huggingface_hub~=1.11.0;python_version>=\"3.10\"",
     "hypothesis>=6.135.26",
-    "pytest~=9.0",
+    "pytest~=9.0;python_version>=\"3.10\"",
+    "pytest~=8.0;python_version<\"3.10\"",
     "ruff>=0.14.14",
     "wheel~=0.46.3",
     "mypy",
@@ -114,7 +115,7 @@ license-files = ["LICENSE"]
 "ramalama" = ["py.typed"]
 
 [tool.setuptools.dynamic]
-version = {attr = "ramalama.version.version"}
+version = {attr = "ramalama.version.__version__"}
 
 [tool.codespell]
 skip = ["build", "ramalama.egg-info", "logos", ".git", "venv", ".venv", ".tox", ".pixi"]
@@ -275,4 +276,5 @@ dev = { features = ["dev"], solve-group = "default" }
 tox = ">=4.30.2,<5"
 
 [tool.mypy]
-python_version = "3.10"
+python_version = "3.9"
+exclude = ["setup\\.py"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,7 @@
+[pytest]
+testpaths = test
+markers =
+    e2e
+    distro_integration
+    slow: tests that take more than ~30 seconds, usually running an inference server
+addopts = -m 'not e2e and not slow' --color=yes --durations=10

--- a/ramalama.spec
+++ b/ramalama.spec
@@ -61,7 +61,6 @@ a = Analysis(
         'ramalama.file_loaders',
         'argcomplete',
         'yaml',
-        'jsonschema',
         'jinja2',
     ],
     hookspath=[],

--- a/ramalama/__init__.py
+++ b/ramalama/__init__.py
@@ -1,11 +1,13 @@
 """ramalama client module."""
 
+from __future__ import annotations
+
 import sys
 
 from ramalama import cli
 from ramalama.cli import HelpException, init_cli, print_version
 from ramalama.common import perror
 
-assert sys.version_info >= (3, 10), "Python 3.10 or greater is required."
+assert sys.version_info >= (3, 9), "Python 3.9 or greater is required."
 
 __all__ = ["cli", "perror", "init_cli", "print_version", "HelpException"]

--- a/ramalama/amdkfd.py
+++ b/ramalama/amdkfd.py
@@ -1,5 +1,7 @@
 """utilities for working with AMDKFD driver"""
 
+from __future__ import annotations
+
 import glob
 
 # Heap types in memory properties

--- a/ramalama/annotations.py
+++ b/ramalama/annotations.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 # These annotations are based off the standards:
 # https://github.com/opencontainers/image-spec/blob/main/annotations.md
 # https://github.com/CloudNativeAI/model-spec

--- a/ramalama/arg_types.py
+++ b/ramalama/arg_types.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import argparse
 from dataclasses import make_dataclass
-from typing import List, Protocol, get_type_hints
+from typing import List, Optional, Protocol, Union, get_type_hints
 
 from ramalama.config_types import COLOR_OPTIONS, SUPPORTED_ENGINES, SUPPORTED_RUNTIMES, PathStr
 
@@ -12,21 +14,21 @@ def protocol_to_dataclass(proto_cls):
 
 
 class EngineArgType(Protocol):
-    engine: SUPPORTED_ENGINES | None
+    engine: Optional[SUPPORTED_ENGINES]
 
 
 EngineArgs = protocol_to_dataclass(EngineArgType)
 
 
 class ContainerArgType(Protocol):
-    container: bool | None
+    container: Optional[bool]
 
 
 ContainerArgs = protocol_to_dataclass(ContainerArgType)
 
 
 class StoreArgType(Protocol):
-    engine: SUPPORTED_ENGINES | None
+    engine: Optional[SUPPORTED_ENGINES]
     container: bool
     store: str
 
@@ -43,18 +45,18 @@ class BaseEngineArgsType(Protocol):
     quiet: bool
     image: str
     # Optional attributes (accessed via getattr)
-    pull: str | None
-    network: str | None
-    oci_runtime: str | None
-    selinux: bool | None
-    nocapdrop: bool | None
-    device: list[str] | None
-    podman_keep_groups: bool | None
+    pull: Optional[str]
+    network: Optional[str]
+    oci_runtime: Optional[str]
+    selinux: Optional[bool]
+    nocapdrop: Optional[bool]
+    device: Optional[List[str]]
+    podman_keep_groups: Optional[bool]
     # Optional attributes for labels
-    MODEL: str | None
-    runtime: str | None
-    port: str | int | None  # Can be string (e.g., "8080:8080") or int
-    subcommand: str | None
+    MODEL: Optional[str]
+    runtime: Optional[str]
+    port: Union[str, int, None]  # Can be string (e.g., "8080:8080") or int
+    subcommand: Optional[str]
 
 
 BaseEngineArgs = protocol_to_dataclass(BaseEngineArgsType)
@@ -68,7 +70,7 @@ class DefaultArgsType(Protocol):
     quiet: bool
     dryrun: bool
     engine: SUPPORTED_ENGINES
-    noout: bool | None
+    noout: Optional[bool]
 
 
 DefaultArgs = protocol_to_dataclass(DefaultArgsType)
@@ -79,19 +81,19 @@ class ChatSubArgsType(Protocol):
     url: str
     color: COLOR_OPTIONS
     list: bool
-    model: str | None
-    rag: str | None
-    api_key: str | None
-    ARGS: List[str] | None
-    max_tokens: int | None
-    temp: float | None
+    model: Optional[str]
+    rag: Optional[str]
+    api_key: Optional[str]
+    ARGS: Optional[List[str]]
+    max_tokens: Optional[int]
+    temp: Optional[float]
 
 
 ChatSubArgs = protocol_to_dataclass(ChatSubArgsType)
 
 
 class ChatArgsType(DefaultArgsType, ChatSubArgsType):
-    ignore: bool | None  # runtime-only
+    ignore: Optional[bool]  # runtime-only
 
 
 class RagArgsType(DefaultArgsType, Protocol):

--- a/ramalama/benchmarks/errors.py
+++ b/ramalama/benchmarks/errors.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 class MissingStorageFolderError(Exception):
     def __init__(self):
         message = """

--- a/ramalama/benchmarks/manager.py
+++ b/ramalama/benchmarks/manager.py
@@ -1,7 +1,10 @@
+from __future__ import annotations
+
 import json
 from dataclasses import asdict
 from functools import cached_property
 from pathlib import Path
+from typing import Union
 
 from ramalama.benchmarks.errors import MissingStorageFolderError
 from ramalama.benchmarks.schemas import BenchmarkRecord, DeviceInfoV1, get_benchmark_record
@@ -12,7 +15,7 @@ BENCHMARKS_FILENAME = "benchmarks.jsonl"
 
 
 class BenchmarksManager:
-    def __init__(self, storage_folder: str | Path | None):
+    def __init__(self, storage_folder: Union[str, Path, None]):
         if storage_folder is None:
             raise MissingStorageFolderError
 

--- a/ramalama/benchmarks/schemas.py
+++ b/ramalama/benchmarks/schemas.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 import platform
 import socket
 from dataclasses import dataclass, field, fields
 from datetime import datetime, timezone
 from functools import lru_cache
-from typing import Any, ClassVar, Literal, TypeVar, overload
+from typing import Any, ClassVar, Literal, Optional, TypeVar, overload
 
 from ramalama.common import get_accel
 
@@ -47,7 +49,7 @@ class TestConfigurationV1(TestConfiguration):
     container_runtime: str = ""
     inference_engine: str = ""
     version: Literal["v1"] = "v1"
-    runtime_args: list[str] | None = None
+    runtime_args: Optional[list[str]] = None
 
 
 @dataclass
@@ -58,48 +60,48 @@ class LlamaBenchResult:
 @dataclass
 class LlamaBenchResultV1(LlamaBenchResult):
     version: Literal["v1"] = "v1"
-    build_commit: str | None = None
-    build_number: int | None = None
-    backends: str | None = None
-    cpu_info: str | None = None
-    gpu_info: str | None = None
-    model_filename: str | None = None
-    model_type: str | None = None
-    model_size: int | None = None
-    model_n_params: int | None = None
-    n_batch: int | None = None
-    n_ubatch: int | None = None
-    n_threads: int | None = None
-    cpu_mask: str | None = None
-    cpu_strict: int | None = None
-    poll: int | None = None
-    type_k: str | None = None
-    type_v: str | None = None
-    n_gpu_layers: int | None = None
-    n_cpu_moe: int | None = None
-    split_mode: str | None = None
-    main_gpu: int | None = None
-    no_kv_offload: int | None = None
-    flash_attn: int | None = None
-    devices: str | None = None
-    tensor_split: str | None = None
-    tensor_buft_overrides: str | None = None
-    use_mmap: int | None = None
-    embeddings: int | None = None
-    no_op_offload: int | None = None
-    no_host: int | None = None
-    use_direct_io: int | None = None
-    fit_target: int | None = None
-    n_prompt: int | None = None
-    n_gen: int | None = None
-    n_depth: int | None = None
-    test_time: str | None = None
-    avg_ns: int | None = None
-    stddev_ns: int | None = None
-    avg_ts: float | None = None
-    stddev_ts: float | None = None
-    samples_ns: str | None = None  # JSON array stored as string
-    samples_ts: str | None = None  # JSON array stored as string
+    build_commit: Optional[str] = None
+    build_number: Optional[int] = None
+    backends: Optional[str] = None
+    cpu_info: Optional[str] = None
+    gpu_info: Optional[str] = None
+    model_filename: Optional[str] = None
+    model_type: Optional[str] = None
+    model_size: Optional[int] = None
+    model_n_params: Optional[int] = None
+    n_batch: Optional[int] = None
+    n_ubatch: Optional[int] = None
+    n_threads: Optional[int] = None
+    cpu_mask: Optional[str] = None
+    cpu_strict: Optional[int] = None
+    poll: Optional[int] = None
+    type_k: Optional[str] = None
+    type_v: Optional[str] = None
+    n_gpu_layers: Optional[int] = None
+    n_cpu_moe: Optional[int] = None
+    split_mode: Optional[str] = None
+    main_gpu: Optional[int] = None
+    no_kv_offload: Optional[int] = None
+    flash_attn: Optional[int] = None
+    devices: Optional[str] = None
+    tensor_split: Optional[str] = None
+    tensor_buft_overrides: Optional[str] = None
+    use_mmap: Optional[int] = None
+    embeddings: Optional[int] = None
+    no_op_offload: Optional[int] = None
+    no_host: Optional[int] = None
+    use_direct_io: Optional[int] = None
+    fit_target: Optional[int] = None
+    n_prompt: Optional[int] = None
+    n_gen: Optional[int] = None
+    n_depth: Optional[int] = None
+    test_time: Optional[str] = None
+    avg_ns: Optional[int] = None
+    stddev_ns: Optional[int] = None
+    avg_ts: Optional[float] = None
+    stddev_ts: Optional[float] = None
+    samples_ns: Optional[str] = None  # JSON array stored as string
+    samples_ts: Optional[str] = None  # JSON array stored as string
 
     @classmethod
     def from_payload(cls, payload: dict) -> "LlamaBenchResultV1":

--- a/ramalama/benchmarks/utilities.py
+++ b/ramalama/benchmarks/utilities.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 import json
+from typing import Optional
 
 from ramalama.benchmarks.schemas import (
     BenchmarkRecord,
@@ -31,7 +34,7 @@ def print_bench_results(records: list[BenchmarkRecord]):
         return
     normalized_records: list[BenchmarkRecordV1] = [normalize_benchmark_record(result) for result in records]
 
-    rows: list[dict[str, object | None]] = []
+    rows: list[dict[str, Optional[object]]] = []
     for i, item in enumerate(normalized_records):
         result = item.result
         model = result.model_filename or ""

--- a/ramalama/chat.py
+++ b/ramalama/chat.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+from __future__ import annotations
 
 import _thread
 import cmd
@@ -16,6 +17,7 @@ import urllib.request
 from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import timedelta
+from typing import Optional
 
 from ramalama.arg_types import ChatArgsType
 from ramalama.chat_providers import ChatProvider, ChatRequestOptions
@@ -92,15 +94,15 @@ def add_api_key(args, headers=None):
 
 @dataclass
 class ChatOperationalArgs:
-    name: str | None = None
-    keepalive: int | None = None
-    monitor: "ServerMonitor | None" = None
+    name: Optional[str] = None
+    keepalive: Optional[int] = None
+    monitor: "Optional[ServerMonitor]" = None
 
 
 class Spinner:
     def __init__(self, wait_time: float = 0.1):
         self._stop_event: threading.Event = threading.Event()
-        self._thread: threading.Thread | None = None
+        self._thread: Optional[threading.Thread] = None
         self.wait_time = wait_time
 
     def __enter__(self):
@@ -146,8 +148,8 @@ class RamaLamaShell(cmd.Cmd):
     def __init__(
         self,
         args: ChatArgsType,
-        operational_args: ChatOperationalArgs | None = None,
-        provider: ChatProvider | None = None,
+        operational_args: Optional[ChatOperationalArgs] = None,
+        provider: Optional[ChatProvider] = None,
     ):
         if operational_args is None:
             operational_args = ChatOperationalArgs()
@@ -162,7 +164,7 @@ class RamaLamaShell(cmd.Cmd):
         self.url = self.provider.build_url()
 
         self.prep_rag_message()
-        self.mcp_agent: LLMAgent | None = None
+        self.mcp_agent: Optional[LLMAgent] = None
         self.initialize_mcp()
 
         self.content: list[str] = []
@@ -275,7 +277,7 @@ class RamaLamaShell(cmd.Cmd):
         options = self._build_request_options(stream=stream, max_tokens=max_tokens)
         return self.provider.create_request(messages, options)
 
-    def _resolve_model_name(self) -> str | None:
+    def _resolve_model_name(self) -> Optional[str]:
         runtime = getattr(self.args, "runtime", None)
         if runtime:
             plugin = get_runtime(runtime)
@@ -283,7 +285,7 @@ class RamaLamaShell(cmd.Cmd):
                 return None
         return getattr(self.args, "model", None)
 
-    def _build_request_options(self, *, stream: bool, max_tokens: int | None) -> ChatRequestOptions:
+    def _build_request_options(self, *, stream: bool, max_tokens: Optional[int]) -> ChatRequestOptions:
         temperature = getattr(self.args, "temp", None)
         if max_tokens is not None and max_tokens <= 0:
             max_tokens = None
@@ -533,7 +535,7 @@ class RamaLamaShell(cmd.Cmd):
 
         max_timeout = 16
 
-        last_error: Exception | None = None
+        last_error: Optional[Exception] = None
 
         spinner = Spinner().start()
 
@@ -827,8 +829,8 @@ def _report_server_exit(monitor):
 
 def chat(
     args: ChatArgsType,
-    operational_args: ChatOperationalArgs | None = None,
-    provider: ChatProvider | None = None,
+    operational_args: Optional[ChatOperationalArgs] = None,
+    provider: Optional[ChatProvider] = None,
 ):
     if args.dryrun:
         assert args.ARGS is not None

--- a/ramalama/chat_providers/__init__.py
+++ b/ramalama/chat_providers/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from ramalama.chat_providers import api_providers, openai
 from ramalama.chat_providers.base import (
     ChatProvider,

--- a/ramalama/chat_providers/api_providers.py
+++ b/ramalama/chat_providers/api_providers.py
@@ -1,15 +1,18 @@
+from __future__ import annotations
+
 from collections.abc import Callable
+from typing import Optional
 
 from ramalama.chat_providers.base import ChatProvider
 from ramalama.chat_providers.openai import OpenAIResponsesChatProvider
 from ramalama.config import ActiveConfig
 
-PROVIDER_API_KEY_RESOLVERS: dict[str, Callable[[], str | None]] = {
+PROVIDER_API_KEY_RESOLVERS: dict[str, Callable[[], Optional[str]]] = {
     "openai": lambda: ActiveConfig().provider.openai.api_key,
 }
 
 
-def get_provider_api_key(scheme: str) -> str | None:
+def get_provider_api_key(scheme: str) -> Optional[str]:
     """Return a configured API key for the given provider scheme, if any."""
 
     if resolver := PROVIDER_API_KEY_RESOLVERS.get(scheme):

--- a/ramalama/chat_providers/base.py
+++ b/ramalama/chat_providers/base.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import json
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
-from typing import Any, TypedDict
+from typing import Any, Optional, TypedDict
 from urllib import error as urllib_error
 from urllib import request as urllib_request
 
@@ -20,15 +22,15 @@ class ChatRequestOptionsDict(RequiredChatRequestOptionsDict, total=False):
     max_tokens: int
 
 
-@dataclass(slots=True)
+@dataclass
 class ChatRequestOptions:
     """Normalized knobs for building a chat completion request."""
 
-    model: str | None
+    model: Optional[str]
     stream: bool = True
-    temperature: float | None = None
-    max_tokens: int | None = None
-    extra: dict[str, Any] | None = None
+    temperature: Optional[float] = None
+    max_tokens: Optional[int] = None
+    extra: Optional[dict[str, Any]] = None
 
     def to_dict(self) -> ChatRequestOptionsDict:
         result: ChatRequestOptionsDict = {'stream': self.stream}
@@ -48,19 +50,19 @@ class ChatRequestOptions:
         return result
 
 
-@dataclass(slots=True)
+@dataclass
 class ChatStreamEvent:
     """A provider-agnostic representation of a streamed delta."""
 
-    text: str | None = None
-    raw: dict[str, Any] | None = None
+    text: Optional[str] = None
+    raw: Optional[dict[str, Any]] = None
     done: bool = False
 
 
 class ChatProviderError(Exception):
     """Raised when a provider request fails or returns an invalid payload."""
 
-    def __init__(self, message: str, *, status_code: int | None = None, payload: Any | None = None):
+    def __init__(self, message: str, *, status_code: Optional[int] = None, payload: Optional[Any] = None):
         super().__init__(message)
         self.status_code = status_code
         self.payload = payload
@@ -75,8 +77,8 @@ class ChatProvider(ABC):
     def __init__(
         self,
         base_url: str,
-        api_key: str | None = None,
-        default_headers: Mapping[str, str] | None = None,
+        api_key: Optional[str] = None,
+        default_headers: Optional[Mapping[str, str]] = None,
     ) -> None:
         if api_key is None:
             api_key = ActiveConfig().api_key
@@ -85,7 +87,7 @@ class ChatProvider(ABC):
         self.api_key = api_key
         self._default_headers: dict[str, str] = dict(default_headers or {})
 
-    def build_url(self, path: str | None = None) -> str:
+    def build_url(self, path: Optional[str] = None) -> str:
         rel = path or self.default_path
         if not rel.startswith("/"):
             rel = f"/{rel}"
@@ -95,8 +97,8 @@ class ChatProvider(ABC):
         self,
         *,
         include_auth: bool = True,
-        extra: dict[str, str] | None = None,
-        options: ChatRequestOptions | None = None,
+        extra: Optional[dict[str, str]] = None,
+        options: Optional[ChatRequestOptions] = None,
     ) -> dict[str, str]:
         headers: dict[str, str] = {
             "Content-Type": "application/json",
@@ -132,13 +134,13 @@ class ChatProvider(ABC):
     # ------------------------------------------------------------------
     # Provider customization points
     # ------------------------------------------------------------------
-    def provider_headers(self, options: ChatRequestOptions | None = None) -> dict[str, str]:
+    def provider_headers(self, options: Optional[ChatRequestOptions] = None) -> dict[str, str]:
         return {}
 
-    def additional_request_headers(self, options: ChatRequestOptions | None = None) -> dict[str, str]:
+    def additional_request_headers(self, options: Optional[ChatRequestOptions] = None) -> dict[str, str]:
         return {}
 
-    def resolve_request_path(self, options: ChatRequestOptions | None = None) -> str:
+    def resolve_request_path(self, options: Optional[ChatRequestOptions] = None) -> str:
         return self.default_path
 
     @abstractmethod
@@ -152,7 +154,7 @@ class ChatProvider(ABC):
     # ------------------------------------------------------------------
     # Error handling
     # ------------------------------------------------------------------
-    def raise_for_status(self, status_code: int, payload: Any | None = None) -> None:
+    def raise_for_status(self, status_code: int, payload: Optional[Any] = None) -> None:
         if status_code >= 400:
             if isinstance(payload, dict) and "error" in payload:
                 err = payload["error"]

--- a/ramalama/chat_providers/openai.py
+++ b/ramalama/chat_providers/openai.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import json
 from collections.abc import Iterable, Mapping, Sequence
 from functools import singledispatch
-from typing import Any, TypedDict
+from typing import Any, Optional, TypedDict
 
 from ramalama.chat_providers.base import ChatProvider, ChatRequestOptions, ChatStreamEvent
 from ramalama.chat_utils import (
@@ -91,7 +93,7 @@ class OpenAICompletionsChatProvider(ChatProvider):
     provider = "openai"
     default_path = "/chat/completions"
 
-    def __init__(self, base_url: str, api_key: str | None = None):
+    def __init__(self, base_url: str, api_key: Optional[str] = None):
         super().__init__(base_url, api_key)
         self._stream_buffer: str = ""
 
@@ -130,7 +132,7 @@ class OpenAICompletionsChatProvider(ChatProvider):
 
         return events
 
-    def _extract_delta(self, payload: Mapping[str, object]) -> str | None:
+    def _extract_delta(self, payload: Mapping[str, object]) -> Optional[str]:
         choices = payload.get("choices")
         if not isinstance(choices, list) or not choices:
             return None
@@ -168,7 +170,7 @@ def message_to_responses_dict(message: Any) -> dict[str, Any]:
 
 
 def create_responses_content(
-    text: str | None, attachments: list[AttachmentPart], content_type: str
+    text: Optional[str], attachments: list[AttachmentPart], content_type: str
 ) -> list[dict[str, Any]] | str:
     """
     TODO: Current structure doesn't correctly reflect document ordering
@@ -237,7 +239,7 @@ def _(message: AssistantMessage) -> dict[str, Any]:
 class ResponsesPayload(TypedDict, total=False):
     input: list[dict[str, Any]]
     model: str
-    temperature: float | None
+    temperature: Optional[float]
     max_completion_tokens: int
     stream: bool
 
@@ -246,7 +248,7 @@ class OpenAIResponsesChatProvider(ChatProvider):
     provider = "openai"
     default_path: str = "/responses"
 
-    def __init__(self, base_url: str, api_key: str | None = None):
+    def __init__(self, base_url: str, api_key: Optional[str] = None):
         super().__init__(base_url, api_key)
         self._stream_buffer: str = ""
 
@@ -311,7 +313,7 @@ class OpenAIResponsesChatProvider(ChatProvider):
         return hinted_type == "response.completed"
 
     @staticmethod
-    def _extract_responses_delta(event_type: str, payload: Mapping[str, Any]) -> str | None:
+    def _extract_responses_delta(event_type: str, payload: Mapping[str, Any]) -> Optional[str]:
         if not event_type:
             event_type = payload.get("type", "") if isinstance(payload, Mapping) else ""
 

--- a/ramalama/chat_utils.py
+++ b/ramalama/chat_utils.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import base64
 import re
 from collections.abc import Iterable
 from dataclasses import dataclass, field
-from typing import Any, Literal, Protocol
+from typing import Any, Literal, Optional, Protocol, Union
 
 from ramalama.console import should_colorize
 
@@ -22,63 +24,63 @@ def sanitize_for_terminal(text: str) -> str:
 RoleType = Literal["system", "user", "assistant", "tool"]
 
 
-@dataclass(slots=True)
+@dataclass
 class ImageURLPart:
     url: str
-    detail: str | None = None
+    detail: Optional[str] = None
     type: Literal["image_url"] = "image_url"
 
 
-@dataclass(slots=True)
+@dataclass
 class ImageBytesPart:
     data: bytes
     mime_type: str = "application/octet-stream"
     type: Literal["image_bytes"] = "image_bytes"
 
 
-@dataclass(slots=True)
+@dataclass
 class ToolCall:
     id: str
     name: str
     arguments: dict[str, Any]
 
 
-AttachmentPart = ImageURLPart | ImageBytesPart
+AttachmentPart = Union[ImageURLPart, ImageBytesPart]
 
 
-@dataclass(slots=True)
+@dataclass
 class SystemMessage:
     role: Literal["system"] = "system"
     text: str = ""
     metadata: dict[str, Any] = field(default_factory=dict)
 
 
-@dataclass(slots=True)
+@dataclass
 class UserMessage:
     role: Literal["user"] = "user"
-    text: str | None = None
+    text: Optional[str] = None
     metadata: dict[str, Any] = field(default_factory=dict)
     attachments: list[AttachmentPart] = field(default_factory=list)
 
 
-@dataclass(slots=True)
+@dataclass
 class AssistantMessage:
     role: Literal["assistant"] = "assistant"
-    text: str | None = None
+    text: Optional[str] = None
     metadata: dict[str, Any] = field(default_factory=dict)
     tool_calls: list[ToolCall] = field(default_factory=list)
     attachments: list[AttachmentPart] = field(default_factory=list)
 
 
-@dataclass(slots=True)
+@dataclass
 class ToolMessage:
     text: str
     role: Literal["tool"] = "tool"
     metadata: dict[str, Any] = field(default_factory=dict)
-    tool_call_id: str | None = None
+    tool_call_id: Optional[str] = None
 
 
-ChatMessageType = SystemMessage | UserMessage | AssistantMessage | ToolMessage
+ChatMessageType = Union[SystemMessage, UserMessage, AssistantMessage, ToolMessage]
 
 
 class StreamParser(Protocol):

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 import copy
 import errno
@@ -9,14 +11,16 @@ import sys
 import urllib.error
 from datetime import datetime, timezone
 from functools import lru_cache
-from typing import Any, get_args
+from typing import Any, Optional, get_args
 from urllib.parse import urlparse
 
 # if autocomplete doesn't exist, just do nothing, don't break
 try:
     import argcomplete
 
-    suppressCompleter: type[argcomplete.completers.SuppressCompleter] | None = argcomplete.completers.SuppressCompleter
+    suppressCompleter: Optional[type[argcomplete.completers.SuppressCompleter]] = (
+        argcomplete.completers.SuppressCompleter
+    )
 except Exception:
     suppressCompleter = None
 
@@ -507,7 +511,7 @@ def human_duration(d):
     return "1 year" if d < 63072000 else f"{d // 31536000} years"
 
 
-def add_network_argument(parser, dflt: str | None = "none"):
+def add_network_argument(parser, dflt: Optional[str] = "none"):
     # Disable network access by default, and give the option to pass any supported network mode into
     # podman if needed:
     # https://docs.podman.io/en/latest/markdown/podman-run.1.html#network-mode-net

--- a/ramalama/cli_arg_normalization.py
+++ b/ramalama/cli_arg_normalization.py
@@ -1,2 +1,7 @@
-def normalize_pull_arg(pull: str, engine: str | None):
+from __future__ import annotations
+
+from typing import Optional
+
+
+def normalize_pull_arg(pull: str, engine: Optional[str]):
     return "always" if engine == "docker" and pull == "newer" else pull

--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -15,8 +15,10 @@ from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
-from typing import IO, TYPE_CHECKING, Any, Literal, Optional, Protocol, TypeAlias, TypedDict, cast, get_args
+from typing import IO, TYPE_CHECKING, Any, Literal, Optional, Protocol, TypedDict, Union, cast, get_args
 
+if TYPE_CHECKING:
+    from typing_extensions import TypeAlias
 import yaml
 
 import ramalama.amdkfd as amdkfd
@@ -75,7 +77,7 @@ def confirm_no_gpu(name, provider) -> bool:
         print("Invalid input. Please enter 'yes' or 'no'.")
 
 
-def handle_provider(machine, config: Config | None = None) -> bool | None:
+def handle_provider(machine, config: Optional[Config] = None) -> Optional[bool]:
     global podman_machine_accel
     name = machine.get("Name")
     provider = machine.get("VMType")
@@ -93,7 +95,7 @@ def handle_provider(machine, config: Config | None = None) -> bool | None:
     return None
 
 
-def apple_vm(engine: SUPPORTED_ENGINES, config: Config | None = None) -> bool:
+def apple_vm(engine: SUPPORTED_ENGINES, config: Optional[Config] = None) -> bool:
     podman_machine_list = [engine, "machine", "list", "--format", "json", "--all-providers"]
     try:
         machines_json = run_cmd(podman_machine_list, ignore_stderr=True, encoding="utf-8").stdout.strip()
@@ -135,13 +137,13 @@ def exec_cmd(args, stdout2null: bool = False, stderr2null: bool = False):
 
 def run_cmd(
     args: Sequence[str],
-    cwd: str | None = None,
-    stdout: int | IO[Any] | None = subprocess.PIPE,
-    stdin: int | IO[Any] | None = subprocess.DEVNULL,
+    cwd: Optional[str] = None,
+    stdout: Union[int, IO[Any], None] = subprocess.PIPE,
+    stdin: Union[int, IO[Any], None] = subprocess.DEVNULL,
     ignore_stderr: bool = False,
     ignore_all: bool = False,
-    encoding: str | None = None,
-    env: dict[str, str] | None = None,
+    encoding: Optional[str] = None,
+    env: Optional[dict[str, str]] = None,
 ) -> subprocess.CompletedProcess[Any]:
     """
     Run the given command arguments.
@@ -312,7 +314,7 @@ class CDI_RETURN_TYPE(TypedDict):
     devices: list[CDI_DEVICE]
 
 
-def load_cdi_config(spec_dirs: list[str]) -> CDI_RETURN_TYPE | None:
+def load_cdi_config(spec_dirs: list[str]) -> Optional[CDI_RETURN_TYPE]:
     # Load and merge all CDI configuration files from the given directories.
     # When multiple CDI configs exist (e.g. /var/run/cdi and /etc/cdi), all are
     # merged so that device "all" and other devices are found regardless of
@@ -352,7 +354,7 @@ def load_cdi_config(spec_dirs: list[str]) -> CDI_RETURN_TYPE | None:
     return {"devices": merged_devices}
 
 
-def get_podman_machine_cdi_config() -> CDI_RETURN_TYPE | None:
+def get_podman_machine_cdi_config() -> Optional[CDI_RETURN_TYPE]:
     cdi_config = run_cmd(["podman", "machine", "ssh", "cat", "/etc/cdi/nvidia.yaml"], encoding="utf-8").stdout.strip()
     if cdi_config:
         return yaml.safe_load(cdi_config)
@@ -390,7 +392,7 @@ def find_in_cdi(devices: list[str]) -> tuple[list[str], list[str]]:
     return configured, unconfigured
 
 
-def check_asahi() -> Literal["asahi"] | None:
+def check_asahi() -> Optional[Literal["asahi"]]:
     if os.path.exists('/proc/device-tree/compatible'):
         try:
             with open('/proc/device-tree/compatible', 'rb') as f:
@@ -411,7 +413,7 @@ def check_metal(args: ContainerArgType) -> bool:
 
 
 @lru_cache(maxsize=1)
-def check_nvidia() -> Literal["cuda"] | None:
+def check_nvidia() -> Optional[Literal["cuda"]]:
     try:
         command = ['nvidia-smi', '--query-gpu=index,uuid', '--format=csv,noheader']
         result = run_cmd(command, encoding="utf-8")
@@ -454,7 +456,7 @@ def check_nvidia() -> Literal["cuda"] | None:
     return None
 
 
-def check_ascend() -> Literal["cann"] | None:
+def check_ascend() -> Optional[Literal["cann"]]:
     try:
         command = ['npu-smi', 'info']
         run_cmd(command, encoding="utf-8")
@@ -466,7 +468,7 @@ def check_ascend() -> Literal["cann"] | None:
     return None
 
 
-def check_rocm_amd() -> Literal["hip"] | None:
+def check_rocm_amd() -> Optional[Literal["hip"]]:
     if is_arm():
         # ROCm is not available for arm64, use Vulkan instead
         return None
@@ -503,7 +505,7 @@ def is_arm() -> bool:
     return platform.machine() in ('arm64', 'aarch64')
 
 
-def check_intel() -> Literal["intel"] | None:
+def check_intel() -> Optional[Literal["intel"]]:
     igpu_num = 0
 
     if platform.system() == "Windows":
@@ -555,7 +557,7 @@ def _check_intel_windows() -> int:
         return 0
 
 
-def check_mthreads() -> Literal["musa"] | None:
+def check_mthreads() -> Optional[Literal["musa"]]:
     try:
         command = ['mthreads-gmi']
         run_cmd(command, encoding="utf-8")
@@ -572,9 +574,9 @@ AccelType: TypeAlias = Literal["asahi", "cuda", "cann", "hip", "intel", "musa"]
 
 @lru_cache(maxsize=1)
 def get_accel() -> AccelType | Literal["none"]:
-    checks: tuple[Callable[[], AccelType | None], ...] = (
+    checks: tuple[Callable[[], Optional[AccelType]], ...] = (
         check_asahi,
-        cast(Callable[[], Literal['cuda'] | None], check_nvidia),
+        cast(Callable[[], Optional[Literal['cuda']]], check_nvidia),
         check_ascend,
         check_rocm_amd,
         check_intel,
@@ -682,10 +684,10 @@ class AccelImageArgsOtherRuntimeRAG(Protocol):
     quiet: bool
 
 
-AccelImageArgs: TypeAlias = None | AccelImageArgsOtherRuntime | AccelImageArgsOtherRuntimeRAG
+AccelImageArgs: TypeAlias = Union[None, AccelImageArgsOtherRuntime, AccelImageArgsOtherRuntimeRAG]
 
 
-def accel_image(config: Config, images: dict[str, str] | None = None, conf_key: str = "image") -> str:
+def accel_image(config: Config, images: Optional[dict[str, str]] = None, conf_key: str = "image") -> str:
     """
     Selects the appropriate image based on config, arguments, environment.
     "images" is a mapping of environment variable names to image names. If not specified,
@@ -716,7 +718,7 @@ def accel_image(config: Config, images: dict[str, str] | None = None, conf_key: 
     return latest_tagged_image(images.get(gpu_type, getattr(config, f"default_{conf_key}")))
 
 
-def ensure_image(conman: str | None, image: str, should_pull: bool = False) -> str:
+def ensure_image(conman: Optional[str], image: str, should_pull: bool = False) -> str:
     """Check if image exists locally; optionally pull it.
 
     Returns the image string on success. If conman is falsy, returns image unchanged.

--- a/ramalama/compat.py
+++ b/ramalama/compat.py
@@ -1,5 +1,7 @@
 """ramalama compat module."""
 
+from __future__ import annotations
+
 import os
 import sys
 from contextlib import contextmanager

--- a/ramalama/compose.py
+++ b/ramalama/compose.py
@@ -1,5 +1,6 @@
-# ramalama/generate/compose.py
+from __future__ import annotations
 
+# ramalama/generate/compose.py
 import os
 import shlex
 from typing import Optional

--- a/ramalama/config.py
+++ b/ramalama/config.py
@@ -1,10 +1,15 @@
+from __future__ import annotations
+
 import json
 import os
 import sys
 from dataclasses import dataclass, field
 from functools import lru_cache
 from pathlib import Path
-from typing import Any, Literal, Mapping, TypeAlias
+from typing import TYPE_CHECKING, Any, Literal, Mapping, Optional
+
+if TYPE_CHECKING:
+    from typing_extensions import TypeAlias
 
 from ramalama.cli_arg_normalization import normalize_pull_arg
 from ramalama.common import apple_vm, available, version_tagged_image
@@ -78,7 +83,7 @@ def get_default_host() -> str:
         return "0.0.0.0"
 
 
-def get_default_engine() -> SUPPORTED_ENGINES | None:
+def get_default_engine() -> Optional[SUPPORTED_ENGINES]:
     """Determine the container manager to use based on environment and platform."""
     if os.path.exists("/run/.toolboxenv"):
         return None
@@ -110,7 +115,7 @@ def coerce_to_bool(value: Any) -> bool:
     raise ValueError(f"Cannot coerce {value!r} to bool")
 
 
-def get_storage_folder(base_path: str | None = None):
+def get_storage_folder(base_path: Optional[str] = None):
     if base_path is None:
         base_path = get_default_store()
 
@@ -136,7 +141,7 @@ class UserConfig:
 
 @dataclass
 class OpenaiProviderConfig:
-    api_key: str | None = None
+    api_key: Optional[str] = None
 
 
 @dataclass
@@ -148,7 +153,7 @@ class ProviderConfig:
 class RamalamaSettings:
     """These settings are not managed directly by the user"""
 
-    config_files: list[str] | None = None
+    config_files: Optional[list[str]] = None
 
 
 @dataclass
@@ -168,7 +173,7 @@ class HTTPClientConfig:
 @dataclass
 class BaseConfig:
     api: str = "none"
-    api_key: str | None = None
+    api_key: Optional[str] = None
     backend: Literal["auto", "vulkan", "rocm", "cuda", "sycl", "openvino"] = "auto"
     benchmarks: Benchmarks = field(default_factory=Benchmarks)
     carimage: str = "registry.access.redhat.com/ubi10-micro:latest"
@@ -179,18 +184,18 @@ class BaseConfig:
     default_rag_image: str = DEFAULT_RAG_IMAGE
     default_tools_image: str = DEFAULT_TOOLS_IMAGE
     dryrun: bool = False
-    engine: SUPPORTED_ENGINES | None = field(default_factory=get_default_engine)
+    engine: Optional[SUPPORTED_ENGINES] = field(default_factory=get_default_engine)
     env: list[str] = field(default_factory=list)
     gguf_quantization_mode: GGUF_QUANTIZATION_MODES = DEFAULT_GGUF_QUANTIZATION_MODE
     host: str = field(default_factory=get_default_host)
     http_client: HTTPClientConfig = field(default_factory=HTTPClientConfig)
     image: str = None  # type: ignore
     images: dict[str, str] = field(default_factory=dict)
-    rag_image: str | None = None
-    tools_image: str | None = None
+    rag_image: Optional[str] = None
+    tools_image: Optional[str] = None
     tools_images: dict[str, str] = field(default_factory=dict)
     keep_groups: bool = False
-    log_level: LogLevel | None = None
+    log_level: Optional[LogLevel] = None
     max_tokens: int = 0
     port: str = "8080"
     prefix: str = None  # type: ignore
@@ -272,7 +277,7 @@ def load_file_config() -> dict[str, Any]:
     return config
 
 
-def load_env_config(env: Mapping[str, str] | None = None) -> dict[str, Any]:
+def load_env_config(env: Optional[Mapping[str, str]] = None) -> dict[str, Any]:
     if env is None:
         env = os.environ
 
@@ -317,7 +322,7 @@ def load_env_config(env: Mapping[str, str] | None = None) -> dict[str, Any]:
     return config
 
 
-def load_config(env: Mapping[str, str] | None = None) -> Config:
+def load_config(env: Optional[Mapping[str, str]] = None) -> Config:
     """Returns a Config object with layers initialized from config file and environment."""
     return Config(load_file_config(), load_env_config(env))
 

--- a/ramalama/config_types.py
+++ b/ramalama/config_types.py
@@ -1,4 +1,9 @@
-from typing import Literal, TypeAlias
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from typing_extensions import TypeAlias
 
 PathStr: TypeAlias = str
 SUPPORTED_ENGINES: TypeAlias = Literal["podman", "docker"]

--- a/ramalama/console.py
+++ b/ramalama/console.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import sys
 

--- a/ramalama/daemon/daemon.py
+++ b/ramalama/daemon/daemon.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+from __future__ import annotations
 
 import argparse
 import errno
@@ -7,6 +8,7 @@ import socket
 import socketserver
 import threading
 from datetime import datetime, timedelta
+from typing import Optional
 
 from ramalama.config import ActiveConfig
 from ramalama.daemon.handler.ramalama import RamalamaHandler
@@ -18,7 +20,7 @@ from ramalama.log_levels import LogLevel
 class ShutdownHandler:
     def __init__(self, server: "RamalamaServer") -> None:
         self.server = server
-        self.idle_check_timer: threading.Timer | None = None
+        self.idle_check_timer: Optional[threading.Timer] = None
 
     def handle_kill(self, signum, frame):
         if self.idle_check_timer:

--- a/ramalama/daemon/dto/errors.py
+++ b/ramalama/daemon/dto/errors.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 class MissingArgumentError(Exception):
     """Exception raised when a required argument is missing."""
 

--- a/ramalama/daemon/dto/model.py
+++ b/ramalama/daemon/dto/model.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 from dataclasses import dataclass
 from typing import Any

--- a/ramalama/daemon/dto/serve.py
+++ b/ramalama/daemon/dto/serve.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 from dataclasses import dataclass
 

--- a/ramalama/daemon/handler/base.py
+++ b/ramalama/daemon/handler/base.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import http.server
 import json
 from abc import ABC, abstractmethod

--- a/ramalama/daemon/handler/daemon.py
+++ b/ramalama/daemon/handler/daemon.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import http.server
 import json
 from datetime import datetime, timedelta

--- a/ramalama/daemon/handler/proxy.py
+++ b/ramalama/daemon/handler/proxy.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import http.server
 import urllib.parse
 import urllib.request

--- a/ramalama/daemon/handler/ramalama.py
+++ b/ramalama/daemon/handler/ramalama.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import http.server
 import traceback
 import urllib.error

--- a/ramalama/daemon/logging.py
+++ b/ramalama/daemon/logging.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import os
 

--- a/ramalama/daemon/service/model_runner.py
+++ b/ramalama/daemon/service/model_runner.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import subprocess
 from datetime import datetime, timedelta
 from typing import Optional

--- a/ramalama/endian.py
+++ b/ramalama/endian.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 from enum import IntEnum
 

--- a/ramalama/engine.py
+++ b/ramalama/engine.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import glob
 import json
 import os
@@ -8,7 +10,7 @@ import time
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Sequence
 from http.client import HTTPConnection, HTTPException
-from typing import Any
+from typing import Any, Optional
 
 # Live reference for checking global vars
 import ramalama.common
@@ -253,7 +255,7 @@ class BuildEngine(BaseEngine):
             # as an equals-separated option (--pull=foo)
             self.add_args(f"--pull={value}")
 
-    def build(self, cfile: str, context: str, /, *, tag: str | None = None) -> str:
+    def build(self, cfile: str, context: str, /, *, tag: Optional[str] = None) -> str:
         """
         Build an image using specified Containerfile path and context dir.
         If tag is provided, the image will be tagged.
@@ -267,7 +269,7 @@ class BuildEngine(BaseEngine):
             return ""
         return self.run_process().stdout.strip()
 
-    def build_containerfile(self, content: str, context: str, /, *, tag: str | None = None):
+    def build_containerfile(self, content: str, context: str, /, *, tag: Optional[str] = None):
         """
         Build an image using the provided Containerfile content and context dir.
         If tag is provided, the image will be tagged.
@@ -315,7 +317,7 @@ def images(args):
         raise (e)
 
 
-def image_inspect(args, name: str, format: str | None = None):
+def image_inspect(args, name: str, format: Optional[str] = None):
     if not name:
         raise ValueError("must specify an image name")
     conman = str(args.engine) if args.engine is not None else None
@@ -377,7 +379,7 @@ def info(args) -> list[Any] | str | dict[str, Any]:
         return str(e)
 
 
-def inspect(args, name: str, format: str | None = None, ignore_stderr: bool = False):
+def inspect(args, name: str, format: Optional[str] = None, ignore_stderr: bool = False):
     if not name:
         raise ValueError("must specify a container name")
     conman = str(args.engine) if args.engine is not None else None
@@ -472,7 +474,7 @@ def add_labels(args, add_label: Callable[[str], None]):
             add_label(f"{label_prefix}={value}")
 
 
-def is_healthy(args, timeout: int = 3, model_name: str | None = None):
+def is_healthy(args, timeout: int = 3, model_name: Optional[str] = None):
     """Check if the runtime server is healthy by delegating to the runtime plugin."""
     from ramalama.plugins.loader import get_runtime
 

--- a/ramalama/file.py
+++ b/ramalama/file.py
@@ -1,5 +1,6 @@
-# The following code is inspired from: https://github.com/ericcurtin/lm-pull/blob/main/lm-pull.py
+from __future__ import annotations
 
+# The following code is inspired from: https://github.com/ericcurtin/lm-pull/blob/main/lm-pull.py
 import os
 import platform
 

--- a/ramalama/file_loaders/__init__.py
+++ b/ramalama/file_loaders/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from ramalama.file_loaders import file_manager, file_types
 
 __all__ = ["file_manager", "file_types"]

--- a/ramalama/file_loaders/file_manager.py
+++ b/ramalama/file_loaders/file_manager.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 from abc import ABC, abstractmethod
 from string import Template

--- a/ramalama/file_loaders/file_types/__init__.py
+++ b/ramalama/file_loaders/file_types/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from ramalama.file_loaders.file_types import base, image, txt
 
 __all__ = ["base", "txt", "image"]

--- a/ramalama/file_loaders/file_types/base.py
+++ b/ramalama/file_loaders/file_types/base.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 
 

--- a/ramalama/file_loaders/file_types/image.py
+++ b/ramalama/file_loaders/file_types/image.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import base64
 import mimetypes
 

--- a/ramalama/file_loaders/file_types/pdf.py
+++ b/ramalama/file_loaders/file_types/pdf.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from ramalama.file_loaders.file_types.base import BaseFileLoader
 
 

--- a/ramalama/file_loaders/file_types/txt.py
+++ b/ramalama/file_loaders/file_types/txt.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from ramalama.file_loaders.file_types.base import BaseFileLoader
 
 

--- a/ramalama/hf_style_repo_base.py
+++ b/ramalama/hf_style_repo_base.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import os
 import re
@@ -5,6 +7,7 @@ import tempfile
 import urllib.request
 from abc import ABC, abstractmethod
 from pathlib import Path
+from typing import Optional
 
 from ramalama.common import (
     SPLIT_MODEL_PATH_RE,
@@ -76,14 +79,14 @@ class HFStyleRepository(ABC):
         self.organization = organization
         self.tag = tag
         self.headers: dict = {}
-        self.blob_url: str | None = None
-        self.model_filename: str | None = None
-        self.model_hash: str | None = None
-        self.mmproj_filename: str | None = None
-        self.mmproj_hash: str | None = None
+        self.blob_url: Optional[str] = None
+        self.model_filename: Optional[str] = None
+        self.model_hash: Optional[str] = None
+        self.mmproj_filename: Optional[str] = None
+        self.mmproj_hash: Optional[str] = None
         self.other_files: list[dict] = []
         self.additional_safetensor_files: list[dict] = []
-        self.safetensors_index_file: str | None = None
+        self.safetensors_index_file: Optional[str] = None
         self.fetch_metadata()
 
     @abstractmethod

--- a/ramalama/http_client.py
+++ b/ramalama/http_client.py
@@ -1,10 +1,12 @@
-# The following code is inspired from: https://github.com/ericcurtin/lm-pull/blob/main/lm-pull.py
+from __future__ import annotations
 
+# The following code is inspired from: https://github.com/ericcurtin/lm-pull/blob/main/lm-pull.py
 import os
 import shutil
 import sys
 import time
 import urllib.request
+from typing import Optional
 
 import ramalama.console as console
 from ramalama.common import perror
@@ -166,7 +168,7 @@ class HttpClient:
         return now_downloaded / elapsed_seconds
 
 
-def download_file(url: str, dest_path: str, headers: dict[str, str] | None = None, show_progress: bool = True):
+def download_file(url: str, dest_path: str, headers: Optional[dict[str, str]] = None, show_progress: bool = True):
     """
     Downloads a file from a given URL to a specified destination path.
 

--- a/ramalama/kube.py
+++ b/ramalama/kube.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import platform
 from typing import Optional, Tuple

--- a/ramalama/layered_config.py
+++ b/ramalama/layered_config.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import MISSING, fields, is_dataclass
 from functools import reduce
 from typing import Any, Type, get_type_hints
@@ -29,7 +31,7 @@ def build_subconfigs(values: dict, obj: Type) -> dict:
     """Facilitates nesting configs by instantiating the child typed object from a dict
 
     NOTE: This implementation does not automatically coerce more complicated config structures
-    involving types like (ConfigObj | None), or list[ConfigObj], etc...
+    involving types like (Optional[ConfigObj]), or list[ConfigObj], etc...
     """
 
     dtypes: dict[str, Type] = get_type_hints(obj)

--- a/ramalama/log_levels.py
+++ b/ramalama/log_levels.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from enum import IntEnum
 from typing import Union

--- a/ramalama/logger.py
+++ b/ramalama/logger.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import sys
 

--- a/ramalama/mcp/mcp_agent.py
+++ b/ramalama/mcp/mcp_agent.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
+from __future__ import annotations
 
 import json
 import logging
 import time
 import urllib.error
 import urllib.request
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from ramalama.config import ActiveConfig
 from ramalama.logger import logger
@@ -19,7 +20,7 @@ class LLMAgent:
         self,
         clients: List[PureMCPClient],
         llm_base_url: str = "http://localhost:8080",
-        model: str | None = None,
+        model: Optional[str] = None,
         args=None,
     ):
         config_level = ActiveConfig().log_level or logging.INFO
@@ -86,7 +87,7 @@ class LLMAgent:
             print(f"  {i}. {name}")
             print(f"     Inputs: {inputs_str}\n")
 
-    def should_use_tools(self, content: str, conversation_history: list[dict[str, str]] | None = None) -> bool:
+    def should_use_tools(self, content: str, conversation_history: Optional[list[dict[str, str]]] = None) -> bool:
         """Determine if the request should be handled by tools using LLM."""
         tools_context = "Available tools:\n"
         for i, tool in enumerate(self.available_tools, 1):
@@ -125,7 +126,7 @@ Should this request use the available tools?"""
         response = self._call_llm(messages)
         return response is not None and response.upper().strip() == "YES"
 
-    def _call_llm(self, messages: List[Dict[str, str]], console_stream: bool = False) -> str | None:
+    def _call_llm(self, messages: List[Dict[str, str]], console_stream: bool = False) -> Optional[str]:
         """
         Call the LLM with the given messages.
         """
@@ -315,7 +316,7 @@ Generate ONLY a JSON object with the arguments. Extract values from the task."""
                 logging.warning("LLM failed to produce valid JSON for tool arguments: %s", response)
                 return {}
 
-    def execute_task(self, task: str, manual: bool = False, stream: bool = False) -> str | None:
+    def execute_task(self, task: str, manual: bool = False, stream: bool = False) -> Optional[str]:
         """Execute one or more relevant tools for a task and combine results."""
         if not self.available_tools:
             return "No tools available."
@@ -360,7 +361,7 @@ Generate ONLY a JSON object with the arguments. Extract values from the task."""
         combined_output = "\n\n".join(tool_outputs)
         return self._result(task, combined_output, stream)
 
-    def execute_specific_tool(self, task: str, tool_name: str, manual: bool = False) -> str | None:
+    def execute_specific_tool(self, task: str, tool_name: str, manual: bool = False) -> Optional[str]:
         """Execute a specific tool by name."""
         if not self.available_tools:
             return "No tools available."
@@ -429,7 +430,7 @@ Generate ONLY a JSON object with the arguments. Extract values from the task."""
         chosen = [name.strip().lower() for name in response.split(",")]
         return [t for t in self.available_tools if t["name"].lower() in chosen]
 
-    def _result(self, task: str, content: str, stream: bool = False) -> str | None:
+    def _result(self, task: str, content: str, stream: bool = False) -> Optional[str]:
         """Format the tool result into a user-friendly response."""
         messages = [
             {

--- a/ramalama/mcp/mcp_client.py
+++ b/ramalama/mcp/mcp_client.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+from __future__ import annotations
+
 import json
 import logging
 import time

--- a/ramalama/model_inspect/__init__.py
+++ b/ramalama/model_inspect/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from ramalama.model_inspect import base_info, error, gguf_info, gguf_parser, safetensor_info, safetensor_parser
 
 __all__ = ["base_info", "error", "gguf_info", "gguf_parser", "safetensor_info", "safetensor_parser"]

--- a/ramalama/model_inspect/base_info.py
+++ b/ramalama/model_inspect/base_info.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import shutil
 import sys

--- a/ramalama/model_inspect/error.py
+++ b/ramalama/model_inspect/error.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 # Basic error when parsing model files
 class ParseError(Exception):
     pass

--- a/ramalama/model_inspect/gguf_info.py
+++ b/ramalama/model_inspect/gguf_info.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from json import dumps
 from typing import Any, Dict, Optional, Union
 

--- a/ramalama/model_inspect/gguf_parser.py
+++ b/ramalama/model_inspect/gguf_parser.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import io
 import struct
 from enum import IntEnum

--- a/ramalama/model_inspect/safetensor_info.py
+++ b/ramalama/model_inspect/safetensor_info.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 from typing import Any, Dict
 

--- a/ramalama/model_inspect/safetensor_parser.py
+++ b/ramalama/model_inspect/safetensor_parser.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import struct
 

--- a/ramalama/model_store/constants.py
+++ b/ramalama/model_store/constants.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 DIRECTORY_NAME_BLOBS = "blobs"
 DIRECTORY_NAME_REFS = "refs"
 DIRECTORY_NAME_SNAPSHOTS = "snapshots"

--- a/ramalama/model_store/global_store.py
+++ b/ramalama/model_store/global_store.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 from dataclasses import dataclass
 from typing import Dict, List

--- a/ramalama/model_store/go2jinja.py
+++ b/ramalama/model_store/go2jinja.py
@@ -1,7 +1,8 @@
+from __future__ import annotations
+
 #
 # Copied from https://github.com/engelmi/go2jinja
 #
-
 import argparse
 import re
 import sys
@@ -29,7 +30,7 @@ class Node:
     end: int
     content: str
 
-    type: NodeType | None
+    type: Optional[NodeType]
 
     prev: Optional["Node"]
     next: Optional["Node"]
@@ -206,7 +207,7 @@ def detect_node_type(stmt: str) -> Optional[NodeType]:
 def parse_go_template(content: str) -> list[Node]:
     root_nodes: list[Node] = []
 
-    prev_expr_node: Node | None = None
+    prev_expr_node: Optional[Node] = None
     current_scope_nodes: list[Node] = []
     start_pos = content.find(GO_SYMBOL_OPEN_BRACKETS)
     end_pos = 0
@@ -365,7 +366,7 @@ def go_to_jinja(content: str) -> str:
             if not pipeline.isspace():
                 pipeline = pipeline.lstrip().rstrip()
 
-            longest_match: FunctionType | None = None
+            longest_match: Optional[FunctionType] = None
             for ft in FUNCTION_MAPPING.keys():
                 if pipeline.startswith(ft.value):
                     if longest_match is None or len(ft.value) > len(longest_match.value):

--- a/ramalama/model_store/reffile.py
+++ b/ramalama/model_store/reffile.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import os
 from dataclasses import dataclass

--- a/ramalama/model_store/snapshot_file.py
+++ b/ramalama/model_store/snapshot_file.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 from enum import IntEnum
 from typing import Dict, Sequence

--- a/ramalama/model_store/store.py
+++ b/ramalama/model_store/store.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import shutil
 import urllib.error
@@ -109,7 +111,7 @@ class ModelStore:
         if snapshot_files is None:
             snapshot_files = []
 
-        ref_file: RefJSONFile | None = self.get_ref_file(model_tag)
+        ref_file: Optional[RefJSONFile] = self.get_ref_file(model_tag)
         if ref_file is None:
             return None
 
@@ -177,7 +179,7 @@ class ModelStore:
     def get_cached_files(self, model_tag: str) -> Tuple[str, list[str], bool]:
         cached_files: list[str] = []
 
-        ref_file: RefJSONFile | None = self.get_ref_file(model_tag)
+        ref_file: Optional[RefJSONFile] = self.get_ref_file(model_tag)
         if ref_file is None:
             return ("", cached_files, False)
 
@@ -280,7 +282,7 @@ class ModelStore:
         # Give preference to the embedded chat template as it's most likely to be
         # compatible with llama.cpp
 
-        def get_embedded_template() -> str | None:
+        def get_embedded_template() -> Optional[str]:
             models = ref_file.model_files
             if not models:
                 return None

--- a/ramalama/model_store/template_conversion.py
+++ b/ramalama/model_store/template_conversion.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 from functools import lru_cache
 

--- a/ramalama/oci_tools.py
+++ b/ramalama/oci_tools.py
@@ -1,11 +1,13 @@
+from __future__ import annotations
+
 import json
 import subprocess
 from dataclasses import dataclass
 from datetime import datetime
 from itertools import chain
-from typing import TypedDict
+from typing import Optional, TypedDict
 
-import ramalama.annotations as annotations
+import ramalama.annotations as oci_annotations
 from ramalama.arg_types import EngineArgType
 from ramalama.common import SemVer, engine_version, run_cmd
 from ramalama.logger import logger
@@ -31,7 +33,7 @@ def convert_from_human_readable_size(input) -> int:
     return int(round(float(value)))
 
 
-def parse_datetime(date_str: str) -> datetime | None:
+def parse_datetime(date_str: str) -> Optional[datetime]:
     try:
         parsed_date = datetime.fromisoformat(date_str.replace(" UTC", "").replace("+0000", "+00:00").replace(" ", "T"))
     except ValueError:
@@ -41,7 +43,7 @@ def parse_datetime(date_str: str) -> datetime | None:
 
 
 class ListModelResponse(TypedDict):
-    modified: datetime | None
+    modified: Optional[datetime]
     name: str
     size: int
 
@@ -102,7 +104,7 @@ def list_artifacts(args: EngineArgType):
             continue
         if "artifactType" not in inspect["Manifest"]:
             continue
-        if inspect["Manifest"]['artifactType'] != annotations.ArtifactTypeModelManifest:
+        if inspect["Manifest"]['artifactType'] != oci_annotations.ArtifactTypeModelManifest:
             continue
         models.append(
             {
@@ -179,7 +181,7 @@ def list_manifests(args: EngineArgType) -> list[ListModelResponse]:
         img = inspect['manifests'][0]
         if 'annotations' not in img:
             continue
-        if annotations.AnnotationModel in img['annotations']:
+        if oci_annotations.AnnotationModel in img['annotations']:
             models.append(
                 {
                     "name": manifest["name"],
@@ -272,8 +274,8 @@ class OciRef:
     registry: str
     repository: str
     specifier: str  # Either the digest or the tag
-    tag: str | None = None
-    digest: str | None = None
+    tag: Optional[str] = None
+    digest: Optional[str] = None
 
     def __str__(self) -> str:
         if self.digest:

--- a/ramalama/ollama_repo_utils.py
+++ b/ramalama/ollama_repo_utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import os
 import urllib.request

--- a/ramalama/path_utils.py
+++ b/ramalama/path_utils.py
@@ -1,5 +1,7 @@
 """Utilities for cross-platform path handling, especially for Windows Docker/Podman support."""
 
+from __future__ import annotations
+
 import os
 import platform
 import string

--- a/ramalama/plugins/interface.py
+++ b/ramalama/plugins/interface.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import argparse
 from abc import ABC, abstractmethod
 from http.client import HTTPConnection
-from typing import Any
+from typing import Any, Optional
 
 
 class RuntimePlugin(ABC):
@@ -9,7 +11,7 @@ class RuntimePlugin(ABC):
     @abstractmethod
     def name(self) -> str: ...
 
-    def get_container_image(self, config: Any, gpu_type: str) -> str | None:
+    def get_container_image(self, config: Any, gpu_type: str) -> Optional[str]:
         return None
 
     def register_subcommands(self, subparsers: "argparse._SubParsersAction") -> None:
@@ -33,7 +35,7 @@ class RuntimePlugin(ABC):
         """Seconds to wait for the runtime server to become ready."""
         return 180
 
-    def service_ready_check(self, conn: HTTPConnection, args: Any, model_name: str | None = None) -> bool:
+    def service_ready_check(self, conn: HTTPConnection, args: Any, model_name: Optional[str] = None) -> bool:
         """Check if the service is ready to receive requests."""
         return True
 

--- a/ramalama/plugins/loader.py
+++ b/ramalama/plugins/loader.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 
 from ramalama.plugins.interface import RuntimePlugin

--- a/ramalama/plugins/registry.py
+++ b/ramalama/plugins/registry.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
+import sys
 from importlib.metadata import entry_points
-from typing import Generic, Type, TypeVar
+from typing import Generic, Optional, Type, TypeVar
 
 T = TypeVar("T")
 
@@ -10,15 +13,19 @@ class PluginRegistry(Generic[T]):
     def __init__(self, group: str, base_class: Type[T]):
         self.group = group
         self.base_class = base_class
-        self._plugins: dict[str, T] | None = None
+        self._plugins: Optional[dict[str, T]] = None
 
     def load(self) -> dict[str, T]:
         if self._plugins is None:
             self._plugins = {}
-            for ep in entry_points(group=self.group):
+            if sys.version_info >= (3, 10):
+                eps = entry_points(group=self.group)
+            else:
+                eps = entry_points().get(self.group, [])  # type: ignore[call-overload]
+            for ep in eps:
                 plugin: T = ep.load()()
                 self._plugins[plugin.name] = plugin  # type: ignore[attr-defined]
         return self._plugins
 
-    def get(self, name: str) -> T | None:
+    def get(self, name: str) -> Optional[T]:
         return self.load().get(name)

--- a/ramalama/plugins/runtimes/inference/common.py
+++ b/ramalama/plugins/runtimes/inference/common.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 from abc import abstractmethod
 from typing import Any

--- a/ramalama/plugins/runtimes/inference/llama_cpp.py
+++ b/ramalama/plugins/runtimes/inference/llama_cpp.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 import copy
 import json
@@ -8,7 +10,7 @@ import tempfile
 from dataclasses import asdict
 from datetime import datetime, timezone
 from http.client import HTTPConnection
-from typing import Any, get_args
+from typing import Any, Optional, get_args
 from urllib.parse import urlparse
 
 from ramalama.benchmarks.manager import BenchmarksManager
@@ -193,7 +195,7 @@ class LlamaCppPlugin(LlamaCppCommands, ContainerizedInferenceRuntimePlugin):
             engine.run()
         return f"{source_model.model_name}-{args.gguf}.gguf"
 
-    def service_ready_check(self, conn: HTTPConnection, args: Any, model_name: str | None = None) -> bool:
+    def service_ready_check(self, conn: HTTPConnection, args: Any, model_name: Optional[str] = None) -> bool:
         container_name = f"container {args.name}" if getattr(args, 'container', None) else 'server'
         conn.request("GET", "/health")
         health_resp = conn.getresponse()
@@ -232,7 +234,7 @@ class LlamaCppPlugin(LlamaCppCommands, ContainerizedInferenceRuntimePlugin):
         logger.debug(f"{self.name} {container_name} is ready")
         return True
 
-    def get_container_image(self, config: Any, detected_gpu_type: str) -> str | None:
+    def get_container_image(self, config: Any, detected_gpu_type: str) -> Optional[str]:
         backend = config.backend
         if backend == "auto":
             preferences = get_gpu_backend_preferences(detected_gpu_type)

--- a/ramalama/plugins/runtimes/inference/llama_cpp_commands.py
+++ b/ramalama/plugins/runtimes/inference/llama_cpp_commands.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 import os
 

--- a/ramalama/plugins/runtimes/inference/mlx.py
+++ b/ramalama/plugins/runtimes/inference/mlx.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import argparse
 import platform
 from http.client import HTTPConnection
-from typing import Any
+from typing import Any, Optional
 
 from ramalama.cli import suppressCompleter
 from ramalama.config import ActiveConfig
@@ -77,7 +79,7 @@ class MlxPlugin(BaseInferenceRuntime):
             logger.info("MLX runtime automatically uses --nocontainer mode")
         args.container = False
 
-    def service_ready_check(self, conn: HTTPConnection, args: Any, model_name: str | None = None) -> bool:
+    def service_ready_check(self, conn: HTTPConnection, args: Any, model_name: Optional[str] = None) -> bool:
         conn.request("GET", "/health")
         resp = conn.getresponse()
         if resp.status != 200:

--- a/ramalama/plugins/runtimes/inference/vllm.py
+++ b/ramalama/plugins/runtimes/inference/vllm.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import argparse
 from http.client import HTTPConnection
-from typing import Any
+from typing import Any, Optional
 
 from ramalama.cli import suppressCompleter
 from ramalama.common import ContainerEntryPoint
@@ -89,7 +91,7 @@ class VllmPlugin(ContainerizedInferenceRuntimePlugin):
         self._add_max_model_len_arg(parser)
         return parser
 
-    def get_container_image(self, config: Any, detected_gpu_type: str) -> str | None:
+    def get_container_image(self, config: Any, detected_gpu_type: str) -> Optional[str]:
         if detected_gpu_type:
             image = config.images.get(f"VLLM_{detected_gpu_type}") or _VLLM_IMAGES.get(detected_gpu_type)
             if image:
@@ -97,7 +99,7 @@ class VllmPlugin(ContainerizedInferenceRuntimePlugin):
 
         return config.images.get("VLLM") or _VLLM_DEFAULT_IMAGE
 
-    def service_ready_check(self, conn: HTTPConnection, args: Any, model_name: str | None = None) -> bool:
+    def service_ready_check(self, conn: HTTPConnection, args: Any, model_name: Optional[str] = None) -> bool:
         conn.request("GET", "/ping")
         resp = conn.getresponse()
         container_name = f"container {args.name}" if getattr(args, 'container', None) else 'server'

--- a/ramalama/prompt_utils.py
+++ b/ramalama/prompt_utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import platform
 

--- a/ramalama/proxy_support.py
+++ b/ramalama/proxy_support.py
@@ -15,6 +15,8 @@ Proxy URL formats:
 - SOCKS5: socks5://proxy:port or socks5h://proxy:port (for DNS through proxy)
 """
 
+from __future__ import annotations
+
 import urllib.request
 
 from ramalama.logger import logger

--- a/ramalama/quadlet.py
+++ b/ramalama/quadlet.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import shlex
 from typing import Optional, Tuple

--- a/ramalama/sandbox.py
+++ b/ramalama/sandbox.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import argparse
 import json
 import platform
 from collections.abc import Callable
-from typing import cast
+from typing import Optional, cast
 
 from ramalama.arg_types import BaseEngineArgsType
 from ramalama.common import run_cmd
@@ -68,7 +70,7 @@ def add_sandbox_subparsers(subparsers: argparse._SubParsersAction, img_comp: Cal
 
 class SandboxEngineArgsType(BaseEngineArgsType):
     ARGS: list[str]
-    workdir: str | None
+    workdir: Optional[str]
 
 
 class SandboxEngine(Engine):

--- a/ramalama/shortnames.py
+++ b/ramalama/shortnames.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import configparser
 import os
 import sysconfig

--- a/ramalama/stack.py
+++ b/ramalama/stack.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import copy
 import os
 

--- a/ramalama/toml_parser.py
+++ b/ramalama/toml_parser.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 
 from ramalama.logger import logger

--- a/ramalama/transports/__init__.py
+++ b/ramalama/transports/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from ramalama.transports import api, huggingface, modelscope, oci, ollama, rlcr, transport_factory, url
 from ramalama.transports.api import APITransport
 from ramalama.transports.huggingface import Huggingface, HuggingfaceRepository

--- a/ramalama/transports/api.py
+++ b/ramalama/transports/api.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any
 
 from ramalama.chat import chat

--- a/ramalama/transports/base.py
+++ b/ramalama/transports/base.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import copy
 import os
 import random
@@ -6,7 +8,10 @@ import subprocess
 import sys
 import time
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Optional, TypeGuard
+from typing import TYPE_CHECKING, Any, Optional
+
+if TYPE_CHECKING:
+    from typing_extensions import TypeGuard
 
 from ramalama import chat
 from ramalama.common import ContainerEntryPoint
@@ -150,7 +155,7 @@ class Transport(TransportBase):
         self._model_store_path: str = model_store_path
         self._model_store: Optional["ModelStore"] = None
 
-        self.draft_model: Transport | None = None
+        self.draft_model: Optional[Transport] = None
 
     def extract_model_identifiers(self):
         model_name = self.model
@@ -453,7 +458,7 @@ class Transport(TransportBase):
             mount_opts += f",ro{self.engine.relabel()}"
             self.engine.add([mount_opts])
 
-    def serve_nonblocking(self, args, cmd: list[str]) -> subprocess.Popen | None:
+    def serve_nonblocking(self, args, cmd: list[str]) -> Optional[subprocess.Popen]:
         if args.container:
             args.name = self.get_container_name(args)
 
@@ -509,7 +514,7 @@ class Transport(TransportBase):
             chat.chat(chat_args)
             return 0
 
-    def chat_operational_args(self, args) -> "ChatOperationalArgs | None":
+    def chat_operational_args(self, args) -> "Optional[ChatOperationalArgs]":
         return None
 
     def wait_for_healthy(self, args):
@@ -744,7 +749,7 @@ class Transport(TransportBase):
         return False
 
 
-def compute_ports(exclude: list[str] | None = None) -> list[int]:
+def compute_ports(exclude: Optional[list[str]] = None) -> list[int]:
     excluded = set() if exclude is None else set(map(int, exclude))
 
     port_range = ActiveConfig().default_port_range
@@ -759,7 +764,7 @@ def compute_ports(exclude: list[str] | None = None) -> list[int]:
     return [first_port] + ports
 
 
-def get_available_port_if_any(exclude: list[str] | None = None) -> int:
+def get_available_port_if_any(exclude: Optional[list[str]] = None) -> int:
     ports = compute_ports(exclude=exclude)
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         chosen_port = 0
@@ -775,7 +780,7 @@ def get_available_port_if_any(exclude: list[str] | None = None) -> int:
         return chosen_port
 
 
-def compute_serving_port(args, quiet: bool = False, exclude: list[str] | None = None) -> str:
+def compute_serving_port(args, quiet: bool = False, exclude: Optional[list[str]] = None) -> str:
     # user probably specified a custom port, don't override the choice
     if hasattr(args, 'port_override'):
         target_port = args.port

--- a/ramalama/transports/huggingface.py
+++ b/ramalama/transports/huggingface.py
@@ -1,7 +1,10 @@
+from __future__ import annotations
+
 import json
 import os
 import urllib.request
 from pathlib import Path
+from typing import Optional
 
 from ramalama.common import run_cmd
 from ramalama.hf_style_repo_base import (
@@ -82,7 +85,7 @@ def fetch_repo_files(repo_name: str, revision: str = "main"):
     base_api_url = f"https://huggingface.co/api/models/{repo_name}/tree/{revision}"
 
     all_files = []
-    next_url: str | None = base_api_url
+    next_url: Optional[str] = base_api_url
 
     # TODO: Handle Diffusers-multifolder layout
     # See https://huggingface.co/docs/diffusers/v0.35.1/using-diffusers/other-formats#diffusers-multifolder

--- a/ramalama/transports/modelscope.py
+++ b/ramalama/transports/modelscope.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import os
 

--- a/ramalama/transports/oci/__init__.py
+++ b/ramalama/transports/oci/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .oci import OCI
 
 __all__ = ["OCI"]

--- a/ramalama/transports/oci/oci.py
+++ b/ramalama/transports/oci/oci.py
@@ -1,11 +1,14 @@
+from __future__ import annotations
+
 import json
 import os
 import subprocess
 import tempfile
 from functools import cached_property
 from textwrap import dedent
+from typing import Optional, Union
 
-import ramalama.annotations as annotations
+import ramalama.annotations as oci_annotations
 from ramalama.common import MNT_DIR, exec_cmd, perror, run_cmd, set_accel_env_vars
 from ramalama.engine import BuildEngine, dry_run
 from ramalama.oci_tools import OciRef, engine_supports_manifest_attributes
@@ -200,7 +203,7 @@ class OCI(Transport):
             f"{oci_spec.LAYER_ANNOTATION_FILE_MEDIATYPE_UNTESTED}=true",
         ]
         if create:
-            cmd.extend(["--replace", "--type", annotations.ArtifactTypeModelManifest])
+            cmd.extend(["--replace", "--type", oci_annotations.ArtifactTypeModelManifest])
         else:
             cmd.extend(["--append"])
 
@@ -245,11 +248,11 @@ class OCI(Transport):
             "manifest",
             "annotate",
             "--annotation",
-            f"{annotations.AnnotationModel}=true",
+            f"{oci_annotations.AnnotationModel}=true",
             "--annotation",
             ociimage_car if args.type == "car" else ociimage_raw,
             "--annotation",
-            f"{annotations.AnnotationTitle}={args.SOURCE}",
+            f"{oci_annotations.AnnotationTitle}={args.SOURCE}",
             target,
             imageid,
         ]
@@ -348,7 +351,7 @@ class OCI(Transport):
     def exists(self) -> bool:
         return self.strategy.exists(self.ref)
 
-    def entrypoint_path(self, mount_dir: str | None = None) -> str:
+    def entrypoint_path(self, mount_dir: Optional[str] = None) -> str:
         return self.strategy.entrypoint_path(self.ref, mount_dir=mount_dir)
 
     def inspect(
@@ -379,7 +382,7 @@ class OCI(Transport):
         else:
             print(f"{out}   Type: {self.strategy.kind.capitalize()}")
 
-    def mount_cmd(self, src: str | OciRef | None = None, dest: str | None = None):
+    def mount_cmd(self, src: Union[str, OciRef, None] = None, dest: Optional[str] = None):
         if isinstance(src, OciRef):
             return self.strategy.mount_arg(src, dest)
         if src is not None:

--- a/ramalama/transports/oci/oci_artifact.py
+++ b/ramalama/transports/oci/oci_artifact.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import hashlib
 import json
 import os
@@ -6,7 +8,7 @@ import urllib.parse
 import urllib.request
 from collections.abc import Iterable
 from tempfile import NamedTemporaryFile
-from typing import Any
+from typing import Any, Optional
 
 from ramalama.common import perror
 from ramalama.logger import logger
@@ -84,7 +86,7 @@ class OCIRegistryClient:
         self.reference = reference
         self.base_url = f"https://{self.registry}/v2/{self.repository}"
 
-        self._bearer_token: str | None = None
+        self._bearer_token: Optional[str] = None
 
     def get_manifest(self) -> tuple[dict[str, Any], str]:
         headers = {"Accept": ",".join(MANIFEST_ACCEPT_HEADERS)}
@@ -130,14 +132,14 @@ class OCIRegistryClient:
                     pass
             raise
 
-    def _prepare_headers(self, headers: dict[str, str] | None = None) -> dict[str, str]:
+    def _prepare_headers(self, headers: Optional[dict[str, str]] = None) -> dict[str, str]:
         final_headers = dict() if headers is None else headers.copy()
         if self._bearer_token is not None:
             final_headers.setdefault("Authorization", f"Bearer {self._bearer_token}")
 
         return final_headers
 
-    def _open(self, url: str, headers: dict[str, str] | None = None):
+    def _open(self, url: str, headers: Optional[dict[str, str]] = None):
         req = urllib.request.Request(url, headers=self._prepare_headers(headers))
         try:
             return urllib.request.urlopen(req, timeout=60)
@@ -152,7 +154,7 @@ class OCIRegistryClient:
                         return urllib.request.urlopen(req, timeout=60)
             raise
 
-    def _request_bearer_token(self, challenge: str) -> str | None:
+    def _request_bearer_token(self, challenge: str) -> Optional[str]:
         scheme, _, params = challenge.partition(" ")
         if scheme.lower() != "bearer":
             return None

--- a/ramalama/transports/oci/resolver.py
+++ b/ramalama/transports/oci/resolver.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import os
 from collections.abc import Callable
-from typing import Literal
+from typing import Literal, Optional
 
 from ramalama.common import run_cmd
 from ramalama.model_store.store import ModelStore
@@ -19,7 +21,7 @@ def _format_oci_reference(oci_ref: OciRef) -> str:
     return f"{repository}:{tag}"
 
 
-def fetch_manifest(oci_ref: OciRef) -> dict | None:
+def fetch_manifest(oci_ref: OciRef) -> Optional[dict]:
     client = OCIRegistryClient(oci_ref.registry, oci_ref.repository, oci_ref.specifier)
     try:
         manifest, _ = client.get_manifest()
@@ -37,7 +39,7 @@ def manifest_kind(oci_ref: OciRef) -> ReferenceKind:
     return "image"
 
 
-def engine_artifact_exists(engine: str, oci_ref: OciRef, runner: Callable | None = None) -> bool:
+def engine_artifact_exists(engine: str, oci_ref: OciRef, runner: Optional[Callable] = None) -> bool:
     runner = runner or run_cmd
     try:
         runner([engine, "artifact", "inspect", _format_oci_reference(oci_ref)], ignore_stderr=True)
@@ -46,7 +48,7 @@ def engine_artifact_exists(engine: str, oci_ref: OciRef, runner: Callable | None
         return False
 
 
-def engine_image_exists(engine: str, oci_ref: OciRef, runner: Callable | None = None) -> bool:
+def engine_image_exists(engine: str, oci_ref: OciRef, runner: Optional[Callable] = None) -> bool:
     runner = runner or run_cmd
     try:
         runner([engine, "image", "inspect", _format_oci_reference(oci_ref)], ignore_stderr=True)
@@ -55,7 +57,7 @@ def engine_image_exists(engine: str, oci_ref: OciRef, runner: Callable | None = 
         return False
 
 
-def resolve_engine_kind(engine: str, oci_ref: OciRef, runner: Callable | None = None) -> ReferenceKind:
+def resolve_engine_kind(engine: str, oci_ref: OciRef, runner: Optional[Callable] = None) -> ReferenceKind:
     if not engine:
         return "unknown"
     engine_name = os.path.basename(engine)
@@ -85,7 +87,7 @@ def model_store_has_snapshot(model_store: ModelStore, oci_ref: OciRef) -> bool:
 
 
 class OCITypeResolver:
-    def __init__(self, engine: str, model_store: ModelStore | None = None, runner: Callable | None = None):
+    def __init__(self, engine: str, model_store: Optional[ModelStore] = None, runner: Optional[Callable] = None):
         self.engine = engine
         self.model_store = model_store
         self.runner = runner or run_cmd

--- a/ramalama/transports/oci/spec.py
+++ b/ramalama/transports/oci/spec.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 import json
 import os
 import stat
 import tarfile
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, Optional
 
 # CNAI_ARTIFACT_TYPE is the media type for a model artifact manifest.
 CNAI_ARTIFACT_TYPE = "application/vnd.cncf.model.manifest.v1+json"
@@ -126,7 +128,7 @@ class FileMetadata:
         return cls.from_dict(data)
 
     @classmethod
-    def from_path(cls, path: str, *, name: str | None = None) -> "FileMetadata":
+    def from_path(cls, path: str, *, name: Optional[str] = None) -> "FileMetadata":
         stat_result = os.stat(path, follow_symlinks=False)
         mtime = datetime.fromtimestamp(stat_result.st_mtime, tz=timezone.utc).isoformat().replace("+00:00", "Z")
         return cls(
@@ -171,7 +173,7 @@ class Descriptor:
     annotations: dict[str, str] = field(default_factory=dict)
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any], *, allowed_media_types: set[str] | None = None) -> "Descriptor":
+    def from_dict(cls, data: dict[str, Any], *, allowed_media_types: Optional[set[str]] = None) -> "Descriptor":
         media_type = _require_str(data.get("mediaType"), "descriptor mediaType is required")
         digest = _require_str(data.get("digest"), "descriptor digest is required")
         size = data.get("size")
@@ -203,19 +205,19 @@ class Descriptor:
             data["annotations"] = self.annotations
         return data
 
-    def filepath(self) -> str | None:
+    def filepath(self) -> Optional[str]:
         value = self.annotations.get(LAYER_ANNOTATION_FILEPATH)
         if value is None:
             return None
         return normalize_layer_filepath(value)
 
-    def file_metadata(self) -> FileMetadata | None:
+    def file_metadata(self) -> Optional[FileMetadata]:
         value = self.annotations.get(LAYER_ANNOTATION_FILE_METADATA)
         if value is None:
             return None
         return FileMetadata.from_json(value)
 
-    def media_type_untested(self) -> bool | None:
+    def media_type_untested(self) -> Optional[bool]:
         value = self.annotations.get(LAYER_ANNOTATION_FILE_MEDIATYPE_UNTESTED)
         if value is None:
             return None

--- a/ramalama/transports/oci/strategies.py
+++ b/ramalama/transports/oci/strategies.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import json
 import posixpath
 from abc import ABC, abstractmethod
-from typing import Generic, Literal, TypeVar
+from typing import Generic, Literal, Optional, TypeVar
 
 from ramalama.common import MNT_DIR, run_cmd
 from ramalama.model_store.store import ModelStore
@@ -18,9 +20,9 @@ class BaseOCIStrategy(Generic[K], ABC):
     """Interface for artifact handling strategies."""
 
     kind: K
-    model_store: ModelStore | None
+    model_store: Optional[ModelStore]
 
-    def __init__(self, *, model_store: ModelStore | None = None):
+    def __init__(self, *, model_store: Optional[ModelStore] = None):
         self.model_store = model_store
 
     @abstractmethod
@@ -32,7 +34,7 @@ class BaseOCIStrategy(Generic[K], ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def mount_arg(self, ref: OciRef, *args, **kwargs) -> str | None:
+    def mount_arg(self, ref: OciRef, *args, **kwargs) -> Optional[str]:
         """Return a mount argument for container run, or None if not applicable."""
         raise NotImplementedError
 
@@ -50,7 +52,7 @@ class BaseOCIStrategy(Generic[K], ABC):
         """Return raw inspect output for the reference."""
         raise NotImplementedError
 
-    def entrypoint_path(self, ref: OciRef, mount_dir: str | None = None) -> str:
+    def entrypoint_path(self, ref: OciRef, mount_dir: Optional[str] = None) -> str:
         mount_dir = mount_dir or MNT_DIR
         filenames = self.filenames(ref)
         if not filenames:
@@ -73,7 +75,7 @@ class BaseImageStrategy(BaseOCIStrategy[Literal['image']]):
         self.engine = engine
         self.model_store = model_store
 
-    def pull(self, ref: OciRef, cmd_args: list[str] | None = None) -> None:
+    def pull(self, ref: OciRef, cmd_args: Optional[list[str]] = None) -> None:
         if cmd_args is None:
             cmd_args = []
         run_cmd([self.engine, "pull", *cmd_args, str(ref)])
@@ -85,7 +87,7 @@ class BaseImageStrategy(BaseOCIStrategy[Literal['image']]):
         except Exception:
             return False
 
-    def remove(self, ref: OciRef, cmd_args: list[str] | None = None) -> bool:
+    def remove(self, ref: OciRef, cmd_args: Optional[list[str]] = None) -> bool:
         if cmd_args is None:
             cmd_args = []
 
@@ -114,7 +116,7 @@ class HttpArtifactStrategy(BaseArtifactStrategy):
     def __init__(self, engine: str = "podman", *, model_store: ModelStore):
         super().__init__(engine=engine, model_store=model_store)
 
-    def pull(self, ref: OciRef, cmd_args: list[str] | None = None) -> None:
+    def pull(self, ref: OciRef, cmd_args: Optional[list[str]] = None) -> None:
         if cmd_args is None:
             cmd_args = []
         if not self.model_store:
@@ -136,7 +138,7 @@ class HttpArtifactStrategy(BaseArtifactStrategy):
         except Exception:
             return False
 
-    def remove(self, ref: OciRef, cmd_args: list[str] | None = None) -> bool:
+    def remove(self, ref: OciRef, cmd_args: Optional[list[str]] = None) -> bool:
         if cmd_args is None:
             cmd_args = []
 
@@ -147,7 +149,7 @@ class HttpArtifactStrategy(BaseArtifactStrategy):
         except Exception:
             return False
 
-    def mount_arg(self, ref: OciRef, dest: str | None = None) -> str | None:
+    def mount_arg(self, ref: OciRef, dest: Optional[str] = None) -> Optional[str]:
         if not self.model_store:
             return None
         snapshot_dir = self.model_store.get_snapshot_directory_from_tag(ref.specifier)
@@ -175,7 +177,7 @@ class PodmanArtifactStrategy(BaseArtifactStrategy):
     def __init__(self, engine: str = "podman", *, model_store: ModelStore):
         super().__init__(engine=engine, model_store=model_store)
 
-    def pull(self, ref: OciRef, cmd_args: list[str] | None = None) -> None:
+    def pull(self, ref: OciRef, cmd_args: Optional[list[str]] = None) -> None:
         if cmd_args is None:
             cmd_args = []
         run_cmd([self.engine, "artifact", "pull", *cmd_args, str(ref)])
@@ -187,10 +189,10 @@ class PodmanArtifactStrategy(BaseArtifactStrategy):
         except Exception:
             return False
 
-    def mount_arg(self, ref: OciRef, dest: str | None = None) -> str:
+    def mount_arg(self, ref: OciRef, dest: Optional[str] = None) -> str:
         return f"--mount=type=artifact,src={str(ref)},destination={dest or MNT_DIR}"
 
-    def remove(self, ref: OciRef, cmd_args: list[str] | None = None) -> bool:
+    def remove(self, ref: OciRef, cmd_args: Optional[list[str]] = None) -> bool:
         if cmd_args is None:
             cmd_args = []
 
@@ -226,7 +228,7 @@ class PodmanArtifactStrategy(BaseArtifactStrategy):
 
         return sorted(names)
 
-    def entrypoint_path(self, ref: OciRef, mount_dir: str | None = None) -> str:
+    def entrypoint_path(self, ref: OciRef, mount_dir: Optional[str] = None) -> str:
         mount_dir = mount_dir or MNT_DIR
         filenames = self.filenames(ref)
         if not filenames:
@@ -246,7 +248,7 @@ class PodmanImageStrategy(BaseImageStrategy):
     def __init__(self, engine: str = "podman", *, model_store: ModelStore):
         super().__init__(engine=engine, model_store=model_store)
 
-    def mount_arg(self, ref: OciRef, dest: str | None = None) -> str:
+    def mount_arg(self, ref: OciRef, dest: Optional[str] = None) -> str:
         return f"--mount=type=image,src={str(ref)},destination={dest or MNT_DIR},subpath=/models,rw=false"
 
 
@@ -254,5 +256,5 @@ class DockerImageStrategy(BaseImageStrategy):
     def __init__(self, engine: str = "docker", *, model_store: ModelStore):
         super().__init__(engine=engine, model_store=model_store)
 
-    def mount_arg(self, ref: OciRef, dest: str | None = None) -> str | None:
+    def mount_arg(self, ref: OciRef, dest: Optional[str] = None) -> Optional[str]:
         return f"--mount=type=volume,src={str(ref)},dst={dest or MNT_DIR},readonly"

--- a/ramalama/transports/oci/strategy.py
+++ b/ramalama/transports/oci/strategy.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import os
 from functools import lru_cache
 from pathlib import Path
-from typing import Literal, TypedDict, cast
+from typing import Literal, Optional, TypedDict, Union, cast
 
 from ramalama.common import SemVer, engine_version
 from ramalama.config import SUPPORTED_ENGINES, ActiveConfig
@@ -57,7 +59,7 @@ class OCIStrategyFactory:
 
     def __init__(
         self,
-        engine: SUPPORTED_ENGINES | Path | str | None,
+        engine: Union[SUPPORTED_ENGINES, Path, str, None],
         model_store: ModelStore,
     ):
         if (engine := engine or ActiveConfig().engine) is None:
@@ -71,7 +73,7 @@ class OCIStrategyFactory:
     def strategies(self, kind: Literal['image', 'artifact']) -> BaseArtifactStrategy | BaseImageStrategy:
         return get_strategy(self.engine, self.engine_name, self.model_store, kind)
 
-    def resolve_kind(self, model: OciRef) -> Literal["image", "artifact"] | None:
+    def resolve_kind(self, model: OciRef) -> Optional[Literal["image", "artifact"]]:
         kind = self._type_resolver.resolve(model)
         if kind == "unknown":
             return None

--- a/ramalama/transports/ollama.py
+++ b/ramalama/transports/ollama.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import os
 import shutil

--- a/ramalama/transports/rlcr.py
+++ b/ramalama/transports/rlcr.py
@@ -1,11 +1,14 @@
+from __future__ import annotations
+
 import os
 import subprocess
+from typing import Optional
 
 from ramalama.common import MNT_DIR, run_cmd
 from ramalama.transports.oci.oci import OCI
 
 
-def find_model_file_in_image(conman: str, model: str) -> str | None:
+def find_model_file_in_image(conman: str, model: str) -> Optional[str]:
     """Inspect the OCI image to find model file location"""
     # First try to get from label
     try:

--- a/ramalama/transports/transport_factory.py
+++ b/ramalama/transports/transport_factory.py
@@ -1,6 +1,12 @@
+from __future__ import annotations
+
 import copy
 from collections.abc import Callable
-from typing import TypeAlias
+from typing import TYPE_CHECKING, Optional, Union
+
+if TYPE_CHECKING:
+    from typing_extensions import TypeAlias
+
 from urllib.parse import urlparse
 
 from ramalama.arg_types import StoreArgType
@@ -17,7 +23,7 @@ from ramalama.transports.ollama import Ollama
 from ramalama.transports.rlcr import RamalamaContainerRegistry
 from ramalama.transports.url import URL
 
-CLASS_MODEL_TYPES: TypeAlias = Huggingface | Ollama | OCI | URL | ModelScope | RamalamaContainerRegistry | APITransport
+CLASS_MODEL_TYPES: TypeAlias = Union[Huggingface, Ollama, OCI, URL, ModelScope, RamalamaContainerRegistry, APITransport]
 
 
 class TransportFactory:
@@ -42,7 +48,7 @@ class TransportFactory:
         self._create = _create
 
         self.pruned_model = self.prune_model_input()
-        self.draft_model: Transport | None = None
+        self.draft_model: Optional[Transport] = None
 
         model_draft = getattr(args, "model_draft", None)
         if model_draft:
@@ -54,34 +60,30 @@ class TransportFactory:
             self.draft_model = draft_model
 
     def detect_model_model_type(self) -> tuple[type[CLASS_MODEL_TYPES], Callable[[], CLASS_MODEL_TYPES]]:
-        match self.model:
-            case model if model.startswith(("huggingface://", "hf://", "hf.co/")):
-                return Huggingface, self.create_huggingface
-            case model if model.startswith(("modelscope://", "ms://")):
-                return ModelScope, self.create_modelscope
-            case model if model.startswith(("ollama://", "ollama.com/library/")):
-                return Ollama, self.create_ollama
-            case model if model.startswith(("oci://", "docker://")):
-                return OCI, self.create_oci
-            case model if model.startswith("rlcr://"):
-                return RamalamaContainerRegistry, self.create_rlcr
-            case model if model.startswith(("http://", "https://", "file:")):
-                return URL, self.create_url
-            case model if model.startswith(("openai://")):
-                return APITransport, self.create_api_transport
-
-        match self.transport:
-            case "huggingface":
-                return Huggingface, self.create_huggingface
-            case "modelscope":
-                return ModelScope, self.create_modelscope
-            case "ollama":
-                return Ollama, self.create_ollama
-            case "rlcr":
-                return RamalamaContainerRegistry, self.create_rlcr
-            case "oci":
-                return OCI, self.create_oci
-
+        if self.model.startswith(("huggingface://", "hf://", "hf.co/")):
+            return Huggingface, self.create_huggingface
+        if self.model.startswith(("modelscope://", "ms://")):
+            return ModelScope, self.create_modelscope
+        if self.model.startswith(("ollama://", "ollama.com/library/")):
+            return Ollama, self.create_ollama
+        if self.model.startswith(("oci://", "docker://")):
+            return OCI, self.create_oci
+        if self.model.startswith("rlcr://"):
+            return RamalamaContainerRegistry, self.create_rlcr
+        if self.model.startswith(("http://", "https://", "file:")):
+            return URL, self.create_url
+        if self.model.startswith(("openai://")):
+            return APITransport, self.create_api_transport
+        if self.transport == "huggingface":
+            return Huggingface, self.create_huggingface
+        if self.transport == "modelscope":
+            return ModelScope, self.create_modelscope
+        if self.transport == "ollama":
+            return Ollama, self.create_ollama
+        if self.transport == "rlcr":
+            return RamalamaContainerRegistry, self.create_rlcr
+        if self.transport == "oci":
+            return OCI, self.create_oci
         raise KeyError(f'transport "{self.transport}" not supported. Must be oci, huggingface, modelscope, or ollama.')
 
     def prune_model_input(self) -> str:
@@ -167,7 +169,7 @@ class TransportFactory:
         return APITransport(self.pruned_model, provider=get_chat_provider(scheme))
 
 
-def New(name, args, transport: str | None = None) -> CLASS_MODEL_TYPES:
+def New(name, args, transport: Optional[str] = None) -> CLASS_MODEL_TYPES:
     if transport is None:
         transport = ActiveConfig().transport
     return TransportFactory(name, args, transport=transport).create()

--- a/ramalama/transports/url.py
+++ b/ramalama/transports/url.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import re
 import shutil

--- a/ramalama/version.py
+++ b/ramalama/version.py
@@ -1,8 +1,12 @@
+from __future__ import annotations
+
 """Version of RamaLamaPy."""
+
+__version__ = "0.19.0"
 
 
 def version():
-    return "0.19.0"
+    return __version__
 
 
 def print_version(args):
@@ -10,3 +14,7 @@ def print_version(args):
         print(version())
     else:
         print("ramalama version %s" % version())
+
+
+if __name__ == "__main__":
+    print(version())

--- a/rpm/ramalama.spec
+++ b/rpm/ramalama.spec
@@ -30,17 +30,16 @@ BuildRequires:    go-md2man
 BuildRequires:    mailcap
 BuildRequires:    make
 BuildRequires:    podman
-BuildRequires:    python3-devel
-BuildRequires:    python3-jsonschema
-BuildRequires:    python3-pytest
-BuildRequires:    python3-jinja2
+BuildRequires:    python%{python3_pkgversion}-devel
+BuildRequires:    python%{python3_pkgversion}-pytest
 
-Provides: python3-ramalama = %{version}-%{release}
-Obsoletes: python3-ramalama < %{version0}-1
+Provides: python%{python3_pkgversion}-ramalama = %{version}-%{release}
+Obsoletes: python%{python3_pkgversion}-ramalama < %{version0}-1
 
 Requires: podman
-Requires: python3-jsonschema
+Requires: python3-argcomplete
 Requires: python3-jinja2
+Requires: python3-pyyaml
 
 %description
 %summary
@@ -73,9 +72,9 @@ make docs
 %files -f %{pyproject_files}
 %doc README.md
 %{_bindir}/%{pypi_name}
-%{bash_completions_dir}/%{pypi_name}
-%{fish_completions_dir}/ramalama.fish
-%{zsh_completions_dir}/_ramalama
+%{_datadir}/bash-completion/completions/%{pypi_name}
+%{_datadir}/fish/vendor_completions.d/ramalama.fish
+%{_datadir}/zsh/site-functions/_ramalama
 %dir %{_datadir}/%{pypi_name}
 %{_datadir}/%{pypi_name}/shortnames.conf
 %{_datadir}/%{pypi_name}/ramalama.conf

--- a/scripts/build_macos_pkg.sh
+++ b/scripts/build_macos_pkg.sh
@@ -9,7 +9,7 @@
 #
 # Requirements:
 # - macOS with Xcode Command Line Tools
-# - Python 3.10+
+# - Python 3.9+
 # - PyInstaller (pip install pyinstaller)
 #
 # Usage: ./scripts/build_macos_pkg.sh

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,53 @@
+"""Shim for setuptools < 61 (e.g. CentOS/RHEL 9) which cannot read PEP 621 [project] metadata.
+
+Newer setuptools (>= 61) reads pyproject.toml directly and ignores this file.
+"""
+
+import glob
+import re
+
+from setuptools import find_packages, setup
+
+# Read version without importing ramalama (it may not be installable yet)
+_version_match = re.search(r'^__version__\s*=\s*["\']([^"\']+)["\']',
+                           open("ramalama/version.py").read(), re.MULTILINE)
+if not _version_match:
+    raise RuntimeError("Unable to find __version__ in ramalama/version.py")
+__version__ = _version_match.group(1)
+
+setup(
+    name="ramalama",
+    version=__version__,
+    description="RamaLama is a command line tool for working with AI LLM models.",
+    long_description=open("README.md").read(),
+    long_description_content_type="text/markdown",
+    license="MIT",
+    python_requires=">=3.9",
+    install_requires=[
+        "argcomplete",
+        "jinja2",
+        "pyyaml",
+    ],
+    packages=find_packages(include=["ramalama", "ramalama.*"]),
+    include_package_data=True,
+    package_data={"ramalama": ["py.typed"]},
+    entry_points={
+        "console_scripts": [
+            "ramalama = ramalama.cli:main",
+        ],
+        "ramalama.runtimes.v1alpha": [
+            "llama.cpp = ramalama.plugins.runtimes.inference.llama_cpp:LlamaCppPlugin",
+            "vllm = ramalama.plugins.runtimes.inference.vllm:VllmPlugin",
+            "mlx = ramalama.plugins.runtimes.inference.mlx:MlxPlugin",
+        ],
+    },
+    data_files=[
+        ("share/ramalama", ["shortnames/shortnames.conf", "docs/ramalama.conf"]),
+        ("share/man/man1", glob.glob("docs/*.1")),
+        ("share/man/man5", glob.glob("docs/*.5")),
+        ("share/man/man7", glob.glob("docs/*.7")),
+        ("share/bash-completion/completions", glob.glob("completions/bash-completion/completions/*")),
+        ("share/zsh/site-functions", glob.glob("completions/zsh/site-functions/*")),
+        ("share/fish/vendor_completions.d", glob.glob("completions/fish/vendor_completions.d/*")),
+    ],
+)

--- a/test/e2e/test_help.py
+++ b/test/e2e/test_help.py
@@ -81,7 +81,7 @@ def test_help_output(subcommand):
     assert result.startswith(f"usage: ramalama {usage_cmd_name}")
 
     # Check if the option section is rendered
-    assert re.search("^options:$", result, re.MULTILINE)
+    assert re.search("^(options|optional arguments):$", result, re.MULTILINE)
 
 
 @pytest.mark.e2e

--- a/test/tmt/no-rpm.fmf
+++ b/test/tmt/no-rpm.fmf
@@ -18,7 +18,6 @@ require:
     - python3-argcomplete
     - python3-huggingface-hub
     - shellcheck
-    - python3-jsonschema
     - python3-pyyaml
     - python3-jinja2
 

--- a/test/unit/test_cli_args.py
+++ b/test/unit/test_cli_args.py
@@ -1,7 +1,7 @@
 import string
 import sys
 from dataclasses import fields
-from typing import get_args
+from typing import Optional, get_args
 from unittest.mock import MagicMock
 
 import pytest
@@ -57,7 +57,7 @@ special_cases = {
 }
 
 
-def args_to_cli_args(args_obj, subcommand: str | None, special_cases: dict | None = None) -> list:
+def args_to_cli_args(args_obj, subcommand: Optional[str], special_cases: Optional[dict] = None) -> list:
     """
     Convert a dataclass instance to CLI arguments for argparse.
     - subcommand: the CLI subcommand (e.g., 'chat')

--- a/test/unit/test_common.py
+++ b/test/unit/test_common.py
@@ -4,6 +4,7 @@ import subprocess
 from contextlib import ExitStack
 from pathlib import Path
 from sys import platform
+from typing import Optional
 from unittest.mock import MagicMock, Mock, mock_open, patch
 
 import pytest
@@ -83,7 +84,7 @@ I have been tampered with
     ],
 )
 def test_verify_checksum(
-    input_file_name: str, content: str, expected_error: type[Exception] | None, expected_result: bool
+    input_file_name: str, content: str, expected_error: Optional[type[Exception]], expected_result: bool
 ):
     # skip this test case on Windows since colon is not a valid file symbol
     if ":" in input_file_name and platform == "win32":

--- a/test/unit/test_inference_engine_plugins.py
+++ b/test/unit/test_inference_engine_plugins.py
@@ -1,6 +1,7 @@
 """Unit tests for runtime plugins (llama.cpp, vllm, mlx)."""
 
 import argparse
+from typing import Optional
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -1118,7 +1119,7 @@ backend = "cuda"
         (None, ["auto", "vulkan"]),  # No GPU
     ],
 )
-def test_get_available_backends(gpu_env: str | None, expected_backends: list[str], monkeypatch):
+def test_get_available_backends(gpu_env: Optional[str], expected_backends: list[str], monkeypatch):
     """Test that available backends are correctly returned based on detected GPU."""
     monkeypatch.setattr("ramalama.common.get_accel", lambda: "none")
 
@@ -1139,7 +1140,7 @@ def test_get_available_backends(gpu_env: str | None, expected_backends: list[str
         (None, ["auto", "vulkan"]),  # No GPU: same on all platforms
     ],
 )
-def test_get_available_backends_windows(gpu_env: str | None, expected_backends: list[str], monkeypatch):
+def test_get_available_backends_windows(gpu_env: Optional[str], expected_backends: list[str], monkeypatch):
     """Test that available backends on Windows prefer vendor-specific backends."""
     monkeypatch.setattr("ramalama.common.get_accel", lambda: "none")
     monkeypatch.setattr("ramalama.plugins.runtimes.inference.llama_cpp.platform.system", lambda: "Windows")

--- a/test/unit/test_oci.py
+++ b/test/unit/test_oci.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Union
+from typing import Optional, Union
 
 import pytest
 
@@ -15,7 +15,7 @@ class Args:
     def __init__(
         self,
         type: str = "raw",
-        gguf: str | None = None,
+        gguf: Optional[str] = None,
         carimage: str = "registry.access.redhat.com/ubi10-micro:latest",
     ):
         self.type = type

--- a/test/unit/test_oci_tools.py
+++ b/test/unit/test_oci_tools.py
@@ -52,7 +52,7 @@ def test_list_models_timezones_in_utc(monkeypatch):
     )
     artifact_inspect_output = {
         "Manifest": {
-            "artifactType": oci_tools.annotations.ArtifactTypeModelManifest,
+            "artifactType": oci_tools.oci_annotations.ArtifactTypeModelManifest,
         }
     }
 


### PR DESCRIPTION
Add support for python 3.9 and EL9 rpm builds.

This is mostly just minor changes to type annotations as the X | Y | None syntax is not supported in python 3.9. The match statement is also not available. Both are easily resolved but the diffs will be large as a result.

Also have to add setup.py for the legacy setuptools version in EL9.

Assisted-by: claude sonnet

## Summary by Sourcery

Add Python 3.9 compatibility and enable EL9 RPM builds, including packaging and CI updates.

Enhancements:
- Broaden runtime support to Python 3.9 by replacing newer typing and match syntax with Optional/Union-based equivalents and conditional entry-point loading.
- Refine version handling by centralizing the package version in ramalama.version.__version__ and wiring packaging tools to use it.

Build:
- Adjust RPM spec and packaging scripts to support EL9 and Python versioned dependencies.
- Introduce a legacy setup.py shim for older setuptools that cannot consume pyproject.toml metadata.
- Update flake.nix and packaging metadata to drop jsonschema and align dependencies across environments.

CI:
- Update GitHub Actions matrices to run tests against Python 3.9 instead of 3.10.
- Extend Packit configuration to build for CentOS Stream 9 and EPEL 9/10 variants.

Documentation:
- Update README and macOS install docs to list Python 3.9+ as the minimum requirement.

Tests:
- Adjust tests to be compatible with Python 3.9 and the updated code paths, including regex expectations and Optional typings.