### PR TITLE
docs: switch demo multimodal model from smolvlm to qwen2.5vl:3b

### DIFF
--- a/docs/demo/ramalama.sh
+++ b/docs/demo/ramalama.sh
@@ -69,6 +69,18 @@ pull() {
     exec_color "ramalama ls | grep --color smollm:135m"
     echo ""
 
+    echo_color "Remove qwen2.5vl:3b model if previously pulled"
+    exec_color "ramalama rm --ignore qwen2.5vl:3b"
+    echo ""
+
+    echo_color "RamaLama Pulling Ollama Image qwen2.5vl:3b"
+    exec_color "ramalama pull qwen2.5vl:3b"
+    echo ""
+
+    echo_color "RamaLama List all AI Models in local store"
+    exec_color "ramalama ls | grep --color qwen2.5vl:3b"
+    echo ""
+
     echo_color "Show RamaLama container images"
     exec_color "podman images | grep ramalama"
     echo ""
@@ -184,8 +196,12 @@ quadlet() {
 }
 
 multi-modal() {
-    echo_color "Serve smolvlm via RamaLama model service"
-    exec_color "ramalama serve --port 8080 --name multi-modal -d smolvlm"
+    echo_color "Serve qwen2.5vl:3b via RamaLama model service"
+    exec_color "ramalama serve --port 8080 --name multi-modal -d qwen2.5vl:3b"
+    echo ""
+
+    echo_color "Waiting for the model service to come up"
+    exec_color "timeout 60 bash -c 'until curl -s -f -o /dev/null http://localhost:8080/v1/models; do sleep 2; done'"
     echo ""
 
     echo_color "Use web browser to show interaction"


### PR DESCRIPTION
## Summary

- Fixes #2713
- Replaces `smolvlm` with `qwen2.5vl:3b` in the multi-modal demo function of `docs/demo/ramalama.sh`
- SmolVLM's Jinja chat template has a bug that outputs `<image>` literally instead of preserving the internal media marker token, causing `mtmd_tokenize` to fail
- An upstream fix is pending at ggml-org/llama.cpp#22342 - once merged and container images rebuilt, SmolVLM can be restored

## Why

The multi-modal camera demo is currently broken. SmolVLM's chat template doesn't handle the `media_marker` content type correctly - it treats it as `type: "image"` and outputs `<image>`, but the multimodal tokenizer needs the actual marker token (e.g. `<__media_abc123__>`) to locate where to insert image embeddings.

`qwen2.5vl:3b` is a working multimodal model already available in `shortnames/shortnames.conf` that handles the media markers correctly.

## Trade-offs

- `qwen2.5vl:3b` is ~2.3GB vs SmolVLM's ~415MB, so first pull takes longer
- `camera-demo.html` needs no changes - it sends standard OpenAI-compatible multimodal requests

## Test plan

- [ ] `ramalama serve --port 8080 --name multi-modal -d qwen2.5vl:3b` starts successfully
- [ ] Opening `camera-demo.html` in a browser captures camera frames and gets AI responses
- [ ] `ramalama stop multi-modal` cleans up correctly