### PR TITLE
sandbox: update agent images to their latest versions

### DIFF
--- a/docs/ramalama-sandbox-goose.1.md.in
+++ b/docs/ramalama-sandbox-goose.1.md.in
@@ -90,7 +90,7 @@ ramalama sandbox goose qwen3:4b
 
 Run the Goose agent with a custom image:
 ```
-ramalama sandbox goose --goose-image ghcr.io/block/goose:1.27.1 qwen3:4b
+ramalama sandbox goose --goose-image ghcr.io/aaif-goose/goose:1.27.1 qwen3:4b
 ```
 
 Turn off thinking mode in the model the agent is connecting to (may result in faster responses):

--- a/docs/ramalama-sandbox.1.md
+++ b/docs/ramalama-sandbox.1.md
@@ -12,7 +12,7 @@ in a container. The agent uses the model for reasoning and tool calling.
 
 The *agent* argument selects which AI agent to run. Currently supported agents:
 
-- **goose** - the Goose AI agent (https://github.com/block/goose)
+- **goose** - the Goose AI agent (https://github.com/aaif-goose/goose)
 - **opencode** - the OpenCode AI agent (https://opencode.ai/)
 
 ## OPTIONS

--- a/ramalama/sandbox.py
+++ b/ramalama/sandbox.py
@@ -45,7 +45,7 @@ def add_sandbox_subparsers(subparsers: argparse._SubParsersAction, img_comp: Cal
     parser.add_argument("MODEL", completer=model_comp)
     parser.add_argument(
         "--goose-image",
-        default="ghcr.io/block/goose:1.28.0",
+        default="ghcr.io/aaif-goose/goose:1.33.1",
         completer=img_comp,
         help="Goose container image",
     )
@@ -59,7 +59,7 @@ def add_sandbox_subparsers(subparsers: argparse._SubParsersAction, img_comp: Cal
     parser.add_argument("MODEL", completer=model_comp)
     parser.add_argument(
         "--opencode-image",
-        default="ghcr.io/anomalyco/opencode:1.3.7",
+        default="ghcr.io/anomalyco/opencode:1.14.30",
         completer=img_comp,
         help="OpenCode container image",
     )

--- a/test/unit/test_sandbox_cmd.py
+++ b/test/unit/test_sandbox_cmd.py
@@ -15,7 +15,7 @@ def _make_args(engine="podman"):
         engine=engine,
         dryrun=False,
         quiet=True,
-        goose_image="ghcr.io/block/goose:latest",
+        goose_image="ghcr.io/aaif-goose/goose:latest",
         name="ramalama_model_abc",
         port="8080",
         thinking=False,
@@ -155,7 +155,7 @@ def test_agent_no_workdir(agent):
 def test_goose_default_image():
     """Goose subcommand should provide a default goose image"""
     _, args = parse_args_from_cmd(["sandbox", "goose", TEST_MODEL])
-    assert args.goose_image.startswith("ghcr.io/block/goose:")
+    assert args.goose_image.startswith("ghcr.io/aaif-goose/goose:")
 
 
 def test_goose_custom_image():


### PR DESCRIPTION
Goose has moved to the `aaif-goose` Github org, update the image location, tests, and docs accordingly.