### PR TITLE
feat: Llama stack image parameter

### DIFF
--- a/docs/options/stack-image.md
+++ b/docs/options/stack-image.md
@@ -1,0 +1,6 @@
+####> This option file is used in:
+####>   ramalama serve
+####> If this file is edited, make sure the changes
+####> are applicable to all of those.
+#### **--stack-image**=
+The image to use to start the [Open-source agentic API server (ogx)](https://ogx-ai.github.io/). It is used when `--api llama-stack` is used. The image will get following environment variables: RAMALAMA_URL the url where the model server is running, INFERENCE_MODEL the model of the model server and RAMALAMA_RUNTIME the runtime used by the model server. The API server must run on port 8321.

--- a/docs/ramalama-serve.1.md.in
+++ b/docs/ramalama-serve.1.md.in
@@ -107,6 +107,8 @@ appending the path to the type, e.g. `--generate kube:/etc/containers/systemd`.
 
 @@option selinux
 
+@@option stack-image
+
 @@option temp
 
 @@option thinking

--- a/docs/ramalama.conf
+++ b/docs/ramalama.conf
@@ -158,6 +158,12 @@
 #
 #rag_image = "quay.io/ramalama/ramalama-rag"
 
+# OCI container image used for running llama-stack server.
+# Can also be overridden with the `--stack-image` flag on the command line or the
+# RAMALAMA_STACK_IMAGE environment variable.
+#
+#stack_image = "quay.io/ramalama/llama-stack"
+
 # User-override entries for GPU-specific tools container images used for
 # GGUF conversion. Built-in GPU defaults (CUDA, ROCm, Intel) are defined
 # internally; entries here override those defaults for the matching GPU type.

--- a/docs/ramalama.conf.5.md
+++ b/docs/ramalama.conf.5.md
@@ -217,6 +217,12 @@ OCI container image used for RAG processing (doc2rag and rag_framework).
 Can also be overridden with the `--rag-image` flag on the command line or the
 RAMALAMA_RAG_IMAGE environment variable.
 
+**stack_image**="quay.io/ramalama/llama-stack"
+
+OCI container image used for running llama-stack server.
+Can also be overridden with the `--stack-image` flag on the command line or the
+RAMALAMA_STACK_IMAGE environment variable.
+
 `[[ramalama.tools_images]]`
 
 User-override entries for GPU-specific tools container images used for GGUF

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -44,6 +44,7 @@ from ramalama.plugins.loader import get_all_runtimes, get_runtime
 from ramalama.prompt_utils import default_prefix
 from ramalama.rag import rag_image
 from ramalama.shortnames import Shortnames
+from ramalama.stack import stack_image
 from ramalama.transports.base import (
     MODEL_TYPES,
     NoGGUFModelFileFound,
@@ -68,6 +69,11 @@ def default_image() -> str:
 @lru_cache(maxsize=1)
 def default_rag_image() -> str:
     return rag_image(ActiveConfig())
+
+
+@lru_cache(maxsize=1)
+def default_stack_image() -> str:
+    return stack_image(ActiveConfig())
 
 
 @lru_cache(maxsize=1)
@@ -835,6 +841,13 @@ def runtime_options(parser, command):
     if command == "serve":
         parser.add_argument(
             "-d", "--detach", action="store_true", dest="detach", help="run the container in detached mode"
+        )
+        parser.add_argument(
+            "--stack-image",
+            default=default_stack_image(),
+            help="OCI container image to run llama-stack server",
+            action=OverrideDefaultAction,
+            completer=local_images,
         )
     parser.add_argument(
         "--device",

--- a/ramalama/config.py
+++ b/ramalama/config.py
@@ -183,6 +183,7 @@ class BaseConfig:
     default_image: str = DEFAULT_IMAGE
     default_rag_image: str = DEFAULT_RAG_IMAGE
     default_tools_image: str = DEFAULT_TOOLS_IMAGE
+    default_stack_image: str = DEFAULT_STACK_IMAGE
     dryrun: bool = False
     engine: Optional[SUPPORTED_ENGINES] = field(default_factory=get_default_engine)
     env: list[str] = field(default_factory=list)
@@ -193,6 +194,7 @@ class BaseConfig:
     images: dict[str, str] = field(default_factory=dict)
     rag_image: Optional[str] = None
     tools_image: Optional[str] = None
+    stack_image: Optional[str] = None
     tools_images: dict[str, str] = field(default_factory=dict)
     keep_groups: bool = False
     log_level: Optional[LogLevel] = None
@@ -203,7 +205,6 @@ class BaseConfig:
     runtime: SUPPORTED_RUNTIMES = "llama.cpp"
     selinux: bool = False
     settings: RamalamaSettings = field(default_factory=RamalamaSettings)
-    stack_image: str = DEFAULT_STACK_IMAGE
     store: str = field(default_factory=get_default_store)
     summarize_after: int = 4
     temp: str = "0.8"

--- a/ramalama/stack.py
+++ b/ramalama/stack.py
@@ -5,15 +5,19 @@ import os
 
 import ramalama.kube as kube
 import ramalama.quadlet as quadlet
-from ramalama.common import exec_cmd, genname, get_accel_env_vars, version_tagged_image
+from ramalama.common import exec_cmd, genname, get_accel_env_vars
 from ramalama.compat import NamedTemporaryFile
 from ramalama.compose import Compose
-from ramalama.config import ActiveConfig
+from ramalama.config import ActiveConfig, Config
 from ramalama.engine import add_labels
 from ramalama.kube import Kube
 from ramalama.plugins.loader import assemble_command
 from ramalama.transports.base import compute_serving_port
 from ramalama.transports.transport_factory import New
+
+
+def stack_image(config: Config) -> str:
+    return config.stack_image or config.default_stack_image
 
 
 class Stack:
@@ -28,7 +32,7 @@ class Stack:
         self.model = New(args.MODEL, args)
         self.model_type = self.model.type
         self.model_port = "8080"
-        self.stack_image = version_tagged_image(ActiveConfig().stack_image)
+        self.stack_image = stack_image(ActiveConfig())
         self.labels = ""
 
     def add_label(self, label):
@@ -68,7 +72,7 @@ class Stack:
         common_env = self._gen_kube_env(env_vars)
         llama_stack_container = {
             "name": "llama-stack",
-            "image": self.stack_image,
+            "image": f"{self.stack_image}",
             "args": ["llama", "stack", "run", "--image-type", "venv", "/etc/ramalama/ramalama-run.yaml"],
             "env_string": f"""\
         env:{common_env}

--- a/ramalama/stack.py
+++ b/ramalama/stack.py
@@ -73,11 +73,13 @@ class Stack:
         llama_stack_container = {
             "name": "llama-stack",
             "image": f"{self.stack_image}",
-            "args": ["llama", "stack", "run", "--image-type", "venv", "/etc/ramalama/ramalama-run.yaml"],
+            "args": [],
             "env_string": f"""\
         env:{common_env}
         - name: RAMALAMA_URL
           value: http://127.0.0.1:{self.model_port}
+        - name: RAMALAMA_RUNTIME
+          value: \"{self.args.runtime}\"
         - name: INFERENCE_MODEL
           value: \"{self.model.model_alias}\"""",
             "port_string": f"""\
@@ -145,7 +147,8 @@ class Stack:
       - "{stack_port}:8123"
     environment:{compose_env}
       - RAMALAMA_URL=http://{self.name}:{self.model_port}
-      - INFERENCE_MODEL="{self.model.model_alias}"
+      - RAMALAMA_RUNTIME={self.args.runtime}
+      - INFERENCE_MODEL={self.model.model_alias}
     depends_on:
       - {self.model.model_name}
     restart: unless-stopped"""

--- a/test/e2e/test_serve.py
+++ b/test/e2e/test_serve.py
@@ -696,6 +696,7 @@ def test_serve_generation_with_llama_api(test_model, generate, env_vars):
         ctx.check_call(["ramalama", "pull", test_model])
 
         extra_args = ["--env", env_vars] if env_vars else []
+        extra_args += ["--stack-image", "quay.io/ramalama/llama-stack:0.18"] if env_vars else []
         extra_args += ['--runtime-args', '--top-p 1.0']
         # Exec ramalama serve
         result = ctx.check_output(
@@ -715,7 +716,6 @@ def test_serve_generation_with_llama_api(test_model, generate, env_vars):
                 test_model,
             ] + extra_args
         )
-
         if generate == 'kube':
             # Test the expected output of the command execution
             assert re.search(r".*Generating Kubernetes YAML file: test.yaml", result)
@@ -730,9 +730,11 @@ def test_serve_generation_with_llama_api(test_model, generate, env_vars):
                 if env_vars:
                     assert len(re.findall(r"name: SEARCH_API_KEY", content)) == 2
                     assert len(re.findall(r'value: "?9999"?', content)) == 2
+                    assert len(re.findall(r'quay.io/ramalama/llama-stack:0.18', content)) == 1
                 else:
                     assert not re.search(r"name: SEARCH_API_KEY", content)
                     assert not re.search(r'value: "?9999"?', content)
+                    assert not re.search(r'quay.io/ramalama/llama-stack:0.18', content)
 
         elif generate == 'compose':
             # Test the expected output of the command execution

--- a/test/unit/test_config_documentation.py
+++ b/test/unit/test_config_documentation.py
@@ -19,7 +19,7 @@ def get_config_fields():
         'default_rag_image',  # Internal constant, users configure 'rag_image' instead
         'default_tools_image',  # Internal constant, users configure via tools_images
         'tools_image',  # Users configure via tools_images, not directly documented
-        'stack_image',  # Internal constant for stack operations
+        'default_stack_image',  # Internal constant for stack operations
         'dryrun',  # Runtime flag, not a persistent config option
         'verify',  # Runtime flag for model verification, not typically configured
     }


### PR DESCRIPTION
The change allows to use a different llama-stack image than the hard-coded `quay.io/ramalama/llama-stack:<version>`

This opens the possibility to build my own stack image with reduced set of features I need: https://github.com/mkristian/ramalama/tree/ogx-stack-image/container-images/llama-stack. This image is just
```
localhost/ogx                                latest               dca7ccb39604  9 hours ago    1.33 GB
```
versus 
```
quay.io/ramalama/llama-stack                 0.19                 eb5604b69e24  9 days ago     11.7 GB
quay.io/ramalama/llama-stack                 0.18                 ed4693c72c8c  5 weeks ago    16.6 GB
quay.io/ramalama/llama-stack                 0.17                 bbee65540072  2 months ago   8.57 GB
```

Changes:

- adds the extra parameter `--stack-image` to the serve command 
- adds RAMALAMA_RUNTIME so the entrypoint can pick the right inference provider from llama-stack/ogx: https://github.com/mkristian/ramalama/blob/ogx-stack-image/container-images/llama-stack/entrypoint.sh
- do not add the start command in the generated kube yaml so ramalama is not bound to the llama-stack version or whether it is llama-stack or the new ogx
