### PR TITLE
fix: prefix localhost/ for locally built RAG images in RagTransport

### DIFF
--- a/ramalama/rag.py
+++ b/ramalama/rag.py
@@ -163,6 +163,8 @@ class RagTransport(OCI):
     def format_model(self, model: str) -> str:
         if getattr(self, "kind", None) is RagSource.DB:
             return model
+        if "/" not in model:
+            model = f"localhost/{model}"
         return super().format_model(model)
 
     def __init__(self, imodel: Transport, cmd: list[str], args: RagArgsType):

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -2,6 +2,8 @@ import os
 
 import pytest
 
+from ramalama.transports.oci.strategy import OCIStrategyFactory
+
 initial_env = os.environ.copy()
 setup_env_vars = {"RAMALAMA__USER__NO_MISSING_GPU_PROMPT": "True"}
 
@@ -23,3 +25,8 @@ def restores_user_environment_at_end_of_tests():
             os.environ[k] = initial_env[k]
         else:
             os.environ.pop(k)
+
+
+@pytest.fixture
+def force_oci_image(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(OCIStrategyFactory, "resolve", lambda self, model: self.strategies("image"))

--- a/test/unit/test_rag_unit.py
+++ b/test/unit/test_rag_unit.py
@@ -51,3 +51,42 @@ class TestRagTransportLocalDB:
 
         assert rt.kind is RagSource.IMAGE
         assert rt.model.endswith(":latest")
+
+
+class TestRagTransportLocalhostPrefix:
+    """Regression tests for local OCI image names without a registry prefix.
+
+    A bare name like ``myrag`` must be prefixed with ``localhost/`` so that
+    OCI resolution does not default to ``docker.io``.  The prefix is added
+    by ``RagTransport.format_model`` and must be transparent to callers
+    regardless of the container engine in use."""
+
+    def test_bare_name_gets_localhost_prefix(self, tmp_path: Path, force_oci_image: None) -> None:
+        rt = _build_rag_transport("myrag", force_oci_image, str(tmp_path / "store"))
+
+        assert rt.kind is RagSource.IMAGE
+        assert rt.model == "localhost/myrag:latest"
+
+    def test_slash_name_keeps_registry(self, tmp_path: Path, force_oci_image: None) -> None:
+        rt = _build_rag_transport("quay.io/org/myrag", force_oci_image, str(tmp_path / "store"))
+
+        assert rt.kind is RagSource.IMAGE
+        assert rt.model == "quay.io/org/myrag:latest"
+        assert not rt.model.startswith("localhost/")
+
+    def test_local_db_skips_prefix(self, tmp_path: Path, force_oci_image: None) -> None:
+        db_dir = tmp_path / "mydb"
+        db_dir.mkdir()
+
+        rt = _build_rag_transport(str(db_dir), force_oci_image, str(tmp_path / "store"))
+
+        assert rt.kind is RagSource.DB
+        assert rt.model == str(db_dir)
+        assert "localhost" not in rt.model
+
+    def test_bare_name_with_docker_engine(self, tmp_path: Path, force_oci_image: None) -> None:
+        args = Namespace(rag="myrag", store=str(tmp_path / "store"), engine="docker")
+        rt = RagTransport(imodel=MagicMock(), cmd=[], args=args)
+
+        assert rt.kind is RagSource.IMAGE
+        assert rt.model == "localhost/myrag:latest"

--- a/test/unit/test_rag_unit.py
+++ b/test/unit/test_rag_unit.py
@@ -7,17 +7,8 @@ import pytest
 from ramalama.rag import RagSource, RagTransport
 
 
-@pytest.fixture
-def force_oci_image(monkeypatch: pytest.MonkeyPatch) -> None:
-    # Shared with test_transport_base: short-circuit OCIStrategyFactory so
-    # we don't need a running container engine.
-    from ramalama.transports.oci.strategy import OCIStrategyFactory
-
-    monkeypatch.setattr(OCIStrategyFactory, "resolve", lambda self, model: self.strategies("image"))
-
-
-def _build_rag_transport(path: str, force_oci_image: None, store: str) -> RagTransport:
-    args = Namespace(rag=path, store=store, engine="podman")
+def _build_rag_transport(path: str, store: str, engine: str = "podman") -> RagTransport:
+    args = Namespace(rag=path, store=store, engine=engine)
     return RagTransport(imodel=MagicMock(), cmd=[], args=args)
 
 
@@ -30,7 +21,7 @@ class TestRagTransportLocalDB:
         db_dir = tmp_path / "collection"
         db_dir.mkdir()
 
-        rt = _build_rag_transport(str(db_dir), force_oci_image, str(tmp_path / "store"))
+        rt = _build_rag_transport(str(db_dir), str(tmp_path / "store"))
 
         assert rt.kind is RagSource.DB
 
@@ -38,7 +29,7 @@ class TestRagTransportLocalDB:
         db_dir = tmp_path / "collection"
         db_dir.mkdir()
 
-        rt = _build_rag_transport(str(db_dir), force_oci_image, str(tmp_path / "store"))
+        rt = _build_rag_transport(str(db_dir), str(tmp_path / "store"))
 
         # Before the fix, this asserted False because self.model had been
         # rewritten by OCI.__init__ to ``<db_dir>:latest``.
@@ -47,7 +38,7 @@ class TestRagTransportLocalDB:
     def test_missing_local_path_classified_as_image(self, tmp_path: Path, force_oci_image: None) -> None:
         missing = tmp_path / "does-not-exist"
 
-        rt = _build_rag_transport(str(missing), force_oci_image, str(tmp_path / "store"))
+        rt = _build_rag_transport(str(missing), str(tmp_path / "store"))
 
         assert rt.kind is RagSource.IMAGE
         assert rt.model.endswith(":latest")
@@ -62,13 +53,13 @@ class TestRagTransportLocalhostPrefix:
     regardless of the container engine in use."""
 
     def test_bare_name_gets_localhost_prefix(self, tmp_path: Path, force_oci_image: None) -> None:
-        rt = _build_rag_transport("myrag", force_oci_image, str(tmp_path / "store"))
+        rt = _build_rag_transport("myrag", str(tmp_path / "store"))
 
         assert rt.kind is RagSource.IMAGE
         assert rt.model == "localhost/myrag:latest"
 
     def test_slash_name_keeps_registry(self, tmp_path: Path, force_oci_image: None) -> None:
-        rt = _build_rag_transport("quay.io/org/myrag", force_oci_image, str(tmp_path / "store"))
+        rt = _build_rag_transport("quay.io/org/myrag", str(tmp_path / "store"))
 
         assert rt.kind is RagSource.IMAGE
         assert rt.model == "quay.io/org/myrag:latest"
@@ -78,15 +69,15 @@ class TestRagTransportLocalhostPrefix:
         db_dir = tmp_path / "mydb"
         db_dir.mkdir()
 
-        rt = _build_rag_transport(str(db_dir), force_oci_image, str(tmp_path / "store"))
+        rt = _build_rag_transport(str(db_dir), str(tmp_path / "store"))
 
         assert rt.kind is RagSource.DB
         assert rt.model == str(db_dir)
         assert "localhost" not in rt.model
 
-    def test_bare_name_with_docker_engine(self, tmp_path: Path, force_oci_image: None) -> None:
-        args = Namespace(rag="myrag", store=str(tmp_path / "store"), engine="docker")
-        rt = RagTransport(imodel=MagicMock(), cmd=[], args=args)
+    @pytest.mark.parametrize("engine", ["podman", "docker"])
+    def test_bare_name_with_engine(self, tmp_path: Path, force_oci_image: None, engine: str) -> None:
+        rt = _build_rag_transport("myrag", str(tmp_path / "store"), engine=engine)
 
         assert rt.kind is RagSource.IMAGE
         assert rt.model == "localhost/myrag:latest"

--- a/test/unit/test_transport_base.py
+++ b/test/unit/test_transport_base.py
@@ -25,13 +25,6 @@ DEFAULT_PORT_RANGE = _CONFIG.default_port_range
 
 
 @pytest.fixture
-def force_oci_image(monkeypatch):
-    from ramalama.transports.oci.strategy import OCIStrategyFactory
-
-    monkeypatch.setattr(OCIStrategyFactory, "resolve", lambda self, model: self.strategies("image"))
-
-
-@pytest.fixture
 def force_oci_artifact(monkeypatch):
     from ramalama.transports.oci.strategy import OCIStrategyFactory
 


### PR DESCRIPTION
## Summary

- Prefix `localhost/` for RAG image names without a registry qualifier before passing to `OCI.__init__()`
- Fixes lookup of locally built RAG images (via `ramalama rag`, `podman build`, or `podman load`)

## Problem

```
$ ramalama rag test.md test:latest
$ ramalama run phi4 --rag test:latest
Error: docker.io/test:latest does not exist.
```

`RagTransport` extends `OCI`, which resolves unqualified names (like `test:latest`) to `docker.io/test:latest` via `OciRef.from_ref_string()`. But locally built images are stored under `localhost/test:latest`.

## Solution

In `RagTransport.__init__()`, detect image names without a `/` (no registry qualifier) and prefix them with `localhost/` before passing to `OCI.__init__()`. This ensures:

- `test:latest` → `localhost/test:latest` (local image, correct)
- `oci://quay.io/repo/image:tag` → unchanged (explicit registry)
- `/path/to/db` → unchanged (local filesystem, detected via `os.path.exists`)

## Test plan

- [ ] `ramalama rag test.md test:latest` creates the RAG database
- [ ] `ramalama run phi4 --rag test:latest` finds the local image
- [ ] `podman load -i podbook.tar && ramalama run phi4 --rag podbook:latest` works
- [ ] RAG images with explicit registry (`oci://quay.io/...`) still resolve correctly

Fixes #2671