### PR TITLE
fix: restore --jinja/--no-jinja flags in llama.cpp command builder

### DIFF
--- a/ramalama/plugins/runtimes/inference/llama_cpp_commands.py
+++ b/ramalama/plugins/runtimes/inference/llama_cpp_commands.py
@@ -71,12 +71,16 @@ class LlamaCppCommands:
             cmd += ["--model", model_path]
 
             mmproj_path = model._get_mmproj_path(is_container, should_generate, dry_run)
-            if mmproj_path:
-                cmd += ["--mmproj", str(mmproj_path)]
-
-            chat_template_path = model._get_chat_template_path(is_container, should_generate, dry_run)
-            if chat_template_path:
-                cmd += ["--chat-template-file", str(chat_template_path)]
+            has_mmproj = bool(mmproj_path) or bool(model._get_mmproj_path(False, False, False))
+            if has_mmproj:
+                if mmproj_path:
+                    cmd += ["--mmproj", str(mmproj_path)]
+                cmd.append("--no-jinja")
+            else:
+                chat_template_path = model._get_chat_template_path(is_container, should_generate, dry_run)
+                if chat_template_path:
+                    cmd += ["--chat-template-file", str(chat_template_path)]
+                cmd.append("--jinja")
 
         cmd.append("--no-warmup")
 


### PR DESCRIPTION
## Summary

- Restore `--jinja`/`--no-jinja` flag logic lost during the refactor from YAML inference specs to Python plugins
- Text models get `--jinja` + `--chat-template-file`
- Multimodal models (with mmproj) get `--no-jinja` and skip `--chat-template-file`
- Handle dryrun mode where `_get_mmproj_path()` returns `""` (falsy) with a fallback check

## Problem

After the plugin refactor, multimodal models like SmolVLM fail with:
```
Server error: 400 - Failed to tokenize prompt
```
With the underlying error: `number of bitmaps (1) does not match number of markers (0)`

This happens because:
1. Multimodal models receive `--jinja` instead of `--no-jinja`
2. `--chat-template-file` is incorrectly applied to multimodal models

The original logic was defined in `inference-spec/engines/llama.cpp.yaml` and was not carried over during the refactor.

## Test plan

- [ ] `ramalama serve --port 8080 --name multi-modal -d smolvlm` - serves successfully
- [ ] Submit an image via the camera demo page - inference works without tokenization errors
- [ ] `ramalama --dryrun run granite` - command includes `--jinja`
- [ ] `ramalama --dryrun run smolvlm` - command includes `--no-jinja` and `--mmproj`

Fixes #2669