### PR TITLE
fix: pin transformers to workaround mlx-lm issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -207,6 +207,8 @@ commands = [
 [tool.tox.env.e2e]
 deps = [
     "mlx-lm ; sys_platform == 'darwin' and platform_machine == 'arm64'",
+    # workaround https://github.com/ml-explore/mlx-lm/issues/1461
+    "transformers<5.13.0 ; sys_platform == 'darwin' and platform_machine == 'arm64'",
     "pytest-timeout"
 ]
 commands = [
@@ -225,6 +227,8 @@ commands = [
 [tool.tox.env.slow]
 deps = [
     "mlx-lm ; sys_platform == 'darwin' and platform_machine == 'arm64'",
+    # workaround https://github.com/ml-explore/mlx-lm/issues/1461
+    "transformers<5.13.0 ; sys_platform == 'darwin' and platform_machine == 'arm64'",
     "pytest-timeout"
 ]
 commands = [


### PR DESCRIPTION
Pin transformers<5.13.0 in tox e2e and slow environments on macos to work around https://github.com/ml-explore/mlx-lm/issues/1461