### PR TITLE
stack: set INFERENCE_MODEL to model_alias

### DIFF
--- a/ramalama/stack.py
+++ b/ramalama/stack.py
@@ -75,7 +75,7 @@ class Stack:
         - name: RAMALAMA_URL
           value: http://127.0.0.1:{self.model_port}
         - name: INFERENCE_MODEL
-          value: {self.model.model_name}""",
+          value: \"{self.model.model_alias}\"""",
             "port_string": f"""\
         ports:
         - containerPort: 8321
@@ -141,7 +141,7 @@ class Stack:
       - "{stack_port}:8123"
     environment:{compose_env}
       - RAMALAMA_URL=http://{self.name}:{self.model_port}
-      - INFERENCE_MODEL={self.model.model_alias}
+      - INFERENCE_MODEL="{self.model.model_alias}"
     depends_on:
       - {self.model.model_name}
     restart: unless-stopped"""


### PR DESCRIPTION
`INFERENCE_MODEL` must match the model served by `ramalama`, which is the alias.