### PR TITLE
Add router mode support to ramalama sandbox

### DIFF
--- a/container-images/pi-agent/Containerfile
+++ b/container-images/pi-agent/Containerfile
@@ -2,7 +2,6 @@ FROM quay.io/fedora/fedora:44
 
 ARG PI_VERSION=0.80.7
 ARG NODE_VERSION=26.5.0
-ARG PI_LLAMA_CPP_VERSION=0.8.1
 ARG PI_WEB_ACCESS_VERSION=0.13.0
 ARG TARGETARCH
 
@@ -43,7 +42,7 @@ RUN echo "Include /home/node/.ssh/config" >> /etc/ssh/ssh_config \
     && echo "StrictHostKeyChecking accept-new" >> /etc/ssh/ssh_config
 
 RUN npm install -g --ignore-scripts @earendil-works/pi-coding-agent@${PI_VERSION} \
-    && pi install npm:pi-llama-cpp@${PI_LLAMA_CPP_VERSION} \
+    && pi install npm:pi-llama-server@1.1.0 \
     && pi install npm:pi-web-access@${PI_WEB_ACCESS_VERSION} \
     && npm cache clean --force \
     && echo '{"workflow":"none"}' > /home/node/.pi/web-search.json \

--- a/container-images/pi-agent/Containerfile
+++ b/container-images/pi-agent/Containerfile
@@ -2,6 +2,7 @@ FROM quay.io/fedora/fedora:44
 
 ARG PI_VERSION=0.80.7
 ARG NODE_VERSION=26.5.0
+ARG PI_LLAMA_SERVER_VERSION=1.1.0
 ARG PI_WEB_ACCESS_VERSION=0.13.0
 ARG TARGETARCH
 
@@ -42,7 +43,7 @@ RUN echo "Include /home/node/.ssh/config" >> /etc/ssh/ssh_config \
     && echo "StrictHostKeyChecking accept-new" >> /etc/ssh/ssh_config
 
 RUN npm install -g --ignore-scripts @earendil-works/pi-coding-agent@${PI_VERSION} \
-    && pi install npm:pi-llama-server@1.1.0 \
+    && pi install npm:pi-llama-server@${PI_LLAMA_SERVER_VERSION} \
     && pi install npm:pi-web-access@${PI_WEB_ACCESS_VERSION} \
     && npm cache clean --force \
     && echo '{"workflow":"none"}' > /home/node/.pi/web-search.json \

--- a/docs/options/models-max.md
+++ b/docs/options/models-max.md
@@ -1,7 +1,7 @@
 ####> This option file is used in:
-####>   ramalama serve
+####>   ramalama sandbox goose, ramalama sandbox opencode, ramalama sandbox pi, ramalama serve
 ####> If this file is edited, make sure the changes
 ####> are applicable to all of those.
 #### **--models-max**=*integer*
 Maximum number of models to load concurrently in router mode (default: 4).
-Only used when `ramalama serve` is invoked in router mode (zero or multiple models).
+Only used when invoked in router mode (zero or multiple models).

--- a/docs/options/prompt.md
+++ b/docs/options/prompt.md
@@ -1,0 +1,6 @@
+####> This option file is used in:
+####>   ramalama sandbox goose, ramalama sandbox opencode, ramalama sandbox pi
+####> If this file is edited, make sure the changes
+####> are applicable to all of those.
+#### **--prompt**
+Instructions for the sandbox agent to process non-interactively.

--- a/docs/ramalama-sandbox-goose.1.md.in
+++ b/docs/ramalama-sandbox-goose.1.md.in
@@ -4,16 +4,19 @@
 ramalama\-sandbox\-goose - run Goose in a sandbox, backed by a local AI Model
 
 ## SYNOPSIS
-**ramalama sandbox goose** [*options*] *model* [arg ...]
+**ramalama sandbox goose** [*options*] [*model* ...]
 
 ## DESCRIPTION
 Run Goose in a container, connected to a local model server also running
 in a container. Goose uses the model for reasoning and tool calling.
 
-When run with no arguments after the model, an interactive session is
-launched. If one or more arguments are provided, they are passed to the agent
-as instructions to process non-interactively. Commands may also be passed via
-stdin.
+When a single model is specified, the server loads that model directly.
+When zero or multiple models are specified, the server starts in router mode
+using llama.cpp's --models-dir, dynamically loading and unloading models.
+With no models, all GGUF models in the store are served.
+
+Use **--prompt** to pass instructions for non-interactive processing.
+Commands may also be passed via stdin.
 
 If the url is not given then two containers are started: a model server (llama-server) and the agent
 container. They communicate via container networking. When the agent session
@@ -54,6 +57,8 @@ Otherwise only the agent container starts using the given url for the openai com
 
 @@option model-draft
 
+@@option models-max
+
 @@option name
 
 @@option ncmoe
@@ -67,6 +72,8 @@ Otherwise only the agent container starts using the given url for the openai com
 @@option port
 
 @@option privileged
+
+@@option prompt
 
 @@option pull
 
@@ -122,7 +129,7 @@ ramalama sandbox goose -w ./src qwen3:4b
 
 Request the agent to perform actions non-interactively:
 ```
-ramalama sandbox goose -w ./src qwen3:4b Please analyze the source code in the current directory
+ramalama sandbox goose -w ./src qwen3:4b --prompt "Please analyze the source code in the current directory"
 ```
 
 Send instructions to the agent via stdin:

--- a/docs/ramalama-sandbox-opencode.1.md.in
+++ b/docs/ramalama-sandbox-opencode.1.md.in
@@ -4,16 +4,19 @@
 ramalama\-sandbox\-opencode - run OpenCode in a sandbox, backed by a local AI Model
 
 ## SYNOPSIS
-**ramalama sandbox opencode** [*options*] *model* [arg ...]
+**ramalama sandbox opencode** [*options*] [*model* ...]
 
 ## DESCRIPTION
 Run OpenCode in a container, connected to a local model server also running
 in a container. OpenCode uses the model for reasoning and tool calling.
 
-When run with no arguments after the model, an interactive TUI session is
-launched. If one or more arguments are provided, they are passed to the agent
-as instructions to process non-interactively. Commands may also be passed via
-stdin.
+When a single model is specified, the server loads that model directly.
+When zero or multiple models are specified, the server starts in router mode
+using llama.cpp's --models-dir, dynamically loading and unloading models.
+With no models, all GGUF models in the store are served.
+
+Use **--prompt** to pass instructions for non-interactive processing.
+Commands may also be passed via stdin.
 
 If the url is not given then two containers are started: a model server (llama-server) and the agent
 container. They communicate via container networking. When the agent session
@@ -52,6 +55,8 @@ Otherwise only the agent container starts using the given url for the openai com
 
 @@option model-draft
 
+@@option models-max
+
 @@option name
 
 @@option ncmoe
@@ -67,6 +72,8 @@ Otherwise only the agent container starts using the given url for the openai com
 @@option port
 
 @@option privileged
+
+@@option prompt
 
 @@option pull
 
@@ -122,7 +129,7 @@ ramalama sandbox opencode -w ./src qwen3:4b
 
 Request the agent to perform actions non-interactively:
 ```
-ramalama sandbox opencode -w ./src qwen3:4b Please analyze the source code in the current directory
+ramalama sandbox opencode -w ./src qwen3:4b --prompt "Please analyze the source code in the current directory"
 ```
 
 Send instructions to the agent via stdin:

--- a/docs/ramalama-sandbox-pi.1.md.in
+++ b/docs/ramalama-sandbox-pi.1.md.in
@@ -4,16 +4,19 @@
 ramalama\-sandbox\-pi - run Pi in a sandbox, backed by a local AI Model
 
 ## SYNOPSIS
-**ramalama sandbox pi** [*options*] *model* [arg ...]
+**ramalama sandbox pi** [*options*] [*model* ...]
 
 ## DESCRIPTION
 Run Pi in a container, connected to a local model server also running
 in a container. Pi uses the model for reasoning and tool calling.
 
-When run with no arguments after the model, an interactive session is
-launched. If one or more arguments are provided, they are passed to the agent
-as instructions to process non-interactively. Commands may also be passed via
-stdin.
+When a single model is specified, the server loads that model directly.
+When zero or multiple models are specified, the server starts in router mode
+using llama.cpp's --models-dir, dynamically loading and unloading models.
+With no models, all GGUF models in the store are served.
+
+Use **--prompt** to pass instructions for non-interactive processing.
+Commands may also be passed via stdin.
 
 Two containers are started: a model server (llama-server) and the agent
 container. They communicate via container networking. When the agent session
@@ -56,6 +59,8 @@ Otherwise only the agent container starts using the given url for the openai com
 
 @@option model-draft
 
+@@option models-max
+
 @@option name
 
 @@option ncmoe
@@ -71,6 +76,8 @@ Otherwise only the agent container starts using the given url for the openai com
 @@option port
 
 @@option privileged
+
+@@option prompt
 
 @@option pull
 
@@ -109,6 +116,16 @@ Run the Pi agent with default settings:
 ramalama sandbox pi qwen3:4b
 ```
 
+Run the Pi agent in router mode (serve all models in the store):
+```
+ramalama sandbox pi
+```
+
+Run the Pi agent with multiple models in router mode:
+```
+ramalama sandbox pi qwen3:4b granite-code:3b
+```
+
 Run the Pi agent with a custom image:
 ```
 ramalama sandbox pi --pi-image myimage:v1 qwen3:4b
@@ -126,7 +143,7 @@ ramalama sandbox pi -w ./src qwen3:4b
 
 Request the agent to perform actions non-interactively:
 ```
-ramalama sandbox pi -w ./src qwen3:4b Please analyze the source code in the current directory
+ramalama sandbox pi -w ./src qwen3:4b --prompt "Please analyze the source code in the current directory"
 ```
 
 Send instructions to the agent via stdin:

--- a/ramalama/plugins/runtimes/inference/llama_cpp.py
+++ b/ramalama/plugins/runtimes/inference/llama_cpp.py
@@ -6,6 +6,7 @@ import json
 import os
 import platform
 import shutil
+import subprocess
 import sys
 import tempfile
 from collections.abc import Mapping
@@ -312,7 +313,6 @@ class LlamaCppPlugin(LlamaCppCommands, ContainerizedInferenceRuntimePlugin):
         except ValueError:
             logger.debug(f"{self.name} {container_name} /models does not include a model list in the response")
             return False
-
         if not model_name:
             if hasattr(args, 'MODEL') and isinstance(args.MODEL, str):
                 model_name = New(args.MODEL, args).model_alias
@@ -539,13 +539,12 @@ class LlamaCppPlugin(LlamaCppCommands, ContainerizedInferenceRuntimePlugin):
 
         super()._serve_handler(args)
 
-    def _serve_router(self, args: argparse.Namespace) -> None:
-        """Serve multiple models using llama.cpp router mode (container-only)."""
+    def _build_router_engine(self, args: argparse.Namespace) -> Engine:
+        """Resolve models and build an Engine with bind mounts for router mode."""
         if not args.container:
             sys.exit("Error: multi-model router mode requires a container runtime.")
 
         set_accel_env_vars()
-        args.port = compute_serving_port(args)
         args.router_mode = True
 
         if args.MODEL:
@@ -563,27 +562,45 @@ class LlamaCppPlugin(LlamaCppCommands, ContainerizedInferenceRuntimePlugin):
         if not models:
             sys.exit("Error: no GGUF models found in the model store. Pull a model first with: ramalama pull <model>")
 
-        if args.container and not args.dryrun:
+        if not args.dryrun and not getattr(args, "image", None):
             config = ActiveConfig()
             should_pull = config.pull in ["always", "missing", "newer"]
             args.image = ensure_image(config.engine, accel_image(config), should_pull=should_pull)
 
-        cmd = assemble_command(args)
+        cmd = self.handle_subcommand("serve", args)
         engine = Engine(args)
         name = getattr(args, "name", None) or genname()
+        args.name = name
         engine.add(["--label", "ai.ramalama", "--name", name, "--env=HOME=/tmp", "--init"])
 
         for host_path, container_name in models:
             mount_path = f"/mnt/models/{container_name}"
             container_host_path = get_container_mount_path(host_path)
-            engine.add([f"--mount=type=bind,src={container_host_path},destination={mount_path},ro"])
+            engine.add([f"--mount=type=bind,src={container_host_path},destination={mount_path},ro{engine.relabel()}"])
 
         engine.add([args.image] + cmd)
+        return engine
+
+    def _serve_router(self, args: argparse.Namespace) -> None:
+        """Serve multiple models using llama.cpp router mode (container-only)."""
+        args.port = compute_serving_port(args)
+        engine = self._build_router_engine(args)
 
         if args.dryrun:
             engine.dryrun()
             return
         engine.exec()
+
+    def serve_router_nonblocking(self, args: argparse.Namespace) -> None:
+        """Start the router-mode server non-blocking (for sandbox use)."""
+        args.detach = True
+        engine = self._build_router_engine(args)
+
+        if args.dryrun:
+            engine.dryrun()
+            return
+
+        subprocess.Popen(engine.exec_args)
 
     @staticmethod
     def _migrate_store_ref_files(store: Any) -> None:

--- a/ramalama/sandbox.py
+++ b/ramalama/sandbox.py
@@ -205,8 +205,7 @@ class Goose(Agent):
         self.engine.add_env_option("GOOSE_PROVIDER=openai")
         self.engine.add_env_option(f"OPENAI_HOST={args.url}")
         self.engine.add_env_option(f"OPENAI_API_KEY={args.api_key}")
-        if self.model_name:
-            self.engine.add_env_option(f"GOOSE_MODEL={self.model_name}")
+        self.engine.add_env_option(f"GOOSE_MODEL={self.model_name}")
         self.engine.add_env_option("GOOSE_TELEMETRY_ENABLED=false")
         self.engine.add_env_option("GOOSE_CLI_SHOW_THINKING=true")
 
@@ -249,7 +248,7 @@ class OpenCode(Agent):
         router_model_ids = getattr(args, "router_model_ids", None)
         if router_model_ids:
             provider_config["models"] = {mid: {"name": mid} for mid in router_model_ids}
-        elif self.model_name:
+        else:
             provider_config["models"] = {
                 self.model_name: {
                     "name": self.model_name,
@@ -261,8 +260,7 @@ class OpenCode(Agent):
                 "ramalama": provider_config,
             },
         }
-        if self.model_name:
-            config["model"] = f"ramalama/{self.model_name}"
+        config["model"] = f"ramalama/{self.model_name}"
         self.engine.add_env_option(f"OPENCODE_CONFIG_CONTENT={json.dumps(config)}")
 
 
@@ -285,9 +283,7 @@ class Pi(Agent):
         self.add_provider_discovery_env(args)
         self.engine.add_workdir(args)
         self.engine.add_args(args.pi_image)
-        pi_args = ["--provider", provider_id]
-        if self.model_name:
-            pi_args += ["--model", self.model_name]
+        pi_args = ["--provider", provider_id, "--model", self.model_name]
         if args.ARGS:
             pi_args += ["-p", args.ARGS]
         self.engine.add(pi_args)
@@ -321,8 +317,10 @@ def run_sandbox(args: SandboxEngineArgsType, agent_cls: type[Agent]) -> None:
     models: list[str] = list(args.MODEL)  # type: ignore[arg-type]
 
     if not sb_args.start_model_server:
+        if len(models) != 1:
+            raise ValueError("ramalama sandbox with --url requires exactly one model")
         sb_args.name = sb_args.name or genname()
-        model_name = models[0] if len(models) == 1 else ""
+        model_name = models[0]
         if sb_args.dryrun:
             agent = agent_cls(sb_args, model_name)
             agent.engine.dryrun()
@@ -396,7 +394,7 @@ def _run_sandbox_router(args: SandboxEngineArgsType, agent_cls: type[Agent]) -> 
     serve_router(cast(argparse.Namespace, args))
 
     if args.dryrun:
-        agent = agent_cls(args, "")
+        agent = agent_cls(args, "dummy")
         agent.engine.dryrun()
         return
 
@@ -407,7 +405,8 @@ def _run_sandbox_router(args: SandboxEngineArgsType, agent_cls: type[Agent]) -> 
             raise ValueError("Router mode requires a resolved serving port")
         model_ids = _query_router_models(args.port)
         args.router_model_ids = model_ids  # type: ignore[attr-defined]
-        first_model = model_ids[0] if model_ids else ""
+        assert model_ids, "router model discovery returned no model IDs"
+        first_model = model_ids[0]
 
         agent = agent_cls(args, first_model)
         agent.run()

--- a/ramalama/sandbox.py
+++ b/ramalama/sandbox.py
@@ -5,12 +5,14 @@ import copy
 import json
 import platform
 from collections.abc import Callable
+from functools import partial
+from http.client import HTTPConnection
 from typing import Optional, cast
 
 from ramalama.arg_types import BaseEngineArgsType
 from ramalama.common import genname, run_cmd
 from ramalama.config import ActiveConfig
-from ramalama.engine import Engine, stop_container
+from ramalama.engine import Engine, is_healthy, stop_container, wait_for_healthy
 from ramalama.plugins.loader import get_runtime
 from ramalama.transports.base import compute_serving_port
 from ramalama.transports.transport_factory import New
@@ -21,7 +23,7 @@ def default_pi_image() -> str:
 
 
 def _add_common_sandbox_args(parser: argparse.ArgumentParser) -> None:
-    """Add --workdir and ARGS arguments shared by all sandbox subcommands."""
+    """Add --workdir and --prompt arguments shared by all sandbox subcommands."""
     parser.add_argument(
         "-w",
         "--workdir",
@@ -37,9 +39,20 @@ def _add_common_sandbox_args(parser: argparse.ArgumentParser) -> None:
         help="OpenAI-compatible API key.",
     )
     parser.add_argument(
-        "ARGS",
-        nargs="*",
+        "--prompt",
+        dest="ARGS",
         help="instructions for the sandbox to process non-interactively",
+    )
+
+
+def _add_router_args(parser: argparse.ArgumentParser) -> None:
+    """Add --models-max argument for router mode."""
+    parser.add_argument(
+        "--models-max",
+        dest="models_max",
+        type=int,
+        default=4,
+        help="maximum number of models to load concurrently in router mode",
     )
 
 
@@ -56,7 +69,7 @@ def add_sandbox_subparsers(subparsers: argparse._SubParsersAction, img_comp: Cal
         # Consider adding this to the plugin interface for commands which need to run an
         # inference server
         runtime._add_inference_args(parser, "serve")  # type: ignore[attr-defined]
-    parser.add_argument("MODEL", completer=model_comp)
+    parser.add_argument("MODEL", nargs="*", default=[], completer=model_comp)
     parser.add_argument(
         "--goose-image",
         default="ghcr.io/aaif-goose/goose:1.43.0",
@@ -64,13 +77,14 @@ def add_sandbox_subparsers(subparsers: argparse._SubParsersAction, img_comp: Cal
         help="Goose container image",
     )
     _add_common_sandbox_args(parser)
+    _add_router_args(parser)
     parser.set_defaults(func=run_sandbox_goose)
     yield parser
 
     parser = subparsers.add_parser("opencode", help="run OpenCode in a sandbox, backed by a local AI Model")
     if getattr(runtime, "_add_inference_args", None):
         runtime._add_inference_args(parser, "serve")  # type: ignore[attr-defined]
-    parser.add_argument("MODEL", completer=model_comp)
+    parser.add_argument("MODEL", nargs="*", default=[], completer=model_comp)
     parser.add_argument(
         "--opencode-image",
         default="ghcr.io/anomalyco/opencode:1.17.20",
@@ -78,13 +92,14 @@ def add_sandbox_subparsers(subparsers: argparse._SubParsersAction, img_comp: Cal
         help="OpenCode container image",
     )
     _add_common_sandbox_args(parser)
+    _add_router_args(parser)
     parser.set_defaults(func=run_sandbox_opencode)
     yield parser
 
     parser = subparsers.add_parser("pi", help="run Pi in a sandbox, backed by a local AI Model")
     if getattr(runtime, "_add_inference_args", None):
         runtime._add_inference_args(parser, "serve")  # type: ignore[attr-defined]
-    parser.add_argument("MODEL", completer=model_comp)
+    parser.add_argument("MODEL", nargs="*", default=[], completer=model_comp)
     parser.add_argument(
         "--pi-image",
         default=default_pi_image(),
@@ -92,12 +107,13 @@ def add_sandbox_subparsers(subparsers: argparse._SubParsersAction, img_comp: Cal
         help="Pi container image",
     )
     _add_common_sandbox_args(parser)
+    _add_router_args(parser)
     parser.set_defaults(func=run_sandbox_pi)
     yield parser
 
 
 class SandboxEngineArgsType(BaseEngineArgsType):
-    ARGS: list[str]
+    ARGS: Optional[str]
     workdir: Optional[str]
     url: Optional[str]
     api_key: Optional[str]
@@ -175,7 +191,7 @@ class Goose(Agent):
         self.engine.add_workdir(args)
         self.engine.add_args(args.goose_image)
         if args.ARGS:
-            self.engine.add_args("run", "-t", " ".join(args.ARGS))
+            self.engine.add_args("run", "-t", args.ARGS)
         elif self.engine.use_tty():
             self.engine.add_args("session")
         else:
@@ -185,7 +201,8 @@ class Goose(Agent):
         self.engine.add_env_option("GOOSE_PROVIDER=openai")
         self.engine.add_env_option(f"OPENAI_HOST={args.url}")
         self.engine.add_env_option(f"OPENAI_API_KEY={args.api_key}")
-        self.engine.add_env_option(f"GOOSE_MODEL={self.model_name}")
+        if self.model_name:
+            self.engine.add_env_option(f"GOOSE_MODEL={self.model_name}")
         self.engine.add_env_option("GOOSE_TELEMETRY_ENABLED=false")
         self.engine.add_env_option("GOOSE_CLI_SHOW_THINKING=true")
 
@@ -212,29 +229,36 @@ class OpenCode(Agent):
         if args.ARGS or not self.engine.use_tty():
             # Use the "run" command to process args from the command-line or stdin non-interatively
             self.engine.add_args("run", "--thinking=true")
-            self.engine.add(args.ARGS)
+            if args.ARGS:
+                self.engine.add_args(args.ARGS)
         # Running on a tty with no arguments will start the TUI for an interactive session
 
     def add_env_options(self, args: OpenCodeArgsType) -> None:
-        config = {
-            "$schema": "https://opencode.ai/config.json",
-            "model": f"ramalama/{self.model_name}",
-            "provider": {
-                "ramalama": {
-                    "npm": "@ai-sdk/openai-compatible",
-                    "name": "RamaLama",
-                    "options": {
-                        "baseURL": f"{args.url}/v1",
-                        "apiKey": args.api_key,
-                    },
-                    "models": {
-                        self.model_name: {
-                            "name": self.model_name,
-                        },
-                    },
-                },
+        provider_config: dict = {
+            "npm": "@ai-sdk/openai-compatible",
+            "name": "RamaLama",
+            "options": {
+                "baseURL": f"{args.url}/v1",
+                "apiKey": args.api_key,
             },
         }
+        router_model_ids = getattr(args, "router_model_ids", None)
+        if router_model_ids:
+            provider_config["models"] = {mid: {"name": mid} for mid in router_model_ids}
+        elif self.model_name:
+            provider_config["models"] = {
+                self.model_name: {
+                    "name": self.model_name,
+                },
+            }
+        config: dict = {
+            "$schema": "https://opencode.ai/config.json",
+            "provider": {
+                "ramalama": provider_config,
+            },
+        }
+        if self.model_name:
+            config["model"] = f"ramalama/{self.model_name}"
         self.engine.add_env_option(f"OPENCODE_CONFIG_CONTENT={json.dumps(config)}")
 
 
@@ -257,9 +281,11 @@ class Pi(Agent):
         self.add_provider_discovery_env(args)
         self.engine.add_workdir(args)
         self.engine.add_args(args.pi_image)
-        pi_args = ["--provider", provider_id, "--model", self.model_name]
+        pi_args = ["--provider", provider_id]
+        if self.model_name:
+            pi_args += ["--model", self.model_name]
         if args.ARGS:
-            pi_args += ["-p", " ".join(args.ARGS)]
+            pi_args += ["-p", args.ARGS]
         self.engine.add(pi_args)
 
     def add_provider_discovery_env(self, args: PiArgsType) -> None:
@@ -280,7 +306,7 @@ def run_sandbox_pi(args: PiArgsType):
     run_sandbox(args, Pi)
 
 
-def run_sandbox(args: SandboxEngineArgsType, agent_cls: type[Agent]):
+def run_sandbox(args: SandboxEngineArgsType, agent_cls: type[Agent]) -> None:
     """Orchestrate model server and sandbox containers."""
 
     if not args.container:  # type: ignore[attr-defined]
@@ -288,42 +314,99 @@ def run_sandbox(args: SandboxEngineArgsType, agent_cls: type[Agent]):
 
     sb_args = copy.copy(args)
     sb_args.start_model_server = args.url is None
+    models: list[str] = list(args.MODEL)  # type: ignore[arg-type]
+
     if not sb_args.start_model_server:
         sb_args.name = sb_args.name or genname()
-
+        model_name = models[0] if len(models) == 1 else ""
         if sb_args.dryrun:
-            agent = agent_cls(sb_args, sb_args.model)
+            agent = agent_cls(sb_args, model_name)
             agent.engine.dryrun()
             return
 
         # Just launch agent
-        agent = agent_cls(sb_args, sb_args.model)
+        agent = agent_cls(sb_args, model_name)
         agent.run()
+        return
+
+    sb_args.port = compute_serving_port(sb_args)
+    sb_args.url = f"http://localhost:{sb_args.port}"
+    if len(models) == 1:
+        sb_args.MODEL = models[0]
+        _run_sandbox_single_model(sb_args, agent_cls)
     else:
-        model = New(sb_args.MODEL, sb_args)
-        sb_args.port = compute_serving_port(sb_args)
-        sb_args.url = f"""http://localhost:{sb_args.port}"""
+        _run_sandbox_router(sb_args, agent_cls)
 
-        if sb_args.dryrun:
-            agent = agent_cls(sb_args, model.model_alias)
-            agent.engine.dryrun()
-            return
 
-        model.ensure_model_exists(sb_args)
+def _run_sandbox_single_model(args: SandboxEngineArgsType, agent_cls: type[Agent]) -> None:
+    """Run sandbox with a single model (original behavior)."""
+    model = New(args.MODEL, args)
 
-        runtime = get_runtime(ActiveConfig().runtime)
-        cmd = runtime.handle_subcommand("serve", cast(argparse.Namespace, sb_args))
+    if args.dryrun:
+        agent = agent_cls(args, model.model_alias)
+        agent.engine.dryrun()
+        return
 
-        model.serve_nonblocking(sb_args, cmd)  # type: ignore[union-attr]
+    model.ensure_model_exists(args)
 
-        agent = agent_cls(sb_args, model.model_alias)
+    runtime = get_runtime(ActiveConfig().runtime)
+    cmd = runtime.handle_subcommand("serve", cast(argparse.Namespace, args))
 
-        try:
-            # Wait for model server to be healthy
-            model.wait_for_healthy(sb_args)  # type: ignore[union-attr]
+    model.serve_nonblocking(args, cmd)  # type: ignore[union-attr]
+    agent = agent_cls(args, model.model_alias)
 
-            # Launch agent
-            agent.run()
-        finally:
-            sb_args.ignore = True  # type: ignore[attr-defined]
-            stop_container(sb_args, sb_args.name, remove=True)  # type: ignore[attr-defined]
+    try:
+        model.wait_for_healthy(args)  # type: ignore[union-attr]
+        agent.run()
+    finally:
+        args.ignore = True  # type: ignore[attr-defined]
+        stop_container(args, args.name, remove=True)  # type: ignore[attr-defined]
+
+
+def _query_router_models(port: int | str) -> list[str]:
+    """Query the llama.cpp router server for available model IDs."""
+    conn = None
+    try:
+        conn = HTTPConnection("127.0.0.1", int(port), timeout=5)
+        conn.request("GET", "/v1/models")
+        resp = conn.getresponse()
+        if resp.status != 200:
+            return []
+        body = json.loads(resp.read())
+        return [m.get("id", "") for m in body.get("data", []) if m.get("id")]
+    except Exception:
+        return []
+    finally:
+        if conn:
+            conn.close()
+
+
+def _run_sandbox_router(args: SandboxEngineArgsType, agent_cls: type[Agent]) -> None:
+    """Run sandbox in router mode (zero or multiple models)."""
+    runtime = get_runtime(ActiveConfig().runtime)
+
+    serve_router = getattr(runtime, "serve_router_nonblocking", None)
+    if serve_router is None:
+        raise ValueError("Router mode (zero or multiple models) is only supported with the llama.cpp runtime.")
+
+    serve_router(cast(argparse.Namespace, args))
+
+    if args.dryrun:
+        agent = agent_cls(args, "")
+        agent.engine.dryrun()
+        return
+
+    try:
+        wait_for_healthy(args, partial(is_healthy))
+
+        if args.port is None:
+            raise ValueError("Router mode requires a resolved serving port")
+        model_ids = _query_router_models(args.port)
+        args.router_model_ids = model_ids  # type: ignore[attr-defined]
+        first_model = model_ids[0] if model_ids else ""
+
+        agent = agent_cls(args, first_model)
+        agent.run()
+    finally:
+        args.ignore = True  # type: ignore[attr-defined]
+        stop_container(args, args.name, remove=True)  # type: ignore[attr-defined]

--- a/ramalama/sandbox.py
+++ b/ramalama/sandbox.py
@@ -22,6 +22,10 @@ def default_pi_image() -> str:
     return ActiveConfig().default_pi_image
 
 
+def _pi_provider_id() -> str:
+    return "llama-server"
+
+
 def _add_common_sandbox_args(parser: argparse.ArgumentParser) -> None:
     """Add --workdir and --prompt arguments shared by all sandbox subcommands."""
     parser.add_argument(
@@ -51,7 +55,7 @@ def _add_router_args(parser: argparse.ArgumentParser) -> None:
         "--models-max",
         dest="models_max",
         type=int,
-        default=4,
+        default=1,
         help="maximum number of models to load concurrently in router mode",
     )
 
@@ -276,7 +280,7 @@ class Pi(Agent):
 
     def __init__(self, args: PiArgsType, model_name: str) -> None:
         super().__init__(args, model_name)
-        provider_id = f"llama-server={args.url}"
+        provider_id = _pi_provider_id()
         self.engine.add_name(f"pi-{args.name}")  # type: ignore[attr-defined]
         self.add_provider_discovery_env(args)
         self.engine.add_workdir(args)
@@ -289,7 +293,7 @@ class Pi(Agent):
         self.engine.add(pi_args)
 
     def add_provider_discovery_env(self, args: PiArgsType) -> None:
-        # pi-llama-cpp discovers and registers providers from LLAMA_SERVER_URL;
+        # pi-llama-server discovers and registers providers from LLAMA_SERVER_URL;
         # --provider then selects the matching provider id for the active session.
         self.engine.add_env_option(f"LLAMA_SERVER_URL={args.url}")
 

--- a/test/e2e/test_sandbox.py
+++ b/test/e2e/test_sandbox.py
@@ -208,7 +208,7 @@ def test_sandbox_dryrun_pi_custom_image():
 @pytest.mark.parametrize("agent", ["goose", "opencode", "pi"])
 def test_sandbox_run(sandbox_ctx, agent):
     """Agent should run successfully."""
-    result = sandbox_ctx.check_output(["ramalama", "sandbox", agent, "--thinking=off", TEST_MODEL, "hi"])
+    result = sandbox_ctx.check_output(["ramalama", "sandbox", agent, "--thinking=off", "--prompt", "hi", TEST_MODEL])
     assert result
 
 
@@ -224,13 +224,19 @@ def test_sandbox_run_cmdline(sandbox_ctx, tmp_path, container_engine, agent):
     # local user's directory under docker
     if container_engine == "docker":
         tmp_path.chmod(0o777)
-    # fmt: off
     result = sandbox_ctx.check_output(
         [
-            "ramalama", "sandbox", agent, "-w", tmp_path, "--seed=1", "--temp=0", TEST_MODEL,
-            "Please", "create", "a", "pyproject.toml", "for", "a", "project", "called",
-            "ramalama", "and", "write", "it", "to", "the", "current", "directory.",
-            "Ensure", "it", "contains", "a", "project", "section.",
+            "ramalama",
+            "sandbox",
+            agent,
+            "-w",
+            tmp_path,
+            "--seed=1",
+            "--temp=0",
+            "--prompt",
+            "Please create a pyproject.toml for a project called ramalama "
+            "and write it to the current directory. Ensure it contains a project section.",
+            TEST_MODEL,
         ]
     )
     pyproject = tmp_path / "pyproject.toml"

--- a/test/e2e/test_sandbox.py
+++ b/test/e2e/test_sandbox.py
@@ -49,7 +49,7 @@ def sandbox_ctx():
     [
         ["goose", r"run -i -\s*$"],
         ["opencode", r"run --thinking=true\s*$"],
-        ["pi", r"--provider llama-server=http://localhost:\d+\s+--model\s+\S+"],
+        ["pi", r"--provider llama-server\s+--model\s+\S+"],
     ],
 )
 def test_sandbox_dryrun_default(agent, cmd):
@@ -186,7 +186,7 @@ def test_sandbox_dryrun_pi_env_vars():
     """Dryrun output should include Pi environment and provider configuration."""
     result = check_output(_dryrun_cmd("pi"))
     assert re.search(r"LLAMA_SERVER_URL=http://localhost:\d+", result)
-    assert re.search(r"--provider llama-server=http://localhost:\d+", result)
+    assert re.search(r"--provider llama-server", result)
 
 
 @pytest.mark.e2e

--- a/test/unit/test_sandbox_cmd.py
+++ b/test/unit/test_sandbox_cmd.py
@@ -6,7 +6,7 @@ import pytest
 
 from ramalama.cli import parse_args_from_cmd
 from ramalama.config import DEFAULT_PI_IMAGE
-from ramalama.sandbox import Goose, OpenCode, Pi
+from ramalama.sandbox import Goose, OpenCode, Pi, _pi_provider_id
 
 TEST_MODEL = "qwen3:4b"
 
@@ -315,6 +315,10 @@ def test_opencode_args():
 # --- Pi-specific tests ---
 
 
+def test_pi_provider_id():
+    """Pi provider id should be the pi-llama-server extension's registered name."""
+    assert _pi_provider_id() == "llama-server"
+
 def test_pi_default_image():
     """Pi subcommand should provide a default pi image"""
     _, args = parse_args_from_cmd(["sandbox", "pi", TEST_MODEL])
@@ -341,7 +345,7 @@ def test_pi_custom_image():
 
 
 def test_pi_env_vars():
-    """Pi should set LLAMA_SERVER_URL for pi-llama-cpp extension"""
+    """Pi should set LLAMA_SERVER_URL for pi-llama-server extension"""
     args = _make_pi_args()
     pi = Pi(args, "Qwen3-4B-Q4_K_M")
     cmd = pi.engine.exec_args
@@ -349,7 +353,7 @@ def test_pi_env_vars():
     assert "--rm" in cmd
     assert f"LLAMA_SERVER_URL={args.url}" in cmd
     assert "--provider" in cmd
-    assert f"llama-server={args.url}" in cmd
+    assert "llama-server" in cmd
     assert "--model" in cmd
     assert "Qwen3-4B-Q4_K_M" in cmd
 
@@ -361,12 +365,12 @@ def test_pi_entrypoint(monkeypatch):
     pi = Pi(args, "test-model")
     cmd = pi.engine.exec_args
     assert "--entrypoint" not in cmd
-    assert "pi install npm:pi-llama-cpp" not in cmd
+    assert "pi install npm:pi-llama-server" not in cmd
     assert "pi install npm:pi-web-access" not in cmd
     assert cmd[-5:] == [
         args.pi_image,
         "--provider",
-        f"llama-server={args.url}",
+        "llama-server",
         "--model",
         "test-model",
     ]
@@ -380,7 +384,7 @@ def test_pi_with_tty(monkeypatch):
     assert pi.engine.exec_args[-5:] == [
         args.pi_image,
         "--provider",
-        f"llama-server={args.url}",
+        "llama-server",
         "--model",
         "test-model",
     ]
@@ -394,7 +398,7 @@ def test_pi_no_tty(monkeypatch):
     assert pi.engine.exec_args[-5:] == [
         args.pi_image,
         "--provider",
-        f"llama-server={args.url}",
+        "llama-server",
         "--model",
         "test-model",
     ]

--- a/test/unit/test_sandbox_cmd.py
+++ b/test/unit/test_sandbox_cmd.py
@@ -78,7 +78,23 @@ def _agent_args(agent):
 def test_sandbox_model_positional(agent):
     """Sandbox cli should accept a model as a positional argument"""
     _, args = parse_args_from_cmd(["sandbox", agent, TEST_MODEL])
-    assert args.MODEL == "hf://bartowski/Qwen_Qwen3-4B-GGUF"
+    assert isinstance(args.MODEL, list)
+    assert len(args.MODEL) == 1
+
+
+@pytest.mark.parametrize("agent", ["goose", "opencode", "pi"])
+def test_sandbox_no_model(agent):
+    """Sandbox cli should accept no model (router mode)"""
+    _, args = parse_args_from_cmd(["sandbox", agent])
+    assert args.MODEL == []
+
+
+@pytest.mark.parametrize("agent", ["goose", "opencode", "pi"])
+def test_sandbox_multiple_models(agent):
+    """Sandbox cli should accept multiple models (router mode)"""
+    _, args = parse_args_from_cmd(["sandbox", agent, TEST_MODEL, TEST_MODEL])
+    assert isinstance(args.MODEL, list)
+    assert len(args.MODEL) == 2
 
 
 @pytest.mark.parametrize("agent", ["goose", "opencode", "pi"])
@@ -228,9 +244,9 @@ def test_goose_no_tty(monkeypatch):
 def test_goose_args():
     """Goose should run "run -t" when args are passed on the command-line"""
     args = _make_args()
-    args.ARGS = ["hello", "ramalama"]
+    args.ARGS = "hello ramalama"
     goose = Goose(args, "test-model")
-    assert goose.engine.exec_args[-3:] == ["run", "-t", " ".join(args.ARGS)]
+    assert goose.engine.exec_args[-3:] == ["run", "-t", "hello ramalama"]
 
 
 # --- OpenCode-specific tests ---
@@ -291,9 +307,9 @@ def test_opencode_no_tty(monkeypatch):
 def test_opencode_args():
     """OpenCode should run "run <message>" when args are passed on the command-line"""
     args = _make_opencode_args()
-    args.ARGS = ["hello", "ramalama"]
+    args.ARGS = "hello ramalama"
     opencode = OpenCode(args, "test-model")
-    assert opencode.engine.exec_args[-4:] == ["run", "--thinking=true", "hello", "ramalama"]
+    assert opencode.engine.exec_args[-3:] == ["run", "--thinking=true", "hello ramalama"]
 
 
 # --- Pi-specific tests ---
@@ -387,6 +403,76 @@ def test_pi_no_tty(monkeypatch):
 def test_pi_args():
     """Pi should pass args as prompt when args are passed on the command-line"""
     args = _make_pi_args()
-    args.ARGS = ["hello", "ramalama"]
+    args.ARGS = "hello ramalama"
     pi = Pi(args, "test-model")
     assert pi.engine.exec_args[-2:] == ["-p", "hello ramalama"]
+
+
+# --- Router-mode agent tests ---
+
+
+def test_goose_router_mode():
+    """Goose should omit GOOSE_MODEL in router mode (empty model_name)"""
+    args = _make_args()
+    goose = Goose(args, "")
+    cmd = goose.engine.exec_args
+    for arg in cmd:
+        assert not arg.startswith("GOOSE_MODEL="), "GOOSE_MODEL should not be set in router mode"
+
+
+def test_opencode_router_mode():
+    """OpenCode should populate models from router_model_ids when available"""
+    args = _make_opencode_args()
+    args.router_model_ids = ["model-a", "model-b"]
+    opencode = OpenCode(args, "model-a")
+    cmd = opencode.engine.exec_args
+    config_arg = None
+    for arg in cmd:
+        if arg.startswith("OPENCODE_CONFIG_CONTENT="):
+            config_arg = arg
+            break
+    assert config_arg is not None
+    config_json = config_arg.split("=", 1)[1]
+    config = json.loads(config_json)
+    assert config["model"] == "ramalama/model-a"
+    models = config["provider"]["ramalama"]["models"]
+    assert "model-a" in models
+    assert "model-b" in models
+
+
+def test_opencode_router_mode_no_models():
+    """OpenCode should omit model-specific config when no models discovered"""
+    args = _make_opencode_args()
+    opencode = OpenCode(args, "")
+    cmd = opencode.engine.exec_args
+    config_arg = None
+    for arg in cmd:
+        if arg.startswith("OPENCODE_CONFIG_CONTENT="):
+            config_arg = arg
+            break
+    assert config_arg is not None
+    config_json = config_arg.split("=", 1)[1]
+    config = json.loads(config_json)
+    assert "model" not in config
+    assert "models" not in config["provider"]["ramalama"]
+
+
+def test_pi_router_mode():
+    """Pi should omit --model in router mode (empty model_name)"""
+    args = _make_pi_args()
+    pi = Pi(args, "")
+    cmd = pi.engine.exec_args
+    assert "--model" not in cmd
+    assert "--provider" in cmd
+
+
+def test_sandbox_prompt_option():
+    """Sandbox cli should accept --prompt for non-interactive instructions"""
+    _, args = parse_args_from_cmd(["sandbox", "pi", TEST_MODEL, "--prompt", "hello world"])
+    assert args.ARGS == "hello world"
+
+
+def test_sandbox_prompt_default_none():
+    """Sandbox cli should default ARGS to None when --prompt is not specified"""
+    _, args = parse_args_from_cmd(["sandbox", "pi", TEST_MODEL])
+    assert args.ARGS is None

--- a/test/unit/test_sandbox_cmd.py
+++ b/test/unit/test_sandbox_cmd.py
@@ -6,7 +6,7 @@ import pytest
 
 from ramalama.cli import parse_args_from_cmd
 from ramalama.config import DEFAULT_PI_IMAGE
-from ramalama.sandbox import Goose, OpenCode, Pi, _pi_provider_id
+from ramalama.sandbox import Agent, Goose, OpenCode, Pi, _pi_provider_id, _run_sandbox_router
 
 TEST_MODEL = "qwen3:4b"
 
@@ -95,6 +95,15 @@ def test_sandbox_multiple_models(agent):
     _, args = parse_args_from_cmd(["sandbox", agent, TEST_MODEL, TEST_MODEL])
     assert isinstance(args.MODEL, list)
     assert len(args.MODEL) == 2
+
+
+@pytest.mark.parametrize("models", [[], [TEST_MODEL, TEST_MODEL]])
+def test_sandbox_external_url_requires_one_model(models):
+    """An external endpoint still requires exactly one model selection."""
+    _, args = parse_args_from_cmd(["sandbox", "goose", *models, "--url", "http://model.example"])
+    args.container = True
+    with pytest.raises(ValueError, match="with --url requires exactly one model"):
+        args.func(args)
 
 
 @pytest.mark.parametrize("agent", ["goose", "opencode", "pi"])
@@ -319,6 +328,7 @@ def test_pi_provider_id():
     """Pi provider id should be the pi-llama-server extension's registered name."""
     assert _pi_provider_id() == "llama-server"
 
+
 def test_pi_default_image():
     """Pi subcommand should provide a default pi image"""
     _, args = parse_args_from_cmd(["sandbox", "pi", TEST_MODEL])
@@ -416,12 +426,11 @@ def test_pi_args():
 
 
 def test_goose_router_mode():
-    """Goose should omit GOOSE_MODEL in router mode (empty model_name)"""
+    """Goose should use the model selected by the router."""
     args = _make_args()
-    goose = Goose(args, "")
+    goose = Goose(args, "model-a")
     cmd = goose.engine.exec_args
-    for arg in cmd:
-        assert not arg.startswith("GOOSE_MODEL="), "GOOSE_MODEL should not be set in router mode"
+    assert "GOOSE_MODEL=model-a" in cmd
 
 
 def test_opencode_router_mode():
@@ -444,10 +453,10 @@ def test_opencode_router_mode():
     assert "model-b" in models
 
 
-def test_opencode_router_mode_no_models():
-    """OpenCode should omit model-specific config when no models discovered"""
+def test_opencode_router_mode_dryrun_model():
+    """OpenCode should configure the placeholder model used for router dry runs."""
     args = _make_opencode_args()
-    opencode = OpenCode(args, "")
+    opencode = OpenCode(args, "dummy")
     cmd = opencode.engine.exec_args
     config_arg = None
     for arg in cmd:
@@ -457,17 +466,47 @@ def test_opencode_router_mode_no_models():
     assert config_arg is not None
     config_json = config_arg.split("=", 1)[1]
     config = json.loads(config_json)
-    assert "model" not in config
-    assert "models" not in config["provider"]["ramalama"]
+    assert config["model"] == "ramalama/dummy"
+    assert config["provider"]["ramalama"]["models"] == {"dummy": {"name": "dummy"}}
 
 
 def test_pi_router_mode():
-    """Pi should omit --model in router mode (empty model_name)"""
+    """Pi should use the model selected by the router."""
     args = _make_pi_args()
-    pi = Pi(args, "")
+    pi = Pi(args, "model-a")
     cmd = pi.engine.exec_args
-    assert "--model" not in cmd
+    assert cmd[cmd.index("--model") + 1] == "model-a"
     assert "--provider" in cmd
+
+
+def test_router_dryrun_uses_nonempty_model(monkeypatch):
+    """Router dry runs should build agents with a representative model name."""
+    selected: dict[str, str] = {}
+
+    class DryRunAgent:
+        def __init__(self, args, model_name):
+            selected["model_name"] = model_name
+            self.engine = SimpleNamespace(dryrun=lambda: None)
+
+    runtime = SimpleNamespace(serve_router_nonblocking=lambda args: None)
+    monkeypatch.setattr("ramalama.sandbox.get_runtime", lambda runtime_name: runtime)
+
+    _run_sandbox_router(SimpleNamespace(dryrun=True), DryRunAgent)  # type: ignore[arg-type]
+
+    assert selected["model_name"] == "dummy"
+
+
+def test_router_requires_discovered_model_ids(monkeypatch):
+    """Router startup should fail if the server exposes no usable model IDs."""
+    runtime = SimpleNamespace(serve_router_nonblocking=lambda args: None)
+    monkeypatch.setattr("ramalama.sandbox.get_runtime", lambda runtime_name: runtime)
+    monkeypatch.setattr("ramalama.sandbox.wait_for_healthy", lambda args, check: None)
+    monkeypatch.setattr("ramalama.sandbox._query_router_models", lambda port: [])
+    monkeypatch.setattr("ramalama.sandbox.stop_container", lambda *args, **kwargs: None)
+    args = SimpleNamespace(dryrun=False, port=8080, name="router")
+
+    with pytest.raises(AssertionError, match="router model discovery returned no model IDs"):
+        _run_sandbox_router(args, Agent)  # type: ignore[arg-type]
 
 
 def test_sandbox_prompt_option():


### PR DESCRIPTION
## Summary

- Allow sandbox subcommands (pi, goose, opencode) to run with zero or multiple models using llama.cpp router mode
  - `ramalama sandbox pi` (no model) — serves all GGUF models from the store
  - `ramalama sandbox pi model1 model2` — serves specified models
  - `ramalama sandbox pi model1` — unchanged single-model behavior
- Refactor `_serve_router` into `_build_router_engine` + `serve_router_nonblocking` for sandbox reuse
- Convert positional `ARGS` to `--prompt` named option (required since MODEL is now `nargs="*"`)
- Add `--models-max` option to sandbox subparsers
- Fix health check to handle both `models`/`data` keys and `name`/`id` fields in `/models` response
- After server is healthy, query `/v1/models` to discover available model IDs and configure agents accordingly

https://github.com/user-attachments/assets/0a9205ea-268e-451d-8877-6b84ee140727

This works best with the pi agent with the build in support for llama.cpp new router mode. if you want to test with this use container_build.sh build pi-agent so that u can have the container to test

right now the container isnt built to test yet

Signed-off-by: Brian <brian@fedora>

🤖 Generated with [Claude Code](https://claude.com/claude-code)