### PR TITLE
huggingface: use the HF_TOKEN env var if it's defined

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,8 @@ jobs:
         with: ${{ matrix.variant.uv-options }}
 
       - name: Run unit tests
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           uv run -- make unit-tests
 
@@ -159,6 +161,8 @@ jobs:
            sudo apt-get upgrade -y podman crun
 
       - name: run e2e-tests
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
            make e2e-tests
 
@@ -219,6 +223,8 @@ jobs:
            sudo apt-get upgrade -y podman crun
 
       - name: run e2e-tests-nocontainer
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
            make e2e-tests-nocontainer
 
@@ -298,6 +304,8 @@ jobs:
            df -h
 
       - name: run e2e-tests-docker
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
            docker info
            make e2e-tests-docker
@@ -344,6 +352,8 @@ jobs:
 
       - name: run e2e-tests-nocontainer
         shell: bash
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           make e2e-tests-nocontainer
 
@@ -454,6 +464,7 @@ jobs:
         shell: pwsh
         env:
           RAMALAMA_CONTAINER_ENGINE: podman
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           Write-Host "Running E2E tests..."
           # Add uv tools to PATH

--- a/.github/workflows/install_ramalama.yml
+++ b/.github/workflows/install_ramalama.yml
@@ -50,5 +50,7 @@ jobs:
           ramalama info
 
       - name: RamaLama pull
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           ramalama pull tinyllama

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -190,6 +190,7 @@ package = "wheel"
 extras = ["dev", "cov"]
 pass_env = [
   "GITHUB_ACTIONS",
+  "HF_TOKEN",
   "RAMALAMA_*",
 ]
 set_env = { COLUMNS = "120" }

--- a/ramalama/transports/huggingface.py
+++ b/ramalama/transports/huggingface.py
@@ -27,8 +27,11 @@ sudo dnf install python3-huggingface-hub
 """
 
 
-def huggingface_token():
-    """Return cached Hugging Face token if it exists otherwise None"""
+def huggingface_token() -> str | None:
+    """Return Hugging Face token from HF_TOKEN env var or cached token file, otherwise None"""
+    if "HF_TOKEN" in os.environ:
+        return os.environ["HF_TOKEN"].strip() or None
+
     token_path = os.path.expanduser(os.path.join("~", ".cache", "huggingface", "token"))
     if os.path.exists(token_path):
         try:
@@ -36,6 +39,8 @@ def huggingface_token():
                 return tokenfile.read().strip()
         except OSError:
             pass
+
+    return None
 
 
 def extract_huggingface_checksum(data):

--- a/test/unit/test_huggingface.py
+++ b/test/unit/test_huggingface.py
@@ -1,0 +1,80 @@
+import os
+import tempfile
+from unittest.mock import patch
+
+from ramalama.transports.huggingface import huggingface_token
+
+
+def test_huggingface_token_from_env() -> None:
+    with patch.dict(os.environ, {"HF_TOKEN": "hf_test_env_token"}):
+        assert huggingface_token() == "hf_test_env_token"
+
+
+def test_huggingface_token_env_takes_precedence_over_file() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        token_path = os.path.join(tmpdir, "token")
+        with open(token_path, "w") as f:
+            f.write("hf_file_token\n")
+        with (
+            patch.dict(os.environ, {"HF_TOKEN": "hf_env_token"}),
+            patch("ramalama.transports.huggingface.os.path.expanduser", return_value=token_path),
+        ):
+            assert huggingface_token() == "hf_env_token"
+
+
+def test_huggingface_token_from_cached_file() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        token_path = os.path.join(tmpdir, "token")
+        with open(token_path, "w") as f:
+            f.write("hf_cached_token\n")
+        with (
+            patch.dict(os.environ, {}, clear=False),
+            patch("ramalama.transports.huggingface.os.path.expanduser", return_value=token_path),
+        ):
+            os.environ.pop("HF_TOKEN", None)
+            assert huggingface_token() == "hf_cached_token"
+
+
+def test_huggingface_token_file_whitespace_stripped() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        token_path = os.path.join(tmpdir, "token")
+        with open(token_path, "w") as f:
+            f.write("  hf_whitespace_token  \n")
+        with (
+            patch.dict(os.environ, {}, clear=False),
+            patch("ramalama.transports.huggingface.os.path.expanduser", return_value=token_path),
+        ):
+            os.environ.pop("HF_TOKEN", None)
+            assert huggingface_token() == "hf_whitespace_token"
+
+
+def test_huggingface_token_empty_env_does_not_fallback_to_file() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        token_path = os.path.join(tmpdir, "token")
+        with open(token_path, "w") as f:
+            f.write("hf_file_token\n")
+        with (
+            patch.dict(os.environ, {"HF_TOKEN": ""}),
+            patch("ramalama.transports.huggingface.os.path.expanduser", return_value=token_path),
+        ):
+            assert huggingface_token() is None
+
+
+def test_huggingface_token_returns_none_when_no_source() -> None:
+    with (
+        patch.dict(os.environ, {}, clear=False),
+        patch("ramalama.transports.huggingface.os.path.exists", return_value=False),
+    ):
+        os.environ.pop("HF_TOKEN", None)
+        assert huggingface_token() is None
+
+
+def test_huggingface_token_returns_none_on_file_read_error() -> None:
+    with (
+        patch.dict(os.environ, {}, clear=False),
+        patch("ramalama.transports.huggingface.os.path.exists", return_value=True),
+        patch("ramalama.transports.huggingface.os.path.expanduser", return_value="/nonexistent/path/token"),
+        patch("builtins.open", side_effect=OSError("permission denied")),
+    ):
+        os.environ.pop("HF_TOKEN", None)
+        assert huggingface_token() is None


### PR DESCRIPTION
Read the `HF_TOKEN` environment variable and include it in requests to huggingface if it's defined. Fall back to reading the cached token from the home directory.

Update CI to pass `HF_TOKEN` through to the `pytest` invocation, both locally and in Github Actions. Note that the `HF_TOKEN` `secret` will only be available if it has been defined in the repo where CI is currently running, and will not be available for PRs submitted from other repos.