### PR TITLE
fix(cuda): tell users to install nvidia-container-toolkit when CDI is…

### DIFF
--- a/ramalama/common.py
+++ b/ramalama/common.py
@@ -440,8 +440,17 @@ def check_nvidia() -> Optional[Literal["cuda"]]:
     configured_has_all = "all" in configured
     if unconfigured and not configured_has_all:
         perror(f"No CDI configuration found for {','.join(unconfigured)}")
-        perror("You can use the \"nvidia-ctk cdi generate\" command from the ")
-        perror("nvidia-container-toolkit to generate a CDI configuration.")
+        # nvidia-ctk ships with the nvidia-container-toolkit, so its absence
+        # means the toolkit itself is not installed. Pointing the user at
+        # "nvidia-ctk cdi generate" in that case is a dead end; tell them to
+        # install the toolkit (recent versions generate the CDI config on install).
+        if shutil.which("nvidia-ctk") is None:
+            perror("The nvidia-container-toolkit does not appear to be installed. Install ")
+            perror("it to enable GPU support; recent versions generate the CDI ")
+            perror("configuration automatically.")
+        else:
+            perror("You can use the \"nvidia-ctk cdi generate\" command from the ")
+            perror("nvidia-container-toolkit to generate a CDI configuration.")
         perror("See ramalama-cuda(7).")
         return None
     elif configured:

--- a/test/unit/test_common.py
+++ b/test/unit/test_common.py
@@ -264,6 +264,29 @@ class TestCheckNvidia:
         mock_run_cmd.return_value.stdout = "0,GPU-08b3c2e8-cb7b-ea3f-7711-a042c580b3e8"
         assert check_nvidia() == "cuda"
 
+    @patch("ramalama.common.perror")
+    @patch("ramalama.common.shutil.which", return_value=None)
+    @patch("ramalama.common.find_in_cdi")
+    @patch("ramalama.common.run_cmd")
+    def test_check_nvidia_no_cdi_toolkit_missing(self, mock_run_cmd, mock_find_in_cdi, _mock_which, mock_perror):
+        mock_find_in_cdi.return_value = ([], ["all"])
+        mock_run_cmd.return_value.stdout = "0,GPU-08b3c2e8-cb7b-ea3f-7711-a042c580b3e8"
+        assert check_nvidia() is None
+        printed = " ".join(str(c.args[0]) for c in mock_perror.call_args_list)
+        assert "nvidia-container-toolkit does not appear to be installed" in printed
+        assert "nvidia-ctk cdi generate" not in printed
+
+    @patch("ramalama.common.perror")
+    @patch("ramalama.common.shutil.which", return_value="/usr/bin/nvidia-ctk")
+    @patch("ramalama.common.find_in_cdi")
+    @patch("ramalama.common.run_cmd")
+    def test_check_nvidia_no_cdi_toolkit_present(self, mock_run_cmd, mock_find_in_cdi, _mock_which, mock_perror):
+        mock_find_in_cdi.return_value = ([], ["all"])
+        mock_run_cmd.return_value.stdout = "0,GPU-08b3c2e8-cb7b-ea3f-7711-a042c580b3e8"
+        assert check_nvidia() is None
+        printed = " ".join(str(c.args[0]) for c in mock_perror.call_args_list)
+        assert "nvidia-ctk cdi generate" in printed
+
     @patch("ramalama.common.run_cmd")
     def test_check_nvidia_smi_failure(self, mock_run_cmd):
         mock_run_cmd.side_effect = subprocess.CalledProcessError(1, "nvidia-smi")


### PR DESCRIPTION
Fixes #2860 and Supersedes #2861.

When nvidia-smi works but CDI is missing, probing for nvidia-ctk avoids suggesting nvidia-ctk cdi generate on hosts that never installed the toolkit.