### PR TITLE
Add speculative decoding CLI args 

### DIFF
--- a/docs/options/spec-draft-n-max.md
+++ b/docs/options/spec-draft-n-max.md
@@ -1,0 +1,6 @@
+####> This option file is used in:
+####>   ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama sandbox pi, ramalama serve
+####> If this file is edited, make sure the changes
+####> are applicable to all of those.
+#### **--spec-draft-n-max**=*N*
+Maximum number of tokens to draft per speculative decoding step (default: 3).

--- a/docs/options/spec-draft-n-min.md
+++ b/docs/options/spec-draft-n-min.md
@@ -1,0 +1,6 @@
+####> This option file is used in:
+####>   ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama sandbox pi, ramalama serve
+####> If this file is edited, make sure the changes
+####> are applicable to all of those.
+#### **--spec-draft-n-min**=*N*
+Minimum number of draft tokens to use for speculative decoding (default: 0).

--- a/docs/options/spec-draft-p-min.md
+++ b/docs/options/spec-draft-p-min.md
@@ -1,0 +1,6 @@
+####> This option file is used in:
+####>   ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama sandbox pi, ramalama serve
+####> If this file is edited, make sure the changes
+####> are applicable to all of those.
+#### **--spec-draft-p-min**=*P*
+Minimum speculative decoding probability, greedy threshold (default: 0.0).

--- a/docs/options/spec-type.md
+++ b/docs/options/spec-type.md
@@ -1,0 +1,9 @@
+####> This option file is used in:
+####>   ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama sandbox pi, ramalama serve
+####> If this file is edited, make sure the changes
+####> are applicable to all of those.
+#### **--spec-type**=*TYPES*
+Comma-separated list of speculative decoding types to enable.
+Available types: draft-simple, draft-eagle3, draft-mtp, ngram-simple,
+ngram-map-k, ngram-map-k4v, ngram-mod, ngram-cache.
+When omitted, speculative decoding is disabled.

--- a/docs/ramalama-run.1.md.in
+++ b/docs/ramalama-run.1.md.in
@@ -80,6 +80,14 @@ Prefix for the user prompt (default: 🦭 > )
 
 @@option selinux
 
+@@option spec-draft-n-max
+
+@@option spec-draft-n-min
+
+@@option spec-draft-p-min
+
+@@option spec-type
+
 @@option summarize-after
 
 @@option temp

--- a/docs/ramalama-sandbox-goose.1.md.in
+++ b/docs/ramalama-sandbox-goose.1.md.in
@@ -76,6 +76,14 @@ Otherwise only the agent container starts using the given url for the openai com
 
 @@option selinux
 
+@@option spec-draft-n-max
+
+@@option spec-draft-n-min
+
+@@option spec-draft-p-min
+
+@@option spec-type
+
 @@option temp
 
 @@option thinking

--- a/docs/ramalama-sandbox-opencode.1.md.in
+++ b/docs/ramalama-sandbox-opencode.1.md.in
@@ -76,6 +76,14 @@ Otherwise only the agent container starts using the given url for the openai com
 
 @@option selinux
 
+@@option spec-draft-n-max
+
+@@option spec-draft-n-min
+
+@@option spec-draft-p-min
+
+@@option spec-type
+
 @@option temp
 
 @@option thinking

--- a/docs/ramalama-sandbox-pi.1.md.in
+++ b/docs/ramalama-sandbox-pi.1.md.in
@@ -80,6 +80,14 @@ Otherwise only the agent container starts using the given url for the openai com
 
 @@option selinux
 
+@@option spec-draft-n-max
+
+@@option spec-draft-n-min
+
+@@option spec-draft-p-min
+
+@@option spec-type
+
 @@option temp
 
 @@option thinking

--- a/docs/ramalama-serve.1.md.in
+++ b/docs/ramalama-serve.1.md.in
@@ -122,6 +122,14 @@ appending the path to the type, e.g. `--generate kube:/etc/containers/systemd`.
 
 @@option selinux
 
+@@option spec-draft-n-max
+
+@@option spec-draft-n-min
+
+@@option spec-draft-p-min
+
+@@option spec-type
+
 @@option stack-image
 
 @@option temp

--- a/ramalama/plugins/runtimes/inference/llama_cpp.py
+++ b/ramalama/plugins/runtimes/inference/llama_cpp.py
@@ -86,6 +86,10 @@ class LlamaCppConfig:
     gguf_quantization_mode: GGUF_QUANTIZATION_MODES = DEFAULT_GGUF_QUANTIZATION_MODE  # type: ignore[assignment]
     ngl: Optional[str] = None
     ncmoe: Optional[int] = None
+    spec_type: Optional[str] = None
+    spec_draft_n_max: Optional[int] = None
+    spec_draft_n_min: Optional[int] = None
+    spec_draft_p_min: Optional[float] = None
     temp: float = 0.8
     thinking: Optional[bool] = None
     threads: int = field(default_factory=_default_threads)
@@ -97,6 +101,14 @@ class LlamaCppConfig:
             self.ngl = str(self.ngl)
         if self.ncmoe is not None:
             self.ncmoe = int(self.ncmoe)
+        if self.spec_type is not None:
+            self.spec_type = str(self.spec_type)
+        if self.spec_draft_n_max is not None:
+            self.spec_draft_n_max = int(self.spec_draft_n_max)
+        if self.spec_draft_n_min is not None:
+            self.spec_draft_n_min = int(self.spec_draft_n_min)
+        if self.spec_draft_p_min is not None:
+            self.spec_draft_p_min = float(self.spec_draft_p_min)
         self.temp = float(self.temp)
         self.threads = int(self.threads)
         if self.thinking is not None:
@@ -441,6 +453,37 @@ class LlamaCppPlugin(LlamaCppCommands, ContainerizedInferenceRuntimePlugin):
                 action=CoerceToBool,
             )
             parser.add_argument("--model-draft", help="Draft model", completer=local_models)
+            parser.add_argument(
+                "--spec-type",
+                dest="spec_type",
+                default=None,
+                help="speculative decoding type(s), comma-separated (e.g. draft-mtp, draft-simple, ngram-simple)",
+                completer=suppressCompleter,
+            )
+            parser.add_argument(
+                "--spec-draft-n-max",
+                dest="spec_draft_n_max",
+                type=int,
+                default=None,
+                help="max number of tokens to draft for speculative decoding (default: 3)",
+                completer=suppressCompleter,
+            )
+            parser.add_argument(
+                "--spec-draft-n-min",
+                dest="spec_draft_n_min",
+                type=int,
+                default=None,
+                help="min number of draft tokens for speculative decoding (default: 0)",
+                completer=suppressCompleter,
+            )
+            parser.add_argument(
+                "--spec-draft-p-min",
+                dest="spec_draft_p_min",
+                type=float,
+                default=None,
+                help="min speculative decoding probability (default: 0.0)",
+                completer=suppressCompleter,
+            )
         self._add_threads_arg(parser)
         if command == "serve":
             parser.add_argument(

--- a/ramalama/plugins/runtimes/inference/llama_cpp_commands.py
+++ b/ramalama/plugins/runtimes/inference/llama_cpp_commands.py
@@ -129,6 +129,22 @@ class LlamaCppCommands:
                 if ngl is not None:
                     cmd += ["-ngld", ngl_str]
 
+            spec_type = getattr(args, 'spec_type', None)
+            if spec_type:
+                cmd += ["--spec-type", str(spec_type)]
+
+            spec_draft_n_max = getattr(args, 'spec_draft_n_max', None)
+            if spec_draft_n_max is not None:
+                cmd += ["--spec-draft-n-max", str(spec_draft_n_max)]
+
+            spec_draft_n_min = getattr(args, 'spec_draft_n_min', None)
+            if spec_draft_n_min is not None:
+                cmd += ["--spec-draft-n-min", str(spec_draft_n_min)]
+
+            spec_draft_p_min = getattr(args, 'spec_draft_p_min', None)
+            if spec_draft_p_min is not None:
+                cmd += ["--spec-draft-p-min", str(spec_draft_p_min)]
+
         threads = getattr(args, 'threads', None)
         if threads is not None:
             cmd += ["--threads", str(threads)]

--- a/test/unit/test_inference_engine_plugins.py
+++ b/test/unit/test_inference_engine_plugins.py
@@ -46,6 +46,10 @@ def make_ns(
     webui="on",
     thinking=None,
     model_draft=None,
+    spec_type=None,
+    spec_draft_n_max=None,
+    spec_draft_n_min=None,
+    spec_draft_p_min=None,
     runtime_args=None,
     engine_args=None,
     gguf=None,
@@ -70,6 +74,10 @@ def make_ns(
         webui=webui,
         thinking=thinking,
         model_draft=model_draft,
+        spec_type=spec_type,
+        spec_draft_n_max=spec_draft_n_max,
+        spec_draft_n_min=spec_draft_n_min,
+        spec_draft_p_min=spec_draft_p_min,
         runtime_args=runtime_args or [],
         engine_args=engine_args or [],
         gguf=gguf,
@@ -142,6 +150,10 @@ class TestLlamaCppConfig:
         assert config.backend == "auto"
         assert config.cache_reuse is None
         assert config.ngl is None
+        assert config.spec_type is None
+        assert config.spec_draft_n_max is None
+        assert config.spec_draft_n_min is None
+        assert config.spec_draft_p_min is None
         assert config.temp == 0.8
         assert config.thinking is None
         assert config.threads > 0
@@ -154,6 +166,15 @@ class TestLlamaCppConfig:
         assert config.temp == 0.5
         assert config.threads == 8
         assert config.thinking is False
+
+    def test_coerces_spec_string_values(self):
+        config = LlamaCppConfig(
+            spec_type="draft-mtp", spec_draft_n_max="5", spec_draft_n_min="1", spec_draft_p_min="0.9"
+        )
+        assert config.spec_type == "draft-mtp"
+        assert config.spec_draft_n_max == 5
+        assert config.spec_draft_n_min == 1
+        assert config.spec_draft_p_min == 0.9
 
 
 class TestSyncArgsToRuntimeConfig:
@@ -381,6 +402,54 @@ class TestLlamaCppPlugin:
         cmd = self.plugin.handle_subcommand("serve", ns)
 
         assert "-ncmoe" not in cmd
+
+    @patch("ramalama.plugins.runtimes.inference.llama_cpp_commands.should_colorize", return_value=False)
+    def test_serve_spec_type(self, mock_colorize):
+        ns = make_ns(spec_type="draft-mtp")
+        cmd = self.plugin.handle_subcommand("serve", ns)
+
+        assert "--spec-type" in cmd
+        assert cmd[cmd.index("--spec-type") + 1] == "draft-mtp"
+
+    @patch("ramalama.plugins.runtimes.inference.llama_cpp_commands.should_colorize", return_value=False)
+    def test_serve_spec_type_default_omitted(self, mock_colorize):
+        ns = make_ns()
+        cmd = self.plugin.handle_subcommand("serve", ns)
+
+        assert "--spec-type" not in cmd
+
+    @patch("ramalama.plugins.runtimes.inference.llama_cpp_commands.should_colorize", return_value=False)
+    def test_serve_spec_draft_n_max(self, mock_colorize):
+        ns = make_ns(spec_draft_n_max=5)
+        cmd = self.plugin.handle_subcommand("serve", ns)
+
+        assert "--spec-draft-n-max" in cmd
+        assert cmd[cmd.index("--spec-draft-n-max") + 1] == "5"
+
+    @patch("ramalama.plugins.runtimes.inference.llama_cpp_commands.should_colorize", return_value=False)
+    def test_serve_spec_draft_n_min(self, mock_colorize):
+        ns = make_ns(spec_draft_n_min=0)
+        cmd = self.plugin.handle_subcommand("serve", ns)
+
+        assert "--spec-draft-n-min" in cmd
+        assert cmd[cmd.index("--spec-draft-n-min") + 1] == "0"
+
+    @patch("ramalama.plugins.runtimes.inference.llama_cpp_commands.should_colorize", return_value=False)
+    def test_serve_spec_draft_p_min(self, mock_colorize):
+        ns = make_ns(spec_draft_p_min=0.9)
+        cmd = self.plugin.handle_subcommand("serve", ns)
+
+        assert "--spec-draft-p-min" in cmd
+        assert cmd[cmd.index("--spec-draft-p-min") + 1] == "0.9"
+
+    @patch("ramalama.plugins.runtimes.inference.llama_cpp_commands.should_colorize", return_value=False)
+    def test_serve_spec_draft_defaults_omitted(self, mock_colorize):
+        ns = make_ns()
+        cmd = self.plugin.handle_subcommand("serve", ns)
+
+        assert "--spec-draft-n-max" not in cmd
+        assert "--spec-draft-n-min" not in cmd
+        assert "--spec-draft-p-min" not in cmd
 
     @patch("ramalama.plugins.runtimes.inference.llama_cpp_commands.should_colorize", return_value=False)
     def test_serve_max_tokens(self, mock_colorize):


### PR DESCRIPTION
Enable MTP and other speculative decoding modes from the CLI by exposing llama.cpp's --spec-type and the most commonly tuned --spec-draft-* knobs.