### PR TITLE
e2e: disable failing tests and environments

### DIFF
--- a/.tekton/integration/pipelines/e2e-tests.yaml
+++ b/.tekton/integration/pipelines/e2e-tests.yaml
@@ -17,7 +17,6 @@ spec:
     - linux-d160-m4xlarge/arm64
     - linux/ppc64le
     - linux/s390x
-    - linux-g64xlarge/amd64
   - name: commands
     description: Test commands to run
     type: array

--- a/test/e2e/test_serve.py
+++ b/test/e2e/test_serve.py
@@ -478,6 +478,7 @@ def test_generation_with_bad_add_to_unit_flag_value(test_model):
 @pytest.mark.slow
 @skip_if_no_container
 @pytest.mark.xfail("config.option.container_engine == 'docker'", reason="docker login does not support --tls-verify")
+@pytest.mark.skip(reason="pushing to the local registry hangs since Fedora 44")
 def test_quadlet_and_kube_generation_with_container_registry(container_registry, is_container, test_model):
     with RamalamaExecWorkspace() as ctx:
         authfile = (Path(ctx.workspace_dir) / "authfile.json").as_posix()


### PR DESCRIPTION
Skip the `test_quadlet_and_kube_generation_with_container_registry` test. The push to the local registry hangs since Fedora 44 (in the podman-in-podman environment) and will require further debugging.

Remove the e2e test environment that requests a GPU instance in AWS. This test almost always fails due to lack of available instances.