### PR TITLE
Fix handling of IPv6 addresses and use :: as the default listen address

### DIFF
--- a/container-images/scripts/rag_framework
+++ b/container-images/scripts/rag_framework
@@ -107,9 +107,14 @@ def eprint(e, exit_code):
 # Helper Classes and Functions
 
 
+def _bracket_host(host: str) -> str:
+    return f"[{host}]" if ":" in host else host
+
+
 async def request(host: str, port: int, path: str, timeout: int = 10):
+    host_str = _bracket_host(host)
     async with aiohttp.ClientSession(
-        f"http://{host}:{port}",
+        f"http://{host_str}:{port}",
         timeout=aiohttp.ClientTimeout(total=timeout),
     ) as session:
         async with session.get(path) as resp:
@@ -121,6 +126,7 @@ async def wait_for_llama_server(host: str, port: int, total_timeout: int = 120, 
     end_time = time.monotonic() + total_timeout
     last_print = 0
     request_timeout = 1  # Timeout per individual HTTP request
+    host_str = _bracket_host(host)
 
     while time.monotonic() < end_time:
         try:
@@ -130,18 +136,18 @@ async def wait_for_llama_server(host: str, port: int, total_timeout: int = 120, 
 
             now = time.monotonic()
             if now - last_print >= print_interval:
-                print(f"Server at {host}:{port} is running but not ready (status={resp.status}), retrying...")
+                print(f"Server at {host_str}:{port} is running but not ready (status={resp.status}), retrying...")
                 last_print = now
 
         except Exception as e:
             now = time.monotonic()
             if now - last_print >= print_interval:
-                print(f"Error connecting to {host}:{port}: {e}, retrying...")
+                print(f"Error connecting to {host_str}:{port}: {e}, retrying...")
                 last_print = now
 
         await asyncio.sleep(1)
 
-    raise TimeoutError(f"LLaMA server at {host}:{port} did not become ready after {total_timeout} seconds.")
+    raise TimeoutError(f"LLaMA server at {host_str}:{port} did not become ready after {total_timeout} seconds.")
 
 
 class qdrant:
@@ -212,9 +218,10 @@ class OpenAICompatibleRagService:
             # setup qdrant
             self.vectordb = qdrant(vector_path)
 
+        model_host_str = _bracket_host(model_host)
         self.llm = openai.AsyncOpenAI(
             api_key="your-api-key",
-            base_url=f"http://{model_host}:{model_port}",
+            base_url=f"http://{model_host_str}:{model_port}",
             http_client=openai.DefaultAioHttpClient(),
         )
 
@@ -503,7 +510,7 @@ serve_parser = subparsers.add_parser('serve', help='Run RAG as OpenAI-compatible
 serve_parser.add_argument("vector_path", type=str, help="Path to the vector database")
 serve_parser.add_argument("--model-host", default="localhost", help="The hostname where the model is being served")
 serve_parser.add_argument("--model-port", default=8080, type=int, help="The port where the model is being served")
-serve_parser.add_argument("--host", default="0.0.0.0", help="Host to bind server")
+serve_parser.add_argument("--host", default="::", help="Host to bind server")
 serve_parser.add_argument("--port", default=8081, type=int, help="Port for RAG API")
 serve_parser.set_defaults(func=serve_rag_api)
 

--- a/docs/options/host.md
+++ b/docs/options/host.md
@@ -2,5 +2,5 @@
 ####>   ramalama sandbox goose, ramalama sandbox opencode, ramalama serve
 ####> If this file is edited, make sure the changes
 ####> are applicable to all of those.
-#### **--host**="0.0.0.0"
-IP address for llama.cpp to listen on.
+#### **--host**="::"
+IP address for llama.cpp to listen on. Defaults to "::" (dual-stack) on systems with IPv6 support, "0.0.0.0" on IPv4-only systems.

--- a/docs/ramalama.conf
+++ b/docs/ramalama.conf
@@ -110,7 +110,7 @@
 
 # IP address for llama.cpp to listen on.
 #
-#host = "0.0.0.0"
+#host = "::"
 
 # Pass `--group-add keep-groups` to podman, when using podman.
 # In some cases this is needed to access the gpu from a rootless container

--- a/docs/ramalama.conf.5.md
+++ b/docs/ramalama.conf.5.md
@@ -141,9 +141,10 @@ Environment variables to be added to the environment used when running in a cont
 The quantization mode used when creating OCI formatted AI Models.
 Available options: Q2_K, Q3_K_S, Q3_K_M, Q3_K_L, Q4_0, Q4_K_S, Q4_K_M, Q5_0, Q5_K_S, Q5_K_M, Q6_K, Q8_0.
 
-**host**="0.0.0.0"
+**host**="::" | "0.0.0.0"
 
 IP address for llama.cpp to listen on.
+Defaults to "::" (dual-stack) on systems with IPv6 support, "0.0.0.0" (IPv4-only) otherwise.
 
 **image**="quay.io/ramalama/ramalama:latest"
 

--- a/ramalama/config.py
+++ b/ramalama/config.py
@@ -66,6 +66,17 @@ def _get_default_config_dirs() -> list[Path]:
 DEFAULT_CONFIG_DIRS = _get_default_config_dirs()
 
 
+def get_default_host() -> str:
+    """Return :: on dual-stack/IPv6 systems, 0.0.0.0 on IPv4-only."""
+    import socket
+
+    try:
+        with socket.socket(socket.AF_INET6, socket.SOCK_STREAM):
+            return "::"
+    except OSError:
+        return "0.0.0.0"
+
+
 def get_default_engine() -> SUPPORTED_ENGINES | None:
     """Determine the container manager to use based on environment and platform."""
     if os.path.exists("/run/.toolboxenv"):
@@ -169,7 +180,7 @@ class BaseConfig:
     engine: SUPPORTED_ENGINES | None = field(default_factory=get_default_engine)
     env: list[str] = field(default_factory=list)
     gguf_quantization_mode: GGUF_QUANTIZATION_MODES = DEFAULT_GGUF_QUANTIZATION_MODE
-    host: str = "0.0.0.0"
+    host: str = field(default_factory=get_default_host)
     http_client: HTTPClientConfig = field(default_factory=HTTPClientConfig)
     image: str = None  # type: ignore
     images: dict[str, str] = field(default_factory=dict)

--- a/ramalama/daemon/daemon.py
+++ b/ramalama/daemon/daemon.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 
 import argparse
+import errno
 import signal
+import socket
 import socketserver
 import threading
 from datetime import datetime, timedelta
@@ -72,9 +74,14 @@ class ShutdownHandler:
 
 
 class RamalamaServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
+    allow_reuse_address = True
+
     def __init__(
         self, host: str, port: int, model_store_path: str, idle_check_interval: timedelta, bind_and_activate=True
     ):
+        # Use AF_INET6 for IPv6 addresses; on dual-stack systems :: accepts IPv4 too
+        if ":" in host:
+            self.address_family = socket.AF_INET6
         # Do not pass a RequestHandlerClass here, we will create a custom handler in finish_request
         super().__init__((host, port), None, bind_and_activate)  # type: ignore
 
@@ -82,7 +89,14 @@ class RamalamaServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
         self.model_runner: ModelRunner = ModelRunner()
         self.idle_check_interval: timedelta = idle_check_interval
 
-        self.allow_reuse_address = True
+    def server_bind(self):
+        # Enable dual-stack so :: accepts IPv4 connections too
+        if self.address_family == socket.AF_INET6:
+            try:
+                self.socket.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
+            except (AttributeError, OSError):
+                pass
+        super().server_bind()
 
     def finish_request(self, request, client_address):
         RamalamaHandler(self.model_store_path, self.model_runner, request, client_address, self)
@@ -115,19 +129,28 @@ class RamalamaServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Ramalama Daemon")
-    parser.add_argument("--host", type=str, default="0.0.0.0")
+    parser.add_argument("--host", type=str, default="::")
     parser.add_argument("--port", type=int, default=8080)
     parser.add_argument("--model-store-path", type=str, default="/models")
 
     return parser.parse_args()
 
 
-def run(host: str = "0.0.0.0", port: int = 8080, model_store_path: str = "/models"):
+def run(host: str = "::", port: int = 8080, model_store_path: str = "/models"):
     configure_logger(ActiveConfig().log_level or LogLevel.DEBUG)
-    logger.debug(f"Starting Ramalama daemon on {host}:{port}...")
-    with RamalamaServer(host, port, model_store_path, timedelta(seconds=10)) as httpd:
-        with ShutdownHandler(httpd):
-            server_thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    host_str = f"[{host}]" if ":" in host else host
+    logger.debug(f"Starting Ramalama daemon on {host_str}:{port}...")
+    try:
+        server = RamalamaServer(host, port, model_store_path, timedelta(seconds=10))
+    except OSError as e:
+        if host != "::" or e.errno not in (errno.EAFNOSUPPORT, errno.EADDRNOTAVAIL, errno.EINVAL):
+            raise
+        host = "0.0.0.0"
+        logger.debug(f"IPv6 not available, falling back to {host}:{port}...")
+        server = RamalamaServer(host, port, model_store_path, timedelta(seconds=10))
+    with server:
+        with ShutdownHandler(server):
+            server_thread = threading.Thread(target=server.serve_forever, daemon=True)
             server_thread.start()
             server_thread.join()
 

--- a/ramalama/engine.py
+++ b/ramalama/engine.py
@@ -196,8 +196,13 @@ class Engine(BaseEngine):
 
         # Convert port to string for processing
         port_str = str(port)
-        host = getattr(self.args, "host", "0.0.0.0")
-        host = f"{host}:" if host != "0.0.0.0" else ""
+        host = getattr(self.args, "host", "::").strip("[]")
+        if host == "::":
+            host = ""
+        elif ":" in host:
+            host = f"[{host}]:"
+        else:
+            host = f"{host}:"
         if ":" in port_str:
             self.add_args("-p", f"{host}{port_str}")
         else:

--- a/ramalama/plugins/runtimes/inference/llama_cpp_commands.py
+++ b/ramalama/plugins/runtimes/inference/llama_cpp_commands.py
@@ -51,8 +51,8 @@ class LlamaCppCommands:
 
         model = New(args.MODEL, args) if hasattr(args, 'MODEL') else None
 
-        # --host: use 0.0.0.0 in container, or the configured host otherwise
-        host = '0.0.0.0' if is_container else getattr(args, 'host', None)
+        # --host: use :: in container, or the configured host otherwise
+        host = '::' if is_container else getattr(args, 'host', None)
         if host is not None:
             cmd += ["--host", str(host)]
 

--- a/ramalama/plugins/runtimes/inference/vllm.py
+++ b/ramalama/plugins/runtimes/inference/vllm.py
@@ -46,8 +46,8 @@ class VllmPlugin(ContainerizedInferenceRuntimePlugin):
         if ctx_size:
             cmd += ["--max-model-len", str(ctx_size)]
 
-        # --host: use 0.0.0.0 in container, or the configured host otherwise
-        host = '0.0.0.0' if is_container else getattr(args, 'host', None)
+        # --host: use :: in container, or the configured host otherwise
+        host = '::' if is_container else getattr(args, 'host', None)
         if host is not None:
             cmd += ["--host", str(host)]
 

--- a/ramalama/quadlet.py
+++ b/ramalama/quadlet.py
@@ -178,8 +178,10 @@ class Quadlet:
 
     def _gen_port(self, quadlet_file: UnitFile):
         if getattr(self.args, "port", "") != "":
-            host = getattr(self.args, "host", None) or "0.0.0.0"
-            quadlet_file.add("Container", "PublishPort", f"{host}:{self.args.port}:{self.args.port}")
+            host = getattr(self.args, "host", None) or "::"
+            host = host.strip("[]")
+            host_str = f"[{host}]" if ":" in host else host
+            quadlet_file.add("Container", "PublishPort", f"{host_str}:{self.args.port}:{self.args.port}")
 
     def _gen_rag_volume(self, quadlet_file: UnitFile):
         files: list[UnitFile] = []

--- a/ramalama/stack.py
+++ b/ramalama/stack.py
@@ -22,7 +22,7 @@ class Stack:
     def __init__(self, args):
         self.args = args
         self.name = getattr(args, "name", None) or genname()
-        self.host = "0.0.0.0"
+        self.host = "::"
         self.model = New(args.MODEL, args)
         self.model_type = self.model.type
         self.model_port = "8080"

--- a/test/e2e/test_rag.py
+++ b/test/e2e/test_rag.py
@@ -194,7 +194,7 @@ def test_rag_error_when_file_is_missing():
     "model, params, expected, expected_regex",
     [
         pytest.param(
-            OLLAMA_MODEL, ["--rag", RAG_MODEL], True, r".*llama-server --host [\w\.]+ --port 8081",
+            OLLAMA_MODEL, ["--rag", RAG_MODEL], True, r".*llama-server --host [\w\.:]+ --port 8081",
             id="check llama-server"
         ),
         pytest.param(

--- a/test/e2e/test_serve.py
+++ b/test/e2e/test_serve.py
@@ -96,7 +96,7 @@ def test_basic_dry_run():
             id="check --network is not present when run within container", marks=skip_if_no_container
         ),
         pytest.param(
-            ["--name", "foobar"], r".*--host 0.0.0.0", None, None, True,
+            ["--name", "foobar"], r".*--host ::", None, None, True,
             id="check --host is not present when run within container", marks=skip_if_no_container
         ),
         pytest.param(
@@ -175,8 +175,8 @@ def test_basic_dry_run():
             ["--selinux", "False"], r".*--security-opt=label=disable", None, None, True,
             id="check --selinux=False disables container separation", marks=skip_if_no_container),
         pytest.param(
-            [], r".*--host 0.0.0.0", None, None, True,
-            id="check default --host value to 0.0.0.0", marks=skip_if_container
+            [], r".*--host (::|0\.0\.0\.0)", None, None, True,
+            id="check default --host value", marks=skip_if_container
         ),
         pytest.param(
             [], r".*--cache-reuse 256", None, None, True,
@@ -410,8 +410,8 @@ def test_quadlet_generation(shared_ctx, test_model):
     )
     with container_file.open("r") as f:
         content = f.read()
-        assert re.search(r".*PublishPort=0.0.0.0:1234:1234", content)
-        assert re.search(r".*llama-server --host 0.0.0.0 --port 1234 --model .*", content)
+        assert re.search(r".*PublishPort=(\[::\]|0\.0\.0\.0):1234:1234", content)
+        assert re.search(r".*llama-server --host (::|0\.0\.0\.0) --port 1234 --model .*", content)
         assert re.search(f".*Mount=type=bind,.*{test_model_full_name}", content)
         assert re.search(r".*Environment=HIP_VISIBLE_DEVICES=99", content)
 
@@ -506,9 +506,10 @@ def test_quadlet_and_kube_generation_with_container_registry(container_registry,
         quadlet_file = Path(ctx.workspace_dir) / "{}.container".format(container_name)
         with quadlet_file.open("r") as f:
             content = f.read()
-            assert re.search(f".*PublishPort=0.0.0.0:{container_port}:{container_port}", content)
+            assert re.search(f".*PublishPort=(\\[::\\]|0\\.0\\.0\\.0):{container_port}:{container_port}", content)
             assert re.search(f".*ContainerName={container_name}", content)
-            assert re.search(f".*Exec=.*llama-server --host 0.0.0.0 --port {container_port} --model .*", content)
+            host_re = r"(::|0\.0\.0\.0)"
+            assert re.search(f".*Exec=.*llama-server --host {host_re} --port {container_port} --model .*", content)
             quadlet_image_source = f"{container_registry.host}:{container_registry.port}/{test_model}"
             assert re.search(
                 f".*Mount=type=image,source={quadlet_image_source},"
@@ -556,13 +557,15 @@ def test_quadlet_and_kube_generation_with_container_registry(container_registry,
             container_spec = containers_spec[0]
             assert 'command' not in container_spec
             model_alias = f"{container_registry.host}:{container_registry.port}/{test_model.split(':')[0]}"
+            expected_host = container_spec['args'][container_spec['args'].index("--host") + 1]
+            assert expected_host in ["::", "0.0.0.0"]
             assert container_spec['args'] == [
                 "--model",
                 "/mnt/models/model.file",
                 "--served-model-name",
                 f"{model_alias}",
                 "--host",
-                "0.0.0.0",
+                expected_host,
                 "--port",
                 "1234",
             ]

--- a/test/unit/data/test_quadlet/ipv6_host/tinyllama.container
+++ b/test/unit/data/test_quadlet/ipv6_host/tinyllama.container
@@ -1,12 +1,11 @@
 [Unit]
-Description=RamaLama oci-model-port AI Model Service
+Description=RamaLama tinyllama AI Model Service
 After=local-fs.target
 
 [Container]
 AddDevice=-/dev/accel
 AddDevice=-/dev/dri
 AddDevice=-/dev/kfd
-AddDevice=nvidia.com/gpu=all
 Image=testimage
 RunInit=true
 Environment=HOME=/tmp
@@ -14,8 +13,8 @@ Exec=
 SecurityLabelDisable=true
 DropCapability=all
 NoNewPrivileges=true
-PublishPort=[::]:8080:8080
-Mount=type=image,source=registry.example.com/model:latest,destination=/mnt/models,subpath=/models,readwrite=false
+PublishPort=[::1]:2020:2020
+Mount=type=image,source=tinyllama,destination=/mnt/models,subpath=/models,readwrite=false
 
 [Install]
 WantedBy=multi-user.target default.target

--- a/test/unit/data/test_quadlet/ipv6_host/tinyllama.image
+++ b/test/unit/data/test_quadlet/ipv6_host/tinyllama.image
@@ -1,0 +1,3 @@
+[Image]
+Image=tinyllama
+

--- a/test/unit/data/test_quadlet/ipv6_host/tinyllama.volume
+++ b/test/unit/data/test_quadlet/ipv6_host/tinyllama.volume
@@ -1,0 +1,4 @@
+[Volume]
+Driver=image
+Image=tinyllama.image
+

--- a/test/unit/data/test_quadlet/portmapping/tinyllama.container
+++ b/test/unit/data/test_quadlet/portmapping/tinyllama.container
@@ -14,7 +14,7 @@ Exec=
 SecurityLabelDisable=true
 DropCapability=all
 NoNewPrivileges=true
-PublishPort=0.0.0.0:2020:2020
+PublishPort=[::]:2020:2020
 Mount=type=image,source=tinyllama,destination=/mnt/models,subpath=/models,readwrite=false
 
 [Install]

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -38,7 +38,7 @@ def test_correct_config_defaults(monkeypatch):
     assert cfg.ctx_size == 0
     assert cfg.engine in ["podman", "docker", None]
     assert cfg.env == []
-    assert cfg.host == "0.0.0.0"
+    assert cfg.host in ["::", "0.0.0.0"]
     assert cfg.image == cfg.default_image
     assert isinstance(cfg.images, dict)
     assert cfg.api == "none"

--- a/test/unit/test_engine.py
+++ b/test/unit/test_engine.py
@@ -114,6 +114,50 @@ class TestEngine(unittest.TestCase):
             mock_stdout.write.assert_called()
 
 
+@pytest.mark.parametrize(
+    "host, port, expected_port_arg",
+    [
+        # Default :: omits host prefix
+        ("::", "8080", "8080:8080"),
+        # IPv4 host uses bare host prefix
+        ("127.0.0.1", "8080", "127.0.0.1:8080:8080"),
+        # IPv6 host gets bracketed
+        ("::1", "8080", "[::1]:8080:8080"),
+        ("fe80::1", "3000", "[fe80::1]:3000:3000"),
+        # Port range passthrough with default host
+        ("::", "8080:8081", "8080:8081"),
+        # Port range with IPv4 host
+        ("127.0.0.1", "8080:8081", "127.0.0.1:8080:8081"),
+        # Port range with IPv6 host
+        ("::1", "8080:8081", "[::1]:8080:8081"),
+    ],
+    ids=[
+        "default-ipv6-wildcard",
+        "ipv4-host",
+        "ipv6-loopback",
+        "ipv6-link-local",
+        "port-range-default",
+        "port-range-ipv4",
+        "port-range-ipv6",
+    ],
+)
+def test_add_port_with_host(host, port, expected_port_arg):
+    base_args = Namespace(
+        engine="podman",
+        debug=False,
+        dryrun=False,
+        pull="never",
+        image="test-image:latest",
+        quiet=True,
+        selinux=False,
+        host=host,
+        port=port,
+    )
+    engine = ramalama.engine.Engine(base_args)
+    p_index = engine.exec_args.index("-p")
+    assert engine.exec_args[p_index + 1] == expected_port_arg
+
+
 @patch("ramalama.engine.HTTPConnection")
 def test_is_healthy_conn(mock_conn):
     args = Namespace(MODEL="themodel", name="thecontainer", port=8080, debug=False)

--- a/test/unit/test_inference_engine_plugins.py
+++ b/test/unit/test_inference_engine_plugins.py
@@ -31,7 +31,7 @@ def make_ns(
     cache_reuse=256,
     max_tokens=0,
     port="8080",
-    host="0.0.0.0",
+    host="::",
     logfile=None,
     debug=False,
     webui="on",
@@ -147,7 +147,7 @@ class TestLlamaCppPlugin:
         expected_entry = "--server" if container_image_is_ggml else "llama-server"
         assert cmd[0] == expected_entry
         assert "--host" in cmd
-        assert cmd[cmd.index("--host") + 1] == "0.0.0.0"
+        assert cmd[cmd.index("--host") + 1] == "::"
         assert "--port" in cmd
         assert cmd[cmd.index("--port") + 1] == "8080"
         assert "--model" in cmd
@@ -622,7 +622,7 @@ class TestMlxPlugin:
         mock_model = make_transport_model()
         mock_new.return_value = mock_model
 
-        ns = make_ns(temp=0.7, port="8080", host="0.0.0.0", MODEL="ollama://mymodel")
+        ns = make_ns(temp=0.7, port="8080", host="::", MODEL="ollama://mymodel")
         cmd = self.plugin.handle_subcommand("serve", ns)
 
         assert cmd[0] == "mlx_lm.server"

--- a/test/unit/test_loader.py
+++ b/test/unit/test_loader.py
@@ -23,7 +23,7 @@ def make_cli_args(**kwargs) -> argparse.Namespace:
         "cache_reuse": None,
         "max_tokens": 0,
         "port": "8080",
-        "host": "0.0.0.0",
+        "host": "::",
         "logfile": None,
         "debug": False,
         "webui": "on",

--- a/test/unit/test_quadlet.py
+++ b/test/unit/test_quadlet.py
@@ -14,7 +14,7 @@ class Args:
         name: str = "",
         rag: str = "",
         port: str = "",
-        host: str = "0.0.0.0",
+        host: str = "::",
         env: list = [],
         MODEL: Optional[str] = None,
         add_to_unit=None,
@@ -111,6 +111,17 @@ DATA_PATH = Path(__file__).parent / "data" / "test_quadlet"
                 accel_type="intel",
             ),
             DATA_PATH / "localhost",
+        ),
+        (
+            Input(
+                model_name="tinyllama",
+                model_src_blob="sha256-2af3b81862c6be03c769683af18efdadb2c33f60ff32ab6f83e42c043d6c7816",
+                model_dest_name="tinyllama",
+                image="testimage",
+                args=Args(port="2020", host="::1"),
+                accel_type="intel",
+            ),
+            DATA_PATH / "ipv6_host",
         ),
         (
             Input(


### PR DESCRIPTION
Properly bracket IPv6 addresses in port mappings, URLs, and log messages, and set AF_INET6 on the daemon's TCPServer when binding to an IPv6 address.

Binding to 0.0.0.0 is only correct on IPv4 single stack systems. All platform default to dual-stack nowadays so switch the default address to :: which accepts both IPv4 and IPv6 connections. As this does not work on IPv4 single-stack systems, auto-detect and fall back to 0.0.0.0.

Fixes: #2624