### PR TITLE
mask Authorization header in debug log output

### DIFF
--- a/ramalama/http_client.py
+++ b/ramalama/http_client.py
@@ -60,7 +60,8 @@ class HttpClient:
 
     def urlopen(self, url, headers):
         headers["Range"] = f"bytes={self.file_size}-"
-        logger.debug(f"Running urlopen {url} with headers: {headers}")
+        safe_headers = {k: ("****" if k.lower() == "authorization" else v) for k, v in headers.items()}
+        logger.debug(f"Running urlopen {url} with headers: {safe_headers}")
         request = urllib.request.Request(url, headers=headers)
         self.response = urllib.request.urlopen(request)
 

--- a/test/unit/test_http_client.py
+++ b/test/unit/test_http_client.py
@@ -1,0 +1,95 @@
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ramalama.http_client import HttpClient
+
+
+@pytest.fixture(autouse=True)
+def _ensure_logger_propagation():
+    """Ensure the ramalama logger propagates so caplog can capture records."""
+    log = logging.getLogger("ramalama")
+    orig = log.propagate
+    log.propagate = True
+    yield
+    log.propagate = orig
+
+
+class TestUrlopenHeaderMasking:
+    def test_authorization_header_masked_in_debug_log(self, caplog):
+        client = HttpClient()
+        client.file_size = 0
+        headers = {
+            "Authorization": "Bearer hf_secrettoken123",
+            "Accept": "application/octet-stream",
+        }
+
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.getheader.return_value = "1024"
+
+        with patch("urllib.request.urlopen", return_value=mock_response):
+            with caplog.at_level(logging.DEBUG, logger="ramalama"):
+                client.urlopen("https://example.com/model.gguf", headers)
+
+        debug_messages = [r.message for r in caplog.records if r.levelno == logging.DEBUG]
+        log_line = next((m for m in debug_messages if "Running urlopen" in m), None)
+        assert log_line is not None, "Expected 'Running urlopen' in debug log output"
+
+        assert "hf_secrettoken123" not in log_line
+        assert "****" in log_line
+        assert "application/octet-stream" in log_line
+
+    def test_no_authorization_header_logged_normally(self, caplog):
+        client = HttpClient()
+        client.file_size = 0
+        headers = {"Accept": "application/octet-stream"}
+
+        mock_response = MagicMock()
+        mock_response.status = 200
+
+        with patch("urllib.request.urlopen", return_value=mock_response):
+            with caplog.at_level(logging.DEBUG, logger="ramalama"):
+                client.urlopen("https://example.com/model.gguf", headers)
+
+        debug_messages = [r.message for r in caplog.records if r.levelno == logging.DEBUG]
+        log_line = next((m for m in debug_messages if "Running urlopen" in m), None)
+        assert log_line is not None, "Expected 'Running urlopen' in debug log output"
+
+        assert "****" not in log_line
+        assert "application/octet-stream" in log_line
+
+    def test_authorization_header_masked_case_insensitive(self, caplog):
+        client = HttpClient()
+        client.file_size = 0
+        headers = {"authorization": "Bearer hf_secrettoken123"}
+
+        mock_response = MagicMock()
+        mock_response.status = 200
+
+        with patch("urllib.request.urlopen", return_value=mock_response):
+            with caplog.at_level(logging.DEBUG, logger="ramalama"):
+                client.urlopen("https://example.com/model.gguf", headers)
+
+        debug_messages = [r.message for r in caplog.records if r.levelno == logging.DEBUG]
+        log_line = next((m for m in debug_messages if "Running urlopen" in m), None)
+        assert log_line is not None, "Expected 'Running urlopen' in debug log output"
+
+        assert "hf_secrettoken123" not in log_line
+        assert "****" in log_line
+
+    def test_authorization_header_still_sent_in_request(self):
+        client = HttpClient()
+        client.file_size = 0
+        token = "Bearer hf_secrettoken123"
+        headers = {"Authorization": token}
+
+        mock_response = MagicMock()
+        mock_response.status = 200
+
+        with patch("urllib.request.urlopen", return_value=mock_response) as mock_urlopen:
+            client.urlopen("https://example.com/model.gguf", headers)
+
+        request = mock_urlopen.call_args[0][0]
+        assert request.get_header("Authorization") == token


### PR DESCRIPTION
Prevents bearer tokens from leaking into debug logs by redacting the Authorization header value before logging.