### PR TITLE
use the HF_TOKEN environment variable, and set it in CI environments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,8 @@ jobs:
       github.event_name == 'pull_request' ||
       github.ref == 'refs/heads/main' ||
       github.repository_owner != 'containers'
+    env:
+      HF_TOKEN: ${{ vars.HF_TOKEN }}
     strategy:
       fail-fast: false
       matrix:
@@ -105,6 +107,8 @@ jobs:
       github.event_name == 'pull_request' ||
       github.ref == 'refs/heads/main' ||
       github.repository_owner != 'containers'
+    env:
+      HF_TOKEN: ${{ vars.HF_TOKEN }}
     needs:
       - lint
       - unit-test
@@ -167,6 +171,8 @@ jobs:
       github.event_name == 'pull_request' ||
       github.ref == 'refs/heads/main' ||
       github.repository_owner != 'containers'
+    env:
+      HF_TOKEN: ${{ vars.HF_TOKEN }}
     needs:
       - lint
       - unit-test
@@ -227,6 +233,8 @@ jobs:
       github.event_name == 'pull_request' ||
       github.ref == 'refs/heads/main' ||
       github.repository_owner != 'containers'
+    env:
+      HF_TOKEN: ${{ vars.HF_TOKEN }}
     needs:
       - lint
       - unit-test
@@ -307,6 +315,8 @@ jobs:
       github.event_name == 'pull_request' ||
       github.ref == 'refs/heads/main' ||
       github.repository_owner != 'containers'
+    env:
+      HF_TOKEN: ${{ vars.HF_TOKEN }}
     needs:
       - lint
       - unit-test
@@ -352,6 +362,8 @@ jobs:
       github.event_name == 'pull_request' ||
       github.ref == 'refs/heads/main' ||
       github.repository_owner != 'containers'
+    env:
+      HF_TOKEN: ${{ vars.HF_TOKEN }}
     needs:
       - lint
       - unit-test

--- a/.github/workflows/install_ramalama.yml
+++ b/.github/workflows/install_ramalama.yml
@@ -12,6 +12,8 @@ jobs:
       github.event_name == 'pull_request' ||
       github.ref == 'refs/heads/main' ||
       github.repository_owner != 'containers'
+    env:
+      HF_TOKEN: ${{ vars.HF_TOKEN }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]  # Runs on Ubuntu and macOS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -190,6 +190,7 @@ package = "wheel"
 extras = ["dev", "cov"]
 pass_env = [
   "GITHUB_ACTIONS",
+  "HF_TOKEN",
   "RAMALAMA_*",
 ]
 set_env = { COLUMNS = "120" }

--- a/ramalama/transports/huggingface.py
+++ b/ramalama/transports/huggingface.py
@@ -27,8 +27,12 @@ sudo dnf install python3-huggingface-hub
 """
 
 
-def huggingface_token():
-    """Return cached Hugging Face token if it exists otherwise None"""
+def huggingface_token() -> str | None:
+    """Return Hugging Face token from HF_TOKEN env var or cached token file, otherwise None"""
+    token = os.environ.get("HF_TOKEN")
+    if token:
+        return token
+
     token_path = os.path.expanduser(os.path.join("~", ".cache", "huggingface", "token"))
     if os.path.exists(token_path):
         try:
@@ -36,6 +40,8 @@ def huggingface_token():
                 return tokenfile.read().strip()
         except OSError:
             pass
+
+    return None
 
 
 def extract_huggingface_checksum(data):

--- a/test/unit/test_huggingface.py
+++ b/test/unit/test_huggingface.py
@@ -1,0 +1,68 @@
+import os
+import tempfile
+from unittest.mock import patch
+
+from ramalama.transports.huggingface import huggingface_token
+
+
+def test_huggingface_token_from_env() -> None:
+    with patch.dict(os.environ, {"HF_TOKEN": "hf_test_env_token"}):
+        assert huggingface_token() == "hf_test_env_token"
+
+
+def test_huggingface_token_env_takes_precedence_over_file() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        token_path = os.path.join(tmpdir, "token")
+        with open(token_path, "w") as f:
+            f.write("hf_file_token\n")
+        with (
+            patch.dict(os.environ, {"HF_TOKEN": "hf_env_token"}),
+            patch("ramalama.transports.huggingface.os.path.expanduser", return_value=token_path),
+        ):
+            assert huggingface_token() == "hf_env_token"
+
+
+def test_huggingface_token_from_cached_file() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        token_path = os.path.join(tmpdir, "token")
+        with open(token_path, "w") as f:
+            f.write("hf_cached_token\n")
+        with (
+            patch.dict(os.environ, {}, clear=False),
+            patch("ramalama.transports.huggingface.os.path.expanduser", return_value=token_path),
+        ):
+            os.environ.pop("HF_TOKEN", None)
+            assert huggingface_token() == "hf_cached_token"
+
+
+def test_huggingface_token_file_whitespace_stripped() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        token_path = os.path.join(tmpdir, "token")
+        with open(token_path, "w") as f:
+            f.write("  hf_whitespace_token  \n")
+        with (
+            patch.dict(os.environ, {}, clear=False),
+            patch("ramalama.transports.huggingface.os.path.expanduser", return_value=token_path),
+        ):
+            os.environ.pop("HF_TOKEN", None)
+            assert huggingface_token() == "hf_whitespace_token"
+
+
+def test_huggingface_token_returns_none_when_no_source() -> None:
+    with (
+        patch.dict(os.environ, {}, clear=False),
+        patch("ramalama.transports.huggingface.os.path.exists", return_value=False),
+    ):
+        os.environ.pop("HF_TOKEN", None)
+        assert huggingface_token() is None
+
+
+def test_huggingface_token_returns_none_on_file_read_error() -> None:
+    with (
+        patch.dict(os.environ, {}, clear=False),
+        patch("ramalama.transports.huggingface.os.path.exists", return_value=True),
+        patch("ramalama.transports.huggingface.os.path.expanduser", return_value="/nonexistent/path/token"),
+        patch("builtins.open", side_effect=OSError("permission denied")),
+    ):
+        os.environ.pop("HF_TOKEN", None)
+        assert huggingface_token() is None


### PR DESCRIPTION
Use the `HF_TOKEN` environment variable, if set, when making requests to huggingface. Fall back to the cached token.
Update the GitHub Actions and tox config to pass `HF_TOKEN` through to the test invocations.