### PR TITLE
renovate: run lockFileMaintenance once a week

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,6 +6,11 @@
     "ignorePaths": [
         "container-images/common/*.txt"
     ],
+    "lockFileMaintenance": {
+        "schedule": [
+            "* 0-9 * * 1"
+        ]
+    },
     "packageRules": [
         {
             "groupName": "CI updates",
@@ -17,6 +22,6 @@
         }
     ],
     "schedule": [
-        "before 9am on Monday"
+        "* 0-9 * * 1"
     ]
 }


### PR DESCRIPTION
Only run `lockFileMaintenance` on Monday morning, to reduce the number of open PRs.

Use `cron` syntax everywhere, as recommended by `renovate`.

[skip ci]