### PR TITLE
docs: improve demo script with mode selection and navigation fixes

### DIFF
--- a/docs/demo/README.md
+++ b/docs/demo/README.md
@@ -1,19 +1,31 @@
-# RamaLama
+# RamaLama Demo
 
 This script demonstrates running RamaLama with a sample workflow that pulls a model, serves it, and allows testing inference through a browser or curl.
 
 ## Requirements
 
-- [RamaLama](https://github.com/) installed and available in your PATH  
-- [Podman](https://podman.io/) installed and configured  
+- [RamaLama](https://github.com/containers/ramalama) installed and available in your PATH
+- [Podman](https://podman.io/) installed and configured
 
 ## Usage
 
-Run the script:
+Run the full demo (all sections including multi-modal, MCP, and RAG):
 
 ```bash
 ./ramalama.sh
-````
+```
+
+Run only the multi-modal demo (after core demos):
+
+```bash
+./ramalama.sh multi-modal
+```
+
+Run only the MCP + RAG demo (after core demos):
+
+```bash
+./ramalama.sh mcp
+```
 
 Override the browser (optional):
 
@@ -21,23 +33,42 @@ Override the browser (optional):
 BROWSER=google-chrome ./ramalama.sh
 ```
 
+## Demo Modes
+
+The script supports three demo modes for the final section, selectable via the first argument:
+
+| Mode | Command | Description |
+|------|---------|-------------|
+| `all` (default) | `./ramalama.sh` or `./ramalama.sh all` | Runs all demos: multi-modal, MCP, and RAG |
+| `multi-modal` | `./ramalama.sh multi-modal` | Serves SmolVLM and opens a camera interaction app in the browser |
+| `mcp` | `./ramalama.sh mcp` | Runs MCP server tools with phi4 and a RAG demo with a vector database |
+
+All modes share the same core demos: version, pull, run, serve (including llama-stack), kubernetes, and quadlet.
+
 ## Features
 
-* Pulls and runs the `smollm:135m` and `granite` models with RamaLama
-* Opens the service endpoint in your browser automatically
-* Waits for the service to be ready before testing inference
-* Performs a sample inference with `curl` against the `granite3.1-dense` model
+* Pulls and runs the `smollm:135m` and `granite` models
+* Shows container security features (cap-drop, network isolation)
+* Serves models via REST API with browser interaction
+* Demonstrates llama-stack API integration
+* Generates Kubernetes YAML and Quadlet files for model deployment
+* Multi-modal: camera-based vision inference with SmolVLM
+* MCP: tool-calling with MCP server and RAG document retrieval
 
-## Advanced usage
+## Running Individual Functions
 
-You can also call specific functions from the script directly, for example:
+You can run specific demo sections directly (these run only the named function, without the core demos):
 
 ```bash
+./ramalama.sh version
 ./ramalama.sh pull
 ./ramalama.sh run
-./ramalama.sh test
+./ramalama.sh serve
+./ramalama.sh kubernetes
+./ramalama.sh quadlet
+./ramalama.sh rag
 ```
 
 Extra arguments can be passed after the function name if supported.
 
----
+> Note: `multi-modal`, `mcp`, and `all` are demo modes (see Demo Modes above) and will run the core demos as well.

--- a/docs/demo/ramalama.sh
+++ b/docs/demo/ramalama.sh
@@ -9,6 +9,7 @@ if [[ -z "${SCRIPT_DIR}" ]]; then
    echo "Error: Could not determine script directory." >&2
    exit 1
 fi
+REPO_ROOT="$( cd -- "${SCRIPT_DIR}/../.." &> /dev/null && pwd )"
 
 #set -eou pipefail
 IFS=$'\n\t'
@@ -19,9 +20,9 @@ bold=$(tput bold)
 cyan=$(tput setaf 6)
 reset=$(tput sgr0)
 
-# Allow overriding browser (default: firefox
-# On Mac, we need to use open -a Firefox to open Firefox
+# Allow overriding browser (default: firefox)
 BROWSER="${BROWSER:-firefox}"
+
 echo_color() {
     echo "${cyan}$1${reset}"
 }
@@ -65,7 +66,7 @@ pull() {
     echo ""
 
     echo_color "RamaLama List all AI Models in local store"
-    exec_color "ramalama ls | grep --color smollm"
+    exec_color "ramalama ls | grep --color smollm:135m"
     echo ""
 
     echo_color "Show RamaLama container images"
@@ -84,8 +85,8 @@ run() {
     echo ""
     exec_color "ramalama --dryrun run granite | grep --color -- --cap-drop.*privileges"
     echo ""
-    # exec_color "ramalama --dryrun run granite | grep --color -- --network.*none"
-    # echo ""
+    exec_color "ramalama --dryrun run granite | grep --color -- --network.*none"
+    echo ""
 
     echo_color "run granite via RamaLama run"
     exec_color "ramalama run --ngl 0 granite"
@@ -97,7 +98,7 @@ run() {
 
 serve() {
     echo_color "Serve granite via RamaLama model service"
-    exec_color "ramalama serve --port 8090 --name granite-service -d granite"
+    exec_color "ramalama serve --port 8080 --name granite-service -d granite"
     echo ""
 
     echo_color "List RamaLama containers"
@@ -109,7 +110,7 @@ serve() {
     echo ""
 
     echo_color "Use web browser to show interaction"
-    exec_color "$BROWSER http://localhost:8090"
+    exec_color "$BROWSER http://localhost:8080"
     echo ""
 
     echo_color "Stop the ramalama container"
@@ -117,16 +118,15 @@ serve() {
     echo ""
 
     echo_color "Serve granite via RamaLama model service"
-    exec_color "ramalama serve --port 8085 --api llama-stack --name granite-service -d granite &"
+    exec_color "ramalama serve --port 8085 --api llama-stack --name granite-service -d granite"
     echo ""
-    
+
     echo_color "Waiting for the model service to come up"
-    exec_color "timeout 5 bash -c 'until curl -s -f -o /dev/null http://localhost:8085/v1/openai/v1/models; do sleep 1; done';"
+    exec_color "timeout 25 bash -c 'until curl -s -f -o /dev/null http://localhost:8085/v1/openai/v1/models; do sleep 2; done'"
     echo ""
 
     echo_color "Inference against the model using llama-stack API"
-    exec_color "printf '\n'; curl --no-progress-meter http://localhost:8085/v1/openai/v1/chat/completions -H 'Content-Type: application/json' -d '{ \"model\": \"granite3.1-dense\", \"messages\": [{\"role\": \"user\", \"content\": \"Tell me a joke\"}], \"stream\": false }' | grep -oP '\"content\"\\s*:\\s*\"\\K[^\"]+'"
-
+    exec_color "printf \"\\n\"; curl --no-progress-meter http://localhost:8085/v1/openai/v1/chat/completions -H \"Content-Type: application/json\" -d '{ \"model\": \"library/granite3.1-dense\", \"messages\": [{\"role\": \"user\", \"content\": \"Tell me a joke\"}], \"stream\": false }' | grep -Po '\"content\"\\s*:\\s*\"\\K[^\"]*' | head -1"
     echo ""
 
     echo_color "Stop the ramalama container"
@@ -185,7 +185,7 @@ quadlet() {
 
 multi-modal() {
     echo_color "Serve smolvlm via RamaLama model service"
-    exec_color "ramalama serve --port 8080  --pull=never  --name multi-modal -d smolvlm"
+    exec_color "ramalama serve --port 8080 --name multi-modal -d smolvlm"
     echo ""
 
     echo_color "Use web browser to show interaction"
@@ -200,32 +200,52 @@ multi-modal() {
     clear
 }
 
+ensure_demo_tools() {
+    DEMO_TOOLS_DIR="${REPO_ROOT}/../ramalama-demo-tools"
+    if [ ! -d "$DEMO_TOOLS_DIR" ]; then
+        if ! git clone https://github.com/bmahabirbu/ramalama-demo-tools "$DEMO_TOOLS_DIR"; then
+            echo "Error: failed to clone ramalama-demo-tools into $DEMO_TOOLS_DIR" >&2
+            return 1
+        fi
+    else
+        if ! git -C "$DEMO_TOOLS_DIR" pull --ff-only; then
+            echo "Error: failed to update $DEMO_TOOLS_DIR" >&2
+            return 1
+        fi
+    fi
+}
+
 mcp () {
     echo_color "Start MCP server and use it with a LLM"
 
     # Check if gemini.env exists
-    if [ -f ../gemini.env ]; then
+    if [ -f "${REPO_ROOT}/../gemini.env" ]; then
         # shellcheck disable=SC1091
-        source ../gemini.env
+        source "${REPO_ROOT}/../gemini.env"
         GEMINI_AVAILABLE=true
     else
-        echo_color "Warning: ../gemini.env not found. Skipping Gemini chat."
+        echo_color "Warning: gemini.env not found. Skipping Gemini chat."
         GEMINI_AVAILABLE=false
     fi
 
-    # Clone the ramalama-demo-tools repo for RAG database and MCP server
-    cd .. || return
-    git clone https://github.com/bmahabirbu/ramalama-demo-tools
-    cd ramalama-demo-tools || return
-    git pull
+    ensure_demo_tools
 
-    # Start MCP server
-    exec_color "nohup uv run mcp-test-server.py >/dev/null 2>&1 &"
+    # Start MCP server directly (not via exec_color) so we can capture PID
+    cd "$DEMO_TOOLS_DIR" || return
+    MCP_LOG="${DEMO_TOOLS_DIR}/mcp-server.log"
+    echo -n "
+${bold}$ nohup uv run mcp-test-server.py >$MCP_LOG 2>&1 &${reset}"
+    read -r
+    nohup uv run mcp-test-server.py >"$MCP_LOG" 2>&1 &
     MCP_PID=$!
     trap 'kill "$MCP_PID" 2>/dev/null' EXIT
 
+    # Wait for MCP server to be ready
+    echo_color "Waiting for MCP server to start..."
+    timeout 15 bash -c 'until curl -s -f -o /dev/null http://127.0.0.1:8000/mcp 2>/dev/null; do sleep 1; done'
+
     # Run ramalama server
-    cd ../ramalama || return
+    cd "$REPO_ROOT" || return
     exec_color "ramalama run phi4 --mcp http://127.0.0.1:8000/mcp"
     # show /tool list of tools and click 1 to show output
     # prompt "list all the files on my desktop"
@@ -247,12 +267,14 @@ mcp () {
 
 
 rag (){
+    cd "$REPO_ROOT" || return
     echo_color "Create a rag database and use it with a LLM"
     exec_color "echo Brian loves cheese > test.md"
-    exec_color "ramalama rag test.md test:latest"  
+    exec_color "ramalama rag test.md test:latest"
     exec_color "ramalama run phi4 --rag test:latest"
     # prompt "what food does brian like?"
-    exec_color "podman load -i ../ramalama-demo-tools/podbook.tar"
+    ensure_demo_tools
+    exec_color "podman load -i ${DEMO_TOOLS_DIR}/podbook.tar"
     # # We need this timer so the port is cleared out from the previous run
     # # This is a workaround a fix is needed in the future
     time sleep 5
@@ -263,39 +285,53 @@ rag (){
     clear
 }
 
-if [[ $# -eq 0 ]]; then
-    # No argument: runs the whole demo script
-    setup
+DEMO_MODE="${1:-}"
+ALLOWED_FUNCTIONS=(version pull run serve kubernetes quadlet rag)
 
-    version
-
-    pull
-
-    run
-
-    serve
-
-    kubernetes
-
-    quadlet
-
-    mcp
-
-    rag
-    # Disable multi-modal for macos for now needs work
-    # multi-modal
-
-else
-    # Runs only the called function as an argument
+if [[ "$DEMO_MODE" == "mcp" || "$DEMO_MODE" == "multi-modal" || "$DEMO_MODE" == "all" ]]; then
+    shift
+elif [[ $# -gt 0 ]]; then
     cmd="$1"
-    if declare -f "$cmd" > /dev/null; then
-        "$cmd" "${@:2}"   # extra arguments if there is any
-
+    if printf '%s\n' "${ALLOWED_FUNCTIONS[@]}" | grep -Fxq -- "$cmd"; then
+        setup
+        "$cmd" "${@:2}"
+        echo_color "End of Demo"
+        echo "Thank you!"
+        exit 0
     else
-        echo "Error: function '$cmd' not found"
+        echo "Error: unknown command '$cmd'"
+        echo "Usage: $0 [all|multi-modal|mcp|${ALLOWED_FUNCTIONS[*]}]"
         exit 1
     fi
 fi
 
-    echo_color "End of Demo"
-    echo "Thank you!"
+# Default to all demos if no mode specified
+DEMO_MODE="${DEMO_MODE:-all}"
+
+setup
+
+version
+
+pull
+
+run
+
+serve
+
+kubernetes
+
+quadlet
+
+if [[ "$DEMO_MODE" == "all" ]]; then
+    multi-modal
+    mcp
+    rag
+elif [[ "$DEMO_MODE" == "mcp" ]]; then
+    mcp
+    rag
+else
+    multi-modal
+fi
+
+echo_color "End of Demo"
+echo "Thank you!"


### PR DESCRIPTION
## Summary

- Add demo mode selection: `all` (default), `multi-modal`, `mcp`
- Fix broken directory navigation in `mcp()` and `rag()` functions
- Fix multiple issues found while running the demo end-to-end
- Update README.md with usage documentation

## Changes

**Mode selection:**
- `./ramalama.sh` or `./ramalama.sh all` - runs all demos (multi-modal + mcp + rag)
- `./ramalama.sh multi-modal` - runs only multi-modal demo
- `./ramalama.sh mcp` - runs only mcp + rag demos
- `./ramalama.sh <function>` - runs a single function (e.g., `serve`, `pull`)

**Bug fixes in the script:**
- Fix `mcp()` navigation: `cd ../ramalama` fails because the script is in `docs/demo/`, not the repo root. Now uses `REPO_ROOT` derived from `SCRIPT_DIR`
- Fix `rag()` path for `podbook.tar` using `REPO_ROOT`
- Fix serve port from 8090 to 8080 (llama-server default)
- Fix llama-stack serve: remove trailing `&` (`-d` already detaches)
- Fix model name in curl from `granite3.1-dense` to `library/granite3.1-dense` (must match `--alias`)
- Increase llama-stack timeout from 5s to 25s with 2s sleep intervals
- Restore `--network.*none` grep in `run()` demo
- Remove `--pull=never` from smolvlm serve

## Test plan

- [ ] `./ramalama.sh` - runs all core demos + multi-modal + mcp + rag
- [ ] `./ramalama.sh multi-modal` - runs core demos + multi-modal only
- [ ] `./ramalama.sh mcp` - runs core demos + mcp + rag only
- [ ] `./ramalama.sh serve` - runs only the serve function
- [ ] `./ramalama.sh nonexistent` - shows error and usage