### PR TITLE
Add ramalama.conf tempdir setting for TMPDIR selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ uv.lock
 !.pixi/config.toml
 *~
 *#
+.mypy_cache

--- a/bin/ramalama
+++ b/bin/ramalama
@@ -1,16 +1,13 @@
 #!/usr/bin/env python3
 
-import os
 import sys
+
+from ramalama.config import ActiveConfig, ensure_tmpdir
 
 
 def main():
     if not sys.stdout.isatty():
         sys.stdout.reconfigure(line_buffering=True)
-
-    if sys.platform != 'win32':
-        # default TMPDIR environment to /var/tmp on non Windows platforms
-        os.environ["TMPDIR"] = os.getenv("TMPDIR", "/var/tmp")
 
     sys.path.insert(0, './')
     try:
@@ -19,6 +16,7 @@ def main():
         print(f"ramalama module not found in sys.path: {sys.path}", file=sys.stderr)
         raise
 
+    ensure_tmpdir(ActiveConfig())
     ramalama.cli.main()
 
 

--- a/docs/options/authfile.md
+++ b/docs/options/authfile.md
@@ -1,5 +1,5 @@
 ####> This option file is used in:
-####>   ramalama bench, ramalama perplexity, ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama serve
+####>   ramalama bench, ramalama perplexity, ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama sandbox pi, ramalama serve
 ####> If this file is edited, make sure the changes
 ####> are applicable to all of those.
 #### **--authfile**=*path*

--- a/docs/options/backend.md
+++ b/docs/options/backend.md
@@ -1,5 +1,5 @@
 ####> This option file is used in:
-####>   ramalama bench, ramalama perplexity, ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama serve
+####>   ramalama bench, ramalama perplexity, ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama sandbox pi, ramalama serve
 ####> If this file is edited, make sure the changes
 ####> are applicable to all of those.
 #### **--backend**=*auto* | vulkan | rocm | cuda | sycl | openvino | cann | musa

--- a/docs/options/cache-reuse.md
+++ b/docs/options/cache-reuse.md
@@ -1,5 +1,5 @@
 ####> This option file is used in:
-####>   ramalama perplexity, ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama serve
+####>   ramalama perplexity, ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama sandbox pi, ramalama serve
 ####> If this file is edited, make sure the changes
 ####> are applicable to all of those.
 #### **--cache-reuse**=*BYTES*

--- a/docs/options/ctx-size.md
+++ b/docs/options/ctx-size.md
@@ -1,5 +1,5 @@
 ####> This option file is used in:
-####>   ramalama perplexity, ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama serve
+####>   ramalama perplexity, ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama sandbox pi, ramalama serve
 ####> If this file is edited, make sure the changes
 ####> are applicable to all of those.
 #### **--ctx-size**, **-c**

--- a/docs/options/device.md
+++ b/docs/options/device.md
@@ -1,5 +1,5 @@
 ####> This option file is used in:
-####>   ramalama bench, ramalama perplexity, ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama serve
+####>   ramalama bench, ramalama perplexity, ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama sandbox pi, ramalama serve
 ####> If this file is edited, make sure the changes
 ####> are applicable to all of those.
 #### **--device**

--- a/docs/options/env.md
+++ b/docs/options/env.md
@@ -1,5 +1,5 @@
 ####> This option file is used in:
-####>   ramalama bench, ramalama perplexity, ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama serve
+####>   ramalama bench, ramalama perplexity, ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama sandbox pi, ramalama serve
 ####> If this file is edited, make sure the changes
 ####> are applicable to all of those.
 #### **--env**=

--- a/docs/options/help.md
+++ b/docs/options/help.md
@@ -1,5 +1,5 @@
 ####> This option file is used in:
-####>   ramalama bench, ramalama perplexity, ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama serve
+####>   ramalama bench, ramalama perplexity, ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama sandbox pi, ramalama serve
 ####> If this file is edited, make sure the changes
 ####> are applicable to all of those.
 #### **--help**, **-h**

--- a/docs/options/host.md
+++ b/docs/options/host.md
@@ -1,5 +1,5 @@
 ####> This option file is used in:
-####>   ramalama sandbox goose, ramalama sandbox opencode, ramalama serve
+####>   ramalama sandbox goose, ramalama sandbox opencode, ramalama sandbox pi, ramalama serve
 ####> If this file is edited, make sure the changes
 ####> are applicable to all of those.
 #### **--host**="::"

--- a/docs/options/image.md
+++ b/docs/options/image.md
@@ -1,5 +1,5 @@
 ####> This option file is used in:
-####>   ramalama bench, ramalama perplexity, ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama serve
+####>   ramalama bench, ramalama perplexity, ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama sandbox pi, ramalama serve
 ####> If this file is edited, make sure the changes
 ####> are applicable to all of those.
 #### **--image**=IMAGE

--- a/docs/options/keep-groups.md
+++ b/docs/options/keep-groups.md
@@ -1,5 +1,5 @@
 ####> This option file is used in:
-####>   ramalama bench, ramalama perplexity, ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama serve
+####>   ramalama bench, ramalama perplexity, ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama sandbox pi, ramalama serve
 ####> If this file is edited, make sure the changes
 ####> are applicable to all of those.
 #### **--keep-groups**

--- a/docs/options/logfile.md
+++ b/docs/options/logfile.md
@@ -1,5 +1,5 @@
 ####> This option file is used in:
-####>   ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama serve
+####>   ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama sandbox pi, ramalama serve
 ####> If this file is edited, make sure the changes
 ####> are applicable to all of those.
 #### **--logfile**=*path*

--- a/docs/options/max-tokens.md
+++ b/docs/options/max-tokens.md
@@ -1,5 +1,5 @@
 ####> This option file is used in:
-####>   ramalama perplexity, ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama serve
+####>   ramalama perplexity, ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama sandbox pi, ramalama serve
 ####> If this file is edited, make sure the changes
 ####> are applicable to all of those.
 #### **--max-tokens**=*integer*

--- a/docs/options/model-draft.md
+++ b/docs/options/model-draft.md
@@ -1,5 +1,5 @@
 ####> This option file is used in:
-####>   ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama serve
+####>   ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama sandbox pi, ramalama serve
 ####> If this file is edited, make sure the changes
 ####> are applicable to all of those.
 #### **--model-draft**

--- a/docs/options/name.md
+++ b/docs/options/name.md
@@ -1,5 +1,5 @@
 ####> This option file is used in:
-####>   ramalama bench, ramalama perplexity, ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama serve
+####>   ramalama bench, ramalama perplexity, ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama sandbox pi, ramalama serve
 ####> If this file is edited, make sure the changes
 ####> are applicable to all of those.
 #### **--name**, **-n**

--- a/docs/options/ncmoe.md
+++ b/docs/options/ncmoe.md
@@ -1,5 +1,5 @@
 ####> This option file is used in:
-####>   ramalama bench, ramalama perplexity, ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama serve
+####>   ramalama bench, ramalama perplexity, ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama sandbox pi, ramalama serve
 ####> If this file is edited, make sure the changes
 ####> are applicable to all of those.
 #### **--ncmoe**

--- a/docs/options/network.md
+++ b/docs/options/network.md
@@ -1,5 +1,5 @@
 ####> This option file is used in:
-####>   ramalama bench, ramalama perplexity, ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama serve
+####>   ramalama bench, ramalama perplexity, ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama sandbox pi, ramalama serve
 ####> If this file is edited, make sure the changes
 ####> are applicable to all of those.
 #### **--network**=*none*

--- a/docs/options/ngl.md
+++ b/docs/options/ngl.md
@@ -1,5 +1,5 @@
 ####> This option file is used in:
-####>   ramalama bench, ramalama perplexity, ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama serve
+####>   ramalama bench, ramalama perplexity, ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama sandbox pi, ramalama serve
 ####> If this file is edited, make sure the changes
 ####> are applicable to all of those.
 #### **--ngl**

--- a/docs/options/oci-runtime.md
+++ b/docs/options/oci-runtime.md
@@ -1,5 +1,5 @@
 ####> This option file is used in:
-####>   ramalama bench, ramalama perplexity, ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama serve
+####>   ramalama bench, ramalama perplexity, ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama sandbox pi, ramalama serve
 ####> If this file is edited, make sure the changes
 ####> are applicable to all of those.
 #### **--oci-runtime**

--- a/docs/options/port.md
+++ b/docs/options/port.md
@@ -1,5 +1,5 @@
 ####> This option file is used in:
-####>   ramalama sandbox goose, ramalama sandbox opencode, ramalama serve
+####>   ramalama sandbox goose, ramalama sandbox opencode, ramalama sandbox pi, ramalama serve
 ####> If this file is edited, make sure the changes
 ####> are applicable to all of those.
 #### **--port**, **-p**

--- a/docs/options/privileged.md
+++ b/docs/options/privileged.md
@@ -1,5 +1,5 @@
 ####> This option file is used in:
-####>   ramalama bench, ramalama perplexity, ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama serve
+####>   ramalama bench, ramalama perplexity, ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama sandbox pi, ramalama serve
 ####> If this file is edited, make sure the changes
 ####> are applicable to all of those.
 #### **--privileged**

--- a/docs/options/pull.md
+++ b/docs/options/pull.md
@@ -1,5 +1,5 @@
 ####> This option file is used in:
-####>   ramalama bench, ramalama perplexity, ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama serve
+####>   ramalama bench, ramalama perplexity, ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama sandbox pi, ramalama serve
 ####> If this file is edited, make sure the changes
 ####> are applicable to all of those.
 #### **--pull**=*policy*

--- a/docs/options/runtime-args.md
+++ b/docs/options/runtime-args.md
@@ -1,5 +1,5 @@
 ####> This option file is used in:
-####>   ramalama bench, ramalama perplexity, ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama serve
+####>   ramalama bench, ramalama perplexity, ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama sandbox pi, ramalama serve
 ####> If this file is edited, make sure the changes
 ####> are applicable to all of those.
 #### **--runtime-args**="*args*"

--- a/docs/options/seed.md
+++ b/docs/options/seed.md
@@ -1,5 +1,5 @@
 ####> This option file is used in:
-####>   ramalama bench, ramalama perplexity, ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama serve
+####>   ramalama bench, ramalama perplexity, ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama sandbox pi, ramalama serve
 ####> If this file is edited, make sure the changes
 ####> are applicable to all of those.
 #### **--seed**=

--- a/docs/options/selinux.md
+++ b/docs/options/selinux.md
@@ -1,5 +1,5 @@
 ####> This option file is used in:
-####>   ramalama bench, ramalama perplexity, ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama serve
+####>   ramalama bench, ramalama perplexity, ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama sandbox pi, ramalama serve
 ####> If this file is edited, make sure the changes
 ####> are applicable to all of those.
 #### **--selinux**=*true*

--- a/docs/options/temp.md
+++ b/docs/options/temp.md
@@ -1,5 +1,5 @@
 ####> This option file is used in:
-####>   ramalama perplexity, ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama serve
+####>   ramalama perplexity, ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama sandbox pi, ramalama serve
 ####> If this file is edited, make sure the changes
 ####> are applicable to all of those.
 #### **--temp**="0.8"

--- a/docs/options/thinking.md
+++ b/docs/options/thinking.md
@@ -1,5 +1,5 @@
 ####> This option file is used in:
-####>   ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama serve
+####>   ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama sandbox pi, ramalama serve
 ####> If this file is edited, make sure the changes
 ####> are applicable to all of those.
 #### **--thinking**=*BOOL*

--- a/docs/options/threads.md
+++ b/docs/options/threads.md
@@ -1,5 +1,5 @@
 ####> This option file is used in:
-####>   ramalama bench, ramalama perplexity, ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama serve
+####>   ramalama bench, ramalama perplexity, ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama sandbox pi, ramalama serve
 ####> If this file is edited, make sure the changes
 ####> are applicable to all of those.
 #### **--threads**, **-t**

--- a/docs/options/tls-verify.md
+++ b/docs/options/tls-verify.md
@@ -1,5 +1,5 @@
 ####> This option file is used in:
-####>   ramalama bench, ramalama perplexity, ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama serve
+####>   ramalama bench, ramalama perplexity, ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama sandbox pi, ramalama serve
 ####> If this file is edited, make sure the changes
 ####> are applicable to all of those.
 #### **--tls-verify**=*true*

--- a/docs/options/webui.md
+++ b/docs/options/webui.md
@@ -1,5 +1,5 @@
 ####> This option file is used in:
-####>   ramalama sandbox goose, ramalama sandbox opencode, ramalama serve
+####>   ramalama sandbox goose, ramalama sandbox opencode, ramalama sandbox pi, ramalama serve
 ####> If this file is edited, make sure the changes
 ####> are applicable to all of those.
 #### **--webui**=*on* | *off*

--- a/docs/options/workdir.md
+++ b/docs/options/workdir.md
@@ -1,5 +1,5 @@
 ####> This option file is used in:
-####>   ramalama sandbox goose, ramalama sandbox opencode
+####>   ramalama sandbox goose, ramalama sandbox opencode, ramalama sandbox pi
 ####> If this file is edited, make sure the changes
 ####> are applicable to all of those.
 #### **--workdir**, **-w**

--- a/docs/ramalama.1.md
+++ b/docs/ramalama.1.md
@@ -191,7 +191,7 @@ although the recommended way is to use the `ramalama.conf` file.
 | RAMALAMA_IN_CONTAINER     | run RamaLama in the default container     |
 | RAMALAMA_STORE            | location to store AI Models               |
 | RAMALAMA_TRANSPORT        | default AI Model transport (huggingface, OCI, ollama) |
-| TMPDIR                    | directory for temporary files; defaults to `/var/tmp` if unset |
+| TMPDIR                    | host temporary directory; used when **tempdir** is not configured in ramalama.conf(5); defaults to `/var/tmp`|
 
 ## SEE ALSO
 **[podman(1)](https://github.com/containers/podman/blob/main/docs/source/markdown/podman.1.md)**, **docker(1)**, **[ramalama.conf(5)](ramalama.conf.5.md)**, **[ramalama-cuda(7)](ramalama-cuda.7.md)**, **[ramalama-macos(7)](ramalama-macos.7.md)**

--- a/docs/ramalama.conf
+++ b/docs/ramalama.conf
@@ -162,6 +162,12 @@
 #
 #store = "$HOME/.local/share/ramalama"
 
+# Directory for temporary files (convert, RAG, and similar operations).
+# When set, overrides the host TMPDIR environment variable.
+# When unset, the host TMPDIR is used; on non-Windows systems, /var/tmp is used if TMPDIR is unset or empty.
+#
+#tempdir = "/var/tmp"
+
 # Automatically summarize conversation history after N messages to prevent context growth
 # When enabled, ramalama will periodically condense older messages into a summary,
 # keeping only recent messages and the summary. This prevents the context from growing

--- a/docs/ramalama.conf.5.md
+++ b/docs/ramalama.conf.5.md
@@ -171,6 +171,10 @@ Options: `llama.cpp`, `vllm`, `mlx`.
 
 **store**="$HOME/.local/share/ramalama": Directory where AI models and data are stored.
 
+**tempdir**="": Directory for temporary files used by operations such as convert and RAG.
+When set in `ramalama.conf`, this value is applied as `TMPDIR` and overrides the host environment.
+When unset, the host `TMPDIR` is used. On non-Windows systems, if `TMPDIR` is unset or empty, `/var/tmp` is used.
+
 **summarize_after**=4: Automatically summarize chat history after N messages to limit context growth.
 Set to 0 to disable.
 

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -32,6 +32,7 @@ from ramalama.config import (
     SUPPORTED_ENGINES,
     ActiveConfig,
     coerce_to_bool,
+    ensure_tmpdir,
     load_file_config,
 )
 from ramalama.config_types import COLOR_OPTIONS
@@ -1278,6 +1279,7 @@ def main() -> None:
     args: argparse.Namespace
     try:
         parser, args = init_cli()
+        ensure_tmpdir(ActiveConfig())
         try:
             import argcomplete
 

--- a/ramalama/config.py
+++ b/ramalama/config.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 import sys
+import tempfile
 from dataclasses import dataclass, field
 from functools import lru_cache
 from pathlib import Path
@@ -16,10 +17,11 @@ from ramalama.log_levels import LogLevel, coerce_log_level
 from ramalama.toml_parser import TOMLParser
 
 DEFAULT_IMAGE: str = version_tagged_image("quay.io/ramalama/ramalama")
-DEFAULT_STACK_IMAGE: str = version_tagged_image("quay.io/ramalama/llama-stack")
-DEFAULT_RAG_IMAGE: str = version_tagged_image("quay.io/ramalama/ramalama-rag")
-DEFAULT_TOOLS_IMAGE: str = version_tagged_image("quay.io/ramalama/ramalama-tools")
 DEFAULT_PI_IMAGE: str = version_tagged_image("quay.io/ramalama/pi-agent")
+DEFAULT_RAG_IMAGE: str = version_tagged_image("quay.io/ramalama/ramalama-rag")
+DEFAULT_STACK_IMAGE: str = version_tagged_image("quay.io/ramalama/llama-stack")
+DEFAULT_TMPDIR = "/var/tmp"
+DEFAULT_TOOLS_IMAGE: str = version_tagged_image("quay.io/ramalama/ramalama-tools")
 
 
 def _get_default_config_dirs() -> list[Path]:
@@ -190,6 +192,7 @@ class BaseConfig:
     settings: RamalamaSettings = field(default_factory=RamalamaSettings)
     store: str = field(default_factory=get_default_store)
     summarize_after: int = 4
+    tempdir: Optional[str] = None
     transport: str = "ollama"
     user: UserConfig = field(default_factory=UserConfig)
     verify: bool = True
@@ -303,6 +306,26 @@ def load_env_config(env: Optional[Mapping[str, str]] = None) -> dict[str, Any]:
     if log_level := config.get("log_level"):
         config["log_level"] = coerce_log_level(log_level)
     return config
+
+
+def ensure_tmpdir(config: Optional[Config] = None) -> None:
+    """Set ``TMPDIR`` for tempfile-backed operations.
+
+    When ``tempdir`` is set in ``ramalama.conf``, it overrides the host ``TMPDIR``.
+    Otherwise the host value is kept. On non-Windows systems, if neither is set,
+    ``/var/tmp`` is used.
+    """
+    if sys.platform == "win32":
+        return
+    if config is not None and config.is_set("tempdir"):
+        value = (config.tempdir or "").strip()
+        if value:
+            os.environ["TMPDIR"] = os.path.expanduser(value)
+            tempfile.tempdir = None
+            return
+    if not os.environ.get("TMPDIR", "").strip():
+        os.environ["TMPDIR"] = DEFAULT_TMPDIR
+        tempfile.tempdir = None
 
 
 def load_config(env: Optional[Mapping[str, str]] = None) -> Config:

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -1,11 +1,14 @@
 import os
+import sys
 from unittest.mock import patch
 
 import pytest
 
 from ramalama.config import (
+    DEFAULT_TMPDIR,
     ActiveConfig,
     BaseConfig,
+    ensure_tmpdir,
     get_default_engine,
     get_default_store,
     load_config,
@@ -680,3 +683,41 @@ class TestConfigIntegration:
             # Values not set in any layer should return False
             assert cfg.is_set("host") is False
             assert cfg.is_set("port") is False
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="TMPDIR default is non-Windows only")
+class TestEnsureTmpdir:
+    def test_config_tempdir_overrides_host(self, monkeypatch):
+        monkeypatch.setenv("TMPDIR", "/host/tmp")
+        with patch("ramalama.config.load_file_config", return_value={"tempdir": "/config/tmp"}):
+            config = load_config()
+        ensure_tmpdir(config)
+        assert os.environ["TMPDIR"] == "/config/tmp"
+
+    def test_host_tmpdir_when_config_unset(self, monkeypatch):
+        monkeypatch.setenv("TMPDIR", "/host/tmp")
+        with patch("ramalama.config.load_file_config", return_value={}):
+            config = load_config()
+        ensure_tmpdir(config)
+        assert os.environ["TMPDIR"] == "/host/tmp"
+
+    def test_default_var_tmp_when_unset(self, monkeypatch):
+        monkeypatch.delenv("TMPDIR", raising=False)
+        with patch("ramalama.config.load_file_config", return_value={}):
+            config = load_config()
+        ensure_tmpdir(config)
+        assert os.environ["TMPDIR"] == DEFAULT_TMPDIR
+
+    def test_empty_host_tmpdir_uses_default(self, monkeypatch):
+        monkeypatch.setenv("TMPDIR", "   ")
+        with patch("ramalama.config.load_file_config", return_value={}):
+            config = load_config()
+        ensure_tmpdir(config)
+        assert os.environ["TMPDIR"] == DEFAULT_TMPDIR
+
+    def test_env_layer_tempdir_overrides_host(self, monkeypatch):
+        monkeypatch.setenv("TMPDIR", "/host/tmp")
+        with patch("ramalama.config.load_file_config", return_value={}):
+            config = load_config({"RAMALAMA_TEMPDIR": "/env/tmp"})
+        ensure_tmpdir(config)
+        assert os.environ["TMPDIR"] == "/env/tmp"


### PR DESCRIPTION
Packaged installs call cli.main directly, so default /var/tmp was never applied. Apply tempdir from config (overriding host TMPDIR when set), otherwise honor host TMPDIR, then fall back to /var/tmp on Unix.

Fixes https://github.com/containers/ramalama/issues/2731