### PR TITLE
e2e: fix registry push test by using --network=host

### DIFF
--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -68,19 +68,21 @@ def container_registry():
             passwd_hash = bcrypt.hashpw(registry_password.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
             pwfile.write(f"{registry_username}:{passwd_hash}")
 
-        # Start the registry
+        # Start the registry with --network=host to avoid pasta port-forwarding
+        # issues with large blob uploads on newer Fedora/podman versions.
         # fmt: off
         subprocess.run(
             [
                 ramalama_container_engine, "run", "-d", "--rm",
                 "--name", registry_name,
-                "-p", f"{registry_port}:5000",
+                "--network=host",
                 "-v", f"{work_dir.as_posix()}:/auth:Z",
                 "-e", "REGISTRY_AUTH=htpasswd",
                 "-e", "REGISTRY_AUTH_HTPASSWD_REALM='Registry Realm'",
                 "-e", "REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd",
                 "-e", "REGISTRY_HTTP_TLS_CERTIFICATE=/auth/domain.crt",
                 "-e", "REGISTRY_HTTP_TLS_KEY=/auth/domain.key",
+                "-e", f"REGISTRY_HTTP_ADDR=0.0.0.0:{registry_port}",
                 registry_image,
             ],
             check=True,

--- a/test/e2e/test_serve.py
+++ b/test/e2e/test_serve.py
@@ -478,7 +478,6 @@ def test_generation_with_bad_add_to_unit_flag_value(test_model):
 @pytest.mark.slow
 @skip_if_no_container
 @pytest.mark.xfail("config.option.container_engine == 'docker'", reason="docker login does not support --tls-verify")
-@pytest.mark.skip(reason="pushing to the local registry hangs since Fedora 44")
 def test_quadlet_and_kube_generation_with_container_registry(container_registry, is_container, test_model):
     with RamalamaExecWorkspace() as ctx:
         authfile = (Path(ctx.workspace_dir) / "authfile.json").as_posix()


### PR DESCRIPTION
The container_registry fixture used -p port forwarding which routes through pasta on rootless podman. Pasta drops large TLS blob uploads with EOF on newer Fedora/podman versions, causing the push to hang.

Switch the registry container to --network=host with REGISTRY_HTTP_ADDR so it listens directly on the host, bypassing pasta port-forwarding.

Fixes: #2792 