### PR TITLE
Refactor runtime specific config handling into the runtime plugins

### DIFF
--- a/docs/options/backend.md
+++ b/docs/options/backend.md
@@ -2,7 +2,7 @@
 ####>   ramalama bench, ramalama perplexity, ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama serve
 ####> If this file is edited, make sure the changes
 ####> are applicable to all of those.
-#### **--backend**=*auto* | vulkan | rocm | cuda | sycl | openvino
+#### **--backend**=*auto* | vulkan | rocm | cuda | sycl | openvino | cann | musa
 
 GPU backend to use for inference (default: auto).
 
@@ -12,6 +12,8 @@ Available backends depend on the detected GPU hardware.
 - **AMD GPUs**: vulkan (Linux/macOS) or rocm (Windows)
 - **NVIDIA GPUs**: cuda
 - **Intel GPUs**: vulkan (Linux/macOS) or sycl (Windows); openvino available as explicit option
+- **Ascend NPUs**: cann
+- **MUSA GPUs**: musa
 - **No GPU**: vulkan (CPU fallback)
 
 **Platform-specific behavior**:
@@ -24,6 +26,8 @@ Available backends depend on the detected GPU hardware.
 - **cuda**: Use NVIDIA CUDA backend (NVIDIA GPUs only)
 - **sycl**: Use Intel SYCL/oneAPI backend (Intel GPUs only)
 - **openvino**: Use Intel OpenVINO backend (Intel GPUs only); uses `quay.io/ramalama/openvino`
+- **cann**: Use Huawei CANN backend (Ascend NPUs only); uses `quay.io/ramalama/cann`
+- **musa**: Use Moore Threads MUSA backend (MUSA GPUs only); uses `quay.io/ramalama/musa`
 
 **Available choices**: The allowed values for `--backend` are dynamically determined based on
 your detected GPU hardware. For example, on a system with an AMD GPU, only `auto`, `vulkan`,

--- a/docs/ramalama.conf
+++ b/docs/ramalama.conf
@@ -27,26 +27,6 @@
 # If both are set, the config value here takes precedence over the environment variable.
 #api_key = ""
 
-# GPU backend to use for inference (default: auto).
-#
-# Valid options: auto, vulkan, rocm, cuda, sycl, openvino
-# - auto (default): Automatically selects the preferred backend based on detected GPU
-#   - AMD GPUs: vulkan (Linux/macOS) or rocm (Windows)
-#   - NVIDIA GPUs: cuda
-#   - Intel GPUs: vulkan (Linux/macOS) or sycl (Windows); openvino available as explicit option
-#   - No GPU: vulkan (CPU fallback)
-# - vulkan: Use Vulkan-based inference (compatible with AMD, Intel, and CPU)
-# - rocm: Use AMD ROCm backend (AMD GPUs only)
-# - cuda: Use NVIDIA CUDA backend (NVIDIA GPUs only)
-# - sycl: Use Intel SYCL/oneAPI backend (Intel GPUs only)
-# - openvino: Use Intel OpenVINO backend (Intel GPUs only); uses quay.io/ramalama/openvino
-#
-# Platform-specific behavior: On Windows, vulkan is not supported on WSL2, so
-# vendor-specific backends (rocm for AMD, sycl for Intel) are automatically
-# preferred when using backend="auto".
-#
-#backend = "auto"
-
 # OCI model car image
 # Image to use when building and pushing --type=car models
 #
@@ -76,11 +56,6 @@
 # Environment variables to be added when running model within a container
 #
 #env = []
-
-# Specify the default quantization used when creating OCI formatted AI Models.
-# Options: Q2_K, Q3_K_S, Q3_K_M, Q3_K_L, Q4_0, Q4_K_S, Q4_K_M, Q5_0, Q5_K_S, Q5_K_M, Q6_K, Q8_0.
-#
-#gguf_quantization_mode = "Q4_K_M"
 
 # OCI container image to run with the specified AI model
 #
@@ -194,16 +169,6 @@
 #
 #summarize_after = 4
 
-# Temperature of the response from the AI Model
-# llama.cpp explains this as:
-#
-#    The lower the number is, the more deterministic the response is.
-#
-#    The higher the number is the more creative the response, but more likely to hallucinate when set too high.
-#
-#        Usage: Lower numbers are good for virtual assistants where we need deterministic responses. Higher numbers are good for roleplay or creative tasks like editing stories
-#temp=0.8
-
 # Specify the default transport to be used for pulling and pushing of AI Models.
 # Options: oci, ollama, huggingface.
 #
@@ -255,3 +220,68 @@
 
 [ramalama.user]
 #no_missing_gpu_prompt = false
+
+
+# Runtime-specific configuration.
+# Each runtime plugin defines its own config section under [ramalama.runtimes.<name>].
+# The key name uses underscores (e.g. llama_cpp for the "llama.cpp" runtime).
+
+[ramalama.runtimes.llama_cpp]
+
+# GPU backend to use for inference (default: auto).
+#
+# Valid options: auto, vulkan, rocm, cuda, sycl, openvino, cann, musa
+# - auto (default): Automatically selects the preferred backend based on detected GPU
+#   - AMD GPUs: vulkan (Linux/macOS) or rocm (Windows)
+#   - NVIDIA GPUs: cuda
+#   - Intel GPUs: vulkan (Linux/macOS) or sycl (Windows); openvino available as explicit option
+#   - Ascend NPUs: cann
+#   - MUSA GPUs: musa
+#   - No GPU: vulkan (CPU fallback)
+# - vulkan: Use Vulkan-based inference (compatible with AMD, Intel, and CPU)
+# - rocm: Use AMD ROCm backend (AMD GPUs only)
+# - cuda: Use NVIDIA CUDA backend (NVIDIA GPUs only)
+# - sycl: Use Intel SYCL/oneAPI backend (Intel GPUs only)
+# - openvino: Use Intel OpenVINO backend (Intel GPUs only); uses quay.io/ramalama/openvino
+# - cann: Use Huawei CANN backend (Ascend NPUs only); uses quay.io/ramalama/cann
+# - musa: Use Moore Threads MUSA backend (MUSA GPUs only); uses quay.io/ramalama/musa
+#
+# Platform-specific behavior: On Windows, vulkan is not supported on WSL2, so
+# vendor-specific backends (rocm for AMD, sycl for Intel) are automatically
+# preferred when using backend="auto".
+#
+#backend = "auto"
+
+# Min chunk size to attempt reusing from the cache via KV shifting
+#
+#cache_reuse = 256
+
+# Specify the default quantization used when creating OCI formatted AI Models.
+# Options: Q2_K, Q3_K_S, Q3_K_M, Q3_K_L, Q4_0, Q4_K_S, Q4_K_M, Q5_0, Q5_K_S, Q5_K_M, Q6_K, Q8_0.
+#
+#gguf_quantization_mode = "Q4_K_M"
+
+# Number of layers to offload to the GPU (-1 = all layers)
+#
+#ngl = -1
+
+# Temperature of the response from the AI Model.
+# Lower values are more deterministic, higher values are more creative.
+#
+#temp = "0.8"
+
+# Enable/disable thinking mode in reasoning models
+#
+#thinking = true
+
+# Number of CPU threads to use for inference.
+# Default is half the available CPU cores (minimum 4).
+#
+#threads = 4
+
+[ramalama.runtimes.mlx]
+
+# Temperature of the response from the AI Model.
+# Lower values are more deterministic, higher values are more creative.
+#
+#temp = "0.8"

--- a/docs/ramalama.conf.5.md
+++ b/docs/ramalama.conf.5.md
@@ -67,37 +67,7 @@ This value can also be set via `RAMALAMA_API_KEY`.
 
 **Model conversion options:**
 
-**backend**="auto"
-
-GPU backend to use for inference (default: auto).
-
-This setting affects which container image is selected and how GPU resources are utilized.
-
-Valid options: auto, vulkan, rocm, cuda, sycl, openvino
-
-- **auto** (default): Automatically selects the preferred backend based on detected GPU:
-  - AMD GPUs: vulkan (Linux/macOS) or rocm (Windows)
-  - NVIDIA GPUs: cuda
-  - Intel GPUs: vulkan (Linux/macOS) or sycl (Windows); openvino available as explicit option
-  - No GPU: vulkan (CPU fallback)
-
-- **vulkan**: Use Vulkan-based inference (compatible with AMD, Intel, and CPU)
-- **rocm**: Use AMD ROCm backend (AMD GPUs only)
-- **cuda**: Use NVIDIA CUDA backend (NVIDIA GPUs only)
-- **sycl**: Use Intel SYCL/oneAPI backend (Intel GPUs only)
-- **openvino**: Use Intel OpenVINO backend (Intel GPUs only); uses `quay.io/ramalama/openvino`
-
-**Platform-specific behavior**: On Windows, vulkan is not supported on WSL2, so vendor-specific backends (rocm for AMD, sycl for Intel) are automatically preferred when using `backend="auto"`.
-
-The RAMALAMA_BACKEND environment variable overrides this field.
-
-Example configuration:
-```toml
-[ramalama]
-backend = "vulkan"  # Force Vulkan for all GPUs
-```
-
-**carimage**="registry.access.redhat.com/ubi10-micro:latest"
+**carimage**="registry.access.redhat.com/ubi10-micro:latest": OCI model car image used when building and pushing `--type=car` models.
 
 **container**=true: Run RamaLama in a container by default.
 Override via `RAMALAMA_IN_CONTAINER`.
@@ -121,9 +91,6 @@ Override via `RAMALAMA_CONTAINER_ENGINE`.
 
 **env**=[]: Environment variables added to the container runtime environment.
 Example: "LLAMA_ARG_THREADS=10".
-
-**gguf_quantization_mode**="Q4_K_M": Quantization mode used while creating OCI-formatted AI models.
-Options: `Q2_K`, `Q3_K_S`, `Q3_K_M`, `Q3_K_L`, `Q4_0`, `Q4_K_S`, `Q4_K_M`, `Q5_0`, `Q5_K_S`, `Q5_K_M`, `Q6_K`, `Q8_0`.
 
 **host**="::" | "0.0.0.0"
 
@@ -207,10 +174,6 @@ Options: `llama.cpp`, `vllm`, `mlx`.
 **summarize_after**=4: Automatically summarize chat history after N messages to limit context growth.
 Set to 0 to disable.
 
-**temp**="0.8": Response sampling temperature.
-- Lower values: more deterministic output
-- Higher values: more creative output (higher hallucination risk)
-
 **Transport and HTTP options:**
 
 **transport**="ollama": Default transport used for pull/push operations.
@@ -256,3 +219,60 @@ The `ramalama.user` table contains user preferences.
 
 When `no_missing_gpu_prompt = true`, RamaLama suppresses the interactive prompt on macOS Podman VMs without GPU acceleration (for example, `applehv`).
 This value can also be set via `RAMALAMA_USER__NO_MISSING_GPU_PROMPT`.
+
+## RAMALAMA.RUNTIMES TABLE
+Runtime-specific configuration. Each runtime plugin defines its own config section
+under `[ramalama.runtimes.<name>]`. The key name uses underscores (e.g. `llama_cpp`
+for the "llama.cpp" runtime).
+
+`[[ramalama.runtimes.llama_cpp]]`
+
+**backend**="auto": GPU backend to use for inference.
+This setting affects which container image is selected and how GPU resources are utilized.
+
+Valid options: `auto`, `vulkan`, `rocm`, `cuda`, `sycl`, `openvino`, `cann`, `musa`.
+
+- **auto** (default): Automatically selects the preferred backend based on detected GPU:
+  - AMD GPUs: vulkan (Linux/macOS) or rocm (Windows)
+  - NVIDIA GPUs: cuda
+  - Intel GPUs: vulkan (Linux/macOS) or sycl (Windows); openvino available as explicit option
+  - Ascend NPUs: cann
+  - MUSA GPUs: musa
+  - No GPU: vulkan (CPU fallback)
+
+- **vulkan**: Use Vulkan-based inference (compatible with AMD, Intel, and CPU)
+- **rocm**: Use AMD ROCm backend (AMD GPUs only)
+- **cuda**: Use NVIDIA CUDA backend (NVIDIA GPUs only)
+- **sycl**: Use Intel SYCL/oneAPI backend (Intel GPUs only)
+- **openvino**: Use Intel OpenVINO backend (Intel GPUs only); uses `quay.io/ramalama/openvino`
+- **cann**: Use Huawei CANN backend (Ascend NPUs only); uses `quay.io/ramalama/cann`
+- **musa**: Use Moore Threads MUSA backend (MUSA GPUs only); uses `quay.io/ramalama/musa`
+
+**Platform-specific behavior**: On Windows, vulkan is not supported on WSL2, so vendor-specific backends (rocm for AMD, sycl for Intel) are automatically preferred when using `backend="auto"`.
+
+Example configuration:
+
+    [ramalama.runtimes.llama_cpp]
+    backend = "vulkan"  # Force Vulkan for all GPUs
+
+**cache_reuse**=256: Min chunk size to attempt reusing from the cache via KV shifting.
+
+**gguf_quantization_mode**="Q4_K_M": Quantization mode used when creating OCI-formatted AI models.
+Options: `Q2_K`, `Q3_K_S`, `Q3_K_M`, `Q3_K_L`, `Q4_0`, `Q4_K_S`, `Q4_K_M`, `Q5_0`, `Q5_K_S`, `Q5_K_M`, `Q6_K`, `Q8_0`.
+
+**ngl**=-1: Number of layers to offload to the GPU. Set to -1 to offload all layers.
+
+**temp**="0.8": Response sampling temperature.
+- Lower values: more deterministic output
+- Higher values: more creative output (higher hallucination risk)
+
+**thinking**=true: Enable/disable thinking mode in reasoning models.
+
+**threads**=4: Number of CPU threads to use for inference.
+Default is half the available CPU cores (minimum 4).
+
+`[[ramalama.runtimes.mlx]]`
+
+**temp**="0.8": Response sampling temperature.
+- Lower values: more deterministic output
+- Higher values: more creative output (higher hallucination risk)

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -217,12 +217,12 @@ def parse_args_from_cmd(cmd: list[str]) -> tuple[argparse.ArgumentParser, argpar
     args = parser.parse_args(cmd)
     post_parse_setup(args)
 
-    # Update config field that store runtime specific config which can be overridden via the cli
-    # e.g Config.image and Config.rag_image etc...
-    # TODO(owalsh): refactor this to remove runtime specific config from the global config object
     for arg in args.__dict__.keys() & config._fields:
         if getattr(args, arg) != getattr(config, arg):
             setattr(config, arg, getattr(args, arg))
+
+    runtime_plugin = get_runtime(config.runtime)
+    runtime_plugin.sync_args_to_runtime_config(args, config)
     return parser, args
 
 
@@ -976,10 +976,13 @@ def chat_parser(subparsers):
         default=ActiveConfig().max_tokens,
         help="maximum number of tokens to generate (0 = unlimited)",
     )
+    config = ActiveConfig()
+    rt_config = get_runtime(config.runtime).get_runtime_config(config)
+    temp_default = rt_config.temp if rt_config and hasattr(rt_config, "temp") else 0.8
     parser.add_argument(
         "--temp",
         type=float,
-        default=float(ActiveConfig().temp),
+        default=temp_default,
         help="temperature of the response from the AI model",
     )
     parser.add_argument(

--- a/ramalama/config.py
+++ b/ramalama/config.py
@@ -6,10 +6,7 @@ import sys
 from dataclasses import dataclass, field
 from functools import lru_cache
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal, Mapping, Optional
-
-if TYPE_CHECKING:
-    from typing_extensions import TypeAlias
+from typing import Any, Literal, Mapping, Optional
 
 from ramalama.cli_arg_normalization import normalize_pull_arg
 from ramalama.common import apple_vm, available, version_tagged_image
@@ -22,21 +19,6 @@ DEFAULT_IMAGE: str = version_tagged_image("quay.io/ramalama/ramalama")
 DEFAULT_STACK_IMAGE: str = version_tagged_image("quay.io/ramalama/llama-stack")
 DEFAULT_RAG_IMAGE: str = version_tagged_image("quay.io/ramalama/ramalama-rag")
 DEFAULT_TOOLS_IMAGE: str = version_tagged_image("quay.io/ramalama/ramalama-tools")
-GGUF_QUANTIZATION_MODES: TypeAlias = Literal[
-    "Q2_K",
-    "Q3_K_S",
-    "Q3_K_M",
-    "Q3_K_L",
-    "Q4_0",
-    "Q4_K_S",
-    "Q4_K_M",
-    "Q5_0",
-    "Q5_K_S",
-    "Q5_K_M",
-    "Q6_K",
-    "Q8_0",
-]
-DEFAULT_GGUF_QUANTIZATION_MODE: GGUF_QUANTIZATION_MODES = "Q4_K_M"
 
 
 def _get_default_config_dirs() -> list[Path]:
@@ -174,7 +156,6 @@ class HTTPClientConfig:
 class BaseConfig:
     api: str = "none"
     api_key: Optional[str] = None
-    backend: Literal["auto", "vulkan", "rocm", "cuda", "sycl", "openvino"] = "auto"
     benchmarks: Benchmarks = field(default_factory=Benchmarks)
     carimage: str = "registry.access.redhat.com/ubi10-micro:latest"
     container: bool = None  # type: ignore
@@ -187,7 +168,6 @@ class BaseConfig:
     dryrun: bool = False
     engine: Optional[SUPPORTED_ENGINES] = field(default_factory=get_default_engine)
     env: list[str] = field(default_factory=list)
-    gguf_quantization_mode: GGUF_QUANTIZATION_MODES = DEFAULT_GGUF_QUANTIZATION_MODE
     host: str = field(default_factory=get_default_host)
     http_client: HTTPClientConfig = field(default_factory=HTTPClientConfig)
     image: str = None  # type: ignore
@@ -203,11 +183,11 @@ class BaseConfig:
     prefix: str = None  # type: ignore
     pull: str = "newer"
     runtime: SUPPORTED_RUNTIMES = "llama.cpp"
+    runtimes: dict[str, Any] = field(default_factory=dict)
     selinux: bool = False
     settings: RamalamaSettings = field(default_factory=RamalamaSettings)
     store: str = field(default_factory=get_default_store)
     summarize_after: int = 4
-    temp: str = "0.8"
     transport: str = "ollama"
     user: UserConfig = field(default_factory=UserConfig)
     verify: bool = True

--- a/ramalama/plugins/interface.py
+++ b/ramalama/plugins/interface.py
@@ -2,14 +2,43 @@ from __future__ import annotations
 
 import argparse
 from abc import ABC, abstractmethod
+from collections.abc import Mapping
+from dataclasses import asdict, fields
 from http.client import HTTPConnection
-from typing import Any, Optional
+from typing import Any, Optional, Type
 
 
 class RuntimePlugin(ABC):
+    config_type: Optional[Type] = None
+
     @property
     @abstractmethod
     def name(self) -> str: ...
+
+    @property
+    def config_key(self) -> str:
+        return self.name.replace(".", "_").replace("-", "_")
+
+    def get_runtime_config(self, config: Any) -> Any:
+        """Return the typed runtime config, hydrated from config.runtimes."""
+        if self.config_type is None:
+            return None
+        raw = config.runtimes.get(self.config_key, {})
+        if not isinstance(raw, Mapping):
+            raise ValueError(f"config.runtimes.{self.config_key} must be a mapping, got {type(raw).__name__}")
+        known = {f.name for f in fields(self.config_type)}
+        return self.config_type(**{k: v for k, v in raw.items() if k in known})
+
+    def sync_args_to_runtime_config(self, args: argparse.Namespace, config: Any) -> None:
+        """Sync CLI args into the runtime config section."""
+        if self.config_type is None:
+            return
+        rt_config = self.get_runtime_config(config)
+        rt_fields = {f.name for f in fields(rt_config)}
+        for arg_name in vars(args).keys() & rt_fields:
+            if getattr(args, arg_name) != getattr(rt_config, arg_name):
+                setattr(rt_config, arg_name, getattr(args, arg_name))
+        config.runtimes[self.config_key] = asdict(rt_config)
 
     def get_container_image(self, config: Any, gpu_type: str) -> Optional[str]:
         return None

--- a/ramalama/plugins/runtimes/inference/llama_cpp.py
+++ b/ramalama/plugins/runtimes/inference/llama_cpp.py
@@ -7,10 +7,10 @@ import os
 import platform
 import shutil
 import tempfile
-from dataclasses import asdict
+from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from http.client import HTTPConnection
-from typing import Any, Optional, get_args
+from typing import Any, Literal, Optional, get_args
 from urllib.parse import urlparse
 
 from ramalama.benchmarks.manager import BenchmarksManager
@@ -40,7 +40,7 @@ from ramalama.common import (
     set_gpu_type_env_vars,
     version_tagged_image,
 )
-from ramalama.config import GGUF_QUANTIZATION_MODES, ActiveConfig, DefaultConfig
+from ramalama.config import ActiveConfig, DefaultConfig, coerce_to_bool
 from ramalama.engine import Engine, dry_run, image_inspect
 from ramalama.logger import logger
 from ramalama.path_utils import file_uri_to_path
@@ -54,6 +54,43 @@ from ramalama.rag import RagTransport
 from ramalama.transports.api import APITransport
 from ramalama.transports.base import compute_serving_port
 from ramalama.transports.transport_factory import New, TransportFactory
+
+GGUF_QUANTIZATION_MODES = Literal[
+    "Q2_K",
+    "Q3_K_S",
+    "Q3_K_M",
+    "Q3_K_L",
+    "Q4_0",
+    "Q4_K_S",
+    "Q4_K_M",
+    "Q5_0",
+    "Q5_K_S",
+    "Q5_K_M",
+    "Q6_K",
+    "Q8_0",
+]
+DEFAULT_GGUF_QUANTIZATION_MODE: GGUF_QUANTIZATION_MODES = "Q4_K_M"  # type: ignore[assignment]
+
+
+@dataclass
+class LlamaCppConfig:
+    backend: Literal["auto", "vulkan", "rocm", "cuda", "sycl", "openvino", "cann", "musa"] = "auto"
+    cache_reuse: Optional[int] = None
+    gguf_quantization_mode: GGUF_QUANTIZATION_MODES = DEFAULT_GGUF_QUANTIZATION_MODE  # type: ignore[assignment]
+    ngl: Optional[str] = None
+    temp: float = 0.8
+    thinking: Optional[bool] = None
+    threads: int = field(default_factory=_default_threads)
+
+    def __post_init__(self):
+        if self.cache_reuse is not None:
+            self.cache_reuse = int(self.cache_reuse)
+        if self.ngl is not None:
+            self.ngl = str(self.ngl)
+        self.temp = float(self.temp)
+        self.threads = int(self.threads)
+        if self.thinking is not None:
+            self.thinking = coerce_to_bool(self.thinking)
 
 
 class AddPathOrUrl(argparse.Action):
@@ -134,6 +171,8 @@ _LLAMA_CPP_IMAGES: dict[str, str] = {
 
 
 class LlamaCppPlugin(LlamaCppCommands, ContainerizedInferenceRuntimePlugin):
+    config_type = LlamaCppConfig
+
     @property
     def name(self) -> str:
         return "llama.cpp"
@@ -231,7 +270,8 @@ class LlamaCppPlugin(LlamaCppCommands, ContainerizedInferenceRuntimePlugin):
         return True
 
     def get_container_image(self, config: Any, detected_gpu_type: str) -> Optional[str]:
-        backend = config.backend
+        rt_config = self.get_runtime_config(config)
+        backend = rt_config.backend
         if backend == "auto":
             preferences = get_gpu_backend_preferences(detected_gpu_type)
             if preferences:
@@ -271,13 +311,13 @@ class LlamaCppPlugin(LlamaCppCommands, ContainerizedInferenceRuntimePlugin):
     # --- subcommand registration ---
 
     def _add_backend_arg(self, parser: "argparse.ArgumentParser") -> None:
-        config = ActiveConfig()
+        rt_config = self.get_runtime_config(ActiveConfig())
         parser.add_argument(
             "--backend",
             dest="backend",
-            default=config.backend,
+            default=rt_config.backend,
             choices=get_available_backends(),
-            help="GPU backend to use (auto, vulkan, rocm, cuda, sycl, openvino). See man page for details.",
+            help="GPU backend to use (auto, vulkan, rocm, cuda, sycl, openvino, cann, musa). See man page for details.",
         )
 
     def _add_ngl_arg(self, parser: "argparse.ArgumentParser") -> None:
@@ -290,14 +330,15 @@ class LlamaCppPlugin(LlamaCppCommands, ContainerizedInferenceRuntimePlugin):
         )
 
     def _add_threads_arg(self, parser: "argparse.ArgumentParser") -> None:
-        def_threads = _default_threads()
+        rt_config = self.get_runtime_config(ActiveConfig())
         parser.add_argument(
             "-t",
             "--threads",
             type=int,
-            default=def_threads,
+            default=rt_config.threads,
             help=(
-                f"number of cpu threads to use, the default is {def_threads} on this system, -1 means use this default"
+                f"number of cpu threads to use, the default is {rt_config.threads} on this system,"
+                " -1 means use this default"
             ),
             completer=suppressCompleter,
         )
@@ -305,12 +346,12 @@ class LlamaCppPlugin(LlamaCppCommands, ContainerizedInferenceRuntimePlugin):
     def _add_inference_args(self, parser: "argparse.ArgumentParser", command: str) -> None:
         """Add llama.cpp-specific inference args to an already-created parser."""
         super()._add_inference_args(parser, command)
-        config = ActiveConfig()
+        rt_config = self.get_runtime_config(ActiveConfig())
         parser.add_argument(
             "--temp",
             dest="temp",
             type=float,
-            default=config.temp,
+            default=rt_config.temp,
             help="temperature of the response from the AI model",
             completer=suppressCompleter,
         )
@@ -498,6 +539,7 @@ class LlamaCppPlugin(LlamaCppCommands, ContainerizedInferenceRuntimePlugin):
 
         # convert
         config = ActiveConfig()
+        rt_config = self.get_runtime_config(config)
         convert_parser = subparsers.add_parser(
             "convert",
             help="convert AI Model from local storage to OCI Image",
@@ -508,9 +550,9 @@ class LlamaCppPlugin(LlamaCppCommands, ContainerizedInferenceRuntimePlugin):
             "--gguf",
             choices=get_args(GGUF_QUANTIZATION_MODES),
             nargs="?",
-            const=config.gguf_quantization_mode,
+            const=rt_config.gguf_quantization_mode,
             default=None,
-            help=f"GGUF quantization format. If specified without value, {config.gguf_quantization_mode} is used.",
+            help=f"GGUF quantization format. If specified without value, {rt_config.gguf_quantization_mode} is used.",
         )
         add_network_argument(convert_parser)
         convert_parser.add_argument(

--- a/ramalama/plugins/runtimes/inference/mlx.py
+++ b/ramalama/plugins/runtimes/inference/mlx.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import platform
+from dataclasses import dataclass
 from http.client import HTTPConnection
 from typing import Any, Optional
 
@@ -12,19 +13,29 @@ from ramalama.plugins.runtimes.inference.common import BaseInferenceRuntime
 from ramalama.transports.transport_factory import New
 
 
+@dataclass
+class MlxConfig:
+    temp: float = 0.8
+
+    def __post_init__(self):
+        self.temp = float(self.temp)
+
+
 class MlxPlugin(BaseInferenceRuntime):
+    config_type = MlxConfig
+
     @property
     def name(self) -> str:
         return "mlx"
 
     def _add_inference_args(self, parser: "argparse.ArgumentParser", command: str) -> None:
         super()._add_inference_args(parser, command)
-        config = ActiveConfig()
+        rt_config = self.get_runtime_config(ActiveConfig())
         parser.add_argument(
             "--temp",
             dest="temp",
             type=float,
-            default=config.temp,
+            default=rt_config.temp,
             help="temperature of the response from the AI model",
             completer=suppressCompleter,
         )

--- a/ramalama/plugins/runtimes/inference/rag/cli.py
+++ b/ramalama/plugins/runtimes/inference/rag/cli.py
@@ -1,12 +1,13 @@
 """CLI registration for the ``ramalama rag`` subcommand."""
 
 from ramalama.cli import OverrideDefaultAction, default_image, default_rag_image, local_images, suppressCompleter
+from ramalama.config import ActiveConfig
 from ramalama.plugins.runtimes.inference.llama_cpp import AddPathOrUrl
-from ramalama.plugins.runtimes.inference.llama_cpp_commands import _default_threads
 
 
 def register_rag_subcommand(plugin, subparsers):
     """Register the ``rag`` subcommand on the given subparsers action."""
+    rt_config = plugin.get_runtime_config(ActiveConfig())
     parser = subparsers.add_parser(
         "rag",
         help="convert documents to a RAG vector database and package as a container image",
@@ -75,13 +76,12 @@ def register_rag_subcommand(plugin, subparsers):
         action=OverrideDefaultAction,
         completer=local_images,
     )
-    def_threads = _default_threads()
     parser.add_argument(
         "-t",
         "--threads",
         type=int,
-        default=def_threads,
-        help=f"number of CPU threads to use (default: {def_threads})",
+        default=rt_config.threads,
+        help=f"number of CPU threads to use (default: {rt_config.threads})",
         completer=suppressCompleter,
     )
     parser.set_defaults(func=lambda args: _rag_dispatch(plugin, args))

--- a/ramalama/plugins/runtimes/inference/rag/handler.py
+++ b/ramalama/plugins/runtimes/inference/rag/handler.py
@@ -14,7 +14,6 @@ from ramalama.common import ensure_image, perror, set_accel_env_vars
 from ramalama.config import ActiveConfig
 from ramalama.plugins.interface import RuntimePlugin
 from ramalama.plugins.loader import assemble_command
-from ramalama.plugins.runtimes.inference.llama_cpp_commands import _default_threads
 from ramalama.transports.base import compute_serving_port
 from ramalama.transports.transport_factory import New
 
@@ -112,6 +111,10 @@ def rag_handler(plugin: RuntimePlugin, args: argparse.Namespace) -> None:
 
 def _build_serve_args(args, model_name, port, runtime_args=None, ctx_size=None, cache_reuse=None):
     """Build argparse.Namespace for an internal llama.cpp serve session."""
+    from ramalama.plugins.loader import get_runtime
+
+    config = ActiveConfig()
+    rt_config = get_runtime("llama.cpp").get_runtime_config(config)
     return argparse.Namespace(
         MODEL=model_name,
         subcommand="serve",
@@ -124,7 +127,7 @@ def _build_serve_args(args, model_name, port, runtime_args=None, ctx_size=None, 
         quiet=True,
         noout=True,
         image=args.image,
-        pull=getattr(args, "pull", ActiveConfig().pull),
+        pull=getattr(args, "pull", config.pull),
         network=None,
         oci_runtime=None,
         selinux=False,
@@ -141,7 +144,7 @@ def _build_serve_args(args, model_name, port, runtime_args=None, ctx_size=None, 
         ctx_size=ctx_size,
         cache_reuse=cache_reuse,
         ngl=getattr(args, "ngl", None),
-        threads=getattr(args, "threads", _default_threads()),
+        threads=getattr(args, "threads", rt_config.threads),
         temp=0.0,
         thinking=None,
         max_tokens=0,
@@ -154,7 +157,7 @@ def _build_serve_args(args, model_name, port, runtime_args=None, ctx_size=None, 
         gguf=None,
         authfile=None,
         tlsverify=True,
-        verify=ActiveConfig().verify,
+        verify=config.verify,
     )
 
 

--- a/test/e2e/test_convert.py
+++ b/test/e2e/test_convert.py
@@ -17,7 +17,7 @@ from test.e2e.utils import RamalamaExecWorkspace
 @pytest.mark.e2e
 def test_convert_custom_gguf_config():
     config = """
-    [ramalama]
+    [ramalama.runtimes.llama_cpp]
     gguf_quantization_mode="Q5_0"
     """
 

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -47,7 +47,6 @@ def test_correct_config_defaults(monkeypatch):
     assert cfg.pull in ["newer", "always"]  # depends on engine
     assert cfg.runtime == "llama.cpp"
     assert cfg.store == get_default_store()
-    assert cfg.temp == "0.8"
     assert cfg.transport == "ollama"
     assert cfg.verify is True
 
@@ -72,15 +71,8 @@ def test_config_defaults_not_set(monkeypatch):
     assert cfg.is_set("pull") is False
     assert cfg.is_set("runtime") is False
     assert cfg.is_set("store") is False
-    assert cfg.is_set("temp") is False
     assert cfg.is_set("transport") is False
     assert cfg.is_set("verify") is False
-
-
-@pytest.mark.parametrize("backend", ["auto", "vulkan", "rocm", "cuda", "sycl", "openvino"])
-def test_base_config_accepts_valid_backend(backend):
-    config = BaseConfig(backend=backend)
-    assert config.backend == backend
 
 
 def test_base_config_normalizes_pull_for_docker():

--- a/test/unit/test_config_documentation.py
+++ b/test/unit/test_config_documentation.py
@@ -47,11 +47,12 @@ def get_documented_fields_in_conf():
     documented = set()
 
     # Subsections that contain their own field documentation (these fields should not be extracted)
-    subsections_with_fields = {'benchmarks', 'http_client', 'user'}
+    subsections_with_fields = {'benchmarks', 'http_client', 'user', 'runtimes'}
 
     # Track which section we're in to exclude nested fields under commented subsections
-    in_commented_nested_section = False
-    section_pattern = r'^\s*(#?)\s*\[ramalama\.([a-z_]+)\]'
+    in_nested_section = False
+    in_nested_section_is_commented = False
+    section_pattern = r'^\s*(#?)\s*\[ramalama\.([a-z_]+)(?:\.[a-z_]+)*\]'
     main_section_pattern = r'^\s*\[ramalama\]'
     prev_line_blank = False
 
@@ -60,7 +61,7 @@ def get_documented_fields_in_conf():
 
         # Check if we're at the main [ramalama] section
         if re.match(main_section_pattern, line):
-            in_commented_nested_section = False
+            in_nested_section = False
             prev_line_blank = current_line_blank
             continue
 
@@ -71,32 +72,35 @@ def get_documented_fields_in_conf():
             section_name = section_match.group(2)
             documented.add(section_name)
             # Skip fields if it's a commented nested section OR if it's a subsection with its own fields
-            in_commented_nested_section = is_commented or (section_name in subsections_with_fields)
+            in_nested_section = is_commented or (section_name in subsections_with_fields)
+            in_nested_section_is_commented = is_commented
             prev_line_blank = current_line_blank
             continue
 
         # Check if we hit a new uncommented section (which ends any nested section)
         if re.match(r'^\s*\[', line) and not line.strip().startswith('#'):
-            in_commented_nested_section = False
+            in_nested_section = False
 
-        # If we're in a commented subsection, stay in it until we see a clear exit point
-        # Exit point: blank line followed by a comment that starts a new field's documentation
-        if in_commented_nested_section:
+        # If we're in a nested subsection, skip its fields
+        if in_nested_section:
             # If this line has a field definition, skip it
             if '=' in line:
                 prev_line_blank = current_line_blank
                 continue
-            # If previous line was blank and this is a comment (but not empty), might be exiting
-            elif prev_line_blank and line.strip().startswith('#') and line.strip() not in ['#', '']:
-                # This looks like the start of a new field's documentation, exit
-                in_commented_nested_section = False
+            elif (
+                in_nested_section_is_commented
+                and prev_line_blank
+                and line.strip().startswith('#')
+                and line.strip() not in ['#', '']
+            ):
+                in_nested_section = False
             # Otherwise stay in the section
             else:
                 prev_line_blank = current_line_blank
                 continue
 
-        # Only match fields when not in a commented nested subsection
-        if not in_commented_nested_section:
+        # Only match fields when not in a nested subsection
+        if not in_nested_section:
             match = re.match(pattern, line)
             if match:
                 field_name = match.group(1)
@@ -128,12 +132,12 @@ def get_documented_fields_in_manpage():
     documented = set()
 
     # Subsections that contain their own **field** documentation (these fields should not be extracted)
-    subsections_with_fields = {'http_client', 'user'}
+    subsections_with_fields = {'http_client', 'user', 'runtimes'}
 
     # Track which section we're in
     current_section = None
     main_section_pattern = r'^`\[\[ramalama\]\]`$'
-    section_pattern = r'^`\[\[ramalama\.([a-z_]+)\]\]`'
+    section_pattern = r'^`\[\[ramalama\.([a-z_]+)(?:\.[a-z_]+)*\]\]`'
     in_main_section = False
 
     for line in lines:

--- a/test/unit/test_inference_engine_plugins.py
+++ b/test/unit/test_inference_engine_plugins.py
@@ -18,8 +18,8 @@ from ramalama.compat import NamedTemporaryFile
 from ramalama.config import DEFAULT_IMAGE, load_config
 from ramalama.plugins.interface import InferenceRuntimePlugin
 from ramalama.plugins.runtimes.inference.common import ContainerizedInferenceRuntimePlugin
-from ramalama.plugins.runtimes.inference.llama_cpp import LlamaCppPlugin, get_available_backends
-from ramalama.plugins.runtimes.inference.mlx import MlxPlugin
+from ramalama.plugins.runtimes.inference.llama_cpp import LlamaCppConfig, LlamaCppPlugin, get_available_backends
+from ramalama.plugins.runtimes.inference.mlx import MlxConfig, MlxPlugin
 from ramalama.plugins.runtimes.inference.vllm import VllmPlugin
 
 
@@ -119,6 +119,93 @@ def make_transport_model(
     model._get_chat_template_path.return_value = chat_template_path
     model.draft_model = draft_model
     return model
+
+
+class TestLlamaCppConfig:
+    @pytest.mark.parametrize("backend", ["auto", "vulkan", "rocm", "cuda", "sycl", "openvino", "cann", "musa"])
+    def test_accepts_valid_backend(self, backend):
+        config = LlamaCppConfig(backend=backend)
+        assert config.backend == backend
+
+    def test_defaults(self):
+        config = LlamaCppConfig()
+        assert config.backend == "auto"
+        assert config.cache_reuse is None
+        assert config.ngl is None
+        assert config.temp == 0.8
+        assert config.thinking is None
+        assert config.threads > 0
+
+    def test_coerces_string_values(self):
+        config = LlamaCppConfig(ngl="4", cache_reuse="512", temp="0.5", threads="8", thinking="false")
+        assert config.ngl == "4"
+        assert config.cache_reuse == 512
+        assert config.temp == 0.5
+        assert config.threads == 8
+        assert config.thinking is False
+
+
+class TestSyncArgsToRuntimeConfig:
+    """Tests for RuntimePlugin.sync_args_to_runtime_config persistence."""
+
+    def setup_method(self):
+        self.plugin = LlamaCppPlugin()
+
+    def _make_config(self, runtimes=None):
+        config = MagicMock()
+        config.runtimes = runtimes or {}
+        return config
+
+    def test_overrides_persist_for_subsequent_get_runtime_config(self):
+        config = self._make_config()
+        args = make_ns(ngl=99, temp=0.5, threads=16, cache_reuse=512)
+        self.plugin.sync_args_to_runtime_config(args, config)
+
+        rt = self.plugin.get_runtime_config(config)
+        assert rt.ngl == "99"
+        assert rt.temp == 0.5
+        assert rt.threads == 16
+        assert rt.cache_reuse == 512
+
+    def test_preserves_existing_values_when_args_match(self):
+        defaults = LlamaCppConfig()
+        config = self._make_config()
+        args = make_ns(ngl=defaults.ngl, temp=float(defaults.temp), cache_reuse=defaults.cache_reuse)
+        self.plugin.sync_args_to_runtime_config(args, config)
+
+        rt = self.plugin.get_runtime_config(config)
+        assert rt.ngl == defaults.ngl
+        assert rt.cache_reuse == defaults.cache_reuse
+
+    def test_merges_with_preexisting_runtime_config(self):
+        config = self._make_config(runtimes={"llama_cpp": {"backend": "cuda", "ngl": 10}})
+        args = make_ns(ngl=42)
+        self.plugin.sync_args_to_runtime_config(args, config)
+
+        rt = self.plugin.get_runtime_config(config)
+        assert rt.ngl == "42"
+        assert rt.backend == "cuda"
+
+    def test_ignores_args_not_in_runtime_config(self):
+        config = self._make_config()
+        args = make_ns(port="9999", host="0.0.0.0")
+        self.plugin.sync_args_to_runtime_config(args, config)
+
+        rt = self.plugin.get_runtime_config(config)
+        assert not hasattr(rt, "port")
+        assert not hasattr(rt, "host")
+
+    def test_unknown_fields_in_config_are_ignored(self):
+        config = self._make_config(runtimes={"llama_cpp": {"backend": "cuda", "bogus": 123}})
+        rt = self.plugin.get_runtime_config(config)
+        assert rt.backend == "cuda"
+        assert not hasattr(rt, "bogus")
+
+    @pytest.mark.parametrize("bad_value", ["cuda", 42, ["a", "b"], True])
+    def test_non_mapping_runtime_config_raises(self, bad_value):
+        config = self._make_config(runtimes={"llama_cpp": bad_value})
+        with pytest.raises(ValueError, match=r"config\.runtimes\.llama_cpp must be a mapping"):
+            self.plugin.get_runtime_config(config)
 
 
 class TestLlamaCppPlugin:
@@ -488,14 +575,14 @@ class TestLlamaCppPlugin:
 
     def test_get_container_image_cuda(self):
         config = MagicMock()
-        config.backend = "auto"
+        config.runtimes = {"llama_cpp": {"backend": "auto"}}
         config.images.get.return_value = None
         image = self.plugin.get_container_image(config, "CUDA_VISIBLE_DEVICES")
         assert image == version_tagged_image("quay.io/ramalama/cuda")
 
     def test_get_container_image_no_gpu(self):
         config = MagicMock()
-        config.backend = "auto"
+        config.runtimes = {"llama_cpp": {"backend": "auto"}}
         config.images.get.return_value = None
         config.default_image = version_tagged_image("quay.io/ramalama/ramalama")
         image = self.plugin.get_container_image(config, "")
@@ -503,7 +590,7 @@ class TestLlamaCppPlugin:
 
     def test_get_container_image_user_override(self):
         config = MagicMock()
-        config.backend = "auto"
+        config.runtimes = {"llama_cpp": {"backend": "auto"}}
         config.images.get.side_effect = lambda key, default=None: {
             "CUDA_VISIBLE_DEVICES": "custom/cuda:v1.0",
         }.get(key, default)
@@ -619,6 +706,17 @@ class TestVllmPlugin:
         ns = make_rag_gen_ns()
         with pytest.raises(NotImplementedError):
             self.plugin.handle_subcommand("rag", ns)
+
+
+class TestMlxConfig:
+    def test_defaults(self):
+        config = MlxConfig()
+        assert config.temp == 0.8
+
+    def test_coerces_string_values(self):
+        config = MlxConfig(temp="0.5")
+        assert config.temp == 0.5
+        assert isinstance(config.temp, float)
 
 
 class TestMlxPlugin:
@@ -970,6 +1068,11 @@ class TestConfigureSubcommandsFiltering:
         ("cuda", "CUDA_VISIBLE_DEVICES", version_tagged_image("quay.io/ramalama/cuda")),
         ("sycl", "INTEL_VISIBLE_DEVICES", version_tagged_image("quay.io/ramalama/intel-gpu")),
         ("openvino", "INTEL_VISIBLE_DEVICES", version_tagged_image("quay.io/ramalama/openvino")),
+        # Ascend and MUSA backends
+        ("cann", "ASCEND_VISIBLE_DEVICES", version_tagged_image("quay.io/ramalama/cann")),
+        ("auto", "ASCEND_VISIBLE_DEVICES", version_tagged_image("quay.io/ramalama/cann")),
+        ("musa", "MUSA_VISIBLE_DEVICES", version_tagged_image("quay.io/ramalama/musa")),
+        ("auto", "MUSA_VISIBLE_DEVICES", version_tagged_image("quay.io/ramalama/musa")),
         # Force backend even with different GPU (warns but allows)
         ("rocm", "CUDA_VISIBLE_DEVICES", version_tagged_image("quay.io/ramalama/rocm")),
         ("cuda", "HIP_VISIBLE_DEVICES", version_tagged_image("quay.io/ramalama/cuda")),
@@ -982,7 +1085,7 @@ def test_backend_selection(backend: str, gpu_env: str, expected_result: str, mon
 
     with NamedTemporaryFile('w', delete_on_close=False) as f:
         f.write(f"""\
-[ramalama]
+[ramalama.runtimes.llama_cpp]
 backend = "{backend}"
             """)
         f.flush()
@@ -1025,7 +1128,7 @@ def test_backend_selection_windows(backend: str, gpu_env: str, expected_result: 
 
     with NamedTemporaryFile('w', delete_on_close=False) as f:
         f.write(f"""\
-[ramalama]
+[ramalama.runtimes.llama_cpp]
 backend = "{backend}"
             """)
         f.flush()
@@ -1069,8 +1172,10 @@ def test_vllm_backend_image_selection(gpu_env: str, backend: str, expected_image
     with NamedTemporaryFile('w', delete_on_close=False) as f:
         f.write(f"""\
 [ramalama]
-backend = "{backend}"
 runtime = "vllm"
+
+[ramalama.runtimes.llama_cpp]
+backend = "{backend}"
             """)
         f.flush()
 
@@ -1096,7 +1201,7 @@ def test_backend_incompatibility_warning(monkeypatch):
 
     with NamedTemporaryFile('w', delete_on_close=False) as f:
         f.write("""\
-[ramalama]
+[ramalama.runtimes.llama_cpp]
 backend = "cuda"
             """)
         f.flush()
@@ -1131,6 +1236,8 @@ backend = "cuda"
         ("CUDA_VISIBLE_DEVICES", ["auto", "cuda"]),  # NVIDIA
         ("INTEL_VISIBLE_DEVICES", ["auto", "vulkan", "sycl", "openvino"]),  # Intel (Vulkan preferred)
         ("ASAHI_VISIBLE_DEVICES", ["auto", "vulkan"]),  # Asahi
+        ("ASCEND_VISIBLE_DEVICES", ["auto", "cann"]),  # Ascend
+        ("MUSA_VISIBLE_DEVICES", ["auto", "musa"]),  # MUSA
         (None, ["auto", "vulkan"]),  # No GPU
     ],
 )


### PR DESCRIPTION
Follow-up to #2456: the inference runtime command line arg parsing and container command building logic has been refactored into plugins but the runtime specific config params remained in the global config object.

This adds a method for plugins to register their own config sub types and construct them from the raw config passed through by the global config.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>