### PR TITLE
Remove epel10.0 packit target

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -81,7 +81,6 @@ jobs:
     dist_git_branches: &fedora_targets
       - fedora-all
       - epel10
-      - epel10.0
       - epel9
 
   - job: koji_build
@@ -95,5 +94,4 @@ jobs:
     dist_git_branches:
       - fedora-branched # rawhide updates are created automatically
       - epel10
-      - epel10.0
       - epel9


### PR DESCRIPTION
EPEL 10.0 was retired almost six months ago.  Remove the epel10.0 packit target, and only build for the main epel10 target.

This intentionally doesn't add the epel10.1 or epel10.2 targets.  This will cause packit to only submit new versions to the leading EPEL 10 minor version, not older branches.  This is a better fit for the EPEL updates policy and the overall vision for EPEL 10.  It also helps prevent upgrade path problems of an older EPEL minor version getting ahead of a newer EPEL minor version due to an outdated packit config.

This was already fixed in Fedora dist-git, but was later overwritten by a packit pull request.

https://bugzilla.redhat.com/show_bug.cgi?id=2412412
https://src.fedoraproject.org/rpms/ramalama/pull-request/52