### PR TITLE
fix: add CDI device resource limits for non-NVIDIA GPUs in Kubernetes YAML

### DIFF
--- a/ramalama/kube.py
+++ b/ramalama/kube.py
@@ -215,6 +215,16 @@ class Kube:
         resources:
           limits:
              'nvidia.com/gpu=all': 1"""
+
+        devices = get_gpu_devices()
+        if devices:
+            limits = "".join(
+                f"\n             'podman.io/device={path}': 1" for path in devices.values()
+            )
+            return f"""
+        resources:
+          limits:{limits}"""
+
         return ""
 
     def __gen_container(self, container_args):

--- a/ramalama/kube.py
+++ b/ramalama/kube.py
@@ -218,9 +218,7 @@ class Kube:
 
         devices = get_gpu_devices()
         if devices:
-            limits = "".join(
-                f"\n             'podman.io/device={path}': 1" for path in devices.values()
-            )
+            limits = "".join(f"\n             'podman.io/device={path}': 1" for path in devices.values())
             return f"""
         resources:
           limits:{limits}"""

--- a/test/unit/data/test_kube/basic_hostpath.yaml
+++ b/test/unit/data/test_kube/basic_hostpath.yaml
@@ -54,6 +54,11 @@ spec:
           name: dri
         - mountPath: /dev/kfd
           name: kfd
+        resources:
+          limits:
+             'podman.io/device=/dev/accel': 1
+             'podman.io/device=/dev/dri': 1
+             'podman.io/device=/dev/kfd': 1
       volumes:
       - hostPath:
           path: /path/to/model.file

--- a/test/unit/data/test_kube/with_chat_template.yaml
+++ b/test/unit/data/test_kube/with_chat_template.yaml
@@ -56,6 +56,11 @@ spec:
           name: dri
         - mountPath: /dev/kfd
           name: kfd
+        resources:
+          limits:
+             'podman.io/device=/dev/accel': 1
+             'podman.io/device=/dev/dri': 1
+             'podman.io/device=/dev/kfd': 1
       volumes:
       - hostPath:
           path: /path/to/model.file

--- a/test/unit/data/test_kube/with_custom_name.yaml
+++ b/test/unit/data/test_kube/with_custom_name.yaml
@@ -54,6 +54,11 @@ spec:
           name: dri
         - mountPath: /dev/kfd
           name: kfd
+        resources:
+          limits:
+             'podman.io/device=/dev/accel': 1
+             'podman.io/device=/dev/dri': 1
+             'podman.io/device=/dev/kfd': 1
       volumes:
       - hostPath:
           path: /path/to/model.file

--- a/test/unit/data/test_kube/with_env.yaml
+++ b/test/unit/data/test_kube/with_env.yaml
@@ -56,6 +56,11 @@ spec:
           name: dri
         - mountPath: /dev/kfd
           name: kfd
+        resources:
+          limits:
+             'podman.io/device=/dev/accel': 1
+             'podman.io/device=/dev/dri': 1
+             'podman.io/device=/dev/kfd': 1
       volumes:
       - hostPath:
           path: /path/to/model.file

--- a/test/unit/data/test_kube/with_mmproj.yaml
+++ b/test/unit/data/test_kube/with_mmproj.yaml
@@ -56,6 +56,11 @@ spec:
           name: dri
         - mountPath: /dev/kfd
           name: kfd
+        resources:
+          limits:
+             'podman.io/device=/dev/accel': 1
+             'podman.io/device=/dev/dri': 1
+             'podman.io/device=/dev/kfd': 1
       volumes:
       - hostPath:
           path: /path/to/model.file

--- a/test/unit/data/test_kube/with_port.yaml
+++ b/test/unit/data/test_kube/with_port.yaml
@@ -55,6 +55,11 @@ spec:
           name: dri
         - mountPath: /dev/kfd
           name: kfd
+        resources:
+          limits:
+             'podman.io/device=/dev/accel': 1
+             'podman.io/device=/dev/dri': 1
+             'podman.io/device=/dev/kfd': 1
       volumes:
       - hostPath:
           path: /path/to/model.file

--- a/test/unit/data/test_kube/with_port_mapping.yaml
+++ b/test/unit/data/test_kube/with_port_mapping.yaml
@@ -56,6 +56,11 @@ spec:
           name: dri
         - mountPath: /dev/kfd
           name: kfd
+        resources:
+          limits:
+             'podman.io/device=/dev/accel': 1
+             'podman.io/device=/dev/dri': 1
+             'podman.io/device=/dev/kfd': 1
       volumes:
       - hostPath:
           path: /path/to/model.file

--- a/test/unit/data/test_kube/with_rag.yaml
+++ b/test/unit/data/test_kube/with_rag.yaml
@@ -56,6 +56,11 @@ spec:
           name: dri
         - mountPath: /dev/kfd
           name: kfd
+        resources:
+          limits:
+             'podman.io/device=/dev/accel': 1
+             'podman.io/device=/dev/dri': 1
+             'podman.io/device=/dev/kfd': 1
       volumes:
       - hostPath:
           path: /path/to/model.file

--- a/test/unit/test_kube.py
+++ b/test/unit/test_kube.py
@@ -178,6 +178,9 @@ def test_kube_generate(input: Input, expected_file_name: str, monkeypatch):
     # Mock environment variables
     monkeypatch.setattr("ramalama.kube.get_accel_env_vars", lambda: {"TEST_ENV": "test_value"})
 
+    # Mock NVIDIA check to ensure deterministic behavior across systems
+    monkeypatch.setattr("ramalama.kube.check_nvidia", lambda: None)
+
     # Mock version
     monkeypatch.setattr("ramalama.kube.version", lambda: "test-version")
 


### PR DESCRIPTION
## Summary

- Add `podman.io/device` CDI resource limits for non-NVIDIA GPUs (Intel, AMD, etc.) in generated Kubernetes YAML
- Update test fixtures to include the new resource limits
- Add `check_nvidia` mock to tests for deterministic behavior across systems

## Problem

`ramalama serve --generate kube` only generates `nvidia.com/gpu=all` resource limits for NVIDIA GPUs. For Intel, AMD, and other non-NVIDIA GPUs, no resource limits are generated, causing pods to start without GPU access. This results in SYCL device initialization failures and container crash loops on Intel GPU systems.

## Solution

Use the existing `get_gpu_devices()` function to detect available GPU devices (`/dev/dri`, `/dev/kfd`, `/dev/accel`) and generate CDI selectors:
```yaml
resources:
  limits:
    'podman.io/device=/dev/dri': 1
    'podman.io/device=/dev/accel': 1
```

## Test plan

- [ ] `ramalama serve --generate kube --name smollm-service oci://quay.io/ramalama/smollm:1.0` - YAML includes CDI device limits on Intel/AMD systems
- [ ] NVIDIA systems still get `nvidia.com/gpu=all` as before
- [ ] Systems without GPU devices get no resource limits
- [ ] All 12 kube unit tests pass

Fixes #2670