### PR TITLE
Isolate sandbox (goose) with OpenShell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ uv.lock
 *~
 *#
 .mypy_cache
+.vscode/

--- a/container-images/openshell/Containerfile.goose
+++ b/container-images/openshell/Containerfile.goose
@@ -1,0 +1,19 @@
+FROM ghcr.io/nvidia/openshell/supervisor:0.0.97 AS supervisor
+
+FROM ghcr.io/aaif-goose/goose:1.43.0
+
+# Switch to root user.
+# This is needed for openshell-sandbox. It will run goose as non-root user.
+USER root
+
+RUN apt update && apt install iproute2 nftables curl -y
+RUN mkdir -p /var/log
+RUN mkdir -p /sandbox
+RUN chown -R goose:goose /sandbox
+
+RUN mkdir -p /etc/openshell
+COPY container-images/openshell/opa.rego /etc/openshell/opa.rego
+
+COPY --from=supervisor /openshell-sandbox /openshell-sandbox
+
+ENTRYPOINT ["/openshell-sandbox"]

--- a/container-images/openshell/opa.rego
+++ b/container-images/openshell/opa.rego
@@ -1,0 +1,923 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+package openshell.sandbox
+
+default allow_network = false
+
+# --- Static policy data passthrough (queried at sandbox startup) ---
+
+filesystem_policy := data.filesystem_policy
+
+landlock_policy := data.landlock
+
+process_policy := data.process
+
+# --- Network access decision (queried per-CONNECT request) ---
+
+allow_network if {
+	network_policy_for_request
+}
+
+# --- Deny reasons (specific diagnostics for debugging policy denials) ---
+
+deny_reason := "missing input.network" if {
+	not input.network
+}
+
+deny_reason := "missing input.exec" if {
+	input.network
+	not input.exec
+}
+
+deny_reason := reason if {
+	input.network
+	input.exec
+	not network_policy_for_request
+	not endpoint_policy_for_request
+	count(data.network_policies) > 0
+	reason := sprintf("endpoint %s:%d is not allowed by any policy", [input.network.host, input.network.port])
+}
+
+deny_reason := reason if {
+	input.network
+	input.exec
+	not network_policy_for_request
+	endpoint_policy_for_request
+	ancestors_str := concat(" -> ", input.exec.ancestors)
+	cmdline_str := concat(", ", input.exec.cmdline_paths)
+	binary_misses := [r |
+		some name
+		policy := data.network_policies[name]
+		endpoint_allowed(policy, input.network)
+		not binary_allowed(policy, input.exec)
+		r := sprintf("binary '%s' not allowed in policy '%s' (ancestors: [%s], cmdline: [%s]). SYMLINK HINT: the binary path is the kernel-resolved target from /proc/<pid>/exe, not the symlink. If your policy specifies a symlink (e.g., /usr/bin/python3) but the actual binary is /usr/bin/python3.11, either: (1) use the canonical path in your policy (run 'readlink -f /usr/bin/python3' inside the sandbox), or (2) ensure symlink resolution is working (check sandbox logs for 'Cannot access container filesystem')", [input.exec.path, name, ancestors_str, cmdline_str])
+	]
+	count(binary_misses) > 0
+	reason := concat("; ", binary_misses)
+}
+
+deny_reason := "network connections not allowed by policy" if {
+	input.network
+	input.exec
+	not network_policy_for_request
+	count(data.network_policies) == 0
+}
+
+# --- Matched policy name (for audit logging) ---
+#
+# Collects all matching policy names into a set, then deterministically picks
+# the lexicographically smallest.  This avoids a "complete rule conflict" when
+# multiple policies cover the same endpoint (e.g. after draft approval adds an
+# overlapping rule).
+
+_matching_policy_names contains name if {
+	some name
+	policy := data.network_policies[name]
+	endpoint_allowed(policy, input.network)
+	binary_allowed(policy, input.exec)
+}
+
+matched_network_policy := min(_matching_policy_names) if {
+	count(_matching_policy_names) > 0
+}
+
+# --- Core matching logic ---
+
+# True when at least one network policy matches the request (endpoint  binary).
+# Expressed as a boolean so that multiple matching policies don't cause a
+# "complete rule conflict".
+network_policy_for_request if {
+	some name
+	data.network_policies[name]
+	endpoint_allowed(data.network_policies[name], input.network)
+	binary_allowed(data.network_policies[name], input.exec)
+}
+
+endpoint_policy_for_request if {
+	some name
+	data.network_policies[name]
+	endpoint_allowed(data.network_policies[name], input.network)
+}
+
+# Endpoint matching: exact host (case-insensitive)  port in ports list.
+endpoint_allowed(policy, network) if {
+	some endpoint
+	endpoint := policy.endpoints[_]
+	not contains(endpoint.host, "*")
+	lower(endpoint.host) == lower(network.host)
+	endpoint.ports[_] == network.port
+}
+
+# Endpoint matching: glob host pattern  port in ports list.
+# Uses "." as delimiter so "*" matches a single DNS label and "**" matches
+# across label boundaries — consistent with TLS certificate wildcard semantics.
+endpoint_allowed(policy, network) if {
+	some endpoint
+	endpoint := policy.endpoints[_]
+	contains(endpoint.host, "*")
+	glob.match(lower(endpoint.host), ["."], lower(network.host))
+	endpoint.ports[_] == network.port
+}
+
+# Endpoint matching: hostless with allowed_ips — match any host on port.
+# When an endpoint has allowed_ips but no host, it matches any hostname on the
+# given port. The actual IP validation happens in Rust post-DNS-resolution.
+endpoint_allowed(policy, network) if {
+	some endpoint
+	endpoint := policy.endpoints[_]
+	object.get(endpoint, "host", "") == ""
+	count(object.get(endpoint, "allowed_ips", [])) > 0
+	endpoint.ports[_] == network.port
+}
+
+# Binary matching: exact path.
+# SHA256 integrity is enforced in Rust via trust-on-first-use (TOFU) cache,
+# not in Rego. The proxy computes and caches binary hashes at runtime.
+binary_allowed(policy, exec) if {
+	some b
+	b := policy.binaries[_]
+	not contains(b.path, "*")
+	b.path == exec.path
+}
+
+# Binary matching: ancestor exact path (e.g., claude spawns node).
+binary_allowed(policy, exec) if {
+	some b
+	b := policy.binaries[_]
+	not contains(b.path, "*")
+	ancestor := exec.ancestors[_]
+	b.path == ancestor
+}
+
+# Binary matching: glob pattern against exe path or any ancestor.
+# NOTE: cmdline_paths are intentionally excluded — argv[0] is trivially
+# spoofable via execve and must not be used as a grant-access signal.
+binary_allowed(policy, exec) if {
+	some b in policy.binaries
+	contains(b.path, "*")
+	all_paths := array.concat([exec.path], exec.ancestors)
+	some p in all_paths
+	glob.match(b.path, ["/"], p)
+}
+
+user_declared_binary_allowed(policy, exec) if {
+	some b
+	b := policy.binaries[_]
+	not object.get(b, "advisor_proposed", false)
+	not contains(b.path, "*")
+	b.path == exec.path
+}
+
+user_declared_binary_allowed(policy, exec) if {
+	some b
+	b := policy.binaries[_]
+	not object.get(b, "advisor_proposed", false)
+	not contains(b.path, "*")
+	ancestor := exec.ancestors[_]
+	b.path == ancestor
+}
+
+user_declared_binary_allowed(policy, exec) if {
+	some b in policy.binaries
+	not object.get(b, "advisor_proposed", false)
+	contains(b.path, "*")
+	all_paths := array.concat([exec.path], exec.ancestors)
+	some p in all_paths
+	glob.match(b.path, ["/"], p)
+}
+
+# --- Network action (allow / deny) ---
+#
+# These rules are mutually exclusive by construction:
+#   - "allow" requires `network_policy_for_request` (binaryendpoint matched)
+#   - default is "deny" when no policy matches.
+
+default network_action := "deny"
+
+# Explicitly allowed: endpoint  binary match in a network policy → allow.
+network_action := "allow" if {
+	network_policy_for_request
+}
+
+# ===========================================================================
+# L7 request evaluation (queried per-request within a tunnel)
+# ===========================================================================
+
+default allow_request = false
+
+# Per-policy helper: true when this single policy has at least one endpoint
+# matching the L4 request whose L7 rules also permit the specific request.
+# Isolating the endpoint iteration inside a function avoids the regorus
+# "duplicated definition of local variable" error that occurs when the
+# outer `some name` iterates over multiple policies that share a host:port.
+_policy_allows_l7(policy) if {
+	some ep
+	ep := policy.endpoints[_]
+	endpoint_matches_l7_request(ep, input.network, input.request)
+	request_allowed_for_endpoint(input.request, ep)
+}
+
+# L7 request allowed if any matching L4 policy also allows the L7 request
+# AND no deny rule blocks it. Deny rules take precedence over allow rules.
+allow_request if {
+	some name
+	policy := data.network_policies[name]
+	endpoint_allowed(policy, input.network)
+	binary_allowed(policy, input.exec)
+	_policy_allows_l7(policy)
+	not deny_request
+}
+
+# --- L7 deny rules ---
+#
+# Deny rules are evaluated after allow rules and take precedence.
+# If a request matches any deny rule on any matching endpoint, it is blocked
+# even if it would otherwise be allowed.
+
+default deny_request = false
+
+# Per-policy helper: true when this policy has at least one endpoint matching
+# the L4 request whose deny_rules also match the specific L7 request.
+_policy_denies_l7(policy) if {
+	some ep
+	ep := policy.endpoints[_]
+	endpoint_matches_l7_request(ep, input.network, input.request)
+	request_denied_for_endpoint(input.request, ep)
+}
+
+deny_request if {
+	some name
+	policy := data.network_policies[name]
+	endpoint_allowed(policy, input.network)
+	binary_allowed(policy, input.exec)
+	_policy_denies_l7(policy)
+}
+
+# --- L7 deny rule matching: REST method  path  query ---
+
+request_denied_for_endpoint(request, endpoint) if {
+	not jsonrpc_family_endpoint(endpoint)
+	some deny_rule
+	deny_rule := endpoint.deny_rules[_]
+	deny_rule.method
+	method_matches(request.method, deny_rule.method)
+	path_matches(request.path, deny_rule.path)
+	deny_query_params_match(request, deny_rule)
+}
+
+# --- L7 deny rule matching: SQL command ---
+
+request_denied_for_endpoint(request, endpoint) if {
+	some deny_rule
+	deny_rule := endpoint.deny_rules[_]
+	deny_rule.command
+	command_matches(request.command, deny_rule.command)
+}
+
+# --- L7 deny rule matching: JSON-RPC method ---
+
+request_denied_for_endpoint(request, endpoint) if {
+	jsonrpc_family_endpoint(endpoint)
+	request.method == "POST"
+	some deny_rule
+	deny_rule := endpoint.deny_rules[_]
+	deny_rule.method
+	jsonrpc_rule_matches(request, endpoint, deny_rule)
+}
+
+request_denied_for_endpoint(request, endpoint) if {
+	endpoint.protocol == "json-rpc"
+	request.method == "POST"
+	jsonrpc_response_frame_present(request)
+}
+
+# --- L7 deny rule matching: GraphQL operation ---
+
+request_denied_for_endpoint(request, endpoint) if {
+	graphql_request_has_operations(request)
+	some deny_rule
+	deny_rule := endpoint.deny_rules[_]
+	deny_rule.operation_type
+	op := request.graphql.operations[_]
+	graphql_deny_rule_matches_operation(op, deny_rule, endpoint)
+}
+
+# A GraphQL endpoint path is authoritative once it matches. If the parsed
+# GraphQL request is malformed, hash-only without a trusted registry entry, or
+# contains an operation outside the GraphQL allow rules, a broader REST rule on
+# the same host:port must not allow it through.
+request_denied_for_endpoint(request, endpoint) if {
+	endpoint.protocol == "graphql"
+	is_object(request.graphql)
+	not graphql_request_allowed(request, endpoint)
+}
+
+# The same authority applies when a WebSocket endpoint opts into GraphQL
+# operation policy. Once the relay classifies a client text message as a
+# GraphQL-over-WebSocket operation, generic WEBSOCKET_TEXT rules must not bypass
+# operation_type / operation_name / fields policy.
+request_denied_for_endpoint(request, endpoint) if {
+	endpoint.protocol == "websocket"
+	is_object(request.graphql)
+	not graphql_request_allowed(request, endpoint)
+}
+
+# Deny query matching: fail-closed semantics.
+# If no query rules on the deny rule, match unconditionally (any query params).
+# If query rules present, trigger the deny if ANY value for a configured key
+# matches the matcher. This is the inverse of allow-side semantics where ALL
+# values must match. For deny logic, a single matching value is enough to block.
+deny_query_params_match(request, deny_rule) if {
+	deny_query_rules := object.get(deny_rule, "query", {})
+	count(deny_query_rules) == 0
+}
+
+deny_query_params_match(request, deny_rule) if {
+	deny_query_rules := object.get(deny_rule, "query", {})
+	count(deny_query_rules) > 0
+	not deny_query_key_missing(request, deny_query_rules)
+	not deny_query_value_mismatch_all(request, deny_query_rules)
+}
+
+# A configured deny query key is missing from the request entirely.
+# Missing key means the deny rule doesn't apply (fail-open on absence).
+deny_query_key_missing(request, query_rules) if {
+	some key
+	query_rules[key]
+	request_query := object.get(request, "query_params", {})
+	values := object.get(request_query, key, null)
+	values == null
+}
+
+# ALL values for a configured key fail to match the matcher.
+# If even one value matches, deny fires. This rule checks the opposite:
+# true when NO value matches (i.e., every value is a mismatch).
+deny_query_value_mismatch_all(request, query_rules) if {
+	some key
+	matcher := query_rules[key]
+	request_query := object.get(request, "query_params", {})
+	values := object.get(request_query, key, [])
+	count(values) > 0
+	not deny_any_value_matches(values, matcher)
+}
+
+# True if at least one value in the list matches the matcher.
+deny_any_value_matches(values, matcher) if {
+	some i
+	query_value_matches(values[i], matcher)
+}
+
+# --- L7 deny reason ---
+
+request_deny_reason := reason if {
+	input.request
+	graphql_request_error(input.request)
+	reason := sprintf("GraphQL request rejected: %s", [input.request.graphql.error])
+}
+
+request_deny_reason := reason if {
+	input.request
+	not graphql_request_error(input.request)
+	graphql_request_has_unregistered_persisted_query(input.request, matched_endpoint_config)
+	reason := "GraphQL persisted query is not registered"
+}
+
+request_deny_reason := reason if {
+	input.request
+	deny_request
+	graphql_request_has_operations(input.request)
+	not graphql_request_has_unregistered_persisted_query(input.request, matched_endpoint_config)
+	reason := "GraphQL operation blocked by endpoint policy"
+}
+
+request_deny_reason := reason if {
+	input.request
+	not deny_request
+	not allow_request
+	graphql_request_has_operations(input.request)
+	not graphql_request_has_unregistered_persisted_query(input.request, matched_endpoint_config)
+	reason := "GraphQL operation not permitted by policy"
+}
+
+request_deny_reason := reason if {
+	input.request
+	jsonrpc_response_frame_present(input.request)
+	matched_endpoint_config.protocol == "json-rpc"
+	reason := "JSON-RPC response frames are not permitted from client to server"
+}
+
+request_deny_reason := reason if {
+	input.request
+	deny_request
+	not graphql_request_has_operations(input.request)
+	not jsonrpc_response_frame_present(input.request)
+	reason := sprintf("%s %s blocked by deny rule", [input.request.method, input.request.path])
+}
+
+request_deny_reason := reason if {
+	input.request
+	not deny_request
+	not allow_request
+	not graphql_request_has_operations(input.request)
+	not jsonrpc_response_frame_present(input.request)
+	reason := sprintf("%s %s not permitted by policy", [input.request.method, input.request.path])
+}
+
+# --- L7 rule matching: REST method  path ---
+
+request_allowed_for_endpoint(request, endpoint) if {
+	not jsonrpc_family_endpoint(endpoint)
+	some rule
+	rule := endpoint.rules[_]
+	rule.allow.method
+	method_matches(request.method, rule.allow.method)
+	path_matches(request.path, rule.allow.path)
+	query_params_match(request, rule)
+}
+
+# --- L7 rule matching: SQL command ---
+
+request_allowed_for_endpoint(request, endpoint) if {
+	some rule
+	rule := endpoint.rules[_]
+	rule.allow.command
+	command_matches(request.command, rule.allow.command)
+}
+
+# --- L7 rule matching: JSON-RPC method ---
+
+request_allowed_for_endpoint(request, endpoint) if {
+	jsonrpc_family_endpoint(endpoint)
+	request.method == "POST"
+	some rule
+	rule := endpoint.rules[_]
+	rule.allow.method
+	not jsonrpc_response_frame_present(request)
+	jsonrpc_rule_matches(request, endpoint, rule.allow)
+}
+
+# MCP can allow the method layer by endpoint option while still using
+# tool-specific rules to narrow tools/call params.name.
+request_allowed_for_endpoint(request, endpoint) if {
+	endpoint.protocol == "mcp"
+	mcp_allow_all_known_mcp_methods(endpoint)
+	request.method == "POST"
+	not jsonrpc_response_frame_present(request)
+	jsonrpc := object.get(request, "jsonrpc", null)
+	is_object(jsonrpc)
+	jsonrpc_no_parse_error(jsonrpc)
+	method := object.get(jsonrpc, "method", "")
+	is_string(method)
+	method != ""
+	not mcp_tool_call_narrowed_by_policy(endpoint, method)
+}
+
+# MCP Streamable HTTP allows client-to-server JSON-RPC response frames for
+# server-originated requests such as elicitation/create. Generic JSON-RPC keeps
+# response frames denied because it has no MCP request-correlation semantics.
+request_allowed_for_endpoint(request, endpoint) if {
+	endpoint.protocol == "mcp"
+	request.method == "POST"
+	jsonrpc_response_frame_present(request)
+	jsonrpc := object.get(request, "jsonrpc", null)
+	is_object(jsonrpc)
+	jsonrpc_no_parse_error(jsonrpc)
+}
+
+jsonrpc_family_endpoint(endpoint) if {
+	endpoint.protocol == "json-rpc"
+}
+
+jsonrpc_family_endpoint(endpoint) if {
+	endpoint.protocol == "mcp"
+}
+
+mcp_allow_all_known_mcp_methods(endpoint) if {
+	object.get(endpoint, "mcp_allow_all_known_mcp_methods", false)
+}
+
+mcp_tool_call_narrowed_by_policy(endpoint, method) if {
+	method == "tools/call"
+	some rule
+	rule := endpoint.rules[_]
+	params := object.get(rule.allow, "params", {})
+	is_object(params)
+	params.name
+}
+
+# MCP Streamable HTTP uses GET on the JSON-RPC-family endpoint as a receive
+# stream for server-to-client messages. The stream itself has no
+# client-to-server JSON-RPC request body to inspect; allow it once the endpoint
+# path and binary matched.
+request_allowed_for_endpoint(request, endpoint) if {
+	endpoint.protocol == "mcp"
+	request.method == "GET"
+	jsonrpc := object.get(request, "jsonrpc", null)
+	is_object(jsonrpc)
+	object.get(jsonrpc, "receive_stream", false)
+	jsonrpc_no_parse_error(jsonrpc)
+	object.get(jsonrpc, "method", null) == null
+	not object.get(jsonrpc, "has_response", false)
+}
+
+# --- L7 rule matching: GraphQL operation ---
+
+request_allowed_for_endpoint(request, endpoint) if {
+	graphql_request_allowed(request, endpoint)
+}
+
+graphql_request_allowed(request, endpoint) if {
+	graphql_request_has_operations(request)
+	not graphql_request_error(request)
+	not graphql_request_has_unregistered_persisted_query(request, endpoint)
+	not graphql_request_has_unallowed_operation(request, endpoint)
+}
+
+graphql_request_has_operations(request) if {
+	is_object(request.graphql)
+	operations := object.get(request.graphql, "operations", [])
+	count(operations) > 0
+}
+
+graphql_request_error(request) if {
+	is_object(request.graphql)
+	error := object.get(request.graphql, "error", "")
+	error != ""
+}
+
+graphql_request_has_unallowed_operation(request, endpoint) if {
+	op := request.graphql.operations[_]
+	not graphql_operation_allowed(op, endpoint)
+}
+
+graphql_operation_allowed(op, endpoint) if {
+	rule := endpoint.rules[_]
+	rule.allow.operation_type
+	graphql_allow_rule_matches_operation(op, rule.allow, endpoint)
+}
+
+graphql_request_has_unregistered_persisted_query(request, endpoint) if {
+	op := request.graphql.operations[_]
+	graphql_operation_needs_registry(op)
+	not graphql_registered_operation(op, endpoint)
+}
+
+graphql_operation_needs_registry(op) if {
+	object.get(op, "persisted_query", false) == true
+	object.get(op, "operation_type", "") == ""
+}
+
+graphql_registered_operation(op, endpoint) if {
+	object.get(endpoint, "persisted_queries", "deny") == "allow_registered"
+	id := graphql_operation_registry_key(op)
+	endpoint.graphql_persisted_queries[id]
+}
+
+graphql_operation_registry_key(op) := key if {
+	key := object.get(op, "persisted_query_hash", "")
+	key != ""
+}
+
+graphql_operation_registry_key(op) := key if {
+	object.get(op, "persisted_query_hash", "") == ""
+	key := object.get(op, "persisted_query_id", "")
+	key != ""
+}
+
+graphql_effective_operation(op, endpoint) := registered if {
+	graphql_operation_needs_registry(op)
+	key := graphql_operation_registry_key(op)
+	registered := endpoint.graphql_persisted_queries[key]
+}
+
+graphql_effective_operation(op, _) := op if {
+	not graphql_operation_needs_registry(op)
+}
+
+graphql_allow_rule_matches_operation(op, rule, endpoint) if {
+	effective := graphql_effective_operation(op, endpoint)
+	graphql_operation_type_matches(effective, rule)
+	graphql_operation_name_matches(effective, rule)
+	graphql_allow_fields_match(effective, rule)
+}
+
+graphql_deny_rule_matches_operation(op, rule, endpoint) if {
+	effective := graphql_effective_operation(op, endpoint)
+	graphql_operation_type_matches(effective, rule)
+	graphql_operation_name_matches(effective, rule)
+	graphql_deny_fields_match(effective, rule)
+}
+
+graphql_operation_type_matches(_, rule) if {
+	object.get(rule, "operation_type", "") == "*"
+}
+
+graphql_operation_type_matches(op, rule) if {
+	expected := object.get(rule, "operation_type", "")
+	expected != ""
+	expected != "*"
+	lower(object.get(op, "operation_type", "")) == lower(expected)
+}
+
+graphql_operation_name_matches(_, rule) if {
+	object.get(rule, "operation_name", "") == ""
+}
+
+graphql_operation_name_matches(op, rule) if {
+	pattern := object.get(rule, "operation_name", "")
+	pattern != ""
+	name := object.get(op, "operation_name", "")
+	glob.match(pattern, [], name)
+}
+
+# Allow-side field constraints are intentionally all-selected-fields semantics:
+# if a rule declares fields, every root field selected by the operation must
+# match one of the rule patterns. This prevents mixed-operation requests from
+# allowing an unlisted field because one safe field also appeared.
+graphql_allow_fields_match(_, rule) if {
+	count(object.get(rule, "fields", [])) == 0
+}
+
+graphql_allow_fields_match(op, rule) if {
+	count(object.get(rule, "fields", [])) > 0
+	count(object.get(op, "fields", [])) > 0
+	not graphql_operation_has_unmatched_field(op, rule)
+}
+
+graphql_operation_has_unmatched_field(op, rule) if {
+	field := object.get(op, "fields", [])[_]
+	not graphql_field_matches_any(field, object.get(rule, "fields", []))
+}
+
+graphql_deny_fields_match(_, rule) if {
+	count(object.get(rule, "fields", [])) == 0
+}
+
+graphql_deny_fields_match(op, rule) if {
+	field := object.get(op, "fields", [])[_]
+	graphql_field_matches_any(field, object.get(rule, "fields", []))
+}
+
+graphql_field_matches_any(field, patterns) if {
+	pattern := patterns[_]
+	glob.match(pattern, [], field)
+}
+
+# Wildcard "*" matches any method; otherwise case-insensitive exact match.
+# RFC 9110 §9.3.2: HEAD is semantically identical to GET except no response body.
+method_matches(_, "*") if true
+
+method_matches(actual, expected) if {
+	expected != "*"
+	upper(actual) == upper(expected)
+}
+
+method_matches(actual, expected) if {
+	upper(actual) == "HEAD"
+	upper(expected) == "GET"
+}
+
+# Path matching: "**" matches everything; otherwise glob.match with "/" delimiter.
+#
+# INVARIANT: `input.request.path` is canonicalized by the sandbox before
+# policy evaluation — percent-decoded, dot-segments resolved, doubled
+# slashes collapsed, `;params` stripped, `%2F` rejected (unless an
+# endpoint opts in). Patterns here must therefore match canonical paths;
+# do not attempt defensive matching against `..` or `%2e%2e` — those
+# inputs are rejected at the L7 parser boundary before this rule runs.
+path_matches(_, "**") if true
+
+path_matches(actual, pattern) if {
+	pattern != "**"
+	glob.match(pattern, ["/"], actual)
+}
+
+# Query matching:
+# - If no query rules are configured, allow any query params.
+# - For configured keys, all request values for that key must match.
+# - Matcher shape supports either `glob` or `any`.
+query_params_match(request, rule) if {
+	query_rules := object.get(rule.allow, "query", {})
+	not query_mismatch(request, query_rules)
+}
+
+query_mismatch(request, query_rules) if {
+	some key
+	matcher := query_rules[key]
+	not query_key_matches(request, key, matcher)
+}
+
+query_key_matches(request, key, matcher) if {
+	request_query := object.get(request, "query_params", {})
+	values := object.get(request_query, key, null)
+	values != null
+	count(values) > 0
+	not query_value_mismatch(values, matcher)
+}
+
+query_value_mismatch(values, matcher) if {
+	some i
+	value := values[i]
+	not query_value_matches(value, matcher)
+}
+
+query_value_matches(value, matcher) if {
+	is_string(matcher)
+	glob.match(matcher, [], value)
+}
+
+query_value_matches(value, matcher) if {
+	is_object(matcher)
+	glob_pattern := object.get(matcher, "glob", "")
+	glob_pattern != ""
+	glob.match(glob_pattern, [], value)
+}
+
+query_value_matches(value, matcher) if {
+	is_object(matcher)
+	any_patterns := object.get(matcher, "any", [])
+	count(any_patterns) > 0
+	some i
+	glob.match(any_patterns[i], [], value)
+}
+
+# JSON-RPC-family method matching. Generic JSON-RPC policies match only method.
+# MCP policies may also match params.name from tool aliases.
+jsonrpc_rule_matches(request, endpoint, rule) if {
+	jsonrpc := object.get(request, "jsonrpc", null)
+	is_object(jsonrpc)
+	method := object.get(jsonrpc, "method", "")
+	is_string(method)
+	method != ""
+	rule_method := object.get(rule, "method", "")
+	is_string(rule_method)
+	rule_method != ""
+	jsonrpc_rule_method_matches(endpoint, method, rule_method)
+	jsonrpc_rule_params_match_for_protocol(jsonrpc, endpoint, rule)
+}
+
+jsonrpc_rule_method_matches(endpoint, _, rule_method) if {
+	endpoint.protocol == "json-rpc"
+	rule_method == "*"
+}
+
+jsonrpc_rule_method_matches(endpoint, method, rule_method) if {
+	endpoint.protocol == "json-rpc"
+	rule_method != "*"
+	rule_method == method
+}
+
+jsonrpc_rule_method_matches(endpoint, method, rule_method) if {
+	endpoint.protocol == "mcp"
+	glob.match(rule_method, [], method)
+}
+
+jsonrpc_rule_params_match_for_protocol(_, endpoint, _) if {
+	endpoint.protocol == "json-rpc"
+}
+
+jsonrpc_rule_params_match_for_protocol(jsonrpc, endpoint, rule) if {
+	endpoint.protocol == "mcp"
+	jsonrpc_params_match(jsonrpc, rule)
+}
+
+jsonrpc_response_frame_present(request) if {
+	jsonrpc := object.get(request, "jsonrpc", null)
+	is_object(jsonrpc)
+	object.get(jsonrpc, "has_response", false)
+}
+
+jsonrpc_no_parse_error(jsonrpc) if {
+	is_object(jsonrpc)
+	object.get(jsonrpc, "error", null) == null
+}
+
+jsonrpc_no_parse_error(jsonrpc) if {
+	is_object(jsonrpc)
+	object.get(jsonrpc, "error", "") == ""
+}
+
+jsonrpc_params_match(jsonrpc, rule) if {
+	is_object(jsonrpc)
+	param_rules := object.get(rule, "params", {})
+	is_object(param_rules)
+	not jsonrpc_param_mismatch(jsonrpc, param_rules)
+}
+
+jsonrpc_param_mismatch(jsonrpc, param_rules) if {
+	some key
+	matcher := param_rules[key]
+	not jsonrpc_param_key_matches(jsonrpc, key, matcher)
+}
+
+jsonrpc_param_key_matches(jsonrpc, key, matcher) if {
+	is_object(jsonrpc)
+	params := object.get(jsonrpc, "params", {})
+	is_object(params)
+	value := object.get(params, key, null)
+	value != null
+	is_string(value)
+	query_value_matches(value, matcher)
+}
+
+# SQL command matching: "*" matches any; otherwise case-insensitive.
+command_matches(_, "*") if true
+
+command_matches(actual, expected) if {
+	expected != "*"
+	upper(actual) == upper(expected)
+}
+
+# --- Matched endpoint config (for L7 and allowed_ips extraction) ---
+# Returns the raw endpoint object for the matched policy  host:port.
+# Used by Rust to extract L7 config (protocol, tls, enforcement,
+# allow_encoded_slash) and/or allowed_ips for SSRF allowlist validation.
+
+# Per-policy helper: returns matching endpoint configs for a single policy.
+_policy_endpoint_configs(policy) := [ep |
+	some ep
+	ep := policy.endpoints[_]
+	endpoint_matches_request(ep, input.network)
+	endpoint_has_extended_config(ep)
+]
+
+# Collect matching endpoint configs across all policies.  Iterates over
+# _matching_policy_names (a set, safe from regorus variable collisions)
+# then collects per-policy configs via the helper function.
+_matching_endpoint_configs := [cfg |
+	some pname
+	_matching_policy_names[pname]
+	cfgs := _policy_endpoint_configs(data.network_policies[pname])
+	cfg := cfgs[_]
+]
+
+matched_endpoint_config := _matching_endpoint_configs[0] if {
+	count(_matching_endpoint_configs) > 0
+}
+
+_policy_has_exact_declared_endpoint(policy) if {
+	some ep
+	ep := policy.endpoints[_]
+	not object.get(ep, "advisor_proposed", false)
+	not contains(ep.host, "*")
+	lower(ep.host) == lower(input.network.host)
+	ep.ports[_] == input.network.port
+}
+
+exact_declared_endpoint_host if {
+	some pname
+	policy := data.network_policies[pname]
+	user_declared_binary_allowed(policy, input.exec)
+	_policy_has_exact_declared_endpoint(policy)
+}
+
+# Hosted endpoint: exact host match  port in ports list.
+endpoint_matches_request(ep, network) if {
+	not contains(ep.host, "*")
+	lower(ep.host) == lower(network.host)
+	ep.ports[_] == network.port
+}
+
+# Hosted endpoint: glob host match  port in ports list.
+endpoint_matches_request(ep, network) if {
+	contains(ep.host, "*")
+	glob.match(lower(ep.host), ["."], lower(network.host))
+	ep.ports[_] == network.port
+}
+
+# Hostless endpoint with allowed_ips: match on port only.
+endpoint_matches_request(ep, network) if {
+	object.get(ep, "host", "") == ""
+	count(object.get(ep, "allowed_ips", [])) > 0
+	ep.ports[_] == network.port
+}
+
+endpoint_matches_l7_request(ep, network, request) if {
+	endpoint_matches_request(ep, network)
+	endpoint_path_matches_request(ep, request)
+}
+
+endpoint_path_matches_request(ep, request) if {
+	object.get(ep, "path", "") == ""
+}
+
+endpoint_path_matches_request(ep, request) if {
+	path := object.get(ep, "path", "")
+	path != ""
+	path_matches(request.path, path)
+}
+
+# An endpoint has extended config if it specifies L7 protocol, allowed_ips,
+# or an explicit tls mode (e.g. tls: skip).
+endpoint_has_extended_config(ep) if {
+	ep.protocol
+}
+
+endpoint_has_extended_config(ep) if {
+	count(object.get(ep, "allowed_ips", [])) > 0
+}
+
+endpoint_has_extended_config(ep) if {
+	ep.tls
+}

--- a/docs/options/with-openshell.md
+++ b/docs/options/with-openshell.md
@@ -1,0 +1,7 @@
+####> This option file is used in:
+####>   ramalama sandbox goose
+####> If this file is edited, make sure the changes
+####> are applicable to all of those.
+#### **--with-openshell**
+Flag to run the sandbox isolated by OpenShell.
+Uses the default policy, which just enables networking to the inference endpoint.

--- a/docs/ramalama-sandbox-goose.1.md
+++ b/docs/ramalama-sandbox-goose.1.md
@@ -457,11 +457,20 @@ Enable or disable the web UI for the served model (enabled by default). When set
 [//]: # (END   included file options/webui.md)
 
 
+[//]: # (BEGIN included file options/with-openshell.md)
+#### **--with-openshell**
+Flag to run the sandbox isolated by OpenShell.
+Uses the default policy, which just enables networking to the inference endpoint.
+
+[//]: # (END   included file options/with-openshell.md)
+
+
 [//]: # (BEGIN included file options/workdir.md)
 #### **--workdir**, **-w**
 Local directory to mount into the sandbox container at /work
 
 [//]: # (END   included file options/workdir.md)
+
 
 ## EXAMPLES
 
@@ -483,6 +492,11 @@ ramalama sandbox goose --thinking=off qwen3:4b
 Start an interactive session with access to a local directory:
 ```
 ramalama sandbox goose -w ./src qwen3:4b
+```
+
+Start an interactive session with access to a local directory and isolate the agent via OpenShell:
+```
+ramalama sandbox goose --with-openshell -w ./src qwen3:4b
 ```
 
 Request the agent to perform actions non-interactively:

--- a/docs/ramalama-sandbox-goose.1.md.in
+++ b/docs/ramalama-sandbox-goose.1.md.in
@@ -107,7 +107,10 @@ Otherwise only the agent container starts using the given url for the openai com
 
 @@option webui
 
+@@option with-openshell
+
 @@option workdir
+
 
 ## EXAMPLES
 
@@ -129,6 +132,11 @@ ramalama sandbox goose --thinking=off qwen3:4b
 Start an interactive session with access to a local directory:
 ```
 ramalama sandbox goose -w ./src qwen3:4b
+```
+
+Start an interactive session with access to a local directory and isolate the agent via OpenShell:
+```
+ramalama sandbox goose --with-openshell -w ./src qwen3:4b
 ```
 
 Request the agent to perform actions non-interactively:

--- a/ramalama/openshell.py
+++ b/ramalama/openshell.py
@@ -1,0 +1,171 @@
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+from ramalama.engine import Engine
+
+
+@dataclass
+class Route:
+    name: str
+    endpoint: str
+    model: str
+    protocols: list[str]
+    api_key: str
+
+
+@dataclass
+class OpenShellInferenceConfig:
+    routes: list[Route]
+
+    def to_dict(self) -> dict:
+        return {"routes": [route.__dict__ for route in self.routes]}
+
+    def __str__(self) -> str:
+        return yaml.safe_dump(self.to_dict(), indent=2, sort_keys=True)
+
+
+def build_openshell_inference_config(url: str, model: str, api_key: str):
+    return OpenShellInferenceConfig(
+        [
+            Route(
+                name="inference.local",
+                endpoint=f"{url}/v1",
+                model=model,
+                protocols=[
+                    "openai_chat_completions",
+                    "openai_completions",
+                    "openai_responses",
+                    "openai_embeddings",
+                    "model_discovery",
+                ],
+                api_key=api_key,
+            )
+        ]
+    )
+
+
+@dataclass
+class Endpoint:
+    host: str
+    port: str
+    protocol: str
+    enforcement: str
+    access: str
+
+
+@dataclass
+class NetworkPolicy:
+    name: str
+    endpoints: list[Endpoint]
+    binaries: list[str]
+
+    def to_dict(self):
+        return {
+            "name": self.name,
+            "endpoints": [endpoint.__dict__ for endpoint in self.endpoints],
+            "binaries": self.binaries,
+        }
+
+
+@dataclass
+class FileSystemPolicy:
+    include_workdir: bool
+    read_only: list[str]
+    read_write: list[str]
+
+
+@dataclass
+class LandLock:
+    compatibility: str
+
+
+@dataclass
+class AgentProcess:
+    run_as_user: str
+    run_as_group: str
+
+
+@dataclass
+class OpenShellPolicyConfig:
+    version: int
+    filesystem_policy: FileSystemPolicy
+    landlock: LandLock
+    process: AgentProcess
+    network_policies: dict[str, NetworkPolicy]
+
+    def to_dict(self) -> dict:
+        return {
+            "version": self.version,
+            "filesystem_policy": self.filesystem_policy.__dict__,
+            "landlock": self.landlock.__dict__,
+            "process": self.process.__dict__,
+            "network_policies": {key: policy.to_dict() for key, policy in self.network_policies.items()},
+        }
+
+    def __str__(self) -> str:
+        return yaml.safe_dump(self.to_dict(), indent=2, sort_keys=True)
+
+
+def default_openshell_goose_policy_config():
+    return OpenShellPolicyConfig(
+        version=1,
+        filesystem_policy=FileSystemPolicy(
+            include_workdir=True,
+            read_only=["/usr", "/lib", "/lib64", "/bin", "/sbin", "/proc", "/etc", "/dev/urandom", "/var/log"],
+            read_write=["/sandbox", "/tmp", "/dev/null", "/dev/shm", "/home/goose", "/work"],
+        ),
+        landlock=LandLock(compatibility="best_effort"),
+        process=AgentProcess(run_as_user="goose", run_as_group="goose"),
+        network_policies={},
+    )
+
+
+def create_temp_openshell_inference_config(inference_url: str, model_name: str, api_key: str) -> Path:
+    with tempfile.NamedTemporaryFile(delete=False) as f:
+        conf = build_openshell_inference_config(inference_url, model_name, api_key)
+        f.write(f"{conf}".encode("utf-8"))
+        return Path(f.name)
+
+
+def create_temp_openshell_policy_config(policy: OpenShellPolicyConfig) -> Path:
+    with tempfile.NamedTemporaryFile(delete=False) as f:
+        f.write(f"{policy}".encode("utf-8"))
+        return Path(f.name)
+
+
+def add_capabilities(engine: Engine) -> None:
+    engine.add_args(
+        "--security-opt=no-new-privileges",
+        "--security-opt=seccomp=unconfined",
+        "--cap-add=sys_admin",
+        "--cap-add=net_admin",
+        "--cap-add=sys_ptrace",
+        "--cap-add=syslog",
+        "--cap-add=dac_read_search",
+        "--cap-add=setpcap",
+        "--cap-add=setuid",
+        "--cap-add=setgid",
+    )
+
+
+def add_openshell_args(engine: Engine, policy: Path, inference: Path, openshell_image: str, entry_point: str) -> None:
+    engine.add_args(
+        "-v",
+        f"{policy}:/etc/openshell/policy.yaml:ro",
+        "-v",
+        f"{inference}:/etc/openshell/inference-routes.yaml:ro",
+        openshell_image,
+        "--interactive",
+        "--log-level",
+        "error",
+        "--policy-rules",
+        "/etc/openshell/opa.rego",
+        "--policy-data",
+        "/etc/openshell/policy.yaml",
+        "--inference-routes",
+        "/etc/openshell/inference-routes.yaml",
+        entry_point,
+    )

--- a/ramalama/sandbox.py
+++ b/ramalama/sandbox.py
@@ -15,6 +15,16 @@ from ramalama.common import genname, perror, run_cmd
 from ramalama.config import ActiveConfig
 from ramalama.engine import Engine, is_healthy, stop_container, wait_for_healthy
 from ramalama.model_server import ModelServerError, list_server_models
+from ramalama.openshell import (
+    AgentProcess,
+    FileSystemPolicy,
+    LandLock,
+    OpenShellPolicyConfig,
+    add_capabilities,
+    add_openshell_args,
+    create_temp_openshell_inference_config,
+    create_temp_openshell_policy_config,
+)
 from ramalama.plugins.loader import get_runtime
 from ramalama.transports.base import compute_serving_port
 from ramalama.transports.transport_factory import New
@@ -88,6 +98,10 @@ def add_sandbox_subparsers(subparsers: argparse._SubParsersAction, img_comp: Cal
         completer=img_comp,
         help="Goose container image",
     )
+    parser.add_argument(
+        "--with-openshell", help="Isolates the goose agent using an OpenShell policy.", action="store_true"
+    )
+
     _add_common_sandbox_args(parser, model_comp)
     _add_router_args(parser)
     parser.set_defaults(func=run_sandbox_goose)
@@ -130,6 +144,7 @@ class SandboxEngineArgsType(BaseEngineArgsType):
     start_model_server: bool
     name: str
     model: str
+    with_openshell: bool
 
 
 class SandboxEngine(Engine):
@@ -195,13 +210,23 @@ class Goose(Agent):
 
     def __init__(self, args: GooseArgsType, model_name: str) -> None:
         super().__init__(args, model_name)
-        if self.engine.use_podman:
-            if platform.system() != "Windows":
-                self.engine.add_args("--uidmap=+1000:0")
-        self.engine.add_name(f"goose-{args.name}")  # type: ignore[attr-defined]
+
+        self.agent_name = f"goose-{args.name}"
+
+        if args.with_openshell:
+            self.configure_engine_with_openshell(args)
+        else:
+            self.configure_engine(args)
+
+    def configure_engine(self, args: GooseArgsType) -> None:
+        if self.engine.use_podman and platform.system() != "Windows":
+            self.engine.add_args("--uidmap=+1000:0")
+
+        self.engine.add_name(self.agent_name)
         self.add_env_options(args)
         self.engine.add_workdir(args)
         self.engine.add_args(args.goose_image)
+
         if args.ARGS:
             self.engine.add_args("run", "-t", args.ARGS)
         elif self.engine.use_tty():
@@ -209,9 +234,55 @@ class Goose(Agent):
         else:
             self.engine.add_args("run", "-i", "-")
 
+    def configure_engine_with_openshell(self, args: GooseArgsType) -> None:
+        self.engine.add_name(self.agent_name)
+        self.add_env_options(args)
+        self.engine.add_workdir(args)
+
+        if not args.url:
+            raise ValueError("Missing url to model inference provider")
+        if not args.api_key:
+            raise ValueError("Missing api key for model inference provider")
+
+        inference_yaml = create_temp_openshell_inference_config(args.url, self.model_name, args.api_key)
+        policy_yaml = create_temp_openshell_policy_config(Goose.default_openshell_policy(args.workdir is not None))
+        add_capabilities(self.engine)
+        add_openshell_args(
+            self.engine, policy_yaml, inference_yaml, "quay.io/ramalama/goose-openshell:latest", "/usr/local/bin/goose"
+        )
+
+        if args.ARGS:
+            self.engine.add_args("run", "-t", args.ARGS)
+        elif self.engine.use_tty():
+            self.engine.add_args("session")
+        else:
+            self.engine.add_args("run", "-i", "-")
+
+    @staticmethod
+    def default_openshell_policy(use_workdir: bool) -> OpenShellPolicyConfig:
+        ro_dirs = ["/usr", "/lib", "/lib64", "/bin", "/sbin", "/proc", "/etc", "/dev/urandom", "/var/log"]
+
+        rw_dirs = ["/sandbox", "/tmp", "/dev/null", "/dev/shm", "/home/goose"]
+        if use_workdir:
+            rw_dirs.append("/work")
+
+        return OpenShellPolicyConfig(
+            version=1,
+            filesystem_policy=FileSystemPolicy(
+                include_workdir=True,
+                read_only=ro_dirs,
+                read_write=rw_dirs,
+            ),
+            landlock=LandLock(compatibility="best_effort"),
+            process=AgentProcess(run_as_user="goose", run_as_group="goose"),
+            network_policies={},
+        )
+
     def add_env_options(self, args: GooseArgsType) -> None:
+        host = args.url if not args.with_openshell else "https://inference.local:443"
+
         self.engine.add_env_option("GOOSE_PROVIDER=openai")
-        self.engine.add_env_option(f"OPENAI_HOST={args.url}")
+        self.engine.add_env_option(f"OPENAI_HOST={host}")
         self.engine.add_env_option(f"OPENAI_API_KEY={args.api_key}")
         self.engine.add_env_option(f"GOOSE_MODEL={self.model_name}")
         self.engine.add_env_option("GOOSE_TELEMETRY_ENABLED=false")
@@ -233,10 +304,12 @@ class OpenCode(Agent):
 
     def __init__(self, args: OpenCodeArgsType, model_name: str) -> None:
         super().__init__(args, model_name)
-        self.engine.add_name(f"opencode-{args.name}")  # type: ignore[attr-defined]
+
+        self.engine.add_name(f"opencode-{args.name}")
         self.add_env_options(args)
         self.engine.add_workdir(args)
         self.engine.add_args(args.opencode_image)
+
         if args.ARGS or not self.engine.use_tty():
             # Use the "run" command to process args from the command-line or stdin non-interatively
             self.engine.add_args("run", "--thinking=true")
@@ -286,12 +359,14 @@ class Pi(Agent):
 
     def __init__(self, args: PiArgsType, model_name: str) -> None:
         super().__init__(args, model_name)
+
         provider_id = _pi_provider_id()
-        self.engine.add_name(f"pi-{args.name}")  # type: ignore[attr-defined]
+        self.engine.add_name(f"pi-{args.name}")
         self.add_provider_discovery_env(args)
         self.engine.add_workdir(args)
         self.engine.add_args(args.pi_image)
         pi_args = ["--provider", provider_id, "--model", self.model_name]
+
         if args.ARGS:
             pi_args += ["-p", args.ARGS]
         self.engine.add(pi_args)

--- a/test/unit/test_sandbox_cmd.py
+++ b/test/unit/test_sandbox_cmd.py
@@ -23,6 +23,7 @@ def _make_args(engine="podman"):
         url="http://localhost:8080",
         thinking=False,
         workdir=None,
+        with_openshell=False,
         subcommand="sandbox",
         ARGS=[],
     )


### PR DESCRIPTION
This PR is a proposal to add an option to isolate the sandbox agent (only goose for now) with OpenShell. 

This approach requires the `openshell-sandbox` to be present in the agent sandbox container - then no gateway setup is needed. The OPA file (container-images/goose-openshell/opa.rego) is a direct copy from [OpenShell sandbox-policy.rego](https://github.com/NVIDIA/OpenShell/blob/main/crates/openshell-supervisor-network/data/sandbox-policy.rego) and embedded into the sandbox container. 
The custom OpenShell policy as well as the inference configuration are temporarily created and mounted into the container. For a custom policy the `--openshell-policy` can be used.

```shell
$ podman build -f container-images/goose-openshell/Containerfile -t quay.io/ramalama/goose-openshell:latest .
$ ramalama sandbox goose --with-openshell <model>
```