### PR TITLE
only set OpenVINO env vars if the "openvino" backend is selected

### DIFF
--- a/ramalama/plugins/runtimes/inference/llama_cpp.py
+++ b/ramalama/plugins/runtimes/inference/llama_cpp.py
@@ -497,8 +497,10 @@ class LlamaCppPlugin(LlamaCppCommands, ContainerizedInferenceRuntimePlugin):
 
     @staticmethod
     def _set_openvino_env(args: argparse.Namespace) -> None:
-        """Set OpenVINO env vars when Intel GPU is detected (llama.cpp-specific)."""
+        """Set OpenVINO env vars when Intel GPU is detected and openvino backend is selected (llama.cpp-specific)."""
         if not os.environ.get("INTEL_VISIBLE_DEVICES"):
+            return
+        if getattr(args, "backend", None) != "openvino":
             return
 
         openvino_env = [

--- a/test/e2e/test_serve.py
+++ b/test/e2e/test_serve.py
@@ -221,6 +221,29 @@ def test_basic_dry_run():
             [], r".*--reasoning", None, None, False,
             id="check --reasoning not passed by default",
         ),
+        pytest.param(
+            [], "GGML_OPENVINO", None, None, False,
+            id="check OpenVINO env vars not set by default", marks=skip_if_no_container,
+        ),
+        pytest.param(
+            [], "GGML_OPENVINO", None, {"INTEL_VISIBLE_DEVICES": "1"}, False,
+            id="check OpenVINO env vars not set by default for Intel devices", marks=skip_if_no_container,
+        ),
+        pytest.param(
+            [], "GGML_OPENVINO", '[ramalama.runtimes.llama_cpp]\nbackend="openvino"\n',
+            {"INTEL_VISIBLE_DEVICES": "1"}, True,
+            id="check OpenVINO env vars are set for openvino config option", marks=skip_if_no_container,
+        ),
+        pytest.param(
+            ["--backend", "openvino"], "GGML_OPENVINO", None,
+            {"INTEL_VISIBLE_DEVICES": "1"}, True,
+            id="check OpenVINO env vars are set for openvino backend option", marks=skip_if_no_container,
+        ),
+        pytest.param(
+            ["--backend", "openvino"], "GGML_OPENVINO_DEVICE=zpu", None,
+            {"INTEL_VISIBLE_DEVICES": "1", "GGML_OPENVINO_DEVICE": "zpu"}, True,
+            id="check OpenVINO env vars can be overridden", marks=skip_if_no_container,
+        ),
     ],
 )
 # fmt: on

--- a/test/unit/test_inference_engine_plugins.py
+++ b/test/unit/test_inference_engine_plugins.py
@@ -697,6 +697,36 @@ class TestLlamaCppPlugin:
         image = self.plugin.get_container_image(config, "CUDA_VISIBLE_DEVICES")
         assert image == "custom/cuda:v1.0"
 
+    @patch.dict("os.environ", clear=True, INTEL_VISIBLE_DEVICES="1")
+    def test_intel_no_openvino(self):
+        ns = make_ns()
+        self.plugin.handle_subcommand("serve", ns)
+        assert not any("OPENVINO" in item for item in getattr(ns, "env", []))
+
+    @patch.dict("os.environ", clear=True, INTEL_VISIBLE_DEVICES="1")
+    def test_openvino_backend_env_default(self):
+        ns = make_ns()
+        ns.backend = "openvino"
+        self.plugin.handle_subcommand("serve", ns)
+        assert hasattr(ns, "env")
+        assert "GGML_OPENVINO_DEVICE=GPU" in ns.env
+        assert "GGML_OPENVINO_STATEFUL_EXECUTION=1" in ns.env
+
+    @patch.dict(
+        "os.environ",
+        clear=True,
+        INTEL_VISIBLE_DEVICES="1",
+        GGML_OPENVINO_DEVICE="fluxcapacitor",
+        GGML_OPENVINO_STATEFUL_EXECUTION="yesplease",
+    )
+    def test_openvino_backend_env_override(self):
+        ns = make_ns()
+        ns.backend = "openvino"
+        self.plugin.handle_subcommand("serve", ns)
+        assert hasattr(ns, "env")
+        assert "GGML_OPENVINO_DEVICE=fluxcapacitor" in ns.env
+        assert "GGML_OPENVINO_STATEFUL_EXECUTION=yesplease" in ns.env
+
 
 class TestVllmPlugin:
     def setup_method(self):


### PR DESCRIPTION
The env vars are unnecessary when using one of the other backends, `vulkan` (default) or `sycl`.