### PR TITLE
feat: add --caption-images flag for VLM-based image description in RAG

### DIFF
--- a/container-images/scripts/doc2rag
+++ b/container-images/scripts/doc2rag
@@ -145,7 +145,7 @@ class GraniteDoclingConverter:
 # ---------------------------------------------------------------------------
 # Token-aware document chunking (semchunk + tiktoken)
 # ---------------------------------------------------------------------------
-def chunk_documents(docs, max_tokens=400):
+def chunk_documents(docs, max_tokens=400, captioner=None):
     """Chunk a mixed list of DoclingDocument objects and raw text strings.
 
     Uses semchunk (the same splitter docling's HybridChunker uses internally)
@@ -170,7 +170,7 @@ def chunk_documents(docs, max_tokens=400):
         if isinstance(doc, str):
             text = doc
         else:
-            text = _docling_doc_to_text(doc, SectionHeaderItem, TitleItem)
+            text = _docling_doc_to_text(doc, SectionHeaderItem, TitleItem, captioner=captioner)
 
         if not text.strip():
             continue
@@ -188,13 +188,80 @@ def chunk_documents(docs, max_tokens=400):
     return chunks, ids, doc_ids, chunk_indices
 
 
-def _docling_doc_to_text(doc, SectionHeaderItem, TitleItem):
+class ImageCaptioner:
+    """Describe images via a general-purpose VLM (e.g. Gemma 4)."""
+
+    def __init__(self, api_url):
+        self.completions_url = f"{api_url.rstrip('/')}/v1/chat/completions"
+        self.count = 0
+
+    def caption(self, pil_image):
+        self.count += 1
+        sys.stderr.write(f"\r  Captioning image {self.count}...")
+        sys.stderr.flush()
+        buf = io.BytesIO()
+        pil_image.save(buf, format="PNG")
+        image_b64 = base64.b64encode(buf.getvalue()).decode("utf-8")
+
+        payload = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{image_b64}"}},
+                        {"type": "text", "text": "Describe this image in detail. Include all visible text, data, and visual elements."},
+                    ],
+                }
+            ],
+            "max_tokens": 1024,
+            "temperature": 0.0,
+        }
+
+        req = Request(
+            self.completions_url,
+            data=json.dumps(payload).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+        )
+        try:
+            with urlopen(req, timeout=300) as resp:
+                result = json.loads(resp.read())
+        except HTTPError as e:
+            body = e.read().decode("utf-8", errors="replace")
+            logger.warning("Caption request failed (%s): %s", e.code, body)
+            return None
+
+        choices = result.get("choices")
+        if not choices:
+            logger.warning("Caption request returned no choices: %s", result)
+            return None
+
+        return choices[0]["message"]["content"]
+
+
+def _docling_doc_to_text(doc, SectionHeaderItem, TitleItem, captioner=None):
     """Serialize a DoclingDocument to markdown-like text for chunking."""
+    from docling_core.types.doc.document import PictureItem
+
     parts = []
     for item, _level in doc.iterate_items():
         if isinstance(item, (TitleItem, SectionHeaderItem)):
             if item.text:
                 parts.append(f"\n{'#' * min(_level + 1, 6)} {item.text.strip()}\n")
+        elif isinstance(item, PictureItem) and captioner and item.image:
+            description = None
+            try:
+                pil_image = item.image.pil_image
+                if pil_image:
+                    description = captioner.caption(pil_image)
+            except Exception as e:
+                logger.warning("Failed to caption image: %s", e)
+
+            if description:
+                parts.append(f"\n[Image: {description.strip()}]\n")
+            elif getattr(item, "text", None):
+                text = item.text.strip()
+                if text:
+                    parts.append(text)
         elif hasattr(item, "text") and item.text:
             text = item.text.strip()
             if text:
@@ -437,10 +504,16 @@ def run_pipeline(args):
     if not docs:
         raise ValueError("No documents were successfully converted")
 
+    # Set up image captioner if a caption URL is provided
+    caption_url = getattr(args, "caption_url", None)
+    captioner = ImageCaptioner(api_url=caption_url) if caption_url else None
+
     # Chunk
-    perror("Chunking documents...")
+    perror("Chunking and captioning documents..." if captioner else "Chunking documents...")
     chunk_size = getattr(args, "chunk_size", 400)
-    chunks, ids, doc_ids, chunk_indices = chunk_documents(docs, max_tokens=chunk_size)
+    chunks, ids, doc_ids, chunk_indices = chunk_documents(docs, max_tokens=chunk_size, captioner=captioner)
+    if captioner and captioner.count > 0:
+        sys.stderr.write("\n")
     perror(f"  {len(chunks)} chunks created")
 
     # Embed and store
@@ -464,6 +537,7 @@ parser.add_argument("--embed-url", dest="embed_url", help="URL of the llama.cpp 
 parser.add_argument("--embed-model", dest="embed_model", help="Name of the embedding model (stored in metadata)")
 parser.add_argument("--chunk-size", dest="chunk_size", type=int, default=400, help="Max tokens per chunk (default: 400)")
 parser.add_argument("--ctx-size", dest="ctx_size", type=int, default=8192, help="Context size of the VLM server (default: 8192)")
+parser.add_argument("--caption-url", dest="caption_url", help="URL of a VLM server for image captioning (e.g. Gemma 4)")
 parser.add_argument("output", help="Output directory for the Qdrant database")
 parser.add_argument("sources", nargs="+", help="Source files or directories to process")
 

--- a/docs/ramalama-rag.1.md
+++ b/docs/ramalama-rag.1.md
@@ -39,6 +39,12 @@ positional arguments:
 
 ## OPTIONS
 
+#### **--caption-images**=*MODEL*
+Enable image captioning via a VLM to describe charts, diagrams, and photos
+found in documents.  When enabled, a third llama.cpp server is started to
+generate text descriptions of images before chunking.  The model argument
+is optional (default: hf://unsloth/gemma-4-E2B-it-GGUF).
+
 #### **--chunk-size**=*integer*
 Maximum tokens per chunk for embedding (default: 400). Smaller chunks
 are faster to embed but may lose context; larger chunks preserve more

--- a/ramalama/plugins/runtimes/inference/llama_cpp.py
+++ b/ramalama/plugins/runtimes/inference/llama_cpp.py
@@ -409,7 +409,7 @@ class LlamaCppPlugin(LlamaCppCommands, ContainerizedInferenceRuntimePlugin):
         finally:
             from ramalama.plugins.runtimes.inference.rag.handler import _cleanup_servers
 
-            _cleanup_servers(args, embed_serve_args, None, embed_proc, None)
+            _cleanup_servers(args, [embed_serve_args], [embed_proc])
 
     def _serve_rag(self, args: argparse.Namespace, model: Any) -> None:
         if not args.container:
@@ -423,7 +423,7 @@ class LlamaCppPlugin(LlamaCppCommands, ContainerizedInferenceRuntimePlugin):
         finally:
             from ramalama.plugins.runtimes.inference.rag.handler import _cleanup_servers
 
-            _cleanup_servers(args, embed_serve_args, None, embed_proc, None)
+            _cleanup_servers(args, [embed_serve_args], [embed_proc])
 
     def _start_rag_embedding_server(self, args):
         """Start a llama.cpp embedding server for RAG inference and set embed_url on args."""

--- a/ramalama/plugins/runtimes/inference/llama_cpp.py
+++ b/ramalama/plugins/runtimes/inference/llama_cpp.py
@@ -449,7 +449,7 @@ class LlamaCppPlugin(LlamaCppCommands, ContainerizedInferenceRuntimePlugin):
         finally:
             from ramalama.plugins.runtimes.inference.rag.handler import _cleanup_servers
 
-            _cleanup_servers(args, embed_serve_args, None, embed_proc, None)
+            _cleanup_servers(args, [embed_serve_args], [embed_proc])
 
     def _serve_rag(self, args: argparse.Namespace, model: Any) -> None:
         if not args.container:
@@ -463,7 +463,7 @@ class LlamaCppPlugin(LlamaCppCommands, ContainerizedInferenceRuntimePlugin):
         finally:
             from ramalama.plugins.runtimes.inference.rag.handler import _cleanup_servers
 
-            _cleanup_servers(args, embed_serve_args, None, embed_proc, None)
+            _cleanup_servers(args, [embed_serve_args], [embed_proc])
 
     def _start_rag_embedding_server(self, args):
         """Start a llama.cpp embedding server for RAG inference and set embed_url on args."""

--- a/ramalama/plugins/runtimes/inference/llama_cpp_commands.py
+++ b/ramalama/plugins/runtimes/inference/llama_cpp_commands.py
@@ -233,6 +233,10 @@ class LlamaCppCommands:
         if ctx_size:
             cmd += ["--ctx-size", str(ctx_size)]
 
+        caption_url = getattr(args, 'caption_url', None)
+        if caption_url:
+            cmd += ["--caption-url", str(caption_url)]
+
         cmd.append("/output")
 
         if getattr(args, 'PATHS', None) and getattr(args, 'inputdir', None):

--- a/ramalama/plugins/runtimes/inference/llama_cpp_commands.py
+++ b/ramalama/plugins/runtimes/inference/llama_cpp_commands.py
@@ -235,6 +235,10 @@ class LlamaCppCommands:
         if ctx_size:
             cmd += ["--ctx-size", str(ctx_size)]
 
+        caption_url = getattr(args, 'caption_url', None)
+        if caption_url:
+            cmd += ["--caption-url", str(caption_url)]
+
         cmd.append("/output")
 
         if getattr(args, 'PATHS', None) and getattr(args, 'inputdir', None):

--- a/ramalama/plugins/runtimes/inference/rag/cli.py
+++ b/ramalama/plugins/runtimes/inference/rag/cli.py
@@ -3,6 +3,7 @@
 from ramalama.cli import OverrideDefaultAction, default_image, default_rag_image, local_images, suppressCompleter
 from ramalama.plugins.runtimes.inference.llama_cpp import AddPathOrUrl
 from ramalama.plugins.runtimes.inference.llama_cpp_commands import _NGL_DEFAULT, _default_threads
+from ramalama.plugins.runtimes.inference.rag.handler import DEFAULT_CAPTION_MODEL
 
 
 def register_rag_subcommand(plugin, subparsers):
@@ -75,6 +76,16 @@ def register_rag_subcommand(plugin, subparsers):
         help="OCI container image for the RAG processing container",
         action=OverrideDefaultAction,
         completer=local_images,
+    )
+    parser.add_argument(
+        "--caption-images",
+        dest="caption_images",
+        nargs="?",
+        const=DEFAULT_CAPTION_MODEL,
+        default=None,
+        metavar="MODEL",
+        help=f"enable image captioning via a VLM (default model: {DEFAULT_CAPTION_MODEL})",
+        completer=suppressCompleter,
     )
     def_threads = _default_threads()
     parser.add_argument(

--- a/ramalama/plugins/runtimes/inference/rag/cli.py
+++ b/ramalama/plugins/runtimes/inference/rag/cli.py
@@ -3,6 +3,7 @@
 from ramalama.cli import OverrideDefaultAction, default_image, default_rag_image, local_images, suppressCompleter
 from ramalama.config import ActiveConfig
 from ramalama.plugins.runtimes.inference.llama_cpp import AddPathOrUrl
+from ramalama.plugins.runtimes.inference.rag.handler import DEFAULT_CAPTION_MODEL
 
 
 def register_rag_subcommand(plugin, subparsers):
@@ -75,6 +76,16 @@ def register_rag_subcommand(plugin, subparsers):
         help="OCI container image for the RAG processing container",
         action=OverrideDefaultAction,
         completer=local_images,
+    )
+    parser.add_argument(
+        "--caption-images",
+        dest="caption_images",
+        nargs="?",
+        const=DEFAULT_CAPTION_MODEL,
+        default=None,
+        metavar="MODEL",
+        help=f"enable image captioning via a VLM (default model: {DEFAULT_CAPTION_MODEL})",
+        completer=suppressCompleter,
     )
     parser.add_argument(
         "-t",

--- a/ramalama/plugins/runtimes/inference/rag/handler.py
+++ b/ramalama/plugins/runtimes/inference/rag/handler.py
@@ -1,7 +1,7 @@
 """RAG subcommand handler for the llama.cpp plugin.
 
-Orchestrates two containers:
-  1. llama.cpp containers serving VLM (Granite Docling) and embedding (EmbeddingGemma) models
+Orchestrates containers:
+  1. llama.cpp containers serving VLM (Granite Docling), embedding, and optionally a captioning VLM
   2. A lightweight RAG container running doc2rag to convert, chunk, embed, and store documents
 """
 
@@ -13,11 +13,13 @@ from ramalama.common import ensure_image, perror, set_accel_env_vars
 from ramalama.config import ActiveConfig
 from ramalama.plugins.loader import assemble_command
 from ramalama.plugins.runtimes.inference.llama_cpp_commands import _NGL_DEFAULT, _default_threads
+from ramalama.transports.api import APITransport
 from ramalama.transports.base import compute_serving_port
 from ramalama.transports.transport_factory import New
 
 IMAGE_PARSER_MODEL = "hf://ibm-granite/granite-docling-258M-GGUF"
 EMBEDDING_MODEL = "hf://unsloth/embeddinggemma-300m-GGUF"
+DEFAULT_CAPTION_MODEL = "hf://unsloth/gemma-4-E2B-it-GGUF"
 
 
 def rag_handler(plugin, args: argparse.Namespace) -> None:
@@ -29,12 +31,23 @@ def rag_handler(plugin, args: argparse.Namespace) -> None:
 
     docling_model = getattr(args, "docling_model", IMAGE_PARSER_MODEL)
     embedding_model = EMBEDDING_MODEL
+    caption_model = getattr(args, "caption_images", None)
+    if caption_model:
+        perror(f"Image captioning enabled ({caption_model})")
 
     set_accel_env_vars()
 
-    # Allocate ports for both llama.cpp servers
+    # Allocate ports for all llama.cpp servers
+    allocated_ports = []
     docling_port = compute_serving_port(args, quiet=True)
-    embed_port = compute_serving_port(args, quiet=True, exclude=[docling_port])
+    allocated_ports.append(docling_port)
+    embed_port = compute_serving_port(args, quiet=True, exclude=allocated_ports)
+    allocated_ports.append(embed_port)
+
+    caption_port = None
+    if caption_model:
+        caption_port = compute_serving_port(args, quiet=True, exclude=allocated_ports)
+        allocated_ports.append(caption_port)
 
     # Build serve args for the VLM and embedding servers
     vlm_ctx_size = getattr(args, "ctx_size", 8192)
@@ -51,11 +64,22 @@ def rag_handler(plugin, args: argparse.Namespace) -> None:
         cache_reuse=0,
     )
 
+    caption_serve_args = None
+    if caption_model and caption_port:
+        caption_serve_args = _build_serve_args(args, caption_model, caption_port, ctx_size=vlm_ctx_size, cache_reuse=0)
+
     # Pull models
     docling_transport = New(docling_model, docling_serve_args)
     docling_transport.ensure_model_exists(docling_serve_args)
     embed_transport = New(embedding_model, embed_serve_args)
     embed_transport.ensure_model_exists(embed_serve_args)
+
+    caption_transport = None
+    if caption_model and caption_serve_args:
+        caption_transport = New(caption_model, caption_serve_args)
+        if isinstance(caption_transport, APITransport):
+            raise ValueError(f"caption model {caption_model} resolved to an API transport, which cannot serve locally")
+        caption_transport.ensure_model_exists(caption_serve_args)
 
     # Start llama.cpp servers
     docling_cmd = assemble_command(docling_serve_args)
@@ -63,17 +87,28 @@ def rag_handler(plugin, args: argparse.Namespace) -> None:
 
     docling_proc = None
     embed_proc = None
+    caption_proc = None
+    all_serve_args = [docling_serve_args, embed_serve_args]
     try:
         perror("Starting VLM server...")
         docling_proc = docling_transport.serve_nonblocking(docling_serve_args, docling_cmd)  # type: ignore[union-attr]
         perror("Starting embedding server...")
         embed_proc = embed_transport.serve_nonblocking(embed_serve_args, embed_cmd)  # type: ignore[union-attr]
 
+        if caption_transport and caption_serve_args:
+            caption_cmd = assemble_command(caption_serve_args)
+            perror("Starting image captioning server...")
+            caption_proc = caption_transport.serve_nonblocking(caption_serve_args, caption_cmd)  # type: ignore[union-attr]
+            all_serve_args.append(caption_serve_args)
+
         if not args.dryrun:
             _wait_for_server("127.0.0.1", int(docling_port))
             perror("VLM server is ready.")
             _wait_for_server("127.0.0.1", int(embed_port))
             perror("Embedding server is ready.")
+            if caption_port:
+                _wait_for_server("127.0.0.1", int(caption_port))
+                perror("Caption server is ready.")
 
         # Determine the host URL the RAG container will use to reach llama.cpp
         if args.engine == "podman":
@@ -83,6 +118,7 @@ def rag_handler(plugin, args: argparse.Namespace) -> None:
 
         api_url = f"http://{llm_host}:{docling_port}"
         embed_url = f"http://{llm_host}:{embed_port}"
+        caption_url = f"http://{llm_host}:{caption_port}" if caption_port else None
 
         # Run doc2rag in the RAG container
         rag = Rag(args.DESTINATION)
@@ -91,6 +127,7 @@ def rag_handler(plugin, args: argparse.Namespace) -> None:
         args.api_url = api_url
         args.embed_url = embed_url
         args.embed_model = embedding_model
+        args.caption_url = caption_url
         args.nocapdrop = True
 
         # Use the rag image for the doc2rag container
@@ -105,7 +142,7 @@ def rag_handler(plugin, args: argparse.Namespace) -> None:
 
         rag.generate(args, assemble_command(args))
     finally:
-        _cleanup_servers(args, docling_serve_args, embed_serve_args, docling_proc, embed_proc)
+        _cleanup_servers(args, all_serve_args, [docling_proc, embed_proc, caption_proc])
 
 
 def _build_serve_args(args, model_name, port, runtime_args=None, ctx_size=8192, cache_reuse=256):
@@ -174,11 +211,11 @@ def _wait_for_server(host, port, timeout=180):
     raise TimeoutError(f"Server at {host}:{port} did not become ready within {timeout}s")
 
 
-def _cleanup_servers(args, docling_serve_args, embed_serve_args, docling_proc, embed_proc):
+def _cleanup_servers(args, all_serve_args, all_procs):
     """Stop llama.cpp server containers and terminate any lingering processes."""
     from ramalama.engine import stop_container
 
-    for serve_args in [docling_serve_args, embed_serve_args]:
+    for serve_args in all_serve_args:
         name = getattr(serve_args, "name", None)
         if name:
             try:
@@ -188,6 +225,6 @@ def _cleanup_servers(args, docling_serve_args, embed_serve_args, docling_proc, e
                 from ramalama.logger import logger
 
                 logger.debug(f"Failed to stop container {name}: {e}")
-    for proc in [docling_proc, embed_proc]:
+    for proc in all_procs:
         if proc is not None and proc.poll() is None:
             proc.terminate()

--- a/ramalama/plugins/runtimes/inference/rag/handler.py
+++ b/ramalama/plugins/runtimes/inference/rag/handler.py
@@ -1,7 +1,7 @@
 """RAG subcommand handler for the llama.cpp plugin.
 
-Orchestrates two containers:
-  1. llama.cpp containers serving VLM (Granite Docling) and embedding (EmbeddingGemma) models
+Orchestrates containers:
+  1. llama.cpp containers serving VLM (Granite Docling), embedding, and optionally a captioning VLM
   2. A lightweight RAG container running doc2rag to convert, chunk, embed, and store documents
 """
 
@@ -14,11 +14,13 @@ from ramalama.common import ensure_image, perror, set_accel_env_vars
 from ramalama.config import ActiveConfig
 from ramalama.plugins.interface import RuntimePlugin
 from ramalama.plugins.loader import assemble_command
+from ramalama.transports.api import APITransport
 from ramalama.transports.base import compute_serving_port
 from ramalama.transports.transport_factory import New
 
 IMAGE_PARSER_MODEL = "hf://ibm-granite/granite-docling-258M-GGUF"
 EMBEDDING_MODEL = "hf://unsloth/embeddinggemma-300m-GGUF"
+DEFAULT_CAPTION_MODEL = "hf://unsloth/gemma-4-E2B-it-GGUF"
 
 
 def rag_handler(plugin: RuntimePlugin, args: argparse.Namespace) -> None:
@@ -30,12 +32,23 @@ def rag_handler(plugin: RuntimePlugin, args: argparse.Namespace) -> None:
 
     docling_model = getattr(args, "docling_model", IMAGE_PARSER_MODEL)
     embedding_model = EMBEDDING_MODEL
+    caption_model = getattr(args, "caption_images", None)
+    if caption_model:
+        perror(f"Image captioning enabled ({caption_model})")
 
     set_accel_env_vars()
 
-    # Allocate ports for both llama.cpp servers
+    # Allocate ports for all llama.cpp servers
+    allocated_ports = []
     docling_port = compute_serving_port(args, quiet=True)
-    embed_port = compute_serving_port(args, quiet=True, exclude=[docling_port])
+    allocated_ports.append(docling_port)
+    embed_port = compute_serving_port(args, quiet=True, exclude=allocated_ports)
+    allocated_ports.append(embed_port)
+
+    caption_port = None
+    if caption_model:
+        caption_port = compute_serving_port(args, quiet=True, exclude=allocated_ports)
+        allocated_ports.append(caption_port)
 
     # Build serve args for the VLM and embedding servers
     vlm_ctx_size = getattr(args, "ctx_size", 8192)
@@ -52,11 +65,22 @@ def rag_handler(plugin: RuntimePlugin, args: argparse.Namespace) -> None:
         cache_reuse=0,
     )
 
+    caption_serve_args = None
+    if caption_model and caption_port:
+        caption_serve_args = _build_serve_args(args, caption_model, caption_port, ctx_size=vlm_ctx_size, cache_reuse=0)
+
     # Pull models
     docling_transport = New(docling_model, docling_serve_args)
     docling_transport.ensure_model_exists(docling_serve_args)
     embed_transport = New(embedding_model, embed_serve_args)
     embed_transport.ensure_model_exists(embed_serve_args)
+
+    caption_transport = None
+    if caption_model and caption_serve_args:
+        caption_transport = New(caption_model, caption_serve_args)
+        if isinstance(caption_transport, APITransport):
+            raise ValueError(f"caption model {caption_model} resolved to an API transport, which cannot serve locally")
+        caption_transport.ensure_model_exists(caption_serve_args)
 
     # Start llama.cpp servers
     docling_cmd = assemble_command(docling_serve_args)
@@ -64,17 +88,28 @@ def rag_handler(plugin: RuntimePlugin, args: argparse.Namespace) -> None:
 
     docling_proc = None
     embed_proc = None
+    caption_proc = None
+    all_serve_args = [docling_serve_args, embed_serve_args]
     try:
         perror("Starting VLM server...")
         docling_proc = docling_transport.serve_nonblocking(docling_serve_args, docling_cmd)  # type: ignore[union-attr]
         perror("Starting embedding server...")
         embed_proc = embed_transport.serve_nonblocking(embed_serve_args, embed_cmd)  # type: ignore[union-attr]
 
+        if caption_transport and caption_serve_args:
+            caption_cmd = assemble_command(caption_serve_args)
+            perror("Starting image captioning server...")
+            caption_proc = caption_transport.serve_nonblocking(caption_serve_args, caption_cmd)  # type: ignore[union-attr]
+            all_serve_args.append(caption_serve_args)
+
         if not args.dryrun:
             _wait_for_server(plugin, docling_serve_args, docling_transport.model_alias)
             perror("VLM server is ready.")
             _wait_for_server(plugin, embed_serve_args, embed_transport.model_alias)
             perror("Embedding server is ready.")
+            if caption_transport and caption_serve_args:
+                _wait_for_server(plugin, caption_serve_args, caption_transport.model_alias)
+                perror("Caption server is ready.")
 
         # Determine the host URL the RAG container will use to reach llama.cpp
         if args.engine == "podman":
@@ -84,6 +119,7 @@ def rag_handler(plugin: RuntimePlugin, args: argparse.Namespace) -> None:
 
         api_url = f"http://{llm_host}:{docling_port}"
         embed_url = f"http://{llm_host}:{embed_port}"
+        caption_url = f"http://{llm_host}:{caption_port}" if caption_port else None
 
         # Run doc2rag in the RAG container
         rag = Rag(args.DESTINATION)
@@ -92,6 +128,7 @@ def rag_handler(plugin: RuntimePlugin, args: argparse.Namespace) -> None:
         args.api_url = api_url
         args.embed_url = embed_url
         args.embed_model = embedding_model
+        args.caption_url = caption_url
         args.nocapdrop = True
 
         # Use the rag image for the doc2rag container
@@ -108,7 +145,7 @@ def rag_handler(plugin: RuntimePlugin, args: argparse.Namespace) -> None:
 
         rag.generate(args, assemble_command(args))
     finally:
-        _cleanup_servers(args, docling_serve_args, embed_serve_args, docling_proc, embed_proc)
+        _cleanup_servers(args, all_serve_args, [docling_proc, embed_proc, caption_proc])
 
 
 def _build_serve_args(args, model_name, port, runtime_args=None, ctx_size=None, cache_reuse=None):
@@ -181,11 +218,11 @@ def _wait_for_server(plugin: RuntimePlugin, args: argparse.Namespace, model_alia
     raise TimeoutError(f"Server {args.name} did not become ready on port {args.port} within {timeout}s")
 
 
-def _cleanup_servers(args, docling_serve_args, embed_serve_args, docling_proc, embed_proc):
+def _cleanup_servers(args, all_serve_args, all_procs):
     """Stop llama.cpp server containers and terminate any lingering processes."""
     from ramalama.engine import stop_container
 
-    for serve_args in [docling_serve_args, embed_serve_args]:
+    for serve_args in all_serve_args:
         name = getattr(serve_args, "name", None)
         if name:
             try:
@@ -195,6 +232,6 @@ def _cleanup_servers(args, docling_serve_args, embed_serve_args, docling_proc, e
                 from ramalama.logger import logger
 
                 logger.debug(f"Failed to stop container {name}: {e}")
-    for proc in [docling_proc, embed_proc]:
+    for proc in all_procs:
         if proc is not None and proc.poll() is None:
             proc.terminate()


### PR DESCRIPTION
## Summary
- Adds `--caption-images [MODEL]` flag to `ramalama rag` that optionally starts a third llama.cpp server running a general-purpose VLM (default: Gemma 4) to describe charts, diagrams, and photos found in documents
- Image descriptions are injected as `[Image: ...]` text into the document before chunking, improving RAG retrieval for image-heavy content
- Consolidates captioning into a single flag: `--caption-images` uses the default model, `--caption-images hf://some/model` uses a custom one
- Refactors `_cleanup_servers()` to accept lists of servers/processes, supporting a variable number of containers
- Guards against empty VLM API responses and rejects API transport models that cannot serve locally

## Test plan
- [ ] Run `ramalama rag --caption-images ./docs/ myrag:latest` with documents containing images and verify captions appear in chunked text
- [ ] Run `ramalama rag ./docs/ myrag:latest` without `--caption-images` and verify no captioning server is started (backward compatible)
- [ ] Run `ramalama rag --caption-images hf://some/other-model ./docs/ myrag:latest` to verify custom model override works
- [ ] Verify cleanup correctly stops all containers including the caption server

🤖 Generated with [Claude Code](https://claude.com/claude-code)