### PR TITLE
update dependencies in the -rag and -tools images

### DIFF
--- a/container-images/common/Containerfile.tools
+++ b/container-images/common/Containerfile.tools
@@ -10,7 +10,7 @@ ENV VIRTUAL_ENV="/opt/venv" \
     UV_TORCH_BACKEND=$TORCH_BACKEND
 
 # Keep the tag below in sync with the tag used for gguf-py in requirements-tools.in
-ADD --chmod=755 https://github.com/ggml-org/llama.cpp/raw/refs/tags/b8779/convert_hf_to_gguf.py \
+ADD --chmod=755 https://github.com/ggml-org/llama.cpp/raw/refs/tags/b8920/convert_hf_to_gguf.py \
     /usr/bin/
 
 RUN --mount=type=bind,target=/src,relabel=private \

--- a/container-images/common/requirements-rag.txt
+++ b/container-images/common/requirements-rag.txt
@@ -1280,6 +1280,7 @@ pydantic==2.13.3 \
     #   docling-core
     #   fastapi
     #   openai
+    #   pydantic-settings
     #   qdrant-client
     # from https://pypi.org/simple
 pydantic-core==2.46.3 \
@@ -1405,6 +1406,11 @@ pydantic-core==2.46.3 \
     --hash=sha256:ffe0883b56cfc05798bf994164d2b2ff03efe2d22022a2bb080f3b626176dd56
     # via pydantic
     # from https://pypi.org/simple
+pydantic-settings==2.14.0 \
+    --hash=sha256:24285fd4b0e0c06507dd9fdfd331ee23794305352aaec8fc4eb92d4047aeb67d \
+    --hash=sha256:fc8d5d692eb7092e43c8647c1c35a3ecd00e040fcf02ed86f4cb5458ca62182e
+    # via docling-core
+    # from https://pypi.org/simple
 pygments==2.20.0 \
     --hash=sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f \
     --hash=sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176
@@ -1441,6 +1447,11 @@ python-dateutil==2.9.0.post0 \
     --hash=sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3 \
     --hash=sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427
     # via pandas
+    # from https://pypi.org/simple
+python-dotenv==1.2.2 \
+    --hash=sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a \
+    --hash=sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3
+    # via pydantic-settings
     # from https://pypi.org/simple
 pyyaml==6.0.3 \
     --hash=sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c \
@@ -1898,6 +1909,7 @@ typing-inspection==0.4.2 \
     # via
     #   fastapi
     #   pydantic
+    #   pydantic-settings
     # from https://pypi.org/simple
 urllib3==2.6.3 \
     --hash=sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed \

--- a/container-images/common/requirements-tools-cpu-aarch64.txt
+++ b/container-images/common/requirements-tools-cpu-aarch64.txt
@@ -162,9 +162,9 @@ charset-normalizer==3.4.7 \
     --hash=sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464
     # via requests
     # from https://pypi.org/simple
-click==8.3.2 \
-    --hash=sha256:14162b8b3b3550a7d479eafa77dfd3c38d9dc8951f6f69c78913a8f9a7540fd5 \
-    --hash=sha256:1924d2c27c5653561cd2cae4548d1406039cb79b858b747cfea24924bbc1616d
+click==8.3.3 \
+    --hash=sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2 \
+    --hash=sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613
     # via typer
     # from https://pypi.org/simple
 filelock==3.29.0 \
@@ -181,7 +181,7 @@ fsspec==2026.3.0 \
     #   huggingface-hub
     #   torch
     # from https://pypi.org/simple
-gguf @ git+https://github.com/ggml-org/llama.cpp@75f3bc94e649616162981c322e8e6b88ca5491e8#subdirectory=gguf-py
+gguf @ git+https://github.com/ggml-org/llama.cpp@15fa3c493bfcd040b5f4dcb29e1c998a0846de16#subdirectory=gguf-py
     # via -r requirements-tools.in
 h11==0.16.0 \
     --hash=sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1 \
@@ -226,16 +226,16 @@ httpx==0.28.1 \
     --hash=sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad
     # via huggingface-hub
     # from https://pypi.org/simple
-huggingface-hub==1.11.0 \
-    --hash=sha256:15fb3713c7f9cdff7b808a94fd91664f661ab142796bb48c9cd9493e8d166278 \
-    --hash=sha256:42a6de0afbfeb5e022222d36398f029679db4eb4778801aafda32257ae9131ab
+huggingface-hub==1.12.0 \
+    --hash=sha256:7c3fe85e24b652334e5d456d7a812cd9a071e75630fac4365d9165ab5e4a34b6 \
+    --hash=sha256:d74939969585ee35748bd66de09baf84099d461bda7287cd9043bfb99b0e424d
     # via
     #   tokenizers
     #   transformers
     # from https://pypi.org/simple
-idna==3.12 \
-    --hash=sha256:60ffaa1858fac94c9c124728c24fcde8160f3fb4a7f79aa8cdd33a9d1af60a67 \
-    --hash=sha256:724e9952cc9e2bd7550ea784adb098d837ab5267ef67a1ab9cf7846bdbdd8254
+idna==3.13 \
+    --hash=sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242 \
+    --hash=sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3
     # via
     #   anyio
     #   httpx
@@ -452,9 +452,9 @@ numpy==2.4.4 \
     #   mistral-common
     #   transformers
     # from https://pypi.org/simple
-packaging==26.1 \
-    --hash=sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f \
-    --hash=sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de
+packaging==26.2 \
+    --hash=sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e \
+    --hash=sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661
     # via
     #   huggingface-hub
     #   transformers
@@ -1255,14 +1255,14 @@ tqdm==4.67.3 \
     #   huggingface-hub
     #   transformers
     # from https://pypi.org/simple
-transformers==5.5.4 \
-    --hash=sha256:0bd6281b82966fe5a7a16f553ea517a9db1dee6284d7cb224dfd88fc0dd1c167 \
-    --hash=sha256:2e67cadba81fc7608cc07c4dd54f524820bc3d95b1cabd0ef3db7733c4f8b82e
+transformers==5.6.2 \
+    --hash=sha256:e657134c3e5a6bc00a3c35f4e2674bb51adfcd89898495b788a18552bac2b91a \
+    --hash=sha256:f8d3a1bb96778fed9b8aabfd0dd6e19843e4b0f2bb6b59f32b8a92051b0f348f
     # via -r requirements-tools.in
     # from https://pypi.org/simple
-typer==0.24.1 \
-    --hash=sha256:112c1f0ce578bfb4cab9ffdabc68f031416ebcc216536611ba21f04e9aa84c9e \
-    --hash=sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45
+typer==0.25.0 \
+    --hash=sha256:123eaf9f19bb40fd268310e12a542c0c6b4fab9c98d9d23342a01ff95e3ce930 \
+    --hash=sha256:ac01b48823d3db9a83c9e164338057eadbb1c9957a2a6b4eeb486669c560b5dc
     # via
     #   huggingface-hub
     #   transformers

--- a/container-images/common/requirements-tools-cpu.txt
+++ b/container-images/common/requirements-tools-cpu.txt
@@ -162,9 +162,9 @@ charset-normalizer==3.4.7 \
     --hash=sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464
     # via requests
     # from https://pypi.org/simple
-click==8.3.2 \
-    --hash=sha256:14162b8b3b3550a7d479eafa77dfd3c38d9dc8951f6f69c78913a8f9a7540fd5 \
-    --hash=sha256:1924d2c27c5653561cd2cae4548d1406039cb79b858b747cfea24924bbc1616d
+click==8.3.3 \
+    --hash=sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2 \
+    --hash=sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613
     # via typer
     # from https://pypi.org/simple
 filelock==3.29.0 \
@@ -181,7 +181,7 @@ fsspec==2026.3.0 \
     #   huggingface-hub
     #   torch
     # from https://pypi.org/simple
-gguf @ git+https://github.com/ggml-org/llama.cpp@75f3bc94e649616162981c322e8e6b88ca5491e8#subdirectory=gguf-py
+gguf @ git+https://github.com/ggml-org/llama.cpp@15fa3c493bfcd040b5f4dcb29e1c998a0846de16#subdirectory=gguf-py
     # via -r requirements-tools.in
 h11==0.16.0 \
     --hash=sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1 \
@@ -226,16 +226,16 @@ httpx==0.28.1 \
     --hash=sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad
     # via huggingface-hub
     # from https://pypi.org/simple
-huggingface-hub==1.11.0 \
-    --hash=sha256:15fb3713c7f9cdff7b808a94fd91664f661ab142796bb48c9cd9493e8d166278 \
-    --hash=sha256:42a6de0afbfeb5e022222d36398f029679db4eb4778801aafda32257ae9131ab
+huggingface-hub==1.12.0 \
+    --hash=sha256:7c3fe85e24b652334e5d456d7a812cd9a071e75630fac4365d9165ab5e4a34b6 \
+    --hash=sha256:d74939969585ee35748bd66de09baf84099d461bda7287cd9043bfb99b0e424d
     # via
     #   tokenizers
     #   transformers
     # from https://pypi.org/simple
-idna==3.12 \
-    --hash=sha256:60ffaa1858fac94c9c124728c24fcde8160f3fb4a7f79aa8cdd33a9d1af60a67 \
-    --hash=sha256:724e9952cc9e2bd7550ea784adb098d837ab5267ef67a1ab9cf7846bdbdd8254
+idna==3.13 \
+    --hash=sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242 \
+    --hash=sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3
     # via
     #   anyio
     #   httpx
@@ -452,9 +452,9 @@ numpy==2.4.4 \
     #   mistral-common
     #   transformers
     # from https://pypi.org/simple
-packaging==26.1 \
-    --hash=sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f \
-    --hash=sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de
+packaging==26.2 \
+    --hash=sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e \
+    --hash=sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661
     # via
     #   huggingface-hub
     #   transformers
@@ -1255,14 +1255,14 @@ tqdm==4.67.3 \
     #   huggingface-hub
     #   transformers
     # from https://pypi.org/simple
-transformers==5.5.4 \
-    --hash=sha256:0bd6281b82966fe5a7a16f553ea517a9db1dee6284d7cb224dfd88fc0dd1c167 \
-    --hash=sha256:2e67cadba81fc7608cc07c4dd54f524820bc3d95b1cabd0ef3db7733c4f8b82e
+transformers==5.6.2 \
+    --hash=sha256:e657134c3e5a6bc00a3c35f4e2674bb51adfcd89898495b788a18552bac2b91a \
+    --hash=sha256:f8d3a1bb96778fed9b8aabfd0dd6e19843e4b0f2bb6b59f32b8a92051b0f348f
     # via -r requirements-tools.in
     # from https://pypi.org/simple
-typer==0.24.1 \
-    --hash=sha256:112c1f0ce578bfb4cab9ffdabc68f031416ebcc216536611ba21f04e9aa84c9e \
-    --hash=sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45
+typer==0.25.0 \
+    --hash=sha256:123eaf9f19bb40fd268310e12a542c0c6b4fab9c98d9d23342a01ff95e3ce930 \
+    --hash=sha256:ac01b48823d3db9a83c9e164338057eadbb1c9957a2a6b4eeb486669c560b5dc
     # via
     #   huggingface-hub
     #   transformers

--- a/container-images/common/requirements-tools-cu128-aarch64.txt
+++ b/container-images/common/requirements-tools-cu128-aarch64.txt
@@ -162,9 +162,9 @@ charset-normalizer==3.4.7 \
     --hash=sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464
     # via requests
     # from https://pypi.org/simple
-click==8.3.2 \
-    --hash=sha256:14162b8b3b3550a7d479eafa77dfd3c38d9dc8951f6f69c78913a8f9a7540fd5 \
-    --hash=sha256:1924d2c27c5653561cd2cae4548d1406039cb79b858b747cfea24924bbc1616d
+click==8.3.3 \
+    --hash=sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2 \
+    --hash=sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613
     # via typer
     # from https://pypi.org/simple
 cuda-bindings==12.9.6 \
@@ -213,7 +213,7 @@ fsspec==2026.3.0 \
     #   huggingface-hub
     #   torch
     # from https://pypi.org/simple
-gguf @ git+https://github.com/ggml-org/llama.cpp@75f3bc94e649616162981c322e8e6b88ca5491e8#subdirectory=gguf-py
+gguf @ git+https://github.com/ggml-org/llama.cpp@15fa3c493bfcd040b5f4dcb29e1c998a0846de16#subdirectory=gguf-py
     # via -r requirements-tools.in
 h11==0.16.0 \
     --hash=sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1 \
@@ -258,16 +258,16 @@ httpx==0.28.1 \
     --hash=sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad
     # via huggingface-hub
     # from https://pypi.org/simple
-huggingface-hub==1.11.0 \
-    --hash=sha256:15fb3713c7f9cdff7b808a94fd91664f661ab142796bb48c9cd9493e8d166278 \
-    --hash=sha256:42a6de0afbfeb5e022222d36398f029679db4eb4778801aafda32257ae9131ab
+huggingface-hub==1.12.0 \
+    --hash=sha256:7c3fe85e24b652334e5d456d7a812cd9a071e75630fac4365d9165ab5e4a34b6 \
+    --hash=sha256:d74939969585ee35748bd66de09baf84099d461bda7287cd9043bfb99b0e424d
     # via
     #   tokenizers
     #   transformers
     # from https://pypi.org/simple
-idna==3.12 \
-    --hash=sha256:60ffaa1858fac94c9c124728c24fcde8160f3fb4a7f79aa8cdd33a9d1af60a67 \
-    --hash=sha256:724e9952cc9e2bd7550ea784adb098d837ab5267ef67a1ab9cf7846bdbdd8254
+idna==3.13 \
+    --hash=sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242 \
+    --hash=sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3
     # via
     #   anyio
     #   httpx
@@ -582,9 +582,9 @@ nvidia-nvtx-cu12==12.8.90 \
     --hash=sha256:d7ad891da111ebafbf7e015d34879f7112832fc239ff0d7d776b6cb685274615
     # via cuda-toolkit
     # from https://pypi.org/simple
-packaging==26.1 \
-    --hash=sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f \
-    --hash=sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de
+packaging==26.2 \
+    --hash=sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e \
+    --hash=sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661
     # via
     #   huggingface-hub
     #   transformers
@@ -1385,9 +1385,9 @@ tqdm==4.67.3 \
     #   huggingface-hub
     #   transformers
     # from https://pypi.org/simple
-transformers==5.5.4 \
-    --hash=sha256:0bd6281b82966fe5a7a16f553ea517a9db1dee6284d7cb224dfd88fc0dd1c167 \
-    --hash=sha256:2e67cadba81fc7608cc07c4dd54f524820bc3d95b1cabd0ef3db7733c4f8b82e
+transformers==5.6.2 \
+    --hash=sha256:e657134c3e5a6bc00a3c35f4e2674bb51adfcd89898495b788a18552bac2b91a \
+    --hash=sha256:f8d3a1bb96778fed9b8aabfd0dd6e19843e4b0f2bb6b59f32b8a92051b0f348f
     # via -r requirements-tools.in
     # from https://pypi.org/simple
 triton==3.6.0 \
@@ -1407,9 +1407,9 @@ triton==3.6.0 \
     --hash=sha256:e021e87e8f266c6f87bf379b669c43c2800aac6247bdf5d518cb553e3c403c00
     # via torch
     # from https://download.pytorch.org/whl/cu128
-typer==0.24.1 \
-    --hash=sha256:112c1f0ce578bfb4cab9ffdabc68f031416ebcc216536611ba21f04e9aa84c9e \
-    --hash=sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45
+typer==0.25.0 \
+    --hash=sha256:123eaf9f19bb40fd268310e12a542c0c6b4fab9c98d9d23342a01ff95e3ce930 \
+    --hash=sha256:ac01b48823d3db9a83c9e164338057eadbb1c9957a2a6b4eeb486669c560b5dc
     # via
     #   huggingface-hub
     #   transformers

--- a/container-images/common/requirements-tools-cu128.txt
+++ b/container-images/common/requirements-tools-cu128.txt
@@ -162,9 +162,9 @@ charset-normalizer==3.4.7 \
     --hash=sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464
     # via requests
     # from https://pypi.org/simple
-click==8.3.2 \
-    --hash=sha256:14162b8b3b3550a7d479eafa77dfd3c38d9dc8951f6f69c78913a8f9a7540fd5 \
-    --hash=sha256:1924d2c27c5653561cd2cae4548d1406039cb79b858b747cfea24924bbc1616d
+click==8.3.3 \
+    --hash=sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2 \
+    --hash=sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613
     # via typer
     # from https://pypi.org/simple
 cuda-bindings==12.9.6 \
@@ -213,7 +213,7 @@ fsspec==2026.3.0 \
     #   huggingface-hub
     #   torch
     # from https://pypi.org/simple
-gguf @ git+https://github.com/ggml-org/llama.cpp@75f3bc94e649616162981c322e8e6b88ca5491e8#subdirectory=gguf-py
+gguf @ git+https://github.com/ggml-org/llama.cpp@15fa3c493bfcd040b5f4dcb29e1c998a0846de16#subdirectory=gguf-py
     # via -r requirements-tools.in
 h11==0.16.0 \
     --hash=sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1 \
@@ -258,16 +258,16 @@ httpx==0.28.1 \
     --hash=sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad
     # via huggingface-hub
     # from https://pypi.org/simple
-huggingface-hub==1.11.0 \
-    --hash=sha256:15fb3713c7f9cdff7b808a94fd91664f661ab142796bb48c9cd9493e8d166278 \
-    --hash=sha256:42a6de0afbfeb5e022222d36398f029679db4eb4778801aafda32257ae9131ab
+huggingface-hub==1.12.0 \
+    --hash=sha256:7c3fe85e24b652334e5d456d7a812cd9a071e75630fac4365d9165ab5e4a34b6 \
+    --hash=sha256:d74939969585ee35748bd66de09baf84099d461bda7287cd9043bfb99b0e424d
     # via
     #   tokenizers
     #   transformers
     # from https://pypi.org/simple
-idna==3.12 \
-    --hash=sha256:60ffaa1858fac94c9c124728c24fcde8160f3fb4a7f79aa8cdd33a9d1af60a67 \
-    --hash=sha256:724e9952cc9e2bd7550ea784adb098d837ab5267ef67a1ab9cf7846bdbdd8254
+idna==3.13 \
+    --hash=sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242 \
+    --hash=sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3
     # via
     #   anyio
     #   httpx
@@ -582,9 +582,9 @@ nvidia-nvtx-cu12==12.8.90 \
     --hash=sha256:d7ad891da111ebafbf7e015d34879f7112832fc239ff0d7d776b6cb685274615
     # via cuda-toolkit
     # from https://pypi.org/simple
-packaging==26.1 \
-    --hash=sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f \
-    --hash=sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de
+packaging==26.2 \
+    --hash=sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e \
+    --hash=sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661
     # via
     #   huggingface-hub
     #   transformers
@@ -1385,9 +1385,9 @@ tqdm==4.67.3 \
     #   huggingface-hub
     #   transformers
     # from https://pypi.org/simple
-transformers==5.5.4 \
-    --hash=sha256:0bd6281b82966fe5a7a16f553ea517a9db1dee6284d7cb224dfd88fc0dd1c167 \
-    --hash=sha256:2e67cadba81fc7608cc07c4dd54f524820bc3d95b1cabd0ef3db7733c4f8b82e
+transformers==5.6.2 \
+    --hash=sha256:e657134c3e5a6bc00a3c35f4e2674bb51adfcd89898495b788a18552bac2b91a \
+    --hash=sha256:f8d3a1bb96778fed9b8aabfd0dd6e19843e4b0f2bb6b59f32b8a92051b0f348f
     # via -r requirements-tools.in
     # from https://pypi.org/simple
 triton==3.6.0 \
@@ -1407,9 +1407,9 @@ triton==3.6.0 \
     --hash=sha256:e021e87e8f266c6f87bf379b669c43c2800aac6247bdf5d518cb553e3c403c00
     # via torch
     # from https://download.pytorch.org/whl/cu128
-typer==0.24.1 \
-    --hash=sha256:112c1f0ce578bfb4cab9ffdabc68f031416ebcc216536611ba21f04e9aa84c9e \
-    --hash=sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45
+typer==0.25.0 \
+    --hash=sha256:123eaf9f19bb40fd268310e12a542c0c6b4fab9c98d9d23342a01ff95e3ce930 \
+    --hash=sha256:ac01b48823d3db9a83c9e164338057eadbb1c9957a2a6b4eeb486669c560b5dc
     # via
     #   huggingface-hub
     #   transformers

--- a/container-images/common/requirements-tools-rocm6.3.txt
+++ b/container-images/common/requirements-tools-rocm6.3.txt
@@ -162,9 +162,9 @@ charset-normalizer==3.4.7 \
     --hash=sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464
     # via requests
     # from https://pypi.org/simple
-click==8.3.2 \
-    --hash=sha256:14162b8b3b3550a7d479eafa77dfd3c38d9dc8951f6f69c78913a8f9a7540fd5 \
-    --hash=sha256:1924d2c27c5653561cd2cae4548d1406039cb79b858b747cfea24924bbc1616d
+click==8.3.3 \
+    --hash=sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2 \
+    --hash=sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613
     # via typer
     # from https://pypi.org/simple
 filelock==3.29.0 \
@@ -181,7 +181,7 @@ fsspec==2026.3.0 \
     #   huggingface-hub
     #   torch
     # from https://pypi.org/simple
-gguf @ git+https://github.com/ggml-org/llama.cpp@75f3bc94e649616162981c322e8e6b88ca5491e8#subdirectory=gguf-py
+gguf @ git+https://github.com/ggml-org/llama.cpp@15fa3c493bfcd040b5f4dcb29e1c998a0846de16#subdirectory=gguf-py
     # via -r requirements-tools.in
 h11==0.16.0 \
     --hash=sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1 \
@@ -226,16 +226,16 @@ httpx==0.28.1 \
     --hash=sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad
     # via huggingface-hub
     # from https://pypi.org/simple
-huggingface-hub==1.11.0 \
-    --hash=sha256:15fb3713c7f9cdff7b808a94fd91664f661ab142796bb48c9cd9493e8d166278 \
-    --hash=sha256:42a6de0afbfeb5e022222d36398f029679db4eb4778801aafda32257ae9131ab
+huggingface-hub==1.12.0 \
+    --hash=sha256:7c3fe85e24b652334e5d456d7a812cd9a071e75630fac4365d9165ab5e4a34b6 \
+    --hash=sha256:d74939969585ee35748bd66de09baf84099d461bda7287cd9043bfb99b0e424d
     # via
     #   tokenizers
     #   transformers
     # from https://pypi.org/simple
-idna==3.12 \
-    --hash=sha256:60ffaa1858fac94c9c124728c24fcde8160f3fb4a7f79aa8cdd33a9d1af60a67 \
-    --hash=sha256:724e9952cc9e2bd7550ea784adb098d837ab5267ef67a1ab9cf7846bdbdd8254
+idna==3.13 \
+    --hash=sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242 \
+    --hash=sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3
     # via
     #   anyio
     #   httpx
@@ -452,9 +452,9 @@ numpy==2.4.4 \
     #   mistral-common
     #   transformers
     # from https://pypi.org/simple
-packaging==26.1 \
-    --hash=sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f \
-    --hash=sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de
+packaging==26.2 \
+    --hash=sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e \
+    --hash=sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661
     # via
     #   huggingface-hub
     #   transformers
@@ -1259,14 +1259,14 @@ tqdm==4.67.3 \
     #   huggingface-hub
     #   transformers
     # from https://pypi.org/simple
-transformers==5.5.4 \
-    --hash=sha256:0bd6281b82966fe5a7a16f553ea517a9db1dee6284d7cb224dfd88fc0dd1c167 \
-    --hash=sha256:2e67cadba81fc7608cc07c4dd54f524820bc3d95b1cabd0ef3db7733c4f8b82e
+transformers==5.6.2 \
+    --hash=sha256:e657134c3e5a6bc00a3c35f4e2674bb51adfcd89898495b788a18552bac2b91a \
+    --hash=sha256:f8d3a1bb96778fed9b8aabfd0dd6e19843e4b0f2bb6b59f32b8a92051b0f348f
     # via -r requirements-tools.in
     # from https://pypi.org/simple
-typer==0.24.1 \
-    --hash=sha256:112c1f0ce578bfb4cab9ffdabc68f031416ebcc216536611ba21f04e9aa84c9e \
-    --hash=sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45
+typer==0.25.0 \
+    --hash=sha256:123eaf9f19bb40fd268310e12a542c0c6b4fab9c98d9d23342a01ff95e3ce930 \
+    --hash=sha256:ac01b48823d3db9a83c9e164338057eadbb1c9957a2a6b4eeb486669c560b5dc
     # via
     #   huggingface-hub
     #   transformers

--- a/container-images/common/requirements-tools-xpu.txt
+++ b/container-images/common/requirements-tools-xpu.txt
@@ -162,9 +162,9 @@ charset-normalizer==3.4.7 \
     --hash=sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464
     # via requests
     # from https://pypi.org/simple
-click==8.3.2 \
-    --hash=sha256:14162b8b3b3550a7d479eafa77dfd3c38d9dc8951f6f69c78913a8f9a7540fd5 \
-    --hash=sha256:1924d2c27c5653561cd2cae4548d1406039cb79b858b747cfea24924bbc1616d
+click==8.3.3 \
+    --hash=sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2 \
+    --hash=sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613
     # via typer
     # from https://pypi.org/simple
 dpcpp-cpp-rt==2025.2.1 \
@@ -192,7 +192,7 @@ fsspec==2026.3.0 \
     #   huggingface-hub
     #   torch
     # from https://pypi.org/simple
-gguf @ git+https://github.com/ggml-org/llama.cpp@75f3bc94e649616162981c322e8e6b88ca5491e8#subdirectory=gguf-py
+gguf @ git+https://github.com/ggml-org/llama.cpp@15fa3c493bfcd040b5f4dcb29e1c998a0846de16#subdirectory=gguf-py
     # via -r requirements-tools.in
 h11==0.16.0 \
     --hash=sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1 \
@@ -237,16 +237,16 @@ httpx==0.28.1 \
     --hash=sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad
     # via huggingface-hub
     # from https://pypi.org/simple
-huggingface-hub==1.11.0 \
-    --hash=sha256:15fb3713c7f9cdff7b808a94fd91664f661ab142796bb48c9cd9493e8d166278 \
-    --hash=sha256:42a6de0afbfeb5e022222d36398f029679db4eb4778801aafda32257ae9131ab
+huggingface-hub==1.12.0 \
+    --hash=sha256:7c3fe85e24b652334e5d456d7a812cd9a071e75630fac4365d9165ab5e4a34b6 \
+    --hash=sha256:d74939969585ee35748bd66de09baf84099d461bda7287cd9043bfb99b0e424d
     # via
     #   tokenizers
     #   transformers
     # from https://pypi.org/simple
-idna==3.12 \
-    --hash=sha256:60ffaa1858fac94c9c124728c24fcde8160f3fb4a7f79aa8cdd33a9d1af60a67 \
-    --hash=sha256:724e9952cc9e2bd7550ea784adb098d837ab5267ef67a1ab9cf7846bdbdd8254
+idna==3.13 \
+    --hash=sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242 \
+    --hash=sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3
     # via
     #   anyio
     #   httpx
@@ -575,9 +575,9 @@ onemkl-sycl-sparse==2025.2.0 \
     --hash=sha256:bb7cf7ea365d877a4e2f47e8e85d915d22efa80a5b2584d285bda3fc357a6360
     # via torch
     # from https://pypi.org/simple
-packaging==26.1 \
-    --hash=sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f \
-    --hash=sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de
+packaging==26.2 \
+    --hash=sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e \
+    --hash=sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661
     # via
     #   huggingface-hub
     #   transformers
@@ -1428,14 +1428,14 @@ tqdm==4.67.3 \
     #   huggingface-hub
     #   transformers
     # from https://pypi.org/simple
-transformers==5.5.4 \
-    --hash=sha256:0bd6281b82966fe5a7a16f553ea517a9db1dee6284d7cb224dfd88fc0dd1c167 \
-    --hash=sha256:2e67cadba81fc7608cc07c4dd54f524820bc3d95b1cabd0ef3db7733c4f8b82e
+transformers==5.6.2 \
+    --hash=sha256:e657134c3e5a6bc00a3c35f4e2674bb51adfcd89898495b788a18552bac2b91a \
+    --hash=sha256:f8d3a1bb96778fed9b8aabfd0dd6e19843e4b0f2bb6b59f32b8a92051b0f348f
     # via -r requirements-tools.in
     # from https://pypi.org/simple
-typer==0.24.1 \
-    --hash=sha256:112c1f0ce578bfb4cab9ffdabc68f031416ebcc216536611ba21f04e9aa84c9e \
-    --hash=sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45
+typer==0.25.0 \
+    --hash=sha256:123eaf9f19bb40fd268310e12a542c0c6b4fab9c98d9d23342a01ff95e3ce930 \
+    --hash=sha256:ac01b48823d3db9a83c9e164338057eadbb1c9957a2a6b4eeb486669c560b5dc
     # via
     #   huggingface-hub
     #   transformers

--- a/container-images/common/requirements-tools.in
+++ b/container-images/common/requirements-tools.in
@@ -1,6 +1,6 @@
 # requirements for convert_hf_to_gguf.py
 # Keep the tag below in sync with the tag used for convert_hf_to_gguf.py in Containerfile.tools
-git+https://github.com/ggml-org/llama.cpp@b8779#subdirectory=gguf-py
+git+https://github.com/ggml-org/llama.cpp@b8920#subdirectory=gguf-py
 mistral-common
 numpy
 protobuf

--- a/container-images/e2e/Containerfile
+++ b/container-images/e2e/Containerfile
@@ -3,7 +3,8 @@ FROM quay.io/fedora/fedora:43
 ENV HOME=/tmp \
     XDG_RUNTIME_DIR=/tmp \
     TOX_WORK_DIR=/tmp/.tox \
-    PIP_NO_CACHE_DIR=1
+    PIP_NO_CACHE_DIR=1 \
+    GOBIN=/usr/bin
 WORKDIR /src
 ENTRYPOINT ["/usr/bin/entrypoint.sh"]
 
@@ -13,15 +14,15 @@ RUN dnf -y --setopt=install_weak_deps=false install \
     gcc rust cargo \
     $([ $(uname -m) == "x86_64" ] && echo ollama) \
     # for validate and unit-tests
-    shellcheck \
+    shellcheck golang \
     python3 python3-devel python3-pip \
-    perl-Clone perl-FindBin && \
+    perl perl-Clone perl-FindBin && \
     dnf -y clean all
 RUN rpm --restore shadow-utils
 
 COPY container-images/e2e/entrypoint.sh /usr/bin
 COPY container-images/e2e/containers.conf /etc/containers
 COPY . /src
-RUN make install-requirements && make clean
+RUN make install-requirements && make -C docs install-tools && make clean
 RUN chmod -R a+rw /src
 RUN chmod a+rw /etc/subuid /etc/subgid


### PR DESCRIPTION
Brings the version of `convert_hf_to_gguf.py` in sync with `llama.cpp`.

Install `go` in the `e2e` image so `make man-check` will succeed in CI.