### PR TITLE
fix: use model_alias for INFERENCE_MODEL in llama-stack pod

### DIFF
--- a/ramalama/stack.py
+++ b/ramalama/stack.py
@@ -75,7 +75,7 @@ class Stack:
         - name: RAMALAMA_URL
           value: http://127.0.0.1:{self.model_port}
         - name: INFERENCE_MODEL
-          value: {self.model.model_name}""",
+          value: {self.model.model_alias}""",
             "port_string": f"""\
         ports:
         - containerPort: 8321


### PR DESCRIPTION
## Summary

- Fix `INFERENCE_MODEL` env var in llama-stack pod to use `model_alias` instead of `model_name`, matching what `llama-server --alias` reports

## Problem

The llama-stack provider fails with:
```
ValueError: Model granite3.1-dense is not being served. Available models: library/granite3.1-dense
```

The `--alias` flag in `llama-server` uses `model.model_alias` (e.g., `library/granite3.1-dense`), but `INFERENCE_MODEL` was set to `model.model_name` (e.g., `granite3.1-dense`).

## Test plan

- [ ] `ramalama serve --port 8085 --api llama-stack --name granite-service -d granite`
- [ ] `curl http://localhost:8085/v1/openai/v1/models` returns the model
- [ ] `curl http://localhost:8085/v1/openai/v1/chat/completions` with inference request succeeds

Fixes #2668