### PR TITLE
konflux: skip SBOM generation for rocm-tools

### DIFF
--- a/.tekton/pipelines/pull-request-pipeline.yaml
+++ b/.tekton/pipelines/pull-request-pipeline.yaml
@@ -31,6 +31,10 @@ spec:
     description: Skip checks against built image
     name: skip-checks
     type: string
+  - default: "true"
+    description: Skip SBOM generation
+    name: skip-sbom
+    type: string
   - default: "false"
     description: Execute the build with network isolation
     name: hermetic
@@ -232,6 +236,8 @@ spec:
       value: $(tasks.init.results.http-proxy)
     - name: NO_PROXY
       value: $(tasks.init.results.no-proxy)
+    - name: SKIP_SBOM_GENERATION
+      value: $(params.skip-sbom)
     runAfter:
     - wait-for-parent-image
     - prefetch-dependencies
@@ -623,6 +629,11 @@ spec:
       - name: kind
         value: task
       resolver: bundles
+    when:
+    - input: $(params.skip-sbom)
+      operator: in
+      values:
+      - "false"
   workspaces:
   - name: git-auth
     optional: true

--- a/.tekton/pipelines/push-pipeline.yaml
+++ b/.tekton/pipelines/push-pipeline.yaml
@@ -32,6 +32,10 @@ spec:
     name: skip-checks
     type: string
   - default: "false"
+    description: Skip SBOM generation
+    name: skip-sbom
+    type: string
+  - default: "false"
     description: Execute the build with network isolation
     name: hermetic
     type: string
@@ -215,6 +219,8 @@ spec:
       value: "true"
     - name: BUILDAH_FORMAT
       value: $(params.buildah-format)
+    - name: SKIP_SBOM_GENERATION
+      value: $(params.skip-sbom)
     runAfter:
     - wait-for-parent-image
     - prefetch-dependencies
@@ -606,6 +612,11 @@ spec:
       - name: kind
         value: task
       resolver: bundles
+    when:
+    - input: $(params.skip-sbom)
+      operator: in
+      values:
+      - "false"
   workspaces:
   - name: git-auth
     optional: true

--- a/.tekton/rocm-tools/rocm-tools-push.yaml
+++ b/.tekton/rocm-tools/rocm-tools-push.yaml
@@ -31,6 +31,8 @@ spec:
   - name: build-args
     value:
     - TORCH_BACKEND=rocm6.3
+  - name: skip-sbom
+    value: "true"
   pipelineRef:
     name: push-pipeline
   timeouts:


### PR DESCRIPTION
Syft is hanging indefinitely while scanning the (very large) `rocm-tools` image, causing builds to fail.

Also disable SBOM generation for pull request builds, since they're not being reviewed or published.

https://redhat.atlassian.net/browse/KFLUXSPRT-7855