### PR TITLE
fix: sync args.rag with formatted model after OCI init

### DIFF
--- a/ramalama/rag.py
+++ b/ramalama/rag.py
@@ -170,6 +170,7 @@ class RagTransport(OCI):
     def __init__(self, imodel: Transport, cmd: list[str], args: RagArgsType):
         self.kind = RagSource.DB if os.path.exists(args.rag) else RagSource.IMAGE
         super().__init__(args.rag, args.store, args.engine)
+        args.rag = self.model
         self.imodel = imodel
         self.model_cmd = cmd
 

--- a/test/e2e/test_serve.py
+++ b/test/e2e/test_serve.py
@@ -851,7 +851,7 @@ def test_serve_with_rag():
         assert re.search(r".*llama-server", result_a)
         assert re.search(r".*quay.io/.*-rag(@sha256)?:", result_a)
         assert re.search(r".*rag_framework serve", result_a)
-        assert re.search(r".*--mount=type=image,source=quay.io/ramalama/rag,destination=/rag,rw=true", result_a)
+        assert re.search(r".*--mount=type=image,source=quay.io/ramalama/rag:latest,destination=/rag,rw=true", result_a)
 
         result_b = ctx.check_output(
             [

--- a/test/unit/test_rag_unit.py
+++ b/test/unit/test_rag_unit.py
@@ -81,3 +81,9 @@ class TestRagTransportLocalhostPrefix:
 
         assert rt.kind is RagSource.IMAGE
         assert rt.model == "localhost/myrag:latest"
+
+    def test_bare_name_syncs_args_rag(self, tmp_path: Path, force_oci_image: None) -> None:
+        args = Namespace(rag="myrag", store=str(tmp_path / "store"), engine="podman")
+        RagTransport(imodel=MagicMock(), cmd=[], args=args)
+
+        assert args.rag == "localhost/myrag:latest"


### PR DESCRIPTION
## Summary

- Fixes #2711
- After `RagTransport.format_model()` adds the `localhost/` prefix to bare image names, `args.rag` was not updated to match `self.model`. Since `RagEngine.add_rag()` uses `args.rag` directly in the container mount command, the bare name resolved against `docker.io` instead of the local registry, causing `Error: docker.io/<name>:latest does not exist`
- Syncs `args.rag = self.model` after `super().__init__()` so the formatted name propagates to the mount command
- Adds a unit test verifying that `args.rag` reflects the `localhost/` prefix after initialization

## Why

PR #2676 correctly added a `localhost/` prefix via `format_model()` to prevent bare OCI names from defaulting to `docker.io`. However, `format_model()` only updates `self.model` - the `args.rag` field passed to `RagEngine.add_rag()` at mount time was left unchanged, so the fix had no effect on the actual container mount source.

## Test plan

- [x] Unit test `test_bare_name_syncs_args_rag` asserts that `args.rag == "localhost/myrag:latest"` after `RagTransport` init
- [x] All 9 RAG unit tests pass
- [x] All 36 transport base tests pass (conftest fixture shared correctly)