### PR TITLE
add hosts entry to fix RAG and sandbox under Docker

### DIFF
--- a/ramalama/engine.py
+++ b/ramalama/engine.py
@@ -73,6 +73,8 @@ class BaseEngine(ABC):
         network = getattr(self.args, "network", None)
         if network is not None:
             self.exec_args += ["--network", network]
+        elif self.use_docker:
+            self.add_args("--add-host", "host.docker.internal=host-gateway")
 
     def add_oci_runtime(self):
         oci_runtime = getattr(self.args, "oci_runtime", None)

--- a/ramalama/sandbox.py
+++ b/ramalama/sandbox.py
@@ -146,7 +146,9 @@ class SandboxEngine(Engine):
 
     def add_network(self) -> None:
         if getattr(self.args, "start_model_server", True):
-            self.add_args(f"--network=container:{self.args.name}")  # type: ignore[attr-defined]
+            if not getattr(self.args, "network", None):
+                self.args.network = f"container:{self.args.name}"  # type: ignore[attr-defined]
+        super().add_network()
 
     def add_workdir(self, args: SandboxEngineArgsType):
         if args.workdir:

--- a/test/e2e/test_sandbox.py
+++ b/test/e2e/test_sandbox.py
@@ -8,7 +8,6 @@ import pytest
 import requests
 
 from test.conftest import (
-    skip_if_docker,
     skip_if_no_container,
     skip_if_not_windows,
     skip_if_ppc64le,
@@ -265,7 +264,6 @@ def test_sandbox_run_stdin(sandbox_ctx, tmp_path, agent):
 
 @pytest.mark.e2e
 @pytest.mark.slow
-@skip_if_docker
 @skip_if_no_container
 @skip_if_ppc64le
 @skip_if_s390x
@@ -310,7 +308,7 @@ def test_sandbox_using_url(sandbox_ctx, caplog, agent):
                 "sandbox",
                 agent,
                 "--url",
-                f"http://host.containers.internal:{container_port}",
+                f"http://localhost:{container_port}",
                 model,
                 "--prompt",
                 "Hello",
@@ -328,7 +326,6 @@ def test_sandbox_using_url(sandbox_ctx, caplog, agent):
 
 @pytest.mark.e2e
 @pytest.mark.slow
-@skip_if_docker
 @skip_if_no_container
 @skip_if_ppc64le
 @skip_if_s390x

--- a/test/e2e/test_sandbox.py
+++ b/test/e2e/test_sandbox.py
@@ -74,7 +74,7 @@ def test_sandbox_dryrun_default_windows():
 def test_sandbox_dryrun_network(agent):
     """Dryrun output should include container networking."""
     result = check_output(_dryrun_cmd(agent))
-    assert re.search(r"--network=container:", result)
+    assert re.search(r"--network container:", result)
 
 
 @pytest.mark.e2e

--- a/test/unit/test_engine.py
+++ b/test/unit/test_engine.py
@@ -92,6 +92,24 @@ class TestEngine(unittest.TestCase):
         self.assertIn("-p", engine.exec_args)
         self.assertIn("8080:8080", engine.exec_args)
 
+    def test_podman_no_host_internal(self):
+        args = Namespace(**vars(self.base_args))
+        engine = ramalama.engine.Engine(args)
+        self.assertNotIn("--add-host", engine.exec_args)
+
+    def test_docker_network_no_host_internal(self):
+        args = Namespace(**vars(self.base_args))
+        args.engine = "docker"
+        args.network = "net"
+        engine = ramalama.engine.Engine(args)
+        self.assertNotIn("--add-host", engine.exec_args)
+
+    def test_docker_host_internal(self):
+        args = Namespace(**vars(self.base_args))
+        args.engine = "docker"
+        engine = ramalama.engine.Engine(args)
+        self.assertIn("--add-host host.docker.internal=host-gateway", " ".join(engine.exec_args))
+
     def test_add_container_image_applies_engine_args_after_mounts(self):
         args = Namespace(**vars(self.base_args), engine_args=["--label=custom=1"])
         engine = ramalama.engine.Engine(args)

--- a/test/unit/test_sandbox_cmd.py
+++ b/test/unit/test_sandbox_cmd.py
@@ -173,7 +173,7 @@ def test_agent_network(agent):
     """Agent should setup container networking"""
     args, cls = _agent_args(agent)
     obj = cls(args, "test-model")
-    assert "--network=container:ramalama_model_abc" in obj.engine.exec_args
+    assert "--network container:ramalama_model_abc" in " ".join(obj.engine.exec_args)
 
 
 @pytest.mark.parametrize("agent", ["goose", "opencode", "pi"])


### PR DESCRIPTION
Add a `host.docker.internal` hosts entry when running under Docker, enabling the container to connect to services running on the host. This matches the behavior of Docker Desktop and Podman. Only add it if `--network` is not specified, otherwise assume the user has configured the custom network as desired.

Enable sandbox tests to run under Docker.