### PR TITLE
Align --ngl, --cache-reuse, and --thinking with llama-server defaults

### DIFF
--- a/docs/options/cache-reuse.md
+++ b/docs/options/cache-reuse.md
@@ -3,4 +3,5 @@
 ####> If this file is edited, make sure the changes
 ####> are applicable to all of those.
 #### **--cache-reuse**=*BYTES*
-Minimum chunk size (in bytes) to attempt reusing from the cache via KV shifting. (default: 256)
+Minimum chunk size (in bytes) to attempt reusing from the cache via KV shifting.
+When omitted, llama-server uses its built-in default.

--- a/docs/options/ngl.md
+++ b/docs/options/ngl.md
@@ -3,5 +3,5 @@
 ####> If this file is edited, make sure the changes
 ####> are applicable to all of those.
 #### **--ngl**
-Number of GPU layers: `0` means CPU inferencing, `999` means use max GPU layers.
-Default is `-1`; for llama.cpp backends, negative values are mapped to `999` (max layers).
+Number of layers to store in VRAM: a number, `auto`, or `all`.
+When omitted, llama-server defaults to `auto`.

--- a/docs/options/serve-examples-body.md
+++ b/docs/options/serve-examples-body.md
@@ -213,7 +213,7 @@ spec:
       - name: model-server
 	image: quay.io/ramalama/ramalama:0.8
 	command: ["llama-server"]
-	args: ['--port', '8081', '--model', '/mnt/models/model.file', '--alias', 'quay.io/rhatdan/granite:latest', '--temp', '0.8', '--jinja', '--cache-reuse', '256', '-v', '--threads', 16, '--host', '127.0.0.1']
+	args: ['--port', '8081', '--model', '/mnt/models/model.file', '--alias', 'quay.io/rhatdan/granite:latest', '--temp', '0.8', '--jinja', '-v', '--threads', 16, '--host', '127.0.0.1']
 	securityContext:
 	  allowPrivilegeEscalation: false
 	  capabilities:

--- a/docs/options/thinking.md
+++ b/docs/options/thinking.md
@@ -2,5 +2,7 @@
 ####>   ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama serve
 ####> If this file is edited, make sure the changes
 ####> are applicable to all of those.
-#### **--thinking**=*true*
-Enable or disable thinking mode in reasoning models (default: `true`)
+#### **--thinking**=*BOOL*
+Enable or disable thinking mode in reasoning models.
+Maps to `--reasoning on` or `--reasoning off` in llama-server.
+When omitted, llama-server defaults to `auto`.

--- a/docs/ramalama-rag.1.md
+++ b/docs/ramalama-rag.1.md
@@ -63,8 +63,9 @@ Print usage message
 OCI container image to use for the llama.cpp inference servers.
 Defaults to the accelerator-appropriate ramalama image.
 
-#### **--ngl**=*integer*
-Number of layers to offload to the GPU, if available (default: -1, auto).
+#### **--ngl**=*value*
+Number of layers to store in VRAM: a number, `auto`, or `all`.
+When omitted, llama-server defaults to `auto`.
 
 #### **--rag-image**=*IMAGE*
 OCI container image for the RAG processing container.
@@ -95,7 +96,7 @@ $ ramalama rag ./report.pdf quay.io/myuser/report-rag
 
 ### Use a custom number of GPU layers
 ```
-$ ramalama rag --ngl 999 ./docs/ my-rag-image
+$ ramalama rag --ngl all ./docs/ my-rag-image
 ```
 
 ## SEE ALSO

--- a/ramalama/plugins/runtimes/inference/llama_cpp.py
+++ b/ramalama/plugins/runtimes/inference/llama_cpp.py
@@ -47,9 +47,6 @@ from ramalama.path_utils import file_uri_to_path
 from ramalama.plugins.loader import assemble_command
 from ramalama.plugins.runtimes.inference.common import ContainerizedInferenceRuntimePlugin
 from ramalama.plugins.runtimes.inference.llama_cpp_commands import (
-    _CACHE_REUSE_DEFAULT,
-    _NGL_DEFAULT,
-    _THINKING_DEFAULT,
     LlamaCppCommands,
     _default_threads,
 )
@@ -287,9 +284,8 @@ class LlamaCppPlugin(LlamaCppCommands, ContainerizedInferenceRuntimePlugin):
         parser.add_argument(
             "--ngl",
             dest="ngl",
-            type=int,
-            default=_NGL_DEFAULT,
-            help="number of layers to offload to the gpu, if available",
+            default=None,
+            help="number of layers to store in VRAM: a number, 'auto', or 'all' (default: auto)",
             completer=suppressCompleter,
         )
 
@@ -323,7 +319,7 @@ class LlamaCppPlugin(LlamaCppCommands, ContainerizedInferenceRuntimePlugin):
             "--cache-reuse",
             dest="cache_reuse",
             type=int,
-            default=_CACHE_REUSE_DEFAULT,
+            default=None,
             help="min chunk size to attempt reusing from the cache via KV shifting",
             completer=suppressCompleter,
         )
@@ -338,7 +334,7 @@ class LlamaCppPlugin(LlamaCppCommands, ContainerizedInferenceRuntimePlugin):
             )
             parser.add_argument(
                 "--thinking",
-                default=_THINKING_DEFAULT,
+                default=None,
                 help="enable/disable thinking mode in reasoning models",
                 action=CoerceToBool,
             )

--- a/ramalama/plugins/runtimes/inference/llama_cpp_commands.py
+++ b/ramalama/plugins/runtimes/inference/llama_cpp_commands.py
@@ -6,11 +6,6 @@ import os
 from ramalama.console import should_colorize
 from ramalama.transports.transport_factory import New
 
-# llama.cpp-specific defaults — not part of global config
-_NGL_DEFAULT: int = -1
-_CACHE_REUSE_DEFAULT: int = 256
-_THINKING_DEFAULT: bool = True
-
 
 def _default_threads() -> int:
     """Compute the default number of CPU threads for llama.cpp inference."""
@@ -80,8 +75,9 @@ class LlamaCppCommands:
 
         cmd.append("--no-warmup")
 
-        if not getattr(args, 'thinking', None):
-            cmd += ["--reasoning-budget", "0"]
+        thinking = getattr(args, 'thinking', None)
+        if thinking is not None:
+            cmd += ["--reasoning", "on" if thinking else "off"]
 
         if model is not None:
             cmd += ["--alias", model.model_alias]
@@ -104,9 +100,10 @@ class LlamaCppCommands:
         if getattr(args, 'webui', None) == 'off':
             cmd.append("--no-webui")
 
-        ngl = getattr(args, 'ngl', 0)
-        ngl_val = 999 if ngl < 0 else ngl
-        cmd += ["-ngl", str(ngl_val)]
+        ngl = getattr(args, 'ngl', None)
+        if ngl is not None:
+            ngl_str = "all" if ngl == "-1" or ngl == -1 else str(ngl)
+            cmd += ["-ngl", ngl_str]
 
         model_draft = getattr(args, 'model_draft', None)
         if model_draft:
@@ -117,7 +114,8 @@ class LlamaCppCommands:
                     draft_path = draft_model._get_entry_model_path(is_container, should_generate, dry_run)
             if draft_path:
                 cmd += ["--model-draft", draft_path]
-            cmd += ["-ngld", str(ngl_val)]
+            if ngl is not None:
+                cmd += ["-ngld", ngl_str]
 
         threads = getattr(args, 'threads', None)
         if threads is not None:
@@ -159,13 +157,15 @@ class LlamaCppCommands:
             model_path = model._get_entry_model_path(is_container, should_generate, dry_run)
             cmd += ["--model", model_path]
 
-        ngl = getattr(args, 'ngl', 0)
-        ngl_val = 999 if ngl < 0 else ngl
-        cmd += ["-ngl", str(ngl_val)]
+        ngl = getattr(args, 'ngl', None)
+        if ngl is not None:
+            ngl_str = "all" if ngl == "-1" or ngl == -1 else str(ngl)
+            cmd += ["-ngl", ngl_str]
 
         model_draft = getattr(args, 'model_draft', None)
         if model_draft:
-            cmd += ["-ngld", str(ngl_val)]
+            if ngl is not None:
+                cmd += ["-ngld", ngl_str]
 
         threads = getattr(args, 'threads', None)
         if threads is not None:
@@ -186,13 +186,15 @@ class LlamaCppCommands:
             model_path = model._get_entry_model_path(is_container, should_generate, dry_run)
             cmd += ["--model", model_path]
 
-        ngl = getattr(args, 'ngl', 0)
-        ngl_val = 999 if ngl < 0 else ngl
-        cmd += ["-ngl", str(ngl_val)]
+        ngl = getattr(args, 'ngl', None)
+        if ngl is not None:
+            ngl_str = "all" if ngl == "-1" or ngl == -1 else str(ngl)
+            cmd += ["-ngl", ngl_str]
 
         model_draft = getattr(args, 'model_draft', None)
         if model_draft:
-            cmd += ["-ngld", str(ngl_val)]
+            if ngl is not None:
+                cmd += ["-ngld", ngl_str]
 
         threads = getattr(args, 'threads', None)
         if threads is not None:

--- a/ramalama/plugins/runtimes/inference/rag/cli.py
+++ b/ramalama/plugins/runtimes/inference/rag/cli.py
@@ -2,7 +2,7 @@
 
 from ramalama.cli import OverrideDefaultAction, default_image, default_rag_image, local_images, suppressCompleter
 from ramalama.plugins.runtimes.inference.llama_cpp import AddPathOrUrl
-from ramalama.plugins.runtimes.inference.llama_cpp_commands import _NGL_DEFAULT, _default_threads
+from ramalama.plugins.runtimes.inference.llama_cpp_commands import _default_threads
 
 
 def register_rag_subcommand(plugin, subparsers):
@@ -64,9 +64,8 @@ def register_rag_subcommand(plugin, subparsers):
     parser.add_argument(
         "--ngl",
         dest="ngl",
-        type=int,
-        default=_NGL_DEFAULT,
-        help="number of layers to offload to the GPU",
+        default=None,
+        help="number of layers to store in VRAM: a number, 'auto', or 'all' (default: auto)",
         completer=suppressCompleter,
     )
     parser.add_argument(

--- a/ramalama/plugins/runtimes/inference/rag/handler.py
+++ b/ramalama/plugins/runtimes/inference/rag/handler.py
@@ -14,7 +14,7 @@ from ramalama.common import ensure_image, perror, set_accel_env_vars
 from ramalama.config import ActiveConfig
 from ramalama.plugins.interface import RuntimePlugin
 from ramalama.plugins.loader import assemble_command
-from ramalama.plugins.runtimes.inference.llama_cpp_commands import _NGL_DEFAULT, _default_threads
+from ramalama.plugins.runtimes.inference.llama_cpp_commands import _default_threads
 from ramalama.transports.base import compute_serving_port
 from ramalama.transports.transport_factory import New
 
@@ -40,7 +40,7 @@ def rag_handler(plugin: RuntimePlugin, args: argparse.Namespace) -> None:
 
     # Build serve args for the VLM and embedding servers
     vlm_ctx_size = getattr(args, "ctx_size", 8192)
-    embed_ctx_size = getattr(args, "embed_ctx_size", 8192)
+    embed_ctx_size = getattr(args, "embed_ctx_size", None)
     docling_serve_args = _build_serve_args(
         args, docling_model, docling_port, runtime_args=["--special"], ctx_size=vlm_ctx_size
     )
@@ -110,7 +110,7 @@ def rag_handler(plugin: RuntimePlugin, args: argparse.Namespace) -> None:
         _cleanup_servers(args, docling_serve_args, embed_serve_args, docling_proc, embed_proc)
 
 
-def _build_serve_args(args, model_name, port, runtime_args=None, ctx_size=8192, cache_reuse=256):
+def _build_serve_args(args, model_name, port, runtime_args=None, ctx_size=None, cache_reuse=None):
     """Build argparse.Namespace for an internal llama.cpp serve session."""
     return argparse.Namespace(
         MODEL=model_name,
@@ -140,10 +140,10 @@ def _build_serve_args(args, model_name, port, runtime_args=None, ctx_size=8192, 
         port=str(port),
         ctx_size=ctx_size,
         cache_reuse=cache_reuse,
-        ngl=getattr(args, "ngl", _NGL_DEFAULT),
+        ngl=getattr(args, "ngl", None),
         threads=getattr(args, "threads", _default_threads()),
         temp=0.0,
-        thinking=False,
+        thinking=None,
         max_tokens=0,
         seed=None,
         webui="off",

--- a/test/e2e/test_run.py
+++ b/test/e2e/test_run.py
@@ -71,8 +71,8 @@ def test_basic_dry_run():
             id="check test_model", marks=skip_if_no_container
         ),
         pytest.param(
-            [], r".*--cache-reuse 256", None, None, True, None,
-            id="check cache-reuse is being set", marks=skip_if_no_container
+            [], r".*--cache-reuse", None, None, False, None,
+            id="check --cache-reuse not passed by default", marks=skip_if_no_container
         ),
         pytest.param(
             [], r".*--ctx-size", None, None, False, None,
@@ -190,8 +190,8 @@ def test_basic_dry_run():
             id="check --ctx-size 4096", marks=skip_if_container,
         ),
         pytest.param(
-            ["--ctx-size", "4096"], r".*--cache-reuse 256.*", None, None, True, None,
-            id="check --cache-reuse is set by default to 256", marks=skip_if_container,
+            ["--ctx-size", "4096"], r".*--cache-reuse", None, None, False, None,
+            id="check --cache-reuse not passed by default", marks=skip_if_container,
         ),
         pytest.param(
             [], r".*-e ASAHI_VISIBLE_DEVICES=99", None, {"ASAHI_VISIBLE_DEVICES": "99"}, True, None,

--- a/test/e2e/test_serve.py
+++ b/test/e2e/test_serve.py
@@ -76,8 +76,8 @@ def test_basic_dry_run():
             id="check default --name flag", marks=skip_if_no_container
         ),
         pytest.param(
-            [], r".*--cache-reuse 256", None, None, True,
-            id="check --cache-reuse default value (256)", marks=skip_if_no_container
+            [], r".*--cache-reuse", None, None, False,
+            id="check --cache-reuse not passed by default", marks=skip_if_no_container
         ),
         pytest.param(
             [], r".*--no-webui", None, None, False,
@@ -179,8 +179,8 @@ def test_basic_dry_run():
             id="check default --host value", marks=skip_if_container
         ),
         pytest.param(
-            [], r".*--cache-reuse 256", None, None, True,
-            id="check --cache-reuse default value", marks=skip_if_container
+            [], r".*--cache-reuse", None, None, False,
+            id="check --cache-reuse not passed by default", marks=skip_if_container
         ),
         pytest.param(
             ["--host", "127.0.0.1"],
@@ -209,12 +209,16 @@ def test_basic_dry_run():
             id="check --runtime-args=\"--foo='a b c'\""
         ),
         pytest.param(
-            ["--thinking", "False"], r".*--reasoning-budget 0", None, None, True,
-            id="check --reasoning-budget 0 passed to runtime",
+            ["--thinking", "False"], r".*--reasoning off", None, None, True,
+            id="check --reasoning off passed to runtime",
         ),
         pytest.param(
-            [], r".*--reasoning-budget", None, None, False,
-            id="check --reasoning-budget not passed by default",
+            ["--thinking", "True"], r".*--reasoning on", None, None, True,
+            id="check --reasoning on passed to runtime",
+        ),
+        pytest.param(
+            [], r".*--reasoning", None, None, False,
+            id="check --reasoning not passed by default",
         ),
     ],
 )

--- a/test/unit/test_inference_engine_plugins.py
+++ b/test/unit/test_inference_engine_plugins.py
@@ -25,19 +25,19 @@ from ramalama.plugins.runtimes.inference.vllm import VllmPlugin
 
 def make_ns(
     container=True,
-    ngl=-1,
+    ngl=None,
     threads=4,
     temp=0.8,
     seed=None,
     ctx_size=0,
-    cache_reuse=256,
+    cache_reuse=None,
     max_tokens=0,
     port="8080",
     host="::",
     logfile=None,
     debug=False,
     webui="on",
-    thinking=True,
+    thinking=None,
     model_draft=None,
     runtime_args=None,
     gguf=None,
@@ -156,7 +156,7 @@ class TestLlamaCppPlugin:
         assert cmd[cmd.index("--model") + 1] == "/mnt/models/model.file"
         assert "--no-warmup" in cmd
         assert "--alias" in cmd
-        assert "-ngl" in cmd
+        assert "-ngl" not in cmd
 
     @patch("ramalama.plugins.runtimes.inference.llama_cpp_commands.should_colorize", return_value=False)
     def test_serve_nocontainer_uses_configured_host(self, mock_colorize):
@@ -194,15 +194,23 @@ class TestLlamaCppPlugin:
         ns = make_ns(thinking=False)
         cmd = self.plugin.handle_subcommand("serve", ns)
 
-        assert "--reasoning-budget" in cmd
-        assert cmd[cmd.index("--reasoning-budget") + 1] == "0"
+        assert "--reasoning" in cmd
+        assert cmd[cmd.index("--reasoning") + 1] == "off"
 
     @patch("ramalama.plugins.runtimes.inference.llama_cpp_commands.should_colorize", return_value=False)
     def test_serve_thinking_enabled(self, mock_colorize):
         ns = make_ns(thinking=True)
         cmd = self.plugin.handle_subcommand("serve", ns)
 
-        assert "--reasoning-budget" not in cmd
+        assert "--reasoning" in cmd
+        assert cmd[cmd.index("--reasoning") + 1] == "on"
+
+    @patch("ramalama.plugins.runtimes.inference.llama_cpp_commands.should_colorize", return_value=False)
+    def test_serve_thinking_default(self, mock_colorize):
+        ns = make_ns(thinking=None)
+        cmd = self.plugin.handle_subcommand("serve", ns)
+
+        assert "--reasoning" not in cmd
 
     @patch("ramalama.plugins.runtimes.inference.llama_cpp_commands.should_colorize", return_value=False)
     def test_serve_ctx_size(self, mock_colorize):
@@ -242,12 +250,19 @@ class TestLlamaCppPlugin:
         assert cmd[cmd.index("-ngl") + 1] == "40"
 
     @patch("ramalama.plugins.runtimes.inference.llama_cpp_commands.should_colorize", return_value=False)
-    def test_serve_ngl_negative_uses_999(self, mock_colorize):
+    def test_serve_ngl_negative_uses_all(self, mock_colorize):
         ns = make_ns(ngl=-1)
         cmd = self.plugin.handle_subcommand("serve", ns)
 
         assert "-ngl" in cmd
-        assert cmd[cmd.index("-ngl") + 1] == "999"
+        assert cmd[cmd.index("-ngl") + 1] == "all"
+
+    @patch("ramalama.plugins.runtimes.inference.llama_cpp_commands.should_colorize", return_value=False)
+    def test_serve_ngl_default_omitted(self, mock_colorize):
+        ns = make_ns()
+        cmd = self.plugin.handle_subcommand("serve", ns)
+
+        assert "-ngl" not in cmd
 
     @patch("ramalama.plugins.runtimes.inference.llama_cpp_commands.should_colorize", return_value=False)
     def test_serve_max_tokens(self, mock_colorize):

--- a/test/unit/test_loader.py
+++ b/test/unit/test_loader.py
@@ -15,7 +15,7 @@ def make_cli_args(**kwargs) -> argparse.Namespace:
         "container": True,
         "generate": None,
         "dryrun": False,
-        "ngl": -1,
+        "ngl": None,
         "threads": 4,
         "temp": 0.8,
         "seed": None,


### PR DESCRIPTION
The llama-server cli args have evolved over time. Many now have much better default/auto logic, which the ramalama defaults now conflict with e.g --fit is now default which --ngl will interfere with.
Defer to llama-server's own defaults going forward, unless explicitly provided by the user.

Fixes: #2707

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>