### PR TITLE
Clarify Intel Mac support in installation guide

### DIFF
--- a/docs/MACOS_INSTALL.md
+++ b/docs/MACOS_INSTALL.md
@@ -66,6 +66,8 @@ container = false
 
 The easiest way to install RamaLama on macOS is using our self-contained `.pkg` installer. This method includes Python and all dependencies, so you don't need to install anything else (except for the Prerequisites listed above).
 
+**Note: Even though installer works on Intel macs, `ramalama` itself does not work. Intel macs are not supoorted**
+
 ### Download and Install
 
 1. Download the latest installer from the [Releases page](https://github.com/containers/ramalama/releases)
@@ -237,7 +239,7 @@ ramalama --help
 ## System Requirements
 
 - macOS 10.15 (Catalina) or later
-- Intel or Apple Silicon (M1/M2/M3) processor
+- Apple Silicon (M1/M2/M3) processor. **Intel not supported**
 - 4GB RAM minimum (8GB+ recommended for running models)
 - 10GB free disk space
 - Podman or Docker

--- a/docs/MACOS_INSTALL.md
+++ b/docs/MACOS_INSTALL.md
@@ -238,7 +238,7 @@ ramalama --help
 ## System Requirements
 
 - macOS 10.15 (Catalina) or later
-- Apple Silicon (M1/M2/M3) processor. **Intel not supported**
+- Apple Silicon (M1/M2/M3) processor. **Intel Macs are not supported**
 - 4GB RAM minimum (8GB+ recommended for running models)
 - 10GB free disk space
 - Podman or Docker

--- a/docs/MACOS_INSTALL.md
+++ b/docs/MACOS_INSTALL.md
@@ -66,8 +66,7 @@ container = false
 
 The easiest way to install RamaLama on macOS is using our self-contained `.pkg` installer. This method includes Python and all dependencies, so you don't need to install anything else (except for the Prerequisites listed above).
 
-**Note: Even though installer works on Intel macs, `ramalama` itself does not work. Intel macs are not supoorted**
-
+**Note: Even though installer works on Intel macs, `ramalama` itself does not work. Intel macs are not supported**
 ### Download and Install
 
 1. Download the latest installer from the [Releases page](https://github.com/containers/ramalama/releases)


### PR DESCRIPTION
Updated installation notes to clarify that Intel Macs are not supported for running RamaLama.

#2819