### PR TITLE
rag: revert typer to 0.24.2

### DIFF
--- a/container-images/common/requirements-rag.txt
+++ b/container-images/common/requirements-rag.txt
@@ -1886,9 +1886,9 @@ tqdm==4.67.3 \
     #   openai
     #   semchunk
     # from https://pypi.org/simple
-typer==0.25.0 \
-    --hash=sha256:123eaf9f19bb40fd268310e12a542c0c6b4fab9c98d9d23342a01ff95e3ce930 \
-    --hash=sha256:ac01b48823d3db9a83c9e164338057eadbb1c9957a2a6b4eeb486669c560b5dc
+typer==0.24.2 \
+    --hash=sha256:b618bc3d721f9a8d30f3e05565be26416d06e9bcc29d49bc491dc26aba674fa8 \
+    --hash=sha256:ec070dcfca1408e85ee203c6365001e818c3b7fffe686fd07ff2d68095ca0480
     # via docling-core
     # from https://pypi.org/simple
 typing-extensions==4.15.0 \


### PR DESCRIPTION
`docling-core` requires `typer` `<` `0.25.0`, so renovate updating to `0.25.0` made dependencies unresolvable and broke the `ramalama-rag` image build.