### PR TITLE
Fix import order in bin/ramalama to use local package

### DIFF
--- a/bin/ramalama
+++ b/bin/ramalama
@@ -2,8 +2,6 @@
 
 import sys
 
-from ramalama.config import ActiveConfig, ensure_tmpdir
-
 
 def main():
     if not sys.stdout.isatty():
@@ -15,6 +13,8 @@ def main():
     except Exception:
         print(f"ramalama module not found in sys.path: {sys.path}", file=sys.stderr)
         raise
+
+    from ramalama.config import ActiveConfig, ensure_tmpdir
 
     ensure_tmpdir(ActiveConfig())
     ramalama.cli.main()


### PR DESCRIPTION
## Summary
- Moved the `from ramalama.config import ActiveConfig, ensure_tmpdir` import to after `sys.path.insert(0, './')` so the local development version is resolved instead of a system-installed package that may not have `ensure_tmpdir` yet.

## Test plan
- [ ] Run `bin/ramalama list` from the repo root and confirm no `ImportError`
- [ ] Verify `bin/ramalama` still works when installed via pip (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)