### PR TITLE
handle empty HF_ENDPOINT

### DIFF
--- a/ramalama/transports/huggingface.py
+++ b/ramalama/transports/huggingface.py
@@ -29,7 +29,7 @@ sudo dnf install python3-huggingface-hub
 
 def huggingface_endpoint() -> str:
     """Return Hugging Face base URL from HF_ENDPOINT env var, defaulting to https://huggingface.co"""
-    return os.environ.get("HF_ENDPOINT", HuggingfaceRepository.REGISTRY_URL).rstrip("/")
+    return os.environ.get("HF_ENDPOINT", "").rstrip("/") or HuggingfaceRepository.REGISTRY_URL
 
 
 def huggingface_token() -> str | None:

--- a/test/e2e/test_inspect.py
+++ b/test/e2e/test_inspect.py
@@ -8,7 +8,7 @@ import pytest
 from test.e2e.utils import RamalamaExecWorkspace
 
 GGUF_MODEL = "ollama://tinyllama"
-_HF_ENDPOINT = os.environ.get("HF_ENDPOINT", "https://huggingface.co").rstrip("/")
+_HF_ENDPOINT = os.environ.get("HF_ENDPOINT", "").rstrip("/") or "https://huggingface.co"
 ST_MODEL = f"{_HF_ENDPOINT}/LiheYoung/depth-anything-small-hf/resolve/main/model.safetensors"
 _ST_SCHEME = _HF_ENDPOINT.split("://")[0]
 

--- a/test/unit/test_huggingface.py
+++ b/test/unit/test_huggingface.py
@@ -11,6 +11,11 @@ def test_huggingface_endpoint_default() -> None:
         assert huggingface_endpoint() == "https://huggingface.co"
 
 
+def test_huggingface_endpoint_from_env_empty() -> None:
+    with patch.dict(os.environ, {"HF_ENDPOINT": ""}):
+        assert huggingface_endpoint() == "https://huggingface.co"
+
+
 def test_huggingface_endpoint_from_env() -> None:
     with patch.dict(os.environ, {"HF_ENDPOINT": "https://my-mirror.example.com"}):
         assert huggingface_endpoint() == "https://my-mirror.example.com"


### PR DESCRIPTION
Gracefully handle the case where `HF_ENDPOINT` is defined but empty by returning the default value.