### PR TITLE
Document Intel Mac CPU support and clarify platform limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,8 +177,9 @@ RamaLama then pulls AI Models from model registries, starting a chatbot or REST 
 | Hardware                           | Enabled                     |
 | :--------------------------------- | :-------------------------: |
 | CPU                                | &check;                     |
+| Intel Mac (CPU)                    | &check; llama.cpp           |
 | Apple Silicon GPU (Linux / Asahi)  | &check;                     |
-| Apple Silicon GPU (macOS)          | &check; llama.cpp or MLX    |
+| Apple Silicon GPU (macOS)          | &check; llama.cpp Metal, libkrun, or MLX |
 | Apple Silicon GPU (podman-machine) | &check;                     |
 | Nvidia GPU (cuda)                  | &check; See note below      |
 | AMD GPU (rocm, vulkan)             | &check;                     |
@@ -209,8 +210,30 @@ See the [Intel hardware table](https://dgpu-docs.intel.com/devices/hardware-tabl
 ### Moore Threads GPUs
 On systems with Moore Threads GPUs, see [ramalama-musa](docs/ramalama-musa.7.md) documentation for the correct host system configuration.
 
-### MLX Runtime (macOS only)
-The MLX runtime provides optimized inference for Apple Silicon Macs. MLX requires:
+### Intel Mac (CPU only)
+Intel-based Macs are supported for CPU inference with the default **llama.cpp** runtime. GPU acceleration (MLX, libkrun GPU passthrough) is **not** available on Intel Macs.
+
+Use either:
+- **Containers** (recommended): install [Podman](https://podman.io/) or Docker, then run `ramalama run <model>` as usual.
+- **Native**: install `llama.cpp` with Homebrew (`brew install llama.cpp`) and run with `--nocontainer`.
+
+See the [macOS Installation Guide](docs/MACOS_INSTALL.md#intel-mac-cpu-only) for details.
+
+### Apple Silicon GPU (macOS)
+On Apple Silicon Macs, GPU acceleration is available through:
+
+- **Native llama.cpp with Metal (recommended):** install `llama.cpp` with
+  Homebrew (`brew install llama.cpp`) and run with `--nocontainer`. Homebrew's
+  llama.cpp build uses Metal automatically.
+- **Podman with libkrun:** GPU passthrough inside containers; see
+  [ramalama-macos(7)](docs/ramalama-macos.7.md).
+- **MLX:** optional `--runtime=mlx` with `--nocontainer`; the `mlx-lm` project
+  has been less active recently, so Metal is usually the better choice.
+
+See the [macOS Installation Guide](docs/MACOS_INSTALL.md#apple-silicon-gpu-acceleration-options) for details.
+
+### MLX Runtime (Apple Silicon macOS only)
+The MLX runtime is an optional alternative for Apple Silicon Macs. MLX requires:
 - macOS operating system
 - Apple Silicon hardware (M1, M2, M3, or later)
 - Usage with `--nocontainer` option (containers are not supported)

--- a/docs/MACOS_INSTALL.md
+++ b/docs/MACOS_INSTALL.md
@@ -2,15 +2,101 @@
 
 This guide covers the different ways to install RamaLama on macOS.
 
-## GPU acceleration options
+## Platform support
+
+RamaLama runs on both **Intel** and **Apple Silicon** Macs. What differs is
+which runtimes and accelerators are available:
+
+| Platform | Default runtime | GPU acceleration |
+| :------- | :-------------- | :--------------- |
+| Apple Silicon (M1/M2/M3+) | llama.cpp (container, native Metal, or MLX) | Native llama.cpp Metal (`--nocontainer`), libkrun GPU passthrough in Podman, or MLX |
+| Intel Mac | llama.cpp (container or `--nocontainer`) | Not supported (CPU only) |
+
+On Intel Macs, do **not** use `--runtime=mlx` or install `mlx-lm`; MLX requires
+Apple Silicon hardware.
+
+## Intel Mac (CPU only)
+
+Intel Macs use the default **llama.cpp** runtime with CPU inference only.
+There is no GPU passthrough or MLX support on this hardware.
+
+### Option A: Containers (recommended)
+
+Install Podman or Docker Desktop, then use RamaLama normally.
+
+**Podman:**
+
+```bash
+brew install podman
+podman machine init && podman machine start
+```
+
+**Docker Desktop** (alternative; `brew install docker` installs only the CLI and is
+not sufficient—you need the Desktop app):
+
+```bash
+brew install --cask docker
+open -a Docker   # wait until Docker Desktop is running
+```
+
+Then pull and run a model:
+
+```bash
+ramalama pull tinyllama
+ramalama run tinyllama
+```
+
+RamaLama pulls the standard CPU container image (`quay.io/ramalama/ramalama`).
+
+### Option B: Native (no container)
+
+Install llama.cpp on the host and run with `--nocontainer`:
+
+```bash
+brew install llama.cpp
+ramalama --nocontainer run tinyllama
+```
+
+You can persist this in `$HOME/.config/ramalama/ramalama.conf`:
+
+```
+[machine]
+container = false
+```
+
+## Apple Silicon GPU acceleration options
 
 GPU passthrough from a container has unique challenges on macOS, and
 it is not yet as fast as running outside of a container (at the time
-of writing, performance from a container is around 75-80% of native). We
-therefore offer two different options for running ramalama on macOS:
+of writing, performance from a container is around 75-80% of native). On
+**Apple Silicon** Macs there are three options for GPU acceleration:
 
-- Within a podman container, using krunkit for GPU passthrough
-- Without a container, using MLX directly
+- **Native llama.cpp with Metal (recommended):** install `llama.cpp` via
+  Homebrew and run with `--nocontainer`. This uses Apple's Metal backend
+  directly and is generally the best-performing and most actively maintained
+  option on macOS.
+- **Podman with libkrun:** GPU passthrough inside a container (see below).
+- **MLX:** run with `--runtime=mlx` and `--nocontainer` (alternative; the
+  `mlx-lm` project has been less active recently).
+
+### Native llama.cpp Metal (recommended)
+
+Install llama.cpp on the host and run RamaLama without containers:
+
+```bash
+brew install llama.cpp
+ramalama --nocontainer run tinyllama
+```
+
+You can persist this in `$HOME/.config/ramalama/ramalama.conf`:
+
+```
+[machine]
+container = false
+```
+
+Homebrew's `llama.cpp` build uses the Metal backend automatically on Apple
+Silicon, so no separate GPU runtime flag is required.
 
 ### Podman & krunkit Prerequisites
 
@@ -37,7 +123,11 @@ podman machine start
 
 For more details, see [ramalama-macos(7)](ramalama-macos.7.md).
 
-### Native MLX Prerequisites
+### Native MLX (alternative)
+
+MLX is an optional runtime for Apple Silicon Macs. The `mlx-lm` project has
+been less active recently; native llama.cpp with Metal is usually the better
+choice unless you specifically need MLX.
 
 If podman is not used, MLX needs to be installed on the host:
 
@@ -54,8 +144,8 @@ runtime = "mlx"
 ```
 
 If podman is installed, ramalama will default to using it, so if
-you would rather use MLX, either pass the `--nocontainer` flag to
-ramalama or set it in `$HOME/.config/ramalama/ramalama.conf`:
+you would rather use MLX or native llama.cpp Metal, either pass the
+`--nocontainer` flag to ramalama or set it in `$HOME/.config/ramalama/ramalama.conf`:
 
 ```
 [machine]
@@ -240,5 +330,5 @@ ramalama --help
 - Intel or Apple Silicon (M1/M2/M3) processor
 - 4GB RAM minimum (8GB+ recommended for running models)
 - 10GB free disk space
-- Podman or Docker
+- Podman or Docker Desktop
 

--- a/docs/ramalama-macos.7.md
+++ b/docs/ramalama-macos.7.md
@@ -2,7 +2,12 @@
 
 # Configure Podman Machine on Mac for GPU Acceleration
 
-Leveraging GPU acceleration on a Mac with Podman requires the configuration of
+**Intel Macs:** GPU acceleration is not supported. Use the default llama.cpp
+runtime with CPU inference in a Podman/Docker container or with
+`--nocontainer` and host `llama.cpp`. See
+[MACOS_INSTALL.md](https://github.com/containers/ramalama/blob/main/docs/MACOS_INSTALL.md#intel-mac-cpu-only).
+
+**Apple Silicon Macs:** Leveraging GPU acceleration on a Mac with Podman requires the configuration of
 the `libkrun` machine provider.
 
 This can be done by either setting an environment variable or modifying the
@@ -13,7 +18,7 @@ Previously created Podman Machines must be recreated to take
 advantage of the `libkrun` provider.
 
 Note that it is also possible to run ramalama without containers on macOS to
-use MLX directly; for details see
+use native llama.cpp with Metal (recommended) or MLX directly; for details see
 [MACOS-INSTALL.md](https://github.com/containers/ramalama/blob/main/docs/MACOS_INSTALL.md).
 
 ## Configuration Methods:
@@ -35,9 +40,10 @@ For example: `export CONTAINERS_MACHINE_PROVIDER=libkrun`
 ### ramalama.conf
 
 RamaLama can also be run in a limited manner without using containers, by
-specifying the `--nocontainer` option. In this case MLX is used for native
-GPU acceleration, which will result in better performance than the podman
-krunkit solution. To do this, open the `ramalama.conf` file, typically
+specifying the `--nocontainer` option. On Apple Silicon, native llama.cpp
+with Metal is the recommended GPU path; MLX is also available but has been
+less actively maintained. Both options generally outperform the podman krunkit
+solution. To do this, open the `ramalama.conf` file, typically
 located at $HOME/.config/ramalama/ramalama.conf.
 
 Add the following line within the `[machine]` section: `container = false`

--- a/install.sh
+++ b/install.sh
@@ -175,7 +175,10 @@ main() {
 
     if available brew && brew install ramalama; then
       install_uv
-      uv tool install mlx-lm
+      # MLX is Apple Silicon only; skip on Intel Macs.
+      if [ "$os" = "Darwin" ] && [ "$(uname -m)" = "arm64" ]; then
+        uv tool install mlx-lm
+      fi
       return 0
     fi
   fi

--- a/test/unit/test_transport_base.py
+++ b/test/unit/test_transport_base.py
@@ -245,6 +245,20 @@ class TestMLXRuntime:
 
     @patch('ramalama.plugins.runtimes.inference.mlx.platform.system')
     @patch('ramalama.plugins.runtimes.inference.mlx.platform.machine')
+    def test_mlx_post_process_args_intel_mac_error(self, mock_machine, mock_system):
+        """Test that MLX post_process_args fails on Intel Macs"""
+        from ramalama.plugins.runtimes.inference.mlx import MlxPlugin
+
+        mock_system.return_value = "Darwin"
+        mock_machine.return_value = "x86_64"
+
+        args = Namespace(runtime="mlx", container=False, privileged=False)
+
+        with pytest.raises(ValueError, match="MLX runtime is only supported on macOS with Apple Silicon"):
+            MlxPlugin().post_process_args(args)
+
+    @patch('ramalama.plugins.runtimes.inference.mlx.platform.system')
+    @patch('ramalama.plugins.runtimes.inference.mlx.platform.machine')
     def test_mlx_validation_success(self, mock_machine, mock_system):
         """Test that MLX runtime passes validation on macOS with --nocontainer"""
         mock_system.return_value = "Darwin"


### PR DESCRIPTION
Intel Macs already work with the default llama.cpp runtime (containers or --nocontainer) but MLX and GPU acceleration remain Apple Silicon only. Update macOS docs, README hardware table, install.sh mlx-lm skip on x86_64, and add an Intel Mac MLX rejection unit test.

Fixes: https://github.com/containers/ramalama/pull/2820