### PR TITLE
feat: support adding attachments in ramalama run and ramalama chat

### DIFF
--- a/docs/options/attach.md
+++ b/docs/options/attach.md
@@ -1,0 +1,7 @@
+####> This option file is used in:
+####>   ramalama run
+####> If this file is edited, make sure the changes
+####> are applicable to all of those.
+#### **--attach**=**file-path**
+Attaches the given file to the initial request.
+Can be specified multiple times to attach multiple files.

--- a/docs/ramalama-chat.1.md
+++ b/docs/ramalama-chat.1.md
@@ -22,6 +22,10 @@ continue to an interactive chat session after processing the initial prompt.
 OpenAI-compatible API key.
 Can also be set via the RAMALAMA_API_KEY environment variable.
 
+#### **--attach**=**file-path**
+Attaches the given file to the initial request.
+Can be specified multiple times to attach multiple files.
+
 #### **--color**
 Indicate whether or not to use color in the chat.
 Possible values are "never", "always" and "auto". (default: auto)

--- a/docs/ramalama-run.1.md.in
+++ b/docs/ramalama-run.1.md.in
@@ -16,6 +16,8 @@ the execution. URL support means if a model is on a web site or even on your loc
 
 @@option api
 
+@@option attach
+
 @@option authfile
 
 @@option backend

--- a/ramalama/arg_types.py
+++ b/ramalama/arg_types.py
@@ -81,6 +81,7 @@ class ChatSubArgsType(Protocol):
     url: str
     color: COLOR_OPTIONS
     list: bool
+    attachments: Optional[List[PathStr]]
     model: Optional[str]
     rag: Optional[str]
     api_key: Optional[str]

--- a/ramalama/chat.py
+++ b/ramalama/chat.py
@@ -12,6 +12,7 @@ import subprocess
 import sys
 import threading
 import time
+import typing
 import urllib.error
 import urllib.request
 from collections.abc import Sequence
@@ -33,6 +34,7 @@ from ramalama.chat_utils import (
 )
 from ramalama.common import perror
 from ramalama.config import ActiveConfig
+from ramalama.config_types import PathStr
 from ramalama.console import should_colorize
 from ramalama.engine import stop_container
 from ramalama.file_loaders.file_manager import OpanAIChatAPIMessageBuilder
@@ -151,6 +153,9 @@ class RamaLamaShell(cmd.Cmd):
         operational_args: Optional[ChatOperationalArgs] = None,
         provider: Optional[ChatProvider] = None,
     ):
+        # Reload perror here so we can mock it in tests
+        from ramalama.common import perror
+
         if operational_args is None:
             operational_args = ChatOperationalArgs()
 
@@ -168,6 +173,16 @@ class RamaLamaShell(cmd.Cmd):
         self.initialize_mcp()
 
         self.content: list[str] = []
+        self.attachments: list[PathStr] = []
+        if getattr(args, 'attachments', None):
+            invalid_attachments = []
+            for attachment in typing.cast(list[PathStr], args.attachments):
+                if not self._add_attachment(attachment):
+                    invalid_attachments.append(attachment)
+            if invalid_attachments:
+                # Raising an exception here will keep the container running,
+                # so warn the user and ignore the missing attachments
+                perror(f"The following attachments were not valid and were ignored: {', '.join(invalid_attachments)}.")
         self.message_count = 0  # Track messages for summarization
 
     def do_help(self, args):
@@ -175,6 +190,7 @@ class RamaLamaShell(cmd.Cmd):
         print("\nAvailable commands:")
         print("  /help, help, ?    - Show this help message")
         print("  /clear            - Clear conversation history")
+        print("  /attach file      - Attach a file to the next request")
         print("  /bye, exit        - Exit the chat session")
         if self.mcp_agent:
             print("  /tool [question]  - Manually select which MCP tool to use")
@@ -395,6 +411,16 @@ class RamaLamaShell(cmd.Cmd):
         self.conversation_history.append(UserMessage(text=f"/tool {question}"))
         self.conversation_history.append(AssistantMessage(text=str(responses)))
 
+    def _add_attachment(self, path: PathStr) -> bool:
+        """Add a given attachment to the next request;
+        returns False when the path does not point to an accessible file, and True otherwise."""
+        if not os.access(path, os.R_OK):
+            return False
+        if not os.path.isfile(path):
+            return False
+        self.attachments.append(path)
+        return True
+
     def _select_tools(self):
         """Interactive multi-tool selection without prompting for arguments."""
         if not self.mcp_agent or not self.mcp_agent.available_tools:
@@ -481,7 +507,16 @@ class RamaLamaShell(cmd.Cmd):
         if cmd == "/clear":
             self.conversation_history = []
             self.content = []
+            self.attachments = []
             print("Conversation history cleared.")
+            return False
+
+        # Handle attachments
+        if cmd.startswith("/attach "):
+            # capitalization matters for files, so use user_content
+            file = user_content.strip()[8:]
+            if not self._add_attachment(file):
+                print(f'The file {file} does not exist or cannot be accessed.')
             return False
 
         # Handle multi-line input (backslash continuation)
@@ -510,6 +545,12 @@ class RamaLamaShell(cmd.Cmd):
             return False
 
         self.conversation_history.append(UserMessage(text=content))
+
+        if self.attachments:
+            builder = OpanAIChatAPIMessageBuilder()
+            for attachment in self.attachments:
+                self.conversation_history.extend(builder.load(attachment))
+            self.attachments = []
         self.request_in_process = True
         response = self._req()
         if response:

--- a/ramalama/chat.py
+++ b/ramalama/chat.py
@@ -153,9 +153,6 @@ class RamaLamaShell(cmd.Cmd):
         operational_args: Optional[ChatOperationalArgs] = None,
         provider: Optional[ChatProvider] = None,
     ):
-        # Reload perror here so we can mock it in tests
-        from ramalama.common import perror
-
         if operational_args is None:
             operational_args = ChatOperationalArgs()
 
@@ -514,6 +511,8 @@ class RamaLamaShell(cmd.Cmd):
         # Handle attachments
         if cmd.startswith("/attach "):
             # capitalization matters for files, so use user_content
+            # TODO: Maybe create a specialize argument parser for this
+            #       that parses similar to how sh and bash parses arguments.
             file = user_content.strip()[8:]
             if not self._add_attachment(file):
                 print(f'The file {file} does not exist or cannot be accessed.')

--- a/ramalama/chat_providers/openai.py
+++ b/ramalama/chat_providers/openai.py
@@ -48,20 +48,27 @@ def _(message: ToolMessage) -> dict[str, Any]:
     return response
 
 
+def _handle_attachments(attachments: list[AttachmentPart]) -> list[dict[str, Any]]:
+    return [serialize_part(attachment) for attachment in attachments]
+
+
 @message_to_completions_dict.register
 def _(message: UserMessage) -> dict[str, Any]:
+    content: str | list[dict[str, Any]] = message.text or ""
     if message.attachments:
-        raise ValueError("Attachments are not supported by this provider.")
-    return {**message.metadata, 'content': message.text or "", 'role': message.role}
+        content = [{"text": content, "type": "text"}]
+        content.extend(_handle_attachments(message.attachments))
+    return {**message.metadata, 'content': content, 'role': message.role}
 
 
 @message_to_completions_dict.register
 def _(message: AssistantMessage) -> dict[str, Any]:
+    content: str | list[dict[str, Any]] = message.text or ""
     if message.attachments:
-        raise ValueError("Attachments are not supported by this provider.")
+        content = [{"text": content, "type": "text"}]
+        content.extend(_handle_attachments(message.attachments))
 
-    payload = {**message.metadata, 'content': message.text or "", 'role': message.role}
-
+    payload = {**message.metadata, 'content': content, 'role': message.role}
     if message.tool_calls:
         payload['tool_calls'] = [
             {

--- a/ramalama/chat_providers/openai.py
+++ b/ramalama/chat_providers/openai.py
@@ -56,7 +56,7 @@ def _handle_attachments(attachments: list[AttachmentPart]) -> list[dict[str, Any
 def _(message: UserMessage) -> dict[str, Any]:
     content: str | list[dict[str, Any]] = message.text or ""
     if message.attachments:
-        content = [{"text": content, "type": "text"}]
+        content = [{"text": content, "type": "text"}] if content else []
         content.extend(_handle_attachments(message.attachments))
     return {**message.metadata, 'content': content, 'role': message.role}
 
@@ -65,7 +65,7 @@ def _(message: UserMessage) -> dict[str, Any]:
 def _(message: AssistantMessage) -> dict[str, Any]:
     content: str | list[dict[str, Any]] = message.text or ""
     if message.attachments:
-        content = [{"text": content, "type": "text"}]
+        content = [{"text": content, "type": "text"}] if content else []
         content.extend(_handle_attachments(message.attachments))
 
     payload = {**message.metadata, 'content': content, 'role': message.role}

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -34,7 +34,7 @@ from ramalama.config import (
     coerce_to_bool,
     load_file_config,
 )
-from ramalama.config_types import COLOR_OPTIONS
+from ramalama.config_types import COLOR_OPTIONS, PathStr
 from ramalama.endian import EndianMismatchError
 from ramalama.log_levels import LogLevel
 from ramalama.logger import configure_logger, logger
@@ -981,6 +981,13 @@ def chat_parser(subparsers):
         type=float,
         default=float(ActiveConfig().temp),
         help="temperature of the response from the AI model",
+    )
+    parser.add_argument(
+        "--attach",
+        type=PathStr,
+        action='append',
+        dest='attachments',
+        help="add an attachment to the initial request, can be specified multiple times to add multiple files",
     )
     parser.add_argument(
         "ARGS", nargs="*", help="overrides the default prompt, and the output is returned without entering the chatbot"

--- a/ramalama/plugins/runtimes/inference/common.py
+++ b/ramalama/plugins/runtimes/inference/common.py
@@ -16,6 +16,7 @@ from ramalama.cli import (
 )
 from ramalama.common import ContainerEntryPoint, accel_image, ensure_image, set_accel_env_vars
 from ramalama.config import ActiveConfig
+from ramalama.config_types import PathStr
 from ramalama.logger import logger
 from ramalama.plugins.interface import InferenceRuntimePlugin
 from ramalama.plugins.loader import assemble_command
@@ -99,6 +100,14 @@ class BaseInferenceRuntime(InferenceRuntimePlugin):
                 default=config.host,
                 help="IP address to listen",
                 completer=suppressCompleter,
+            )
+        elif command == "run":
+            parser.add_argument(
+                "--attach",
+                type=PathStr,
+                action='append',
+                dest='attachments',
+                help="add an attachment to the initial request, can be specified multiple times to add multiple files",
             )
 
     def register_subcommands(self, subparsers: "argparse._SubParsersAction") -> None:

--- a/test/e2e/test_run.py
+++ b/test/e2e/test_run.py
@@ -289,6 +289,26 @@ def test_run_model_with_prompt(shared_ctx_with_models, test_model):
     ctx.check_call(run_cmd)
 
 
+@pytest.mark.e2e
+@pytest.mark.slow
+def test_run_model_with_prompt_and_attachments(shared_ctx_with_models, test_model):
+    import platform
+    import tempfile
+
+    ctx = shared_ctx_with_models
+
+    with tempfile.NamedTemporaryFile(suffix=".txt") as temp_file:
+        with open(temp_file.name, "w") as f:
+            f.write("First line\nSecond line\nThird line.")
+        run_cmd = ["ramalama", "run", "--temp", "0", "--attach", temp_file.name]
+        if platform.system() in ["Darwin", "Windows"]:
+            # FIXME: continues rambling on Windows and macOS without --max-token
+            run_cmd.extend(["--max-tokens", "100"])
+
+        run_cmd.extend([test_model, "How many lines are in the attached file?"])
+        ctx.check_call(run_cmd)
+
+
 _file_uri_id_suffix = 'C:/dir/file' if platform.system() == "Windows" else '/absolute_dir/file'
 _file_uri_id_relative = "relative_dir/file"
 

--- a/test/e2e/test_run.py
+++ b/test/e2e/test_run.py
@@ -293,13 +293,15 @@ def test_run_model_with_prompt(shared_ctx_with_models, test_model):
 @pytest.mark.slow
 def test_run_model_with_prompt_and_attachments(shared_ctx_with_models, test_model):
     import platform
-    import tempfile
+
+    from ramalama.compat import NamedTemporaryFile
 
     ctx = shared_ctx_with_models
 
-    with tempfile.NamedTemporaryFile(suffix=".txt") as temp_file:
-        with open(temp_file.name, "w") as f:
-            f.write("First line\nSecond line\nThird line.")
+    with NamedTemporaryFile(suffix=".txt", delete_on_close=False) as temp_file:
+        temp_file.write("First line\nSecond line\nThird line.")
+        temp_file.close()
+
         run_cmd = ["ramalama", "run", "--temp", "0", "--attach", temp_file.name]
         if platform.system() in ["Darwin", "Windows"]:
             # FIXME: continues rambling on Windows and macOS without --max-token

--- a/test/unit/providers/test_openai_provider.py
+++ b/test/unit/providers/test_openai_provider.py
@@ -1,10 +1,9 @@
+import base64
 import json
-
-import pytest
 
 from ramalama.chat_providers.base import ChatRequestOptions
 from ramalama.chat_providers.openai import OpenAICompletionsChatProvider, OpenAIResponsesChatProvider
-from ramalama.chat_utils import AssistantMessage, ImageURLPart, ToolCall, ToolMessage, UserMessage
+from ramalama.chat_utils import AssistantMessage, ImageBytesPart, ImageURLPart, ToolCall, ToolMessage, UserMessage
 
 
 def build_payload(content):
@@ -59,11 +58,25 @@ class TestOpenAICompletionsProvider:
         assert len(events) == 1
         assert events[0].text == "Hi there"
 
-    def test_rejects_attachments(self):
-        message = UserMessage(attachments=[ImageURLPart(url="http://img")])
+    def test_serializes_attachments(self):
+        message = UserMessage(
+            text="Analyze this image:",
+            role="user",
+            attachments=[ImageURLPart(url="http://img"), ImageBytesPart(data=b'1234', mime_type='image/png')],
+        )
 
-        with pytest.raises(ValueError):
-            self.provider.build_payload([message], make_options())
+        payload = self.provider.build_payload([message], make_options())
+        messages = payload["messages"][0]["content"]
+        assert len(messages) == 3
+        assert messages[0]["type"] == "text"
+        assert messages[0]["text"] == "Analyze this image:"
+        assert messages[1]["type"] == "image_url"
+        assert messages[1]["image_url"] == {"url": "http://img"}
+        assert messages[2]["type"] == "image_bytes"
+        assert messages[2]["image_bytes"] == {
+            "data": base64.b64encode(b'1234').decode("ascii"),
+            "mime_type": "image/png",
+        }
 
     def test_serializes_tool_calls_and_responses(self):
         tool_call = ToolCall(id="call-1", name="lookup", arguments={"query": "weather"})

--- a/test/unit/test_cli_args.py
+++ b/test/unit/test_cli_args.py
@@ -51,10 +51,7 @@ except ImportError:
 
 parser = get_parser()
 
-special_cases = {
-    "api_key": "api-key",
-    "max_tokens": "max-tokens",
-}
+special_cases = {"api_key": "api-key", "max_tokens": "max-tokens", "attachments": "attach"}
 
 
 def args_to_cli_args(args_obj, subcommand: Optional[str], special_cases: Optional[dict] = None) -> list:
@@ -85,7 +82,15 @@ def args_to_cli_args(args_obj, subcommand: Optional[str], special_cases: Optiona
 
         # TODO: Handle list as positional arguments. This is hacky, maybe introspect the parser for nargs?
         if isinstance(value, list):
-            cli_args.extend(value)
+            if flag == '--attach':
+                # TODO: Do not treat --attach as a special case;
+                #       parser args with action append should have this logic
+                #       parser args with action NARGS should extend the value
+                for arg in value:
+                    cli_args.append(flag)
+                    cli_args.append(arg)
+            else:
+                cli_args.extend(value)
             continue
 
         # Otherwise, add as --flag value
@@ -117,6 +122,13 @@ def test_default_endpoint(chatargs):
 @given(
     st.builds(
         ChatSubArgs,
+        attachments=st.one_of(
+            st.none(),
+            st.lists(
+                st.text(alphabet=string.ascii_letters, min_size=1),
+                max_size=10,
+            ),
+        ),
         prefix=st.sampled_from(['> ', '🦙 > ', '🦭 > ', '🐋 > ']),
         url=st.sampled_from(['https://test.com', 'test.com']),
         temp=st.one_of(

--- a/test/unit/test_file_loader_integration.py
+++ b/test/unit/test_file_loader_integration.py
@@ -6,6 +6,7 @@ import pytest
 
 from ramalama.chat import RamaLamaShell, chat
 from ramalama.chat_utils import ImageURLPart
+from ramalama.compat import NamedTemporaryFile
 
 
 def _text_content(message):
@@ -23,7 +24,7 @@ class TestFileUploadChatIntegration:
         mock_response.__iter__.return_value = [b'{"data": [{"id": "test-model"}]}']
         mock_urlopen.return_value = mock_response
 
-        with tempfile.NamedTemporaryFile(suffix=".txt") as tmp_file:
+        with NamedTemporaryFile(suffix=".txt") as tmp_file:
             with open(tmp_file.name, "w") as f:
                 f.write("This is test content for chat input")
 
@@ -51,7 +52,7 @@ class TestFileUploadChatIntegration:
         mock_response.__iter__.return_value = [b'{"data": [{"id": "test-model"}]}']
         mock_urlopen.return_value = mock_response
 
-        with tempfile.NamedTemporaryFile(suffix=".txt") as tmp_file:
+        with NamedTemporaryFile(suffix=".txt") as tmp_file:
             with open(tmp_file.name, "w") as f:
                 f.write("This is test content for chat input")
 
@@ -93,7 +94,7 @@ class TestFileUploadChatIntegration:
 
     @patch('urllib.request.urlopen')
     @patch('urllib.request.Request')
-    @patch('ramalama.common.perror')
+    @patch('ramalama.chat.perror')
     def test_chat_with_directory_upload(self, mock_err, mock_request, mock_urlopen):
         """Test chat functionality with a single file input."""
         # Mock the models endpoint response
@@ -205,7 +206,7 @@ class TestFileUploadChatIntegration:
         mock_response.__iter__.return_value = [b'{"data": [{"id": "test-model"}]}']
         mock_urlopen.return_value = mock_response
 
-        with tempfile.NamedTemporaryFile(suffix=".txt") as tmp_file:
+        with NamedTemporaryFile(suffix=".txt") as tmp_file:
             with open(tmp_file.name, "w") as f:
                 f.write("")
 
@@ -232,7 +233,7 @@ class TestFileUploadChatIntegration:
         mock_response.__iter__.return_value = [b'{"data": [{"id": "test-model"}]}']
         mock_urlopen.return_value = mock_response
 
-        with tempfile.NamedTemporaryFile(suffix=".txt") as tmp_file:
+        with NamedTemporaryFile(suffix=".txt") as tmp_file:
             unicode_content = "Hello 世界! 🌍\nUnicode test: éñü\nEmoji: 🚀🎉"
             with open(tmp_file.name, "w") as f:
                 f.write(unicode_content)
@@ -319,7 +320,7 @@ class TestFileUploadChatIntegration:
         mock_response.__iter__.return_value = [b'{"data": [{"id": "test-model"}]}']
         mock_urlopen.return_value = mock_response
 
-        with tempfile.NamedTemporaryFile(suffix=".txt") as tmp_file:
+        with NamedTemporaryFile(suffix=".txt") as tmp_file:
             with open(tmp_file.name, "w") as f:
                 f.write("File content")
 
@@ -340,7 +341,7 @@ class TestFileUploadChatIntegration:
 
     def test_chat_function_with_rag_and_dryrun(self):
         """Test that chat function works correctly with rag and dryrun."""
-        with tempfile.NamedTemporaryFile(suffix=".txt") as tmp_file:
+        with NamedTemporaryFile(suffix=".txt") as tmp_file:
             with open(tmp_file.name, "w") as f:
                 f.write("Test content")
 
@@ -373,9 +374,9 @@ class TestImageUploadChatIntegration:
         mock_response.__iter__.return_value = [b'{"data": [{"id": "test-model"}]}']
         mock_urlopen.return_value = mock_response
 
-        with tempfile.NamedTemporaryFile(suffix=".jpg") as tmp_file:
-            with open(tmp_file.name, "wb") as f:
-                f.write(b"fake image data")
+        with NamedTemporaryFile(suffix=".jpg", delete_on_close=False) as tmp_file:
+            tmp_file.write(b"fake image data")
+            tmp_file.close()
 
             mock_args = MagicMock()
             mock_args.rag = tmp_file.name
@@ -403,9 +404,9 @@ class TestImageUploadChatIntegration:
         mock_response.__iter__.return_value = [b'{"data": [{"id": "test-model"}]}']
         mock_urlopen.return_value = mock_response
 
-        with tempfile.NamedTemporaryFile(suffix=".jpg") as tmp_file:
-            with open(tmp_file.name, "wb") as f:
-                f.write(b"fake image data")
+        with NamedTemporaryFile(suffix=".jpg", delete_on_close=False) as tmp_file:
+            tmp_file.write(b"fake image data")
+            tmp_file.close()
 
             mock_args = MagicMock()
             mock_args.attachments = [tmp_file.name]

--- a/test/unit/test_file_loader_integration.py
+++ b/test/unit/test_file_loader_integration.py
@@ -43,6 +43,92 @@ class TestFileUploadChatIntegration:
             assert f"<!--start_document {tmp_file.name}-->" in content
 
     @patch('urllib.request.urlopen')
+    @patch('urllib.request.Request')
+    def test_chat_with_file_input_single_file_attachment(self, mock_request, mock_urlopen):
+        """Test chat functionality with a single file input."""
+        # Mock the models endpoint response
+        mock_response = MagicMock()
+        mock_response.__iter__.return_value = [b'{"data": [{"id": "test-model"}]}']
+        mock_urlopen.return_value = mock_response
+
+        with tempfile.NamedTemporaryFile(suffix=".txt") as tmp_file:
+            with open(tmp_file.name, "w") as f:
+                f.write("This is test content for chat input")
+
+            mock_args = MagicMock()
+            mock_args.attachments = [tmp_file.name]
+            mock_args.rag = None
+            mock_args.ARGS = ["Please analyze this content:"]
+            mock_args.dryrun = False
+            mock_args.max_tokens = None
+            mock_args.runtime = 'llama.cpp'
+            mock_args.model = 'test-model'
+            mock_args.temp = '1.0'
+            mock_args.summarize_after = 0
+
+            shell = RamaLamaShell(mock_args)
+            shell.default("Please analyze this content:")
+
+            # Check that the system message was added to conversation history
+            assert len(shell.conversation_history) == 2
+            message = shell.conversation_history[0]
+            assert message.role == "user"
+            content = message.text or ""
+            assert "Please analyze this content:" in content
+
+            # check the attachment was added
+            message = shell.conversation_history[1]
+            assert message.role == "user"
+            content = message.text or ""
+            assert "This is test content for chat input" in content
+            assert f"<!--start_document {tmp_file.name}-->" in content
+
+            # check the attachment does not get readded on a subsequent event
+            shell.default("Can you simplify your summary?")
+            assert len(shell.conversation_history) == 3
+            message = shell.conversation_history[2]
+            assert message.role == "user"
+            content = message.text or ""
+            assert content == "Can you simplify your summary?"
+
+    @patch('urllib.request.urlopen')
+    @patch('urllib.request.Request')
+    @patch('ramalama.common.perror')
+    def test_chat_with_directory_upload(self, mock_err, mock_request, mock_urlopen):
+        """Test chat functionality with a single file input."""
+        # Mock the models endpoint response
+        mock_response = MagicMock()
+        mock_response.__iter__.return_value = [b'{"data": [{"id": "test-model"}]}']
+        mock_urlopen.return_value = mock_response
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            mock_args = MagicMock()
+            mock_args.attachments = [tmp_dir]
+            mock_args.rag = None
+            mock_args.ARGS = ["Please analyze this content:"]
+            mock_args.dryrun = False
+            mock_args.max_tokens = None
+            mock_args.runtime = 'llama.cpp'
+            mock_args.model = 'test-model'
+            mock_args.temp = '1.0'
+            mock_args.summarize_after = 0
+
+            shell = RamaLamaShell(mock_args)
+
+            shell.default("Please analyze this content:")
+            mock_err.assert_called_once()
+            assert (
+                mock_err.call_args.args[0] == f"The following attachments were not valid and were ignored: {tmp_dir}."
+            )
+
+            # Check that the system message was added to conversation history
+            assert len(shell.conversation_history) == 1
+            message = shell.conversation_history[0]
+            assert message.role == "user"
+            content = message.text or ""
+            assert "Please analyze this content:" in content
+
+    @patch('urllib.request.urlopen')
     def test_chat_with_file_input_directory(self, mock_urlopen):
         """Test chat functionality with a directory input."""
         # Mock the models endpoint response
@@ -307,6 +393,57 @@ class TestImageUploadChatIntegration:
             assert isinstance(part, ImageURLPart)
             assert part.url.startswith("data:image/")
             assert "base64," in part.url
+
+    @patch('urllib.request.urlopen')
+    @patch('urllib.request.Request')
+    def test_chat_with_file_input_single_file_attachment(self, mock_request, mock_urlopen):
+        """Test chat functionality with a single file input."""
+        # Mock the models endpoint response
+        mock_response = MagicMock()
+        mock_response.__iter__.return_value = [b'{"data": [{"id": "test-model"}]}']
+        mock_urlopen.return_value = mock_response
+
+        with tempfile.NamedTemporaryFile(suffix=".jpg") as tmp_file:
+            with open(tmp_file.name, "wb") as f:
+                f.write(b"fake image data")
+
+            mock_args = MagicMock()
+            mock_args.attachments = [tmp_file.name]
+            mock_args.rag = None
+            mock_args.ARGS = ["Please analyze this image:"]
+            mock_args.dryrun = False
+            mock_args.max_tokens = None
+            mock_args.runtime = 'llama.cpp'
+            mock_args.model = 'test-model'
+            mock_args.temp = '1.0'
+            mock_args.summarize_after = 0
+
+            shell = RamaLamaShell(mock_args)
+            shell.default("Please analyze this image:")
+
+            # Check that the system message was added to conversation history
+            assert len(shell.conversation_history) == 2
+            message = shell.conversation_history[0]
+            assert message.role == "user"
+            content = message.text or ""
+            assert "Please analyze this image:" in content
+
+            # check the attachment was added
+            message = shell.conversation_history[1]
+            assert message.role == "user"
+            assert len(message.attachments) == 1
+            part = message.attachments[0]
+            assert isinstance(part, ImageURLPart)
+            assert part.url.startswith("data:image/")
+            assert "base64," in part.url
+
+            # check the attachment does not get readded on a subsequent event
+            shell.default("Can you simplify your summary?")
+            assert len(shell.conversation_history) == 3
+            message = shell.conversation_history[2]
+            assert message.role == "user"
+            content = message.text or ""
+            assert content == "Can you simplify your summary?"
 
     @patch('urllib.request.urlopen')
     def test_chat_with_image_input_directory(self, mock_urlopen):


### PR DESCRIPTION
Added a new repeatable `--attach file` argument to both `ramalama run` and `ramalama chat`. This argument attaches the given file to the initial request to the server. Additionally, in interactive mode, you can attach files to your next request using the `/attach` subcommand.

This is useful for a couple of things:

- Analyzing log files: `ramalama run MODEL --attach server.log What errors occurred at 1pm?
- Analyzing pictures on the command line: `ramalama run MODEL --attach bird.jpg What kind of bird is this?`
- Doing an AI review before committing: `ramalama run MODEL $(git diff --name-only | sed 's/^/--attach /') Do a review of these changes: $(git diff)`

The existing file serialization options inside OpanAIChatAPIMessageBuilder and serialize_part were leveraged to implement this feature.