### PR TITLE
konflux: Pass HF_TOKEN from Kubernetes secret to e2e test containers

### DIFF
--- a/.tekton/integration/pipelines/e2e-tests.yaml
+++ b/.tekton/integration/pipelines/e2e-tests.yaml
@@ -56,14 +56,14 @@ spec:
       value: $(tasks.init.results.e2e-image)
     - name: envs
       value:
-      - RAMALAMA_DEFAULT_IMAGE="$(tasks.init.results.ramalama-image)"
-      - RAMALAMA_DEFAULT_RAG_IMAGE="$(tasks.init.results.ramalama-rag-image)"
-      - RAMALAMA_DEFAULT_TOOLS_IMAGE="$(tasks.init.results.ramalama-tools-image)"
+      - RAMALAMA_DEFAULT_IMAGE=$(tasks.init.results.ramalama-image)
+      - RAMALAMA_DEFAULT_RAG_IMAGE=$(tasks.init.results.ramalama-rag-image)
+      - RAMALAMA_DEFAULT_TOOLS_IMAGE=$(tasks.init.results.ramalama-tools-image)
       - RAMALAMA_STACK_IMAGE=$(tasks.init.results.stack-image)
       - >-
-        RAMALAMA_IMAGES='{"CUDA_VISIBLE_DEVICES": "$(tasks.init.results.cuda-image)"}'
+        RAMALAMA_IMAGES={"CUDA_VISIBLE_DEVICES": "$(tasks.init.results.cuda-image)"}
       - >-
-        RAMALAMA_TOOLS_IMAGES='{"CUDA_VISIBLE_DEVICES": "$(tasks.init.results.cuda-tools-image)"}'
+        RAMALAMA_TOOLS_IMAGES={"CUDA_VISIBLE_DEVICES": "$(tasks.init.results.cuda-tools-image)"}
     taskRef:
       resolver: git
       params:

--- a/.tekton/integration/tasks/test-vm-cmd.yaml
+++ b/.tekton/integration/tasks/test-vm-cmd.yaml
@@ -40,6 +40,12 @@ spec:
       value: $(params.cmd)
     - name: RESULTS_TEST_OUTPUT_PATH
       value: $(results.TEST_OUTPUT.path)
+    - name: HF_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: huggingface-token
+          key: token
+          optional: true
     args:
     - $(params.envs[*])
     script: |
@@ -80,11 +86,15 @@ spec:
 
       mkdir -p scripts
 
-      PODMAN_ENV=()
+      touch scripts/test.env
+      chmod 0600 scripts/test.env
       while [ $# -ne 0 ]; do
-        PODMAN_ENV+=("-e" "$1")
+        printf '%s\n' "$1" >> scripts/test.env
         shift
       done
+      if [ -v HF_TOKEN ]; then
+        printenv -0 HF_TOKEN | xargs -0 printf 'HF_TOKEN=%s\n' >> scripts/test.env
+      fi
 
       cat > scripts/test.sh <<SCRIPTEOF
       #!/bin/bash -ex
@@ -132,9 +142,9 @@ spec:
       --security-opt label=disable \
       --security-opt unmask=/proc/* \
       --device /dev/net/tun \
+      --env-file "\$(dirname \$0)/test.env" \
       -v \$TEMP_DIR:/tmp \
       \${EXTRA_ARGS[*]} \
-      ${PODMAN_ENV[*]} \
       $TEST_IMAGE $TEST_CMD
       SCRIPTEOF
       chmod +x scripts/test.sh


### PR DESCRIPTION
Write the `HF_TOKEN` environment variable along with all other provided env vars to a `test.env` file that is synced to the test VM alongside the test script, and load it via `--env-file` in the `podman run` command.