### PR TITLE
Relax ollama deprecation now that is it pivoting back to llama.cpp

### DIFF
--- a/docs/options/model-transports.md
+++ b/docs/options/model-transports.md
@@ -9,9 +9,8 @@
 | rlcr          | rlcr://   | [`ramalama.com`](https://registry.ramalama.com) |
 | OCI Container Registries | oci://, docker:// | [`opencontainers.org`](https://opencontainers.org)||||Examples: [`quay.io`](https://quay.io),  [`Docker Hub`](https://docker.io),[`Artifactory`](https://artifactory.com)|
 | Hosted API Providers | openai:// | [`api.openai.com`](https://api.openai.com)|
-RamaLama defaults to the Ollama registry transport. This default can be overridden in the `ramalama.conf` file or via the
-`RAMALAMA_TRANSPORT` environment variable. For example, `export RAMALAMA_TRANSPORT=huggingface` changes RamaLama to use the Hugging Face transport.
+Models can be specified using a shortname (e.g. `tiny`) which is resolved via `shortnames.conf`, or with an explicit transport prefix such as `huggingface://`, `oci://`, `ollama://`, `https://`, `http://`, or `file://`. Models in the `<org>/<model>` format without a prefix are pulled from Hugging Face.
 
-Modify individual model transports by specifying the `huggingface://`, `oci://`, `ollama://`, `https://`, `http://`, or `file://` prefix to the model.
+The default transport can be overridden in the `ramalama.conf` file or via the `RAMALAMA_TRANSPORT` environment variable. For example, `export RAMALAMA_TRANSPORT=huggingface` changes RamaLama to use the Hugging Face transport for unqualified model names.
 
 URL support means if a model is on a web site or even on your local system, you can run it directly.

--- a/docs/ramalama-login.1.md
+++ b/docs/ramalama-login.1.md
@@ -9,7 +9,7 @@ ramalama\-login - login to remote registry
 ## DESCRIPTION
 login to remote model registry
 
-By default, RamaLama uses the Ollama registry transport. You can override this default by configuring the `ramalama.conf` file or setting the `RAMALAMA_TRANSPORTS` environment variable. Ensure a registry transport is set before attempting to log in.
+Log in to a remote model registry. You can configure the default transport by setting the `ramalama.conf` file or the `RAMALAMA_TRANSPORT` environment variable. Ensure a registry transport is set before attempting to log in.
 
 ## OPTIONS
 Options are specific to registry types.

--- a/docs/ramalama.1.md
+++ b/docs/ramalama.1.md
@@ -66,11 +66,9 @@ RamaLama supports multiple AI model registries types called transports. Supporte
 | OCI Container Registries | oci://                        | [`opencontainers.org`](https://opencontainers.org) |
 |                          |                               | Examples: [`quay.io`](https://quay.io), [`Docker Hub`](https://docker.io), [`Artifactory`](https://artifactory.com) |
 
-Models specified in the Hugging Face `<org>/<model>` format are automatically pulled from Hugging Face. For models specified without an organization (e.g. `granite-code`), RamaLama currently defaults to the Ollama transport. **Note:** Ollama models are no longer compatible with llama.cpp, and support for the Ollama transport will be removed in a future release. Users should migrate to Hugging Face models.
+Models specified in the Hugging Face `<org>/<model>` format are automatically pulled from Hugging Face. Models can also be specified using a shortname (e.g. `tiny`) which is resolved via `shortnames.conf`, or with an explicit transport prefix such as `huggingface://`, `oci://`, `ollama://`, `https://`, `http://`, or `file://`.
 
-The default transport can be overridden in the `ramalama.conf` file or via the `RAMALAMA_TRANSPORT` environment variable. Running `export RAMALAMA_TRANSPORT=huggingface` changes RamaLama to use the HuggingFace transport.
-
-Modify individual model transports by specifying the `huggingface://`, `oci://`, `ollama://`, `https://`, `http://`, `file://` prefix to the model.
+The default transport can be overridden in the `ramalama.conf` file or via the `RAMALAMA_TRANSPORT` environment variable. Running `export RAMALAMA_TRANSPORT=huggingface` changes RamaLama to use the HuggingFace transport for unqualified model names.
 
 URL support means if a model is on a web site or even on your local system, you can run it directly.
 
@@ -192,7 +190,7 @@ although the recommended way is to use the `ramalama.conf` file.
 | RAMALAMA_IMAGE            | container image to use for serving AI Models |
 | RAMALAMA_IN_CONTAINER     | run RamaLama in the default container     |
 | RAMALAMA_STORE            | location to store AI Models               |
-| RAMALAMA_TRANSPORT        | default AI Model transport (ollama, huggingface, OCI) |
+| RAMALAMA_TRANSPORT        | default AI Model transport (huggingface, OCI, ollama) |
 | TMPDIR                    | directory for temporary files; defaults to `/var/tmp` if unset |
 
 ## SEE ALSO

--- a/docs/ramalama.conf.5.md
+++ b/docs/ramalama.conf.5.md
@@ -176,8 +176,8 @@ Set to 0 to disable.
 
 **Transport and HTTP options:**
 
-**transport**="ollama": Default transport used for pull/push operations.
-Options: `oci`, `ollama`, `huggingface`.
+**transport**="": Default transport used for unqualified model names.
+Options: `huggingface`, `oci`, `ollama`. When unset, unqualified names are resolved via `shortnames.conf`.
 Override via `RAMALAMA_TRANSPORT`.
 
 `[[ramalama.http_client]]`

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -832,17 +832,15 @@ def push_cli(args):
             raise ValueError(f"converting from an OCI based image {args.SOURCE} is not supported")
         target = shortnames.resolve(args.TARGET)
 
-    target_model = New(target, args)
-
     try:
+        target_model = New(target, args)
         target_model.push(source_model, args)
-    except NotImplementedError as e:
+    except (KeyError, NotImplementedError) as e:
         for mtype in MODEL_TYPES:
             if target.startswith(mtype + "://"):
                 raise e
         try:
-            # attempt to push as a container image
-            m = TransportFactory(target, args).create_oci()
+            m = TransportFactory(target, args, transport="oci").create_oci()
             m.push(source_model, args)
         except Exception as e1:
             logger.debug(e1)
@@ -1181,7 +1179,7 @@ def rm_parser(subparsers):
 def _rm_oci_model(model, args) -> bool:
     # attempt to remove as a container image
     try:
-        m = TransportFactory(model, args, ignore_stderr=True).create_oci()
+        m = TransportFactory(model, args, transport="oci", ignore_stderr=True).create_oci()
         return m.remove(args)
     except Exception:
         return False

--- a/ramalama/plugins/runtimes/inference/common.py
+++ b/ramalama/plugins/runtimes/inference/common.py
@@ -199,7 +199,7 @@ class BaseInferenceRuntime(InferenceRuntimePlugin):
             try:
                 probe_args = copy.copy(args)
                 probe_args.quiet = True
-                model = TransportFactory(args.MODEL, probe_args, ignore_stderr=True).create_oci()
+                model = TransportFactory(args.MODEL, probe_args, transport="oci", ignore_stderr=True).create_oci()
                 model.ensure_model_exists(probe_args)
             except Exception as exc:
                 raise e from exc
@@ -231,7 +231,7 @@ class BaseInferenceRuntime(InferenceRuntimePlugin):
                     raise e
                 probe_args = copy.copy(args)
                 probe_args.quiet = True
-                model = TransportFactory(args.MODEL, probe_args, ignore_stderr=True).create_oci()
+                model = TransportFactory(args.MODEL, probe_args, transport="oci", ignore_stderr=True).create_oci()
                 model.ensure_model_exists(probe_args)
                 # Since this is a OCI model, prepend oci://
                 args.MODEL = f"oci://{args.MODEL}"

--- a/ramalama/plugins/runtimes/inference/llama_cpp.py
+++ b/ramalama/plugins/runtimes/inference/llama_cpp.py
@@ -633,7 +633,7 @@ Model "raw" contains the model and a link file model.file to it stored at /.""",
 
         shortnames = get_shortnames()
         tgt = shortnames.resolve(args.TARGET)
-        model = TransportFactory(tgt, args).create_oci()
+        model = TransportFactory(tgt, args, transport="oci").create_oci()
         source_model = _get_source_model(args)
         model.convert(source_model, args)
 

--- a/ramalama/transports/transport_factory.py
+++ b/ramalama/transports/transport_factory.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import copy
-import warnings
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Optional, Union
 
@@ -26,8 +25,6 @@ from ramalama.transports.url import URL
 
 CLASS_MODEL_TYPES: TypeAlias = Union[Huggingface, Ollama, OCI, URL, ModelScope, RamalamaContainerRegistry, APITransport]
 
-_ollama_default_warned = False
-
 
 class TransportFactory:
     def __init__(
@@ -40,8 +37,7 @@ class TransportFactory:
 
         self.model = model
         self.store_path = args.store
-        self._transport_is_implicit = transport is None and not model.startswith("ollama://")
-        self.transport = transport if transport is not None else "ollama"
+        self.transport = transport
         self.engine = args.engine
         self.ignore_stderr = ignore_stderr
         self.container = args.container
@@ -69,7 +65,6 @@ class TransportFactory:
         if self.model.startswith(("modelscope://", "ms://")):
             return ModelScope, self.create_modelscope
         if self.model.startswith("ollama://"):
-            self._warn_ollama_deprecated()
             return Ollama, self.create_ollama
         if self.model.startswith(("oci://", "docker://")):
             return OCI, self.create_oci
@@ -79,37 +74,25 @@ class TransportFactory:
             return URL, self.create_url
         if self.model.startswith(("openai://")):
             return APITransport, self.create_api_transport
-        if self._transport_is_implicit and "/" in self.model:
+        if self.transport is None and "/" in self.model:
             return Huggingface, self.create_huggingface
         if self.transport == "huggingface":
             return Huggingface, self.create_huggingface
         if self.transport == "modelscope":
             return ModelScope, self.create_modelscope
         if self.transport == "ollama":
-            self._warn_ollama_deprecated()
             return Ollama, self.create_ollama
         if self.transport == "rlcr":
             return RamalamaContainerRegistry, self.create_rlcr
         if self.transport == "oci":
             return OCI, self.create_oci
+        if self.transport is None:
+            raise KeyError(
+                f"'{self.model}' is not a known shortname and no transport was specified. "
+                "Use a shortname from shortnames.conf, or specify a transport explicitly "
+                "(e.g. huggingface://, oci://, ollama://)."
+            )
         raise KeyError(f'transport "{self.transport}" not supported. Must be oci, huggingface, modelscope, or ollama.')
-
-    def _warn_ollama_deprecated(self) -> None:
-        global _ollama_default_warned
-        if _ollama_default_warned:
-            return
-        _ollama_default_warned = True
-        msg = ""
-        if self._transport_is_implicit:
-            msg = f"Defaulting to Ollama transport for '{self.model}'.\n"
-        warnings.warn(
-            f"{msg}Note: Ollama models are no longer compatible with llama.cpp. "
-            "Support for Ollama models will be removed in a future release. "
-            "Use the Hugging Face <org>/<model> shorthand format, "
-            "or specify a transport explicitly, e.g. huggingface:// or oci://.",
-            FutureWarning,
-            stacklevel=3,
-        )
 
     def prune_model_input(self) -> str:
 

--- a/test/e2e/test_convert.py
+++ b/test/e2e/test_convert.py
@@ -116,7 +116,7 @@ def test_convert(in_model, out_model, extra_params, expected):
             marks=[skip_if_no_container]
         ),
         pytest.param(
-            "bogus", "foobar", 22, ".*Error: Manifest for bogus:latest was not found in the Ollama registry",
+            "bogus", "foobar", 22, ".*not a known shortname and no transport was specified",
             id="raise error if model doesn't exist",
             marks=[skip_if_no_container]
         ),

--- a/test/e2e/test_inspect.py
+++ b/test/e2e/test_inspect.py
@@ -25,7 +25,7 @@ def test_inspect_non_existent_model(shared_ctx):
     with pytest.raises(CalledProcessError) as exc_info:
         ctx.check_output(["ramalama", "inspect", model_name], stderr=STDOUT)
     assert exc_info.value.returncode == 22
-    assert f"Error: No ref file found for '{model_name}'. Please pull model." in exc_info.value.output.decode("utf-8")
+    assert "not a known shortname and no transport was specified" in exc_info.value.output.decode("utf-8")
 
 
 @pytest.mark.e2e

--- a/test/e2e/test_pull.py
+++ b/test/e2e/test_pull.py
@@ -40,7 +40,7 @@ def test_pull_non_existing_model():
             ctx.check_output(["ramalama", "pull", random_model_name], stderr=STDOUT)
         assert exc_info.value.returncode == 22
         assert re.search(
-            rf".*Error: Manifest for {random_model_name}:latest was not found in the Ollama registry",
+            r".*not a known shortname and no transport was specified",
             exc_info.value.output.decode("utf-8"),
         )
 

--- a/test/e2e/test_rm.py
+++ b/test/e2e/test_rm.py
@@ -16,7 +16,7 @@ def test_delete_non_existing_image():
 
     assert exc_info.value.returncode == 22
     assert re.search(
-        f"Error: Model '{image_name}' not found",
+        "not a known shortname and no transport was specified",
         exc_info.value.output.decode("utf-8"),
     )
 

--- a/test/e2e/test_serve.py
+++ b/test/e2e/test_serve.py
@@ -37,7 +37,7 @@ def chdir(path):
         os.chdir(old_dir)
 
 
-DRY_RUN_TEST_MODEL = "dry_run_model"
+DRY_RUN_TEST_MODEL = "ollama://dry_run_model"
 RAMALAMA_DRY_RUN = ["ramalama", "-q", "--dryrun", "serve"]
 
 
@@ -69,7 +69,7 @@ def test_basic_dry_run():
     "extra_params, pattern, config, env_vars, expected",
     [
         pytest.param(
-            [], f".*{DRY_RUN_TEST_MODEL}.*", None, None, True,
+            [], r".*dry_run_model.*", None, None, True,
             id="check model name", marks=skip_if_no_container
         ),
         pytest.param(
@@ -101,7 +101,7 @@ def test_basic_dry_run():
             id="check --host is not present when run within container", marks=skip_if_no_container
         ),
         pytest.param(
-            ["--name", "foobar"], f".*{DRY_RUN_TEST_MODEL}.*", None, None, True,
+            ["--name", "foobar"], r".*dry_run_model.*", None, None, True,
             id="check test_model with --name foobar", marks=skip_if_no_container
         ),
         pytest.param(
@@ -265,7 +265,7 @@ def test_non_existing_model():
             ctx.check_output(["ramalama", "serve", "NON_EXISTING_MODEL"], stderr=STDOUT)
         assert exc_info.value.returncode == 22
         assert re.search(
-            r".*Error: Manifest for NON_EXISTING_MODEL:latest was not found in the Ollama registry",
+            r".*not a known shortname and no transport was specified",
             exc_info.value.output.decode("utf-8"),
         )
 
@@ -286,7 +286,7 @@ def test_nocontainer_and_name_flag_conflict():
 @pytest.mark.e2e
 @skip_if_no_container
 def test_full_model_name_expansion():
-    result = check_output(RAMALAMA_DRY_RUN + ["smollm"])
+    result = check_output(RAMALAMA_DRY_RUN + ["ollama://smollm"])
     pattern = ".*ai.ramalama.model=ollama://library/smollm:latest"
     assert re.search(pattern, result)
 

--- a/test/unit/test_transport_base.py
+++ b/test/unit/test_transport_base.py
@@ -94,16 +94,9 @@ def test_extract_model_identifiers(
     expected_orga: str,
     force_oci_image,
 ):
-    import ramalama.transports.transport_factory as tf_mod
-
-    tf_mod._ollama_default_warned = False
     args = ARGS()
     args.engine = "podman"
-    import warnings
-
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", FutureWarning)
-        name, tag, orga = TransportFactory(model_input, args).create().extract_model_identifiers()
+    name, tag, orga = TransportFactory(model_input, args).create().extract_model_identifiers()
     assert name == expected_name
     assert tag == expected_tag
     assert orga == expected_orga
@@ -294,7 +287,7 @@ class TestMLXRuntime:
             container=False,
             privileged=False,
             debug=False,
-            MODEL="test-model",
+            MODEL="huggingface://test-org/test-model",
             ARGS=None,
             pull="missing",
             dryrun=True,
@@ -308,16 +301,12 @@ class TestMLXRuntime:
 
         model = Transport(args.MODEL, args.store)
 
-        import warnings
-
         with (
             patch.object(tf_module, 'New', return_value=model),
             patch.object(model, 'ensure_model_exists'),
             patch.object(base_module, 'compute_serving_port', return_value="8080"),
             patch.object(factory_module, 'assemble_command', return_value=[]),
-            warnings.catch_warnings(),
         ):
-            warnings.simplefilter("ignore", FutureWarning)
             plugin = get_runtime("mlx")
             plugin._run_handler(args)
 

--- a/test/unit/test_transport_factory.py
+++ b/test/unit/test_transport_factory.py
@@ -177,45 +177,16 @@ def test_bare_model_with_slash_defaults_to_huggingface():
     assert isinstance(model, Huggingface)
 
 
-def test_bare_model_without_slash_defaults_to_ollama():
-    transport_factory_module._ollama_default_warned = False
+def test_bare_model_without_slash_raises_without_shortname():
     args = ARGS()
-    with pytest.warns(FutureWarning):
-        model = TransportFactory("granite-code", args).create()
-    assert isinstance(model, Ollama)
-
-
-def test_bare_model_without_slash_emits_deprecation_warning():
-    transport_factory_module._ollama_default_warned = False
-    args = ARGS()
-    with pytest.warns(FutureWarning, match="Defaulting to Ollama transport"):
+    with pytest.raises(KeyError, match="not a known shortname"):
         TransportFactory("granite-code", args).create()
 
 
-def test_explicit_ollama_transport_emits_deprecation_warning():
-    transport_factory_module._ollama_default_warned = False
+def test_explicit_ollama_transport_still_works():
     args = ARGS()
-    with pytest.warns(FutureWarning, match="Ollama models are no longer compatible"):
-        TransportFactory("granite-code", args, transport="ollama").create()
-
-
-def test_explicit_ollama_prefix_emits_deprecation_warning():
-    transport_factory_module._ollama_default_warned = False
-    args = ARGS()
-    with pytest.warns(FutureWarning, match="Ollama models are no longer compatible"):
-        TransportFactory("ollama://granite-code", args).create()
-
-
-def test_deprecation_warning_emitted_at_most_once():
-    transport_factory_module._ollama_default_warned = False
-    args = ARGS()
-    with pytest.warns(FutureWarning):
-        TransportFactory("model-a", args).create()
-    import warnings
-
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        TransportFactory("model-b", args).create()
+    model = TransportFactory("granite-code", args, transport="ollama").create()
+    assert isinstance(model, Ollama)
 
 
 def test_transport_factory_passes_scheme_to_get_chat_provider(monkeypatch):


### PR DESCRIPTION
Remove the ollama model deprecation warning as ollama is pivoting back to llama.cpp.

However a number of ollama models remain incompatible so update the logic for unknown shortnames to raise a clear error instead of silently defaulting to ollama transport. Explicit ollama:// prefix and --transport ollama still work.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>