### PR TITLE
infer first model from given server:

### DIFF
--- a/docs/ramalama-sandbox-goose.1.md.in
+++ b/docs/ramalama-sandbox-goose.1.md.in
@@ -11,9 +11,13 @@ Run Goose in a container, connected to a local model server also running
 in a container. Goose uses the model for reasoning and tool calling.
 
 When a single model is specified, the server loads that model directly.
-When zero or multiple models are specified, the server starts in router mode
+When no model and the url is given the command gets the list of models from the
+model server and takes the first model or fails without a model.
+When multiple models are specified, the server starts in router mode
 using llama.cpp's --models-dir, dynamically loading and unloading models.
-With no models, all GGUF models in the store are served.
+When no models and no url the default http://localhost:{port} is used to
+get the first model. If there is no server or no model then it falls back to
+start a model server in router mode where all GGUF models in the store are served.
 
 Use **--prompt** to pass instructions for non-interactive processing.
 Commands may also be passed via stdin.

--- a/docs/ramalama-sandbox-opencode.1.md.in
+++ b/docs/ramalama-sandbox-opencode.1.md.in
@@ -11,9 +11,13 @@ Run OpenCode in a container, connected to a local model server also running
 in a container. OpenCode uses the model for reasoning and tool calling.
 
 When a single model is specified, the server loads that model directly.
-When zero or multiple models are specified, the server starts in router mode
+When no model and the url is given the command gets the list of models from the
+model server and takes the first model or fails without a model.
+When multiple models are specified, the server starts in router mode
 using llama.cpp's --models-dir, dynamically loading and unloading models.
-With no models, all GGUF models in the store are served.
+When no models and no url the default http://localhost:{port} is used to
+get the first model. If there is no server or no model then it falls back to
+start a model server in router mode where all GGUF models in the store are served.
 
 Use **--prompt** to pass instructions for non-interactive processing.
 Commands may also be passed via stdin.

--- a/docs/ramalama-sandbox-pi.1.md.in
+++ b/docs/ramalama-sandbox-pi.1.md.in
@@ -11,9 +11,13 @@ Run Pi in a container, connected to a local model server also running
 in a container. Pi uses the model for reasoning and tool calling.
 
 When a single model is specified, the server loads that model directly.
-When zero or multiple models are specified, the server starts in router mode
+When no model and the url is given the command gets the list of models from the
+model server and takes the first model or fails without a model.
+When multiple models are specified, the server starts in router mode
 using llama.cpp's --models-dir, dynamically loading and unloading models.
-With no models, all GGUF models in the store are served.
+When no models and no url the default http://localhost:{port} is used to
+get the first model. If there is no server or no model then it falls back to
+start a model server in router mode where all GGUF models in the store are served.
 
 Use **--prompt** to pass instructions for non-interactive processing.
 Commands may also be passed via stdin.

--- a/ramalama/sandbox.py
+++ b/ramalama/sandbox.py
@@ -4,15 +4,17 @@ import argparse
 import copy
 import json
 import platform
+import sys
 from collections.abc import Callable
 from functools import partial
 from http.client import HTTPConnection
 from typing import Optional, cast
 
 from ramalama.arg_types import BaseEngineArgsType
-from ramalama.common import genname, run_cmd
+from ramalama.common import genname, perror, run_cmd
 from ramalama.config import ActiveConfig
 from ramalama.engine import Engine, is_healthy, stop_container, wait_for_healthy
+from ramalama.model_server import ModelServerError, list_server_models
 from ramalama.plugins.loader import get_runtime
 from ramalama.transports.base import compute_serving_port
 from ramalama.transports.transport_factory import New
@@ -26,7 +28,7 @@ def _pi_provider_id() -> str:
     return "llama-server"
 
 
-def _add_common_sandbox_args(parser: argparse.ArgumentParser) -> None:
+def _add_common_sandbox_args(parser: argparse.ArgumentParser, model_comp: Callable) -> None:
     """Add --workdir and --prompt arguments shared by all sandbox subcommands."""
     parser.add_argument(
         "-w",
@@ -46,6 +48,13 @@ def _add_common_sandbox_args(parser: argparse.ArgumentParser) -> None:
         "--prompt",
         dest="ARGS",
         help="instructions for the sandbox to process non-interactively",
+    )
+    parser.add_argument(
+        "MODEL",
+        default=[],
+        nargs="*",
+        completer=model_comp,
+        help="AI model to use. Omit to infer the first model from the model server.",
     )
 
 
@@ -73,14 +82,13 @@ def add_sandbox_subparsers(subparsers: argparse._SubParsersAction, img_comp: Cal
         # Consider adding this to the plugin interface for commands which need to run an
         # inference server
         runtime._add_inference_args(parser, "serve")  # type: ignore[attr-defined]
-    parser.add_argument("MODEL", nargs="*", default=[], completer=model_comp)
     parser.add_argument(
         "--goose-image",
         default="ghcr.io/aaif-goose/goose:1.43.0",
         completer=img_comp,
         help="Goose container image",
     )
-    _add_common_sandbox_args(parser)
+    _add_common_sandbox_args(parser, model_comp)
     _add_router_args(parser)
     parser.set_defaults(func=run_sandbox_goose)
     yield parser
@@ -88,14 +96,13 @@ def add_sandbox_subparsers(subparsers: argparse._SubParsersAction, img_comp: Cal
     parser = subparsers.add_parser("opencode", help="run OpenCode in a sandbox, backed by a local AI Model")
     if getattr(runtime, "_add_inference_args", None):
         runtime._add_inference_args(parser, "serve")  # type: ignore[attr-defined]
-    parser.add_argument("MODEL", nargs="*", default=[], completer=model_comp)
     parser.add_argument(
         "--opencode-image",
         default="ghcr.io/anomalyco/opencode:1.17.20",
         completer=img_comp,
         help="OpenCode container image",
     )
-    _add_common_sandbox_args(parser)
+    _add_common_sandbox_args(parser, model_comp)
     _add_router_args(parser)
     parser.set_defaults(func=run_sandbox_opencode)
     yield parser
@@ -103,14 +110,13 @@ def add_sandbox_subparsers(subparsers: argparse._SubParsersAction, img_comp: Cal
     parser = subparsers.add_parser("pi", help="run Pi in a sandbox, backed by a local AI Model")
     if getattr(runtime, "_add_inference_args", None):
         runtime._add_inference_args(parser, "serve")  # type: ignore[attr-defined]
-    parser.add_argument("MODEL", nargs="*", default=[], completer=model_comp)
     parser.add_argument(
         "--pi-image",
         default=default_pi_image(),
         completer=img_comp,
         help="Pi container image",
     )
-    _add_common_sandbox_args(parser)
+    _add_common_sandbox_args(parser, model_comp)
     _add_router_args(parser)
     parser.set_defaults(func=run_sandbox_pi)
     yield parser
@@ -313,12 +319,35 @@ def run_sandbox(args: SandboxEngineArgsType, agent_cls: type[Agent]) -> None:
         raise ValueError("ramalama sandbox requires a container engine")
 
     sb_args = copy.copy(args)
-    sb_args.start_model_server = args.url is None
-    models: list[str] = list(args.MODEL)  # type: ignore[arg-type]
+    sb_args.start_model_server = sb_args.url is None
+    if not sb_args.MODEL:
+        url = sb_args.url or f"http://localhost:{sb_args.port}"
+        try:
+            model_list = list_server_models(url, getattr(sb_args, "api_key", None))
+        except ModelServerError as e:
+            if not sb_args.start_model_server:
+                perror(f"{e}")
+                sys.exit(2)
+            # basically fall through to router-mode without models
+            model_list = []
+        if len(model_list) > 0:
+            sb_args.start_model_server = False
+            sb_args.MODEL = [model_list[0]]  # type: ignore[assignment]
+            print(f"Using first model from server ({url}): {model_list[0]}")
+            sb_args.url = url
+        elif not sb_args.start_model_server:
+            raise ValueError(f"No model found at {url}")
+
+    sb_args.start_model_server = sb_args.url is None
+    # ensure agent container can access model-server on localhost
+    if sb_args.url and (sb_args.url.startswith("http://localhost") or sb_args.url.startswith("https://localhost")):
+        middle = 'docker' if args.engine == 'docker' else 'containers'
+        sb_args.url = sb_args.url.replace("localhost", f"host.{middle}.internal")
+    models: list[str] = list(sb_args.MODEL)  # type: ignore[arg-type]
 
     if not sb_args.start_model_server:
-        if len(models) != 1:
-            raise ValueError("ramalama sandbox with --url requires exactly one model")
+        if len(models) > 1:
+            raise ValueError("ramalama sandbox with --url requires one or no model")
         sb_args.name = sb_args.name or genname()
         model_name = models[0]
         if sb_args.dryrun:

--- a/test/e2e/test_sandbox.py
+++ b/test/e2e/test_sandbox.py
@@ -288,6 +288,8 @@ def test_sandbox_using_url(sandbox_ctx, caplog, agent):
             container_name,
             "--port",
             str(container_port),
+            "--ctx-size",
+            str(8192),
             "--thinking=off",
             "--seed=1",
             "--temp=0",
@@ -310,6 +312,83 @@ def test_sandbox_using_url(sandbox_ctx, caplog, agent):
                 "--url",
                 f"http://host.containers.internal:{container_port}",
                 model,
+                "--prompt",
+                "Hello",
+            ],
+            stderr=subprocess.STDOUT,
+        )
+
+        result = result.lower()
+        assert "hi" in result or "hello" in result or "help" in result or "today" in result or "assistant" in result
+
+    finally:
+        # Stop container
+        sandbox_ctx.check_call(["ramalama", "stop", container_name])
+
+
+@pytest.mark.e2e
+@pytest.mark.slow
+@skip_if_docker
+@skip_if_no_container
+@skip_if_ppc64le
+@skip_if_s390x
+@pytest.mark.parametrize("agent", ["goose", "opencode", "pi"])
+def test_sandbox_using_url_infer_model(sandbox_ctx, caplog, agent):
+    # Configure logging for requests
+    caplog.set_level(logging.CRITICAL, logger="requests")
+    caplog.set_level(logging.CRITICAL, logger="urllib3")
+
+    # Serve an API
+    container_name = f"api{''.join(random.choices(string.ascii_letters + string.digits, k=5))}"
+    container_port = random.randint(64000, 65000)
+
+    sandbox_ctx.check_output(
+        [
+            "ramalama",
+            "serve",
+            "-d",
+            "--name",
+            container_name,
+            "--port",
+            str(container_port),
+            "--ctx-size",
+            str(8192),
+            "--thinking=off",
+            "--seed=1",
+            "--temp=0",
+            TEST_MODEL,
+        ],
+        stderr=subprocess.STDOUT,
+    )
+
+    try:
+        # Inspect the models API
+        models = requests.get(f"http://localhost:{container_port}/models", timeout=60).json()
+        assert len(models["models"]) == 1
+
+        result = sandbox_ctx.check_output(
+            [
+                "ramalama",
+                "sandbox",
+                agent,
+                "--url",
+                f"http://localhost:{container_port}",
+                "--prompt",
+                "Hello",
+            ],
+            stderr=subprocess.STDOUT,
+        )
+
+        result = result.lower()
+        assert "hi" in result or "hello" in result or "help" in result or "today" in result or "assistant" in result
+
+        result = sandbox_ctx.check_output(
+            [
+                "ramalama",
+                "sandbox",
+                agent,
+                "--port",
+                str(container_port),
                 "--prompt",
                 "Hello",
             ],

--- a/test/unit/test_sandbox_cmd.py
+++ b/test/unit/test_sandbox_cmd.py
@@ -97,12 +97,12 @@ def test_sandbox_multiple_models(agent):
     assert len(args.MODEL) == 2
 
 
-@pytest.mark.parametrize("models", [[], [TEST_MODEL, TEST_MODEL]])
-def test_sandbox_external_url_requires_one_model(models):
-    """An external endpoint still requires exactly one model selection."""
-    _, args = parse_args_from_cmd(["sandbox", "goose", *models, "--url", "http://model.example"])
+@pytest.mark.parametrize("agent", ["goose", "opencode", "pi"])
+def test_sandbox_external_url_requires_one_or_no_model(agent):
+    """An external endpoint still requires one or no model selection."""
+    _, args = parse_args_from_cmd(["sandbox", agent, TEST_MODEL, TEST_MODEL, "--url", "http://model.example"])
     args.container = True
-    with pytest.raises(ValueError, match="with --url requires exactly one model"):
+    with pytest.raises(ValueError, match="with --url requires one or no model"):
         args.func(args)
 
 


### PR DESCRIPTION
* `ramalama sandbox <agent>`: the url will default to http://localhost:{port} which is used to infer the models and picks the first. The agent container will get the model-server url http://host.containers.internal:{port} (or host.docker.internal)
* `ramalama sandbox <agent> --url http://example.com:8888`: the first model from this server will be used

Follow up of #2811 