### PR TITLE
Improve flaky e2e push tests

### DIFF
--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -12,6 +12,7 @@ from tempfile import TemporaryDirectory
 import bcrypt
 import pytest
 import requests
+import urllib3
 
 from test.conftest import ramalama_container_engine
 
@@ -85,7 +86,21 @@ def container_registry():
             check=True,
         )
         # fmt: on
-        time.sleep(2)
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+        start_time = time.time()
+        while time.time() - start_time < 30:
+            try:
+                resp = requests.get(
+                    f"https://localhost:{registry_port}/v2/",
+                    verify=False,
+                    timeout=1,
+                )
+                if resp.status_code in (200, 401):
+                    break
+            except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
+                time.sleep(0.5)
+        else:
+            pytest.fail(f"Registry {registry_name} did not become ready within 30s")
 
         try:
             yield Registry(
@@ -96,6 +111,8 @@ def container_registry():
                 port=registry_port,
             )
         finally:
+            print(f"--- Registry logs ({registry_name}) ---", flush=True)
+            subprocess.run([ramalama_container_engine, "logs", registry_name], check=False)
             subprocess.run([ramalama_container_engine, "stop", registry_name], check=False)
 
 

--- a/test/e2e/test_serve.py
+++ b/test/e2e/test_serve.py
@@ -495,7 +495,9 @@ def test_quadlet_and_kube_generation_with_container_registry(container_registry,
 
         # Push test model to the container registry in different modes
         for model_type_flag in [[], ["--type=car"], ["--type=raw"]]:
-            ctx.check_call(["ramalama", "push"] + model_type_flag + auth_flags + [test_model, test_image_url])
+            ctx.check_call(
+                ["ramalama", "push"] + model_type_flag + auth_flags + [test_model, test_image_url], timeout=180
+            )
 
         # Generate a quadlet
         result = ctx.check_output(


### PR DESCRIPTION
The e2e push tests are often failing with a timeout. I cannot reproduce this locally or in github CI runners. Make the registry init more robust and add some logging to help debug this if/when it occurs again:

Replace sleep(2) with active readiness poll on the registry's /v2/ endpoint
Add timeout=180 to push calls so hung processes fail fast
Dump registry container logs on teardown for debugging

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>