### PR TITLE
fix: use ramalama openvino image instead of upstream llama.cpp

### DIFF
--- a/docs/options/backend.md
+++ b/docs/options/backend.md
@@ -23,7 +23,7 @@ Available backends depend on the detected GPU hardware.
 - **rocm**: Use AMD ROCm backend (AMD GPUs only)
 - **cuda**: Use NVIDIA CUDA backend (NVIDIA GPUs only)
 - **sycl**: Use Intel SYCL/oneAPI backend (Intel GPUs only)
-- **openvino**: Use Intel OpenVINO backend (Intel GPUs only); uses `ghcr.io/ggml-org/llama.cpp:full-openvino`
+- **openvino**: Use Intel OpenVINO backend (Intel GPUs only); uses `quay.io/ramalama/openvino`
 
 **Available choices**: The allowed values for `--backend` are dynamically determined based on
 your detected GPU hardware. For example, on a system with an AMD GPU, only `auto`, `vulkan`,

--- a/docs/options/image.md
+++ b/docs/options/image.md
@@ -26,7 +26,7 @@ Accelerated images:
 |  ROCm (AMD)             | quay.io/ramalama/rocm      |
 |  CUDA (NVIDIA)          | quay.io/ramalama/cuda      |
 |  Intel GPU (sycl)       | quay.io/ramalama/intel-gpu |
-|  Intel GPU (openvino)   | ghcr.io/ggml-org/llama.cpp:full-openvino |
+|  Intel GPU (openvino)   | quay.io/ramalama/openvino  |
 |  Asahi (Apple Silicon)  | quay.io/ramalama/asahi     |
 |  CANN (Ascend)          | quay.io/ramalama/cann      |
 |  MUSA (Moore Threads)   | quay.io/ramalama/musa      |

--- a/docs/ramalama.conf
+++ b/docs/ramalama.conf
@@ -39,7 +39,7 @@
 # - rocm: Use AMD ROCm backend (AMD GPUs only)
 # - cuda: Use NVIDIA CUDA backend (NVIDIA GPUs only)
 # - sycl: Use Intel SYCL/oneAPI backend (Intel GPUs only)
-# - openvino: Use Intel OpenVINO backend (Intel GPUs only); uses ghcr.io/ggml-org/llama.cpp:full-openvino
+# - openvino: Use Intel OpenVINO backend (Intel GPUs only); uses quay.io/ramalama/openvino
 #
 # Platform-specific behavior: On Windows, vulkan is not supported on WSL2, so
 # vendor-specific backends (rocm for AMD, sycl for Intel) are automatically

--- a/docs/ramalama.conf.5.md
+++ b/docs/ramalama.conf.5.md
@@ -87,7 +87,7 @@ Valid options: auto, vulkan, rocm, cuda, sycl, openvino
 - **rocm**: Use AMD ROCm backend (AMD GPUs only)
 - **cuda**: Use NVIDIA CUDA backend (NVIDIA GPUs only)
 - **sycl**: Use Intel SYCL/oneAPI backend (Intel GPUs only)
-- **openvino**: Use Intel OpenVINO backend (Intel GPUs only); uses `ghcr.io/ggml-org/llama.cpp:full-openvino`
+- **openvino**: Use Intel OpenVINO backend (Intel GPUs only); uses `quay.io/ramalama/openvino`
 
 **Platform-specific behavior**: On Windows, vulkan is not supported on WSL2, so vendor-specific backends (rocm for AMD, sycl for Intel) are automatically preferred when using `backend="auto"`.
 

--- a/ramalama/plugins/runtimes/inference/llama_cpp.py
+++ b/ramalama/plugins/runtimes/inference/llama_cpp.py
@@ -130,7 +130,7 @@ _LLAMA_CPP_IMAGES: dict[str, str] = {
     "GGML_VK_VISIBLE_DEVICES": version_tagged_image("quay.io/ramalama/ramalama"),
     "HIP_VISIBLE_DEVICES": version_tagged_image("quay.io/ramalama/rocm"),
     "INTEL_VISIBLE_DEVICES": version_tagged_image("quay.io/ramalama/intel-gpu"),
-    "OPENVINO_VISIBLE_DEVICES": "ghcr.io/ggml-org/llama.cpp:full-openvino",
+    "OPENVINO_VISIBLE_DEVICES": version_tagged_image("quay.io/ramalama/openvino"),
     "MUSA_VISIBLE_DEVICES": version_tagged_image("quay.io/ramalama/musa"),
 }
 

--- a/test/unit/test_inference_engine_plugins.py
+++ b/test/unit/test_inference_engine_plugins.py
@@ -958,7 +958,7 @@ class TestConfigureSubcommandsFiltering:
         ("rocm", "HIP_VISIBLE_DEVICES", version_tagged_image("quay.io/ramalama/rocm")),
         ("cuda", "CUDA_VISIBLE_DEVICES", version_tagged_image("quay.io/ramalama/cuda")),
         ("sycl", "INTEL_VISIBLE_DEVICES", version_tagged_image("quay.io/ramalama/intel-gpu")),
-        ("openvino", "INTEL_VISIBLE_DEVICES", "ghcr.io/ggml-org/llama.cpp:full-openvino"),
+        ("openvino", "INTEL_VISIBLE_DEVICES", version_tagged_image("quay.io/ramalama/openvino")),
         # Force backend even with different GPU (warns but allows)
         ("rocm", "CUDA_VISIBLE_DEVICES", version_tagged_image("quay.io/ramalama/rocm")),
         ("cuda", "HIP_VISIBLE_DEVICES", version_tagged_image("quay.io/ramalama/cuda")),
@@ -1003,7 +1003,7 @@ backend = "{backend}"
         ("rocm", "HIP_VISIBLE_DEVICES", version_tagged_image("quay.io/ramalama/rocm")),
         ("vulkan", "INTEL_VISIBLE_DEVICES", DEFAULT_IMAGE),
         ("sycl", "INTEL_VISIBLE_DEVICES", version_tagged_image("quay.io/ramalama/intel-gpu")),
-        ("openvino", "INTEL_VISIBLE_DEVICES", "ghcr.io/ggml-org/llama.cpp:full-openvino"),
+        ("openvino", "INTEL_VISIBLE_DEVICES", version_tagged_image("quay.io/ramalama/openvino")),
     ],
 )
 def test_backend_selection_windows(backend: str, gpu_env: str, expected_result: str, monkeypatch):


### PR DESCRIPTION
## Summary
- Switch the OpenVINO backend container image from `ghcr.io/ggml-org/llama.cpp:full-openvino` to `quay.io/ramalama/openvino`, aligning it with all other backend images hosted under the ramalama registry.
- Updated code, tests, and documentation (backend.md, image.md, ramalama.conf, ramalama.conf.5.md).

## Test plan
- [x] Unit tests pass (`test_backend_selection`, `test_backend_selection_windows`)
- [ ] Verify `ramalama --backend openvino serve` pulls the correct image on an Intel GPU system

🤖 Generated with [Claude Code](https://claude.com/claude-code)