### PR TITLE
Respect bind host from cli args in health check

### DIFF
--- a/ramalama/engine.py
+++ b/ramalama/engine.py
@@ -478,9 +478,13 @@ def is_healthy(args, timeout: int = 3, model_name: Optional[str] = None):
     """Check if the runtime server is healthy by delegating to the runtime plugin."""
     from ramalama.plugins.loader import get_runtime
 
+    bind_host = getattr(args, "host", "127.0.0.1").strip("[]")
+    # use IPv4 loopback when binding to a wildcard address
+    ip_address = "127.0.0.1" if bind_host in ("0.0.0.0", "::") else bind_host
+
     conn = None
     try:
-        conn = HTTPConnection("127.0.0.1", args.port, timeout=timeout)
+        conn = HTTPConnection(ip_address, args.port, timeout=timeout)
         if getattr(args, "debug", False):
             conn.set_debuglevel(1)
         return get_runtime(ActiveConfig().runtime).service_ready_check(conn, args, model_name)

--- a/test/unit/test_engine.py
+++ b/test/unit/test_engine.py
@@ -166,6 +166,23 @@ def test_is_healthy_conn(mock_conn):
 
 
 @pytest.mark.parametrize(
+    "host, expected_host",
+    [
+        pytest.param("0.0.0.0", "127.0.0.1", id="ipv4-wildcard"),
+        pytest.param("::", "127.0.0.1", id="ipv6-wildcard"),
+        pytest.param("[::]", "127.0.0.1", id="ipv6-wildcard-bracketed"),
+        pytest.param("192.168.1.100", "192.168.1.100", id="ipv4-host"),
+        pytest.param("::1", "::1", id="ipv6-loopback"),
+    ],
+)
+@patch("ramalama.engine.HTTPConnection")
+def test_is_healthy_uses_host_arg(mock_conn, host, expected_host):
+    args = Namespace(MODEL="themodel", name="thecontainer", port=8080, debug=False, host=host)
+    ramalama.engine.is_healthy(args, model_name="themodel")
+    mock_conn.assert_called_once_with(expected_host, args.port, timeout=3)
+
+
+@pytest.mark.parametrize(
     "health_status, models_status, models_body, models_msg",
     [
         pytest.param(503, None, "", "", id="health api returns 503 loading"),


### PR DESCRIPTION
The current healthcheck incorrectly assumes the socket is bound to the loopback address.
This will not be true when binding to a specific IP.

Fixes: #2800