### PR TITLE
Move --temp arg from common inference args to llama.cpp and mlx only

### DIFF
--- a/ramalama/plugins/runtimes/inference/common.py
+++ b/ramalama/plugins/runtimes/inference/common.py
@@ -91,14 +91,6 @@ class BaseInferenceRuntime(InferenceRuntimePlugin):
             help="arguments to add to runtime invocation",
             completer=suppressCompleter,
         )
-        parser.add_argument(
-            "--temp",
-            dest="temp",
-            type=float,
-            default=config.temp,
-            help="temperature of the response from the AI model",
-            completer=suppressCompleter,
-        )
         if command == "serve":
             parser.add_argument(
                 "--host",

--- a/ramalama/plugins/runtimes/inference/llama_cpp.py
+++ b/ramalama/plugins/runtimes/inference/llama_cpp.py
@@ -309,6 +309,15 @@ class LlamaCppPlugin(LlamaCppCommands, ContainerizedInferenceRuntimePlugin):
     def _add_inference_args(self, parser: "argparse.ArgumentParser", command: str) -> None:
         """Add llama.cpp-specific inference args to an already-created parser."""
         super()._add_inference_args(parser, command)
+        config = ActiveConfig()
+        parser.add_argument(
+            "--temp",
+            dest="temp",
+            type=float,
+            default=config.temp,
+            help="temperature of the response from the AI model",
+            completer=suppressCompleter,
+        )
         self._add_backend_arg(parser)
         parser.add_argument(
             "--cache-reuse",

--- a/ramalama/plugins/runtimes/inference/mlx.py
+++ b/ramalama/plugins/runtimes/inference/mlx.py
@@ -3,6 +3,8 @@ import platform
 from http.client import HTTPConnection
 from typing import Any
 
+from ramalama.cli import suppressCompleter
+from ramalama.config import ActiveConfig
 from ramalama.logger import logger
 from ramalama.plugins.runtimes.inference.common import BaseInferenceRuntime
 from ramalama.transports.transport_factory import New
@@ -12,6 +14,18 @@ class MlxPlugin(BaseInferenceRuntime):
     @property
     def name(self) -> str:
         return "mlx"
+
+    def _add_inference_args(self, parser: "argparse.ArgumentParser", command: str) -> None:
+        super()._add_inference_args(parser, command)
+        config = ActiveConfig()
+        parser.add_argument(
+            "--temp",
+            dest="temp",
+            type=float,
+            default=config.temp,
+            help="temperature of the response from the AI model",
+            completer=suppressCompleter,
+        )
 
     def _cmd_run(self, args: argparse.Namespace) -> list[str]:
         cmd = ["mlx_lm.server"]

--- a/ramalama/plugins/runtimes/inference/vllm.py
+++ b/ramalama/plugins/runtimes/inference/vllm.py
@@ -59,10 +59,6 @@ class VllmPlugin(ContainerizedInferenceRuntimePlugin):
         if seed is not None:
             cmd += ["--seed", str(seed)]
 
-        temp = getattr(args, 'temp', None)
-        if temp is not None:
-            cmd += ["--temperature", str(temp)]
-
         runtime_args = getattr(args, 'runtime_args', None)
         if runtime_args:
             cmd.extend(runtime_args)

--- a/test/e2e/test_serve.py
+++ b/test/e2e/test_serve.py
@@ -565,8 +565,6 @@ def test_quadlet_and_kube_generation_with_container_registry(container_registry,
                 "0.0.0.0",
                 "--port",
                 "1234",
-                "--temperature",
-                "0.8",
             ]
             volumes_spec = content.get("spec", {}).get("template", {}).get("spec", {}).get("volumes", [])
             assert volumes_spec[0] == {

--- a/test/unit/test_inference_engine_plugins.py
+++ b/test/unit/test_inference_engine_plugins.py
@@ -541,13 +541,6 @@ class TestVllmPlugin:
         assert "--max-model-len" in cmd
         assert cmd[cmd.index("--max-model-len") + 1] == "8192"
 
-    def test_serve_temperature(self):
-        ns = make_ns(temp=0.5)
-        cmd = self.plugin.handle_subcommand("serve", ns)
-
-        assert "--temperature" in cmd
-        assert cmd[cmd.index("--temperature") + 1] == "0.5"
-
     def test_serve_seed(self):
         ns = make_ns(seed=123)
         cmd = self.plugin.handle_subcommand("serve", ns)
@@ -895,7 +888,7 @@ class TestConfigureSubcommandsFiltering:
         from ramalama.cli import configure_subcommands
         from ramalama.config import ActiveConfig
 
-        for runtime in ("llama.cpp", "mlx", "vllm"):
+        for runtime in ("llama.cpp", "mlx"):
             monkeypatch.setattr(ActiveConfig(), "runtime", runtime)
             monkeypatch.setattr(ActiveConfig(), "container", True)
             parser = self._make_parser()


### PR DESCRIPTION
vLLM 0.19.0 appears to have dropped the --temperature cli arg. Remove it from the shared runtime args and add it only to the runtimes that support it.

Fixes: #2635