### PR TITLE
Add ramalama models command to list server-loaded models

### DIFF
--- a/README.md
+++ b/README.md
@@ -1197,6 +1197,7 @@ $ cat /usr/share/ramalama/shortnames.conf
 | [ramalama-list(1)](https://github.com/containers/ramalama/blob/main/docs/ramalama-list.1.md)            | list all downloaded AI Models                              |
 | [ramalama-login(1)](https://github.com/containers/ramalama/blob/main/docs/ramalama-login.1.md)          | login to remote registry                                   |
 | [ramalama-logout(1)](https://github.com/containers/ramalama/blob/main/docs/ramalama-logout.1.md)        | logout from remote registry                                |
+| [ramalama-models(1)](https://github.com/containers/ramalama/blob/main/docs/ramalama-models.1.md)        | list models served by a running inference server           |
 | [ramalama-perplexity(1)](https://github.com/containers/ramalama/blob/main/docs/ramalama-perplexity.1.md)| calculate perplexity for specified AI Model                |
 | [ramalama-pull(1)](https://github.com/containers/ramalama/blob/main/docs/ramalama-pull.1.md)            | pull AI Model from Model registry to local storage         |
 | [ramalama-push(1)](https://github.com/containers/ramalama/blob/main/docs/ramalama-push.1.md)            | push AI Model from local storage to remote registry        |

--- a/docs/ramalama-list.1.md
+++ b/docs/ramalama-list.1.md
@@ -11,6 +11,9 @@ ramalama\-list - list all downloaded AI Models
 ## DESCRIPTION
 List all the AI Models in local storage.
 
+To list models currently loaded by a running inference server (for example after
+**ramalama serve**), use **ramalama-models(1)** instead.
+
 When a downloaded model URI matches an entry in **shortnames.conf**, the table includes a **SHORTNAME** column with the corresponding alias (for example **gemma3:12b** for **hf://ggml-org/gemma-3-12b-it-GGUF**). Models with no configured alias leave **SHORTNAME** empty. See **ramalama-info(1)** for the configured shortname mappings.
 
 ## OPTIONS
@@ -66,7 +69,7 @@ $ ramalama list --json
 ```
 
 ## SEE ALSO
-**[ramalama(1)](ramalama.1.md)**
+**[ramalama(1)](ramalama.1.md)**, **[ramalama-models(1)](ramalama-models.1.md)**
 
 ## HISTORY
 Aug 2024, Originally compiled by Dan Walsh <dwalsh@redhat.com>

--- a/docs/ramalama-models.1.md
+++ b/docs/ramalama-models.1.md
@@ -1,0 +1,51 @@
+% ramalama-models 1
+
+## NAME
+ramalama\-models - list models served by a running inference server
+
+## SYNOPSIS
+**ramalama models** [*options*]
+
+## DESCRIPTION
+List model identifiers exposed by a running inference server, such as one started
+with **ramalama serve**. The command queries the server's OpenAI-compatible
+**/v1/models** endpoint first (works with llama.cpp, MLX, and other OpenAI-compatible
+servers), then falls back to the llama.cpp native **/models** endpoint.
+
+This differs from **ramalama list**, which shows models downloaded to local
+storage.
+
+## OPTIONS
+
+#### **--api-key**
+OpenAI-compatible API key.
+Can also be set in ramalama.conf or via the RAMALAMA_API_KEY environment variable.
+
+#### **--help**, **-h**
+show this help message and exit
+
+#### **--json**
+print model list in json format
+
+#### **--url**=URL
+model server URL (default: http://127.0.0.1:8080)
+
+## EXAMPLES
+
+List models served on the default local endpoint
+```console
+$ ramalama models
+tinyllama
+```
+
+List models from a specific server in JSON format
+```console
+$ ramalama models --url http://localhost:1234 --json
+["granite3-moe", "tinyllama"]
+```
+
+## SEE ALSO
+**[ramalama(1)](ramalama.1.md)**, **[ramalama-serve(1)](ramalama-serve.1.md)**, **[ramalama-list(1)](ramalama-list.1.md)**
+
+## HISTORY
+Jul 2026, Originally compiled by Dan Walsh <dwalsh@redhat.com>

--- a/docs/ramalama.1.md
+++ b/docs/ramalama.1.md
@@ -151,6 +151,7 @@ Show the program version and exit.
 | [ramalama-list(1)](ramalama-list.1.md)            |list all downloaded AI Models|
 | [ramalama-login(1)](ramalama-login.1.md)          |login to remote registry|
 | [ramalama-logout(1)](ramalama-logout.1.md)        |logout from remote registry|
+| [ramalama-models(1)](ramalama-models.1.md)        |list models served by a running inference server|
 | [ramalama-perplexity(1)](ramalama-perplexity.1.md)|calculate the perplexity value of an AI Model|
 | [ramalama-pull(1)](ramalama-pull.1.md)            |pull AI Models from Model registries to local storage|
 | [ramalama-push(1)](ramalama-push.1.md)            |push AI Models from local storage to remote registries|

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -348,6 +348,7 @@ def configure_subcommands(parser):
     list_parser(subparsers)
     login_parser(subparsers)
     logout_parser(subparsers)
+    models_parser(subparsers)
     pull_parser(subparsers)
     push_parser(subparsers)
     rm_parser(subparsers)
@@ -595,6 +596,61 @@ def list_parser(subparsers):
     parser.set_defaults(func=list_cli)
 
 
+def _format_model_server_host(host: str) -> str:
+    host = host.strip("[]")
+    if host in ("0.0.0.0", "::"):
+        return "127.0.0.1"
+    if ":" in host:
+        return f"[{host}]"
+    return host
+
+
+def _default_model_server_url() -> str:
+    config = ActiveConfig()
+    return f"http://{_format_model_server_host(config.host)}:{config.port}"
+
+
+def models_parser(subparsers):
+    config = ActiveConfig()
+    default_url = _default_model_server_url()
+    parser = subparsers.add_parser(
+        "models",
+        help="list models served by a running inference server",
+    )
+    parser.add_argument(
+        "--api-key",
+        type=str,
+        default=config.api_key,
+        help="""OpenAI-compatible API key.
+        Can also be set in ramalama.conf or via the RAMALAMA_API_KEY environment variable.""",
+    )
+    parser.add_argument("--json", dest="json", action="store_true", help="print model list in json format")
+    parser.add_argument(
+        "--url",
+        type=str,
+        default=default_url,
+        help=f"model server URL (default: {default_url})",
+    )
+    parser.set_defaults(func=models_cli)
+
+
+def models_cli(args):
+    from ramalama.model_server import ModelServerError, list_server_models
+
+    try:
+        models = list_server_models(args.url, getattr(args, "api_key", None))
+    except ModelServerError as exc:
+        perror(str(exc))
+        sys.exit(1)
+
+    if args.json:
+        print(json.dumps(models))
+        return
+
+    for model in models:
+        print(model)
+
+
 def human_readable_size(size):
     for unit in ["B", "KB", "MB", "GB", "TB"]:
         if size < 1024:
@@ -691,8 +747,6 @@ def info_cli(args: DefaultArgsType) -> None:
 
 def list_cli(args):
     models = _list_models(args)
-
-    # If JSON output is requested
     if args.json:
         print(json.dumps(models))
         return

--- a/ramalama/model_server.py
+++ b/ramalama/model_server.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Optional
+from urllib import error as urllib_error
+from urllib import request as urllib_request
+
+from ramalama.chat_providers.base import ChatProviderError
+from ramalama.chat_providers.openai import OpenAICompletionsChatProvider
+from ramalama.plugins.runtimes.inference.llama_cpp import parse_models_payload
+
+
+class ModelServerError(Exception):
+    """Raised when a model server request fails or returns an invalid payload."""
+
+
+def normalize_server_url(url: str) -> tuple[str, str]:
+    """Return (server_root, openai_base) for the given server URL."""
+    url = url.rstrip("/")
+    if url.endswith("/v1"):
+        return url[:-3], url
+    return url, f"{url}/v1"
+
+
+def _fetch_json(url: str, api_key: Optional[str] = None) -> tuple[int, Any]:
+    headers: dict[str, str] = {}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+
+    request = urllib_request.Request(url, headers=headers, method="GET")
+    try:
+        with urllib_request.urlopen(request, timeout=10) as response:
+            body = response.read()
+            if not body:
+                return response.status, {}
+            try:
+                return response.status, json.loads(body.decode("utf-8"))
+            except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+                raise ModelServerError(f"Invalid JSON response from model server at {url}") from exc
+    except urllib_error.HTTPError as exc:
+        payload: Any = {}
+        if exc.fp:
+            try:
+                payload = json.loads(exc.read().decode("utf-8"))
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                payload = {}
+        return exc.code, payload
+    except urllib_error.URLError as exc:
+        raise ModelServerError(f"Could not connect to model server at {url}: {exc.reason}") from exc
+
+
+def list_server_models(url: str, api_key: Optional[str] = None) -> list[str]:
+    """Return model identifiers exposed by a running inference server."""
+    server_root, openai_base = normalize_server_url(url)
+
+    try:
+        return OpenAICompletionsChatProvider(openai_base, api_key).list_models()
+    except ChatProviderError as exc:
+        if exc.status_code in (401, 403):
+            raise ModelServerError(
+                "Could not authenticate with the model server. Set RAMALAMA_API_KEY or pass --api-key."
+            ) from exc
+    except urllib_error.HTTPError:
+        pass
+    except urllib_error.URLError as exc:
+        raise ModelServerError(f"Could not connect to model server at {server_root}: {exc.reason}") from exc
+
+    status, payload = _fetch_json(f"{server_root}/models", api_key)
+    if status == 200:
+        try:
+            return parse_models_payload(payload)
+        except ValueError as exc:
+            raise ModelServerError("Invalid model list payload from llama.cpp /models endpoint") from exc
+
+    if status in (401, 403):
+        raise ModelServerError("Could not authenticate with the model server. Set RAMALAMA_API_KEY or pass --api-key.")
+
+    raise ModelServerError(
+        f"Could not list models from {server_root}. Tried /v1/models and /models; last response status was {status}."
+    )

--- a/ramalama/plugins/runtimes/inference/llama_cpp.py
+++ b/ramalama/plugins/runtimes/inference/llama_cpp.py
@@ -8,6 +8,7 @@ import platform
 import shutil
 import sys
 import tempfile
+from collections.abc import Mapping
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from http.client import HTTPConnection
@@ -185,6 +186,30 @@ _LLAMA_CPP_IMAGES: dict[str, str] = {
 }
 
 
+def parse_models_payload(payload: Any) -> list[str]:
+    """Parse model identifiers from a llama-server /models response body."""
+    if not isinstance(payload, Mapping):
+        raise ValueError("Invalid model list payload")
+
+    if isinstance(payload.get("models"), list):
+        models: list[str] = []
+        for entry in payload["models"]:
+            if not isinstance(entry, Mapping):
+                continue
+            if name := entry.get("name") or entry.get("model"):
+                models.append(str(name))
+        return models
+
+    if isinstance(payload.get("data"), list):
+        models = []
+        for entry in payload["data"]:
+            if isinstance(entry, Mapping) and (model_id := entry.get("id")):
+                models.append(str(model_id))
+        return models
+
+    raise ValueError("Invalid model list payload")
+
+
 class LlamaCppPlugin(LlamaCppCommands, ContainerizedInferenceRuntimePlugin):
     config_type = LlamaCppConfig
 
@@ -271,11 +296,12 @@ class LlamaCppPlugin(LlamaCppCommands, ContainerizedInferenceRuntimePlugin):
             return False
 
         body = json.loads(content)
-        if "models" not in body:
+        try:
+            model_names = parse_models_payload(body)
+        except ValueError:
             logger.debug(f"{self.name} {container_name} /models does not include a model list in the response")
             return False
 
-        model_names = [m["name"] for m in body["models"]]
         if not model_name:
             if hasattr(args, 'MODEL') and isinstance(args.MODEL, str):
                 model_name = New(args.MODEL, args).model_alias

--- a/test/unit/test_model_server.py
+++ b/test/unit/test_model_server.py
@@ -1,0 +1,154 @@
+import json
+from argparse import Namespace
+from io import BytesIO
+
+import pytest
+
+from ramalama.chat_providers.base import ChatProviderError
+from ramalama.cli import _default_model_server_url, models_cli
+from ramalama.model_server import (
+    ModelServerError,
+    list_server_models,
+    normalize_server_url,
+)
+from ramalama.plugins.runtimes.inference.llama_cpp import parse_models_payload
+
+
+def test_normalize_server_url_strips_v1_suffix():
+    assert normalize_server_url("http://127.0.0.1:8080/v1") == (
+        "http://127.0.0.1:8080",
+        "http://127.0.0.1:8080/v1",
+    )
+
+
+def test_normalize_server_url_adds_v1_suffix():
+    assert normalize_server_url("http://127.0.0.1:8080") == (
+        "http://127.0.0.1:8080",
+        "http://127.0.0.1:8080/v1",
+    )
+
+
+def test_parse_models_payload_native_shape():
+    payload = {"models": [{"name": "tinyllama"}, {"model": "granite"}]}
+    assert parse_models_payload(payload) == ["tinyllama", "granite"]
+
+
+def test_parse_models_payload_openai_shape():
+    payload = {"object": "list", "data": [{"id": "tinyllama"}, {"id": "granite"}]}
+    assert parse_models_payload(payload) == ["tinyllama", "granite"]
+
+
+def test_default_model_server_url_ipv6(monkeypatch):
+    monkeypatch.setattr(
+        "ramalama.cli.ActiveConfig",
+        lambda: Namespace(host="::1", port="9090", api_key=None),
+    )
+    assert _default_model_server_url() == "http://[::1]:9090"
+
+
+def test_list_server_models_openai(monkeypatch):
+    monkeypatch.setattr(
+        "ramalama.model_server.OpenAICompletionsChatProvider.list_models",
+        lambda self: ["tinyllama"],
+    )
+    assert list_server_models("http://127.0.0.1:8080") == ["tinyllama"]
+
+
+def _mock_urlopen_response(body: bytes, status: int = 200):
+    class MockResponse:
+        def __init__(self):
+            self.status = status
+
+        def read(self):
+            return body
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    return MockResponse()
+
+
+def test_list_server_models_llama_cpp_fallback(monkeypatch):
+    def raise_chat_error(self):
+        raise ChatProviderError("openai failed")
+
+    monkeypatch.setattr(
+        "ramalama.model_server.OpenAICompletionsChatProvider.list_models",
+        raise_chat_error,
+    )
+    monkeypatch.setattr(
+        "ramalama.model_server.urllib_request.urlopen",
+        lambda request, timeout=10: _mock_urlopen_response(json.dumps({"models": [{"name": "router-model"}]}).encode()),
+    )
+    assert list_server_models("http://127.0.0.1:8080") == ["router-model"]
+
+
+def test_list_server_models_reports_connection_error(monkeypatch):
+    from urllib import error as urllib_error
+
+    def raise_chat_error(self):
+        raise urllib_error.URLError("connection refused")
+
+    monkeypatch.setattr(
+        "ramalama.model_server.OpenAICompletionsChatProvider.list_models",
+        raise_chat_error,
+    )
+
+    with pytest.raises(ModelServerError, match="Could not connect"):
+        list_server_models("http://127.0.0.1:8080")
+
+
+def test_list_server_models_http_error_fallback(monkeypatch):
+    from urllib import error as urllib_error
+
+    def raise_http_error(self):
+        raise urllib_error.HTTPError(
+            "http://127.0.0.1:8080/v1/models",
+            404,
+            "Not Found",
+            {},
+            BytesIO(b""),
+        )
+
+    monkeypatch.setattr(
+        "ramalama.model_server.OpenAICompletionsChatProvider.list_models",
+        raise_http_error,
+    )
+    monkeypatch.setattr(
+        "ramalama.model_server.urllib_request.urlopen",
+        lambda request, timeout=10: _mock_urlopen_response(
+            json.dumps({"models": [{"name": "fallback-model"}]}).encode()
+        ),
+    )
+    assert list_server_models("http://127.0.0.1:8080") == ["fallback-model"]
+
+
+def test_models_cli_prints_models(capsys, monkeypatch):
+    monkeypatch.setattr(
+        "ramalama.model_server.list_server_models",
+        lambda url, api_key=None: ["tinyllama", "granite"],
+    )
+    models_cli(Namespace(url="http://127.0.0.1:8080", api_key=None, json=False))
+    assert capsys.readouterr().out == "tinyllama\ngranite\n"
+
+
+def test_models_cli_json_output(capsys, monkeypatch):
+    monkeypatch.setattr(
+        "ramalama.model_server.list_server_models",
+        lambda url, api_key=None: ["tinyllama"],
+    )
+    models_cli(Namespace(url="http://127.0.0.1:8080", api_key=None, json=True))
+    assert capsys.readouterr().out == '["tinyllama"]\n'
+
+
+def test_models_cli_reports_server_error(monkeypatch):
+    monkeypatch.setattr(
+        "ramalama.model_server.list_server_models",
+        lambda url, api_key=None: (_ for _ in ()).throw(ModelServerError("server unavailable")),
+    )
+    with pytest.raises(SystemExit) as exc:
+        models_cli(Namespace(url="http://127.0.0.1:8080", api_key=None, json=False))
+    assert exc.value.code == 1


### PR DESCRIPTION
Query a running inference server's /v1/models or llama.cpp /models endpoints so users can see which models are currently served, distinct from ramalama list which shows locally downloaded models.