### PR TITLE
openvino: remove use of the updates-testing repo

### DIFF
--- a/container-images/scripts/build_llama.sh
+++ b/container-images/scripts/build_llama.sh
@@ -144,9 +144,7 @@ dnf_install_runtime_deps() {
     runtime_pkgs+=(ocl-icd intel-opencl intel-npu-driver)
   fi
   if [ ${#runtime_pkgs[@]} -gt 0 ]; then
-    local enablerepo_flag=""
-    [ "$containerfile" = "openvino" ] && enablerepo_flag="--enablerepo=updates-testing"
-    dnf install -y $enablerepo_flag --setopt=install_weak_deps=false "${runtime_pkgs[@]}"
+    dnf install -y --setopt=install_weak_deps=false "${runtime_pkgs[@]}"
   fi
   dnf -y clean all
 }


### PR DESCRIPTION
The required version of `intel-opencl` is now available in the `updates` repo.