### PR TITLE
Auto-pull draft model in run/serve handlers

### DIFF
--- a/ramalama/plugins/runtimes/inference/common.py
+++ b/ramalama/plugins/runtimes/inference/common.py
@@ -216,6 +216,10 @@ class BaseInferenceRuntime(InferenceRuntimePlugin):
             except Exception as exc:
                 raise e from exc
 
+        draft_model = getattr(model, "draft_model", None)
+        if draft_model is not None:
+            draft_model.ensure_model_exists(args)
+
         self._do_run(args, model)
 
     def _serve_handler(self, args: argparse.Namespace) -> None:
@@ -253,6 +257,10 @@ class BaseInferenceRuntime(InferenceRuntimePlugin):
 
         if isinstance(model, APITransport):
             raise ValueError("ramalama serve is not supported for hosted API transports.")
+
+        draft_model = getattr(model, "draft_model", None)
+        if draft_model is not None:
+            draft_model.ensure_model_exists(args)
 
         self._do_serve(args, model)
 

--- a/ramalama/plugins/runtimes/inference/llama_cpp.py
+++ b/ramalama/plugins/runtimes/inference/llama_cpp.py
@@ -440,6 +440,7 @@ class LlamaCppPlugin(LlamaCppCommands, ContainerizedInferenceRuntimePlugin):
                 help="enable/disable thinking mode in reasoning models",
                 action=CoerceToBool,
             )
+            # TODO: vllm also supports draft/speculative models; refactor to common args
             parser.add_argument("--model-draft", help="Draft model", completer=local_models)
         self._add_threads_arg(parser)
         if command == "serve":

--- a/test/unit/test_api_transport.py
+++ b/test/unit/test_api_transport.py
@@ -126,3 +126,38 @@ def test_run_cli_api_transport_does_not_call_pull(monkeypatch):
 
     transport.pull.assert_not_called()
     transport.run.assert_called_once()
+
+
+@pytest.mark.parametrize("handler", ["_run_handler", "_serve_handler"])
+def test_handler_pulls_draft_model(monkeypatch, handler):
+    from ramalama.plugins.loader import get_runtime
+    from ramalama.plugins.runtimes.inference import common as common_module
+
+    draft = mock.MagicMock()
+    primary = mock.MagicMock()
+    primary.draft_model = draft
+
+    monkeypatch.setattr(common_module, "New", lambda model, args: primary)
+    monkeypatch.setattr(common_module, "compute_serving_port", lambda args: "8080")
+
+    plugin = get_runtime("llama.cpp")
+    monkeypatch.setattr(plugin, "_do_run", lambda args, model: None)
+    monkeypatch.setattr(plugin, "_do_serve", lambda args, model: None)
+
+    model_value = ["hf://org/model"] if handler == "_serve_handler" else "hf://org/model"
+    args = SimpleNamespace(
+        MODEL=model_value,
+        container=False,
+        detach=False,
+        dryrun=True,
+        pull="missing",
+        engine="podman",
+        api="none",
+        generate=None,
+        rag=None,
+    )
+
+    getattr(plugin, handler)(args)
+
+    primary.ensure_model_exists.assert_called_once()
+    draft.ensure_model_exists.assert_called_once()


### PR DESCRIPTION
When --model-draft is specified, ensure_model_exists() was only called on the primary model, requiring users to manually pull the draft model beforehand.
Call ensure_model_exists() on the draft model too so it is automatically pulled like the primary model.