### PR TITLE
feat: add LiteLLM as chat provider for 100+ LLM providers

### DIFF
--- a/ramalama/chat_providers/__init__.py
+++ b/ramalama/chat_providers/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from ramalama.chat_providers import api_providers, openai
+from ramalama.chat_providers import api_providers, litellm, openai
 from ramalama.chat_providers.base import (
     ChatProvider,
     ChatProviderError,
@@ -8,4 +8,12 @@ from ramalama.chat_providers.base import (
     ChatStreamEvent,
 )
 
-__all__ = ["ChatProvider", "ChatProviderError", "ChatRequestOptions", "ChatStreamEvent", "openai", "api_providers"]
+__all__ = [
+    "ChatProvider",
+    "ChatProviderError",
+    "ChatRequestOptions",
+    "ChatStreamEvent",
+    "openai",
+    "litellm",
+    "api_providers",
+]

--- a/ramalama/chat_providers/api_providers.py
+++ b/ramalama/chat_providers/api_providers.py
@@ -4,11 +4,13 @@ from collections.abc import Callable
 from typing import Optional
 
 from ramalama.chat_providers.base import ChatProvider
+from ramalama.chat_providers.litellm import LiteLLMChatProvider
 from ramalama.chat_providers.openai import OpenAIResponsesChatProvider
 from ramalama.config import ActiveConfig
 
 PROVIDER_API_KEY_RESOLVERS: dict[str, Callable[[], Optional[str]]] = {
     "openai": lambda: ActiveConfig().provider.openai.api_key,
+    "litellm": lambda: ActiveConfig().provider.litellm.api_key,
 }
 
 
@@ -24,7 +26,11 @@ def get_provider_api_key(scheme: str) -> Optional[str]:
 DEFAULT_PROVIDERS = {
     "openai": lambda: OpenAIResponsesChatProvider(
         base_url="https://api.openai.com/v1", api_key=get_provider_api_key("openai")
-    )
+    ),
+    "litellm": lambda: LiteLLMChatProvider(
+        base_url=ActiveConfig().provider.litellm.base_url or "http://localhost:4000",
+        api_key=get_provider_api_key("litellm"),
+    ),
 }
 
 

--- a/ramalama/chat_providers/litellm.py
+++ b/ramalama/chat_providers/litellm.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from ramalama.chat_providers.openai import OpenAICompletionsChatProvider
+
+
+class LiteLLMChatProvider(OpenAICompletionsChatProvider):
+    """Chat provider that routes through a LiteLLM proxy.
+
+    LiteLLM (https://github.com/BerriAI/litellm) is an AI gateway that
+    provides a unified OpenAI-compatible endpoint for 100+ LLM providers
+    (Anthropic, Bedrock, Vertex, Gemini, Cohere, Mistral, etc.).
+
+    The provider extends OpenAICompletionsChatProvider since the LiteLLM
+    proxy speaks the OpenAI Chat Completions format natively.
+    """
+
+    provider = "litellm"
+
+    def __init__(self, base_url: str, api_key: Optional[str] = None):
+        super().__init__(base_url, api_key)
+
+
+__all__ = ["LiteLLMChatProvider"]

--- a/ramalama/config.py
+++ b/ramalama/config.py
@@ -127,8 +127,15 @@ class OpenaiProviderConfig:
 
 
 @dataclass
+class LitellmProviderConfig:
+    api_key: Optional[str] = None
+    base_url: Optional[str] = None
+
+
+@dataclass
 class ProviderConfig:
     openai: OpenaiProviderConfig = field(default_factory=OpenaiProviderConfig)
+    litellm: LitellmProviderConfig = field(default_factory=LitellmProviderConfig)
 
 
 @dataclass

--- a/ramalama/transports/transport_factory.py
+++ b/ramalama/transports/transport_factory.py
@@ -72,7 +72,7 @@ class TransportFactory:
             return RamalamaContainerRegistry, self.create_rlcr
         if self.model.startswith(("http://", "https://", "file:")):
             return URL, self.create_url
-        if self.model.startswith(("openai://")):
+        if self.model.startswith(("openai://", "litellm://")):
             return APITransport, self.create_api_transport
         if self.transport is None and "/" in self.model:
             return Huggingface, self.create_huggingface

--- a/test/unit/providers/test_litellm_provider.py
+++ b/test/unit/providers/test_litellm_provider.py
@@ -52,9 +52,7 @@ class TestLiteLLMProvider:
         assert headers == {}
 
     def test_parse_stream_chunk(self):
-        chunk_data = {
-            "choices": [{"delta": {"content": "Hello from LiteLLM"}}]
-        }
+        chunk_data = {"choices": [{"delta": {"content": "Hello from LiteLLM"}}]}
         chunk = b"data: " + json.dumps(chunk_data).encode("utf-8") + b"\n\n"
         events = list(self.provider.parse_stream_chunk(chunk))
 

--- a/test/unit/providers/test_litellm_provider.py
+++ b/test/unit/providers/test_litellm_provider.py
@@ -1,0 +1,79 @@
+import json
+
+from ramalama.chat_providers.base import ChatRequestOptions
+from ramalama.chat_providers.litellm import LiteLLMChatProvider
+from ramalama.chat_utils import SystemMessage, UserMessage
+
+
+def make_options(**overrides):
+    data = {"model": "anthropic/claude-sonnet-4-6", "stream": True}
+    data.update(overrides)
+    return ChatRequestOptions(**data)
+
+
+class TestLiteLLMProvider:
+    def setup_method(self):
+        self.provider = LiteLLMChatProvider("http://localhost:4000")
+
+    def test_provider_name(self):
+        assert self.provider.provider == "litellm"
+
+    def test_base_url(self):
+        assert self.provider.base_url == "http://localhost:4000"
+
+    def test_default_path(self):
+        assert self.provider.default_path == "/chat/completions"
+
+    def test_build_url(self):
+        assert self.provider.build_url() == "http://localhost:4000/chat/completions"
+
+    def test_build_payload(self):
+        messages = [
+            SystemMessage(text="You are helpful."),
+            UserMessage(text="Hello"),
+        ]
+        options = make_options()
+        payload = self.provider.build_payload(messages, options)
+
+        assert payload["stream"] is True
+        assert payload["model"] == "anthropic/claude-sonnet-4-6"
+        assert len(payload["messages"]) == 2
+        assert payload["messages"][0]["role"] == "system"
+        assert payload["messages"][1]["role"] == "user"
+
+    def test_auth_headers_with_key(self):
+        provider = LiteLLMChatProvider("http://localhost:4000", api_key="sk-test")
+        headers = provider.auth_headers()
+        assert headers["Authorization"] == "Bearer sk-test"
+
+    def test_auth_headers_without_key(self):
+        provider = LiteLLMChatProvider("http://localhost:4000", api_key=None)
+        headers = provider.auth_headers()
+        assert headers == {}
+
+    def test_parse_stream_chunk(self):
+        chunk_data = {
+            "choices": [{"delta": {"content": "Hello from LiteLLM"}}]
+        }
+        chunk = b"data: " + json.dumps(chunk_data).encode("utf-8") + b"\n\n"
+        events = list(self.provider.parse_stream_chunk(chunk))
+
+        assert len(events) == 1
+        assert events[0].text == "Hello from LiteLLM"
+
+    def test_parse_stream_done(self):
+        chunk = b"data: [DONE]\n\n"
+        events = list(self.provider.parse_stream_chunk(chunk))
+
+        assert len(events) == 1
+        assert events[0].done is True
+
+    def test_create_request(self):
+        messages = [UserMessage(text="Hi")]
+        options = make_options()
+        request = self.provider.create_request(messages, options)
+
+        assert request.full_url == "http://localhost:4000/chat/completions"
+        assert request.method == "POST"
+        body = json.loads(request.data)
+        assert body["messages"][0]["content"] == "Hi"

--- a/test/unit/test_api_providers.py
+++ b/test/unit/test_api_providers.py
@@ -1,6 +1,7 @@
 import pytest
 
 from ramalama.chat_providers.api_providers import get_chat_provider
+from ramalama.chat_providers.litellm import LiteLLMChatProvider
 from ramalama.chat_providers.openai import OpenAIResponsesChatProvider
 
 
@@ -10,6 +11,13 @@ def test_get_chat_provider_returns_openai_provider():
     assert isinstance(provider, OpenAIResponsesChatProvider)
     assert provider.base_url == "https://api.openai.com/v1"
     assert provider.provider == "openai"
+
+
+def test_get_chat_provider_returns_litellm_provider():
+    provider = get_chat_provider("litellm")
+
+    assert isinstance(provider, LiteLLMChatProvider)
+    assert provider.provider == "litellm"
 
 
 def test_get_chat_provider_raises_for_unknown_scheme():


### PR DESCRIPTION
## Summary

- Add LiteLLM as a chat provider, enabling access to 100+ LLM providers (Anthropic, Bedrock, Vertex, Gemini, Cohere, Mistral, etc.) through a single `litellm://` transport scheme
- The provider extends `OpenAICompletionsChatProvider` since the LiteLLM proxy speaks the OpenAI Chat Completions format natively
- Users point at their running LiteLLM proxy and can use any model it serves

## Motivation

Addresses #2385 ("Expanded hosted provider support") which requests Anthropic, Gemini, and Bedrock providers. LiteLLM solves all of these with one integration instead of individual provider implementations.

## Changes

- `ramalama/chat_providers/litellm.py` - new `LiteLLMChatProvider` extending `OpenAICompletionsChatProvider`
- `ramalama/chat_providers/api_providers.py` - registered `litellm` in `DEFAULT_PROVIDERS` and `PROVIDER_API_KEY_RESOLVERS`
- `ramalama/chat_providers/__init__.py` - exported `litellm` module
- `ramalama/config.py` - added `LitellmProviderConfig` with `api_key` and `base_url` fields
- `test/unit/providers/test_litellm_provider.py` - unit tests
- `test/unit/test_api_providers.py` - provider registry test

## Tests

```python
from ramalama.chat_providers.litellm import LiteLLMChatProvider
from ramalama.chat_providers.base import ChatRequestOptions
from ramalama.chat_utils import UserMessage

provider = LiteLLMChatProvider(base_url='http://localhost:4000', api_key='sk-test')
messages = [UserMessage(text='What is 2+2? Answer in one word.')]
options = ChatRequestOptions(model='anthropic/claude-sonnet-4-6', stream=False, max_tokens=10)
request = provider.create_request(messages, options)
# Send via urllib, parse response
```

```
Non-streaming: 'Four'
Streaming: '1, 2, 3.'
E2E PASSED
```

## Example usage

```bash
# Start a LiteLLM proxy with your providers
litellm --config config.yaml --port 4000

# Chat with any model through LiteLLM
ramalama run litellm://anthropic/claude-sonnet-4-6
ramalama run litellm://gpt-4o
```

## Risk / Compatibility

- Additive only. Existing OpenAI provider untouched.
- No new dependencies - the provider talks to a LiteLLM proxy via HTTP.
- Config fields are optional - defaults to `http://localhost:4000` if no base_url set.
