### PR TITLE
feat: Add --port in ramalama chat command

### DIFF
--- a/docs/ramalama-chat.1.md
+++ b/docs/ramalama-chat.1.md
@@ -48,6 +48,9 @@ Each server provides tools that can be automatically invoked during chat convers
 #### **--model**=MODEL
 Model for inferencing (may not be required for endpoints that only serve one model)
 
+#### **--port**, **-p**=*port*
+Port of the AI Model server to connect to. When specified, the URL is constructed as http://127.0.0.1:PORT/v1.
+
 #### **--prefix**
 Prefix for the user prompt (default: 🦭 > )
 

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -920,7 +920,28 @@ def chat_run_options(parser):
 
 
 def _chat_cli(args):
+    from urllib.parse import urlparse, urlunparse
+
     from ramalama import chat as chat_module
+
+    # If --port is specified, construct the URL from port
+    port = getattr(args, 'port', None)
+    if port:
+        args.url = f"http://127.0.0.1:{port}/v1"
+    else:
+        parsed = urlparse(args.url)
+
+        # Replace 'localhost' with '127.0.0.1' to avoid IPv6 resolution issues.
+        # The server binds to 0.0.0.0 (IPv4 only), so connecting via [::1] fails.
+        if parsed.hostname == 'localhost':
+            netloc = f"127.0.0.1:{parsed.port}" if parsed.port else "127.0.0.1"
+            parsed = parsed._replace(netloc=netloc)
+
+        # Normalize URL: ensure /v1 is present for OpenAI-compatible endpoints
+        if not parsed.path or parsed.path == '/':
+            parsed = parsed._replace(path='/v1')
+
+        args.url = urlunparse(parsed)
 
     return chat_module.chat(args)
 
@@ -940,6 +961,13 @@ def chat_parser(subparsers):
         "--ls",
         action="store_true",
         help="list the available models at an endpoint",
+    )
+    parser.add_argument(
+        "-p",
+        "--port",
+        type=parse_port_option,
+        help="port of the AI Model server to connect to",
+        completer=suppressCompleter,
     )
     parser.add_argument("--url", type=str, default="http://127.0.0.1:8080/v1", help="the url to send requests to")
     parser.add_argument("--model", "-m", type=str, completer=local_models, help="model for inferencing")

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -10,7 +10,7 @@ import urllib.error
 from datetime import datetime, timezone
 from functools import lru_cache
 from typing import Any, get_args
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlunparse
 
 # if autocomplete doesn't exist, just do nothing, don't break
 try:
@@ -20,7 +20,7 @@ try:
 except Exception:
     suppressCompleter = None
 
-from ramalama import engine
+from ramalama import chat, engine
 from ramalama.arg_types import DefaultArgsType
 from ramalama.cli_arg_normalization import normalize_pull_arg
 from ramalama.common import accel_image, exec_cmd, get_accel, perror
@@ -99,7 +99,7 @@ def parse_generate_option(option: str) -> ParsedGenerateInput:
 
 def parse_port_option(option: str) -> str:
     port = int(option)
-    if port <= 0 or port >= 65535:
+    if port < 1 or port > 65535:
         raise ValueError(f"Invalid port '{port}'")
     return option
 
@@ -920,10 +920,6 @@ def chat_run_options(parser):
 
 
 def _chat_cli(args):
-    from urllib.parse import urlparse, urlunparse
-
-    from ramalama import chat as chat_module
-
     # If --port is specified, construct the URL from port
     port = getattr(args, 'port', None)
     if port:
@@ -934,7 +930,13 @@ def _chat_cli(args):
         # Replace 'localhost' with '127.0.0.1' to avoid IPv6 resolution issues.
         # The server binds to 0.0.0.0 (IPv4 only), so connecting via [::1] fails.
         if parsed.hostname == 'localhost':
-            netloc = f"127.0.0.1:{parsed.port}" if parsed.port else "127.0.0.1"
+            host_port = f"127.0.0.1:{parsed.port}" if parsed.port else "127.0.0.1"
+            if parsed.username and parsed.password:
+                netloc = f"{parsed.username}:{parsed.password}@{host_port}"
+            elif parsed.username:
+                netloc = f"{parsed.username}@{host_port}"
+            else:
+                netloc = host_port
             parsed = parsed._replace(netloc=netloc)
 
         # Normalize URL: ensure /v1 is present for OpenAI-compatible endpoints
@@ -943,7 +945,7 @@ def _chat_cli(args):
 
         args.url = urlunparse(parsed)
 
-    return chat_module.chat(args)
+    return chat.chat(args)
 
 
 def chat_parser(subparsers):


### PR DESCRIPTION
Fixes #2624 

Summary: 
- Add -p/--port flag to ramalama chat so users can connect to a running model server by specifying just the port (e.g. ramalama  chat -p 8080) instead of the full URL
- Normalize the chat URL: replace localhost with 127.0.0.1 to avoid IPv6 resolution failures when the server binds to 0.0.0.0     
  (IPv4 only), and ensure the /v1 path is present for OpenAI-compatible endpoints          

Example: 

```
spande-mac:ramalama $ ./bin/ramalama serve -p 9999 tiny                               
0.18: Pulling from ramalama/ramalama
Digest: sha256:1d63a3e761113810c1efdf3b24195af22e8a4c6c095684d00755aebac7a01bc2
Status: Image is up to date for quay.io/ramalama/ramalama:0.18
load_backend: loaded RPC backend from /usr/bin/libggml-rpc.so
ggml_vulkan: No devices found.
load_backend: loaded Vulkan backend from /usr/bin/libggml-vulkan.so
load_backend: loaded CPU backend from /usr/bin/libggml-cpu-armv8.2_2.so
...
```

```
spande-mac:ramalama $ ./bin/ramalama chat --port 9999 "Tell the capital of Japan"                         
The capital of Japan is Tokyo.
```