### PR TITLE
DRAFT: update to use ramalama-stack:0.7.0

### DIFF
--- a/container-images/llama-stack/Containerfile
+++ b/container-images/llama-stack/Containerfile
@@ -1,21 +1,15 @@
 FROM quay.io/fedora/fedora:43
 
-ARG RAMALAMA_STACK_VERSION=0.2.5
-
-# hack that should be removed when the following bug is addressed
-# https://github.com/containers/ramalama-stack/issues/53
-RUN curl --create-dirs --output ~/.llama/providers.d/remote/inference/ramalama.yaml https://raw.githubusercontent.com/containers/ramalama-stack/refs/tags/v${RAMALAMA_STACK_VERSION}/src/ramalama_stack/providers.d/remote/inference/ramalama.yaml && \
-    curl --create-dirs --output /etc/ramalama/ramalama-run.yaml https://raw.githubusercontent.com/containers/ramalama-stack/refs/tags/v${RAMALAMA_STACK_VERSION}/src/ramalama_stack/ramalama-run.yaml
+ARG RAMALAMA_STACK_VERSION=0.2.6
 
 RUN dnf -y install uv gcc python3-devel && \
     dnf -y clean all
 
 RUN uv venv && \
-    uv pip install ramalama-stack==${RAMALAMA_STACK_VERSION} \
-                   milvus-lite
+    uv pip install ramalama_stack==${RAMALAMA_STACK_VERSION}
 
 COPY --chmod=755 container-images/llama-stack/entrypoint.sh /usr/bin/entrypoint.sh
 
 ENTRYPOINT [ "/usr/bin/entrypoint.sh" ]
 
-CMD [ "llama",  "stack",  "run", "--image-type", "venv", "/etc/ramalama/ramalama-run.yaml" ]
+CMD [ "llama",  "stack",  "run", "/root/.llama/distributions/ramalama/ramalama-run.yaml" ]

--- a/container-images/llama-stack/Containerfile
+++ b/container-images/llama-stack/Containerfile
@@ -6,10 +6,11 @@ RUN dnf -y install uv gcc python3-devel && \
     dnf -y clean all
 
 RUN uv venv && \
-    uv pip install ramalama_stack==${RAMALAMA_STACK_VERSION}
+    uv pip install ramalama_stack==${RAMALAMA_STACK_VERSION}  && \
+    install -D -m 0644 /root/.llama/distributions/ramalama/ramalama-run.yaml /etc/ramalama/ramalama-run.yaml
 
 COPY --chmod=755 container-images/llama-stack/entrypoint.sh /usr/bin/entrypoint.sh
 
 ENTRYPOINT [ "/usr/bin/entrypoint.sh" ]
 
-CMD [ "llama",  "stack",  "run", "/root/.llama/distributions/ramalama/ramalama-run.yaml" ]
+CMD [ "llama",  "stack",  "run", "/etc/ramalama/ramalama-run.yaml" ]

--- a/container-images/llama-stack/entrypoint.sh
+++ b/container-images/llama-stack/entrypoint.sh
@@ -6,17 +6,17 @@ source /.venv/bin/activate
 if [ $# -eq 0 ]; then
     exec bash
 else
-    case $RAMALAMA_RUNTIME in
-	vllm)
-	     export VLLM_URL=$RAMALAMA_URL
-	     unset RAMALAMA_URL
-	     ;;
-	llama.cpp)
-	     export LLAMA_CPP_SERVER_URL=$RAMALAMA_URL
-	     unset RAMALAMA_URL
-	     ;;
-	mlx|*)
-	    ;;
+    case "$RAMALAMA_RUNTIME" in
+        vllm)
+            export VLLM_URL="$RAMALAMA_URL"
+            unset RAMALAMA_URL
+            ;;
+        llama.cpp)
+            export LLAMA_CPP_SERVER_URL="$RAMALAMA_URL"
+            unset RAMALAMA_URL
+            ;;
+        mlx|*)
+            ;;
     esac
 
     exec "$@"

--- a/container-images/llama-stack/entrypoint.sh
+++ b/container-images/llama-stack/entrypoint.sh
@@ -6,5 +6,18 @@ source /.venv/bin/activate
 if [ $# -eq 0 ]; then
     exec bash
 else
+    case $RAMALAMA_RUNTIME in
+	vllm)
+	     export VLLM_URL=$RAMALAMA_URL
+	     unset RAMALAMA_URL
+	     ;;
+	llama.cpp)
+	     export LLAMA_CPP_SERVER_URL=$RAMALAMA_URL
+	     unset RAMALAMA_URL
+	     ;;
+	mlx|*)
+	    ;;
+    esac
+
     exec "$@"
 fi

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -25,6 +25,7 @@ from ramalama.arg_types import DefaultArgsType
 from ramalama.cli_arg_normalization import normalize_pull_arg
 from ramalama.common import accel_image, exec_cmd, get_accel, perror
 from ramalama.config import (
+    DEFAULT_STACK_IMAGE_VERSION,
     SUPPORTED_ENGINES,
     ActiveConfig,
     coerce_to_bool,
@@ -51,6 +52,7 @@ from ramalama.transports.base import (
 from ramalama.transports.transport_factory import New, TransportFactory
 from ramalama.version import print_version, version
 
+API_OPTIONS = ["llama-stack", "none"]
 GENERATE_OPTIONS = ["quadlet", "kube", "quadlet/kube", "compose"]
 LIST_SORT_FIELD_OPTIONS = ["size", "modified", "name"]
 LIST_SORT_ORDER_OPTIONS = ["desc", "asc"]
@@ -95,6 +97,32 @@ def parse_generate_option(option: str) -> ParsedGenerateInput:
         output_dir = "."
 
     return ParsedGenerateInput(generate, output_dir)
+
+
+class ParsedApiInput:
+    def __init__(self, api: str, version: str):
+        self.api = api
+        self.version = version
+
+    def __str__(self):
+        return self.api
+
+    def __repr__(self):
+        return self.__str__()
+
+    def __eq__(self, value):
+        return self.api == value
+
+
+def parse_api_option(option: str) -> ParsedApiInput:
+    # default to the latest version of the
+    api, version = option, ""
+    if api.count(":") > 0:
+        api, version = api.split(":", 1)
+    if api == "llama-stack" and version == "":
+        version = DEFAULT_STACK_IMAGE_VERSION
+
+    return ParsedApiInput(api, version)
 
 
 def parse_port_option(option: str) -> str:

--- a/ramalama/config.py
+++ b/ramalama/config.py
@@ -14,7 +14,7 @@ from ramalama.log_levels import LogLevel, coerce_log_level
 from ramalama.toml_parser import TOMLParser
 
 DEFAULT_IMAGE: str = version_tagged_image("quay.io/ramalama/ramalama")
-DEFAULT_STACK_IMAGE: str = version_tagged_image("quay.io/ramalama/llama-stack")
+DEFAULT_STACK_IMAGE: str = version_tagged_image("quay.io/ramalama/llama-stack:0.7.0")
 DEFAULT_RAG_IMAGE: str = version_tagged_image("quay.io/ramalama/ramalama-rag")
 GGUF_QUANTIZATION_MODES: TypeAlias = Literal[
     "Q2_K",

--- a/ramalama/config.py
+++ b/ramalama/config.py
@@ -14,7 +14,8 @@ from ramalama.log_levels import LogLevel, coerce_log_level
 from ramalama.toml_parser import TOMLParser
 
 DEFAULT_IMAGE: str = version_tagged_image("quay.io/ramalama/ramalama")
-DEFAULT_STACK_IMAGE: str = version_tagged_image("quay.io/ramalama/llama-stack:0.7.0")
+DEFAULT_STACK_IMAGE_VERSION: str = "0.7.0"
+DEFAULT_STACK_IMAGE: str = "quay.io/ramalama/llama-stack"
 DEFAULT_RAG_IMAGE: str = version_tagged_image("quay.io/ramalama/ramalama-rag")
 GGUF_QUANTIZATION_MODES: TypeAlias = Literal[
     "Q2_K",

--- a/ramalama/plugins/runtimes/inference/common.py
+++ b/ramalama/plugins/runtimes/inference/common.py
@@ -3,10 +3,12 @@ from abc import abstractmethod
 from typing import Any
 
 from ramalama.cli import (
+    API_OPTIONS,
     GENERATE_OPTIONS,
     OverrideDefaultAction,
     chat_run_options,
     local_models,
+    parse_api_option,
     parse_generate_option,
     parse_port_option,
     runtime_options,
@@ -252,7 +254,8 @@ class ContainerizedInferenceRuntimePlugin(BaseInferenceRuntime):
         parser.add_argument(
             "--api",
             default=config.api,
-            choices=["llama-stack", "none"],
+            type=parse_api_option,
+            choices=API_OPTIONS,
             help="unified API layer for Inference, RAG, Agents, Tools, Safety, Evals, and Telemetry.",
         )
         if command == "serve":

--- a/ramalama/stack.py
+++ b/ramalama/stack.py
@@ -3,7 +3,7 @@ import os
 
 import ramalama.kube as kube
 import ramalama.quadlet as quadlet
-from ramalama.common import exec_cmd, genname, get_accel_env_vars, version_tagged_image
+from ramalama.common import exec_cmd, genname, get_accel_env_vars
 from ramalama.compat import NamedTemporaryFile
 from ramalama.compose import Compose
 from ramalama.config import ActiveConfig
@@ -26,7 +26,7 @@ class Stack:
         self.model = New(args.MODEL, args)
         self.model_type = self.model.type
         self.model_port = "8080"
-        self.stack_image = version_tagged_image(ActiveConfig().stack_image)
+        self.stack_image = f"""{ActiveConfig().stack_image}:{args.api.version}"""
         self.labels = ""
 
     def add_label(self, label):

--- a/ramalama/stack.py
+++ b/ramalama/stack.py
@@ -67,11 +67,13 @@ class Stack:
         llama_stack_container = {
             "name": "llama-stack",
             "image": self.stack_image,
-            "args": ["llama", "stack", "run", "--image-type", "venv", "/etc/ramalama/ramalama-run.yaml"],
+            "args": [],
             "env_string": f"""\
         env:{common_env}
         - name: RAMALAMA_URL
           value: http://127.0.0.1:{self.model_port}
+        - name: RAMALAMA_RUNTIME
+          value: {self.args.runtime}
         - name: INFERENCE_MODEL
           value: {self.model.model_name}""",
             "port_string": f"""\
@@ -91,6 +93,7 @@ class Stack:
         mmproj_dest_path = self.model._get_mmproj_path(True, True, False)
         args2 = copy.copy(self.args)
         args2.port = self.model_port
+        args2.webui = 'off'
         exec_args = assemble_command(args2)
         return (
             self.model.model_name,
@@ -123,7 +126,7 @@ class Stack:
                 k.add("comment", f"# RamaLama service for {self.model.model_alias}")
                 k.add("comment", "# Serving RESTAPIs:")
                 k.add("comment", f"#    Llama Stack: {openai}")
-                k.add("comment", f"#    OpenAI:      {openai}/v1/openai\n")
+                k.add("comment", f"#    OpenAI:      {openai}/v1\n")
                 k.write(self.args.generate.output_dir)
                 return
 

--- a/test/e2e/test_serve.py
+++ b/test/e2e/test_serve.py
@@ -685,7 +685,7 @@ def test_serve_generation(test_model, generate, env_vars):
         )
         for item in itertools.product(
             ["kube", "compose"],
-            [None, "SEARCH_API_KEY=9999"]
+            [None, "SEARCH_API_KEY=9999"],
         )
     ],
 )
@@ -708,7 +708,7 @@ def test_serve_generation_with_llama_api(test_model, generate, env_vars):
                 "--generate",
                 generate,
                 "--api",
-                "llama-stack",
+                "llama-stack:0.6.0",
                 "--dri",
                 "off",
                 test_model,
@@ -725,6 +725,7 @@ def test_serve_generation_with_llama_api(test_model, generate, env_vars):
                 assert re.search(r".*hostPort: 1234", content)
                 assert re.search(r".*/llama-stack", content)
                 assert re.search(r".*'--top-p', '1.0'.*", content)
+                assert re.search(r".*ramalama/llama-stack:0.6.0", content)
 
                 if env_vars:
                     assert len(re.findall(r"name: SEARCH_API_KEY", content)) == 2
@@ -789,7 +790,7 @@ def test_serve_api(caplog):
         )
 
         assert re.search(fr".*Llama Stack RESTAPI: http://localhost:{container_port}", result)
-        assert re.search(fr".*OpenAI RESTAPI: http://localhost:{container_port}/v1/openai", result)
+        assert re.search(fr".*OpenAI RESTAPI: http://localhost:{container_port}/v1", result)
 
         # Inspect the models API
         # FIXME: llama-stack image is currently broken.


### PR DESCRIPTION
This is the proposal to move to a different version schema for llama-stack. Usually the llama-stack-client is bound to the llama-stack version. So any application using llama-stack is (currently) bound to the llama-stack version be the same for server and client. 

If ramalama has a new release then I want to be able to pick the llama-stack version I need for my application. The idea to achieve this is:

- have ramalama-stack the same version as llama-stack
- the commandline argument `--api llama-stack` has the option to specifiy the version like `--api llama-stack:0.6.0` (this is pending in this PR)

Further this container image will use the ramalama_runtime to pick either the vllm-provider, llama.cpp or the generic ramalama provider for the llama-stack, this depends on https://github.com/containers/ramalama-stack/pull/149

Addresses #2480 