### PR TITLE
fix: pass model as positional arg to vllm serve

### DIFF
--- a/ramalama/plugins/runtimes/inference/vllm.py
+++ b/ramalama/plugins/runtimes/inference/vllm.py
@@ -41,7 +41,7 @@ class VllmPlugin(ContainerizedInferenceRuntimePlugin):
 
         if model is not None:
             model_path = model._get_entry_model_path(is_container, should_generate, dry_run)
-            cmd += ["--model", model_path]
+            cmd += [model_path]
             cmd += ["--served-model-name", model.model_alias]
 
         ctx_size = getattr(args, 'ctx_size', None)


### PR DESCRIPTION
## Summary
- Newer vLLM versions expect the model as a positional argument to `vllm serve MODEL` rather than `--model MODEL`
- The `--model` flag is deprecated and will be removed in a future vLLM release
- This change removes `--model` and passes the model path as a positional argument

## Test plan
- [ ] `ramalama --dryrun --runtime vllm serve <model>` shows model as positional arg (no `--model` flag)
- [ ] `ramalama --runtime vllm serve <model>` successfully starts vLLM server

🤖 Generated with [Claude Code](https://claude.com/claude-code)