### PR TITLE
fix: update Community channels for RamaLama project

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,15 +25,6 @@
   </a>
 </p>
 
-
-<!-- <h3 align="center">
-  <a href="https://docs.ramalama.com/">Docs</a> &bull;
-  <a href="https://github.com/containers/ramalama/discussions" title="Community Page">Discussion</a> &bull;
-  <a href="https://blog.ramalama.com" title="RamaLama Blog">Blog</a>
-</h3> -->
-
-
-
 [RamaLama](https://ramalama.ai) strives to make working with AI simple, straightforward, and familiar by using OCI containers.
 <br>
 <br>
@@ -1284,15 +1275,9 @@ so if you like this tool, give some of these repos a :star:, and hey, give us a 
 
 ## Community
 
-For general questions and discussion, please use RamaLama's
+For general questions, ideas, and discussions, please use RamaLama's [Matrix room](https://matrix.to/#/#ramalama:fedoraproject.org) or [Discussions forum](https://github.com/containers/ramalama/discussions).
 
-[`Matrix`](https://matrix.to/#/#ramalama:fedoraproject.org)
-
-For discussions around issues/bugs and features, you can use the GitHub
-[Issues](https://github.com/containers/ramalama/issues)
-and
-[PRs](https://github.com/containers/ramalama/pulls)
-tracking system.
+For discussions around issues/bugs and features, you can use the GitHub [Issues](https://github.com/containers/ramalama/issues) and [PRs](https://github.com/containers/ramalama/pulls) tracking system.
 
 ### Community / Developer Meetups
 

--- a/docsite/docusaurus.config.ts
+++ b/docsite/docusaurus.config.ts
@@ -95,11 +95,6 @@ const config: Config = {
           label: 'Docs',
         },
         {
-          href: 'https://blog.ramalama.com',
-          label: 'Blog',
-          position: 'left',
-        },
-        {
           href: 'https://github.com/containers/ramalama',
           label: 'GitHub',
           position: 'right',
@@ -137,22 +132,18 @@ const config: Config = {
               label: 'Discord',
               href: 'https://discord.gg/MkCXuTRBUn',
             },
-            {
-              label: 'X',
-              href: 'https://x.com/RamaLamaLabs',
-            },
           ],
         },
         {
           title: 'More',
           items: [
             {
-              label: 'Blog',
-              href: 'https://blog.ramalama.com',
-            },
-            {
               label: 'GitHub',
               href: 'https://github.com/containers/ramalama',
+            },
+            {
+              label: 'PyPI',
+              href: 'https://pypi.org/project/ramalama/',
             },
           ],
         },


### PR DESCRIPTION
The docsite has links to an [X account](https://x.com/ramalamalabs) and a [Blog](https://blog.ramalama.com/) that are not official Community channels for the RamaLama project. These can create confusion for people who are trying to engage with and contribute to the project.

This pull request removes the misleading info, and adds a link to [PyPI](https://pypi.org/project/ramalama/) which is more relevant. A slight clean-up of the README file to resurface a link to GH Discussions rounds up the PR.

Signed-off-by: Carol Chen <2913667+cybette@users.noreply.github.com>