### PR TITLE
fix: handle empty chunks in doc2rag with informative error message

### DIFF
--- a/container-images/scripts/doc2rag
+++ b/container-images/scripts/doc2rag
@@ -539,11 +539,11 @@ def run_pipeline(args):
 # ---------------------------------------------------------------------------
 parser = argparse.ArgumentParser(description="Convert documents into a Qdrant RAG vector database")
 parser.add_argument("--debug", action="store_true", help="Enable debug logging")
-parser.add_argument("--api-url", dest="api_url", help="URL of the llama.cpp VLM server for document conversion")
+parser.add_argument("--api-url", dest="api_url", help="URL of the llama.cpp OCR server for text extraction")
 parser.add_argument("--embed-url", dest="embed_url", help="URL of the llama.cpp embedding server")
 parser.add_argument("--embed-model", dest="embed_model", help="Name of the embedding model (stored in metadata)")
 parser.add_argument("--chunk-size", dest="chunk_size", type=int, default=400, help="Max tokens per chunk (default: 400)")
-parser.add_argument("--ctx-size", dest="ctx_size", type=int, default=8192, help="Context size of the VLM server (default: 8192)")
+parser.add_argument("--ctx-size", dest="ctx_size", type=int, default=8192, help="Context size of the OCR server (default: 8192)")
 parser.add_argument("--caption-url", dest="caption_url", help="URL of a VLM server for image captioning (e.g. Gemma 4)")
 parser.add_argument("output", help="Output directory for the Qdrant database")
 parser.add_argument("sources", nargs="+", help="Source files or directories to process")

--- a/container-images/scripts/doc2rag
+++ b/container-images/scripts/doc2rag
@@ -516,6 +516,13 @@ def run_pipeline(args):
         sys.stderr.write("\n")
     perror(f"  {len(chunks)} chunks created")
 
+    if not chunks:
+        raise ValueError(
+            "No text was extracted from the provided documents. "
+            "Granite Docling uses OCR to extract text from images and PDFs. "
+            "If your files contain no readable text, consider using --caption-images for full image processing."
+        )
+
     # Embed and store
     if not args.embed_url:
         raise ValueError("--embed-url is required for embedding")

--- a/ramalama/plugins/runtimes/inference/rag/cli.py
+++ b/ramalama/plugins/runtimes/inference/rag/cli.py
@@ -28,7 +28,7 @@ def register_rag_subcommand(plugin, subparsers):
         "--docling-model",
         dest="docling_model",
         default="hf://ibm-granite/granite-docling-258M-GGUF",
-        help="Granite Docling GGUF model for document conversion",
+        help="Granite Docling GGUF model for OCR (optical character recognition) text extraction from images and PDFs",
         completer=suppressCompleter,
     )
     parser.add_argument(
@@ -44,7 +44,7 @@ def register_rag_subcommand(plugin, subparsers):
         dest="ctx_size",
         type=int,
         default=8192,
-        help="context size for the VLM server (default: 8192)",
+        help="context size for the OCR server (default: 8192)",
         completer=suppressCompleter,
     )
     parser.add_argument(

--- a/ramalama/plugins/runtimes/inference/rag/handler.py
+++ b/ramalama/plugins/runtimes/inference/rag/handler.py
@@ -91,7 +91,7 @@ def rag_handler(plugin: RuntimePlugin, args: argparse.Namespace) -> None:
     caption_proc = None
     all_serve_args = [docling_serve_args, embed_serve_args]
     try:
-        perror("Starting VLM server...")
+        perror("Starting OCR server...")
         docling_proc = docling_transport.serve_nonblocking(docling_serve_args, docling_cmd)  # type: ignore[union-attr]
         perror("Starting embedding server...")
         embed_proc = embed_transport.serve_nonblocking(embed_serve_args, embed_cmd)  # type: ignore[union-attr]
@@ -104,7 +104,7 @@ def rag_handler(plugin: RuntimePlugin, args: argparse.Namespace) -> None:
 
         if not args.dryrun:
             _wait_for_server(plugin, docling_serve_args, docling_transport.model_alias)
-            perror("VLM server is ready.")
+            perror("OCR server is ready.")
             _wait_for_server(plugin, embed_serve_args, embed_transport.model_alias)
             perror("Embedding server is ready.")
             if caption_transport and caption_serve_args:


### PR DESCRIPTION
## Summary
- Fixes a crash in `doc2rag` when Granite Docling OCR extracts no readable text from images/PDFs
- Previously crashed with `RuntimeError: Embedding dimension unknown; call embed() first` because `store_in_qdrant` was called with 0 chunks
- Now raises a clear `ValueError` explaining that Granite Docling uses OCR and suggesting `--caption-images` for full image processing

Closes #2831

## Test plan
- [ ] Run `ramalama rag` with an image that has no readable text (e.g. a photo) and verify the new error message appears
- [ ] Run `ramalama rag` with a text-containing document and verify normal behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)