### PR TITLE
docs: fix ramalama-daemon man page content

### DIFF
--- a/docs/options/help.md
+++ b/docs/options/help.md
@@ -1,5 +1,5 @@
 ####> This option file is used in:
-####>   ramalama bench, ramalama perplexity, ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama sandbox pi, ramalama serve
+####>   ramalama bench, ramalama daemon run, ramalama daemon start, ramalama perplexity, ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama sandbox pi, ramalama serve
 ####> If this file is edited, make sure the changes
 ####> are applicable to all of those.
 #### **--help**, **-h**

--- a/docs/options/host.md
+++ b/docs/options/host.md
@@ -1,6 +1,8 @@
 ####> This option file is used in:
-####>   ramalama sandbox goose, ramalama sandbox opencode, ramalama sandbox pi, ramalama serve
+####>   ramalama daemon run, ramalama daemon start, ramalama sandbox goose, ramalama sandbox opencode, ramalama sandbox pi, ramalama serve
 ####> If this file is edited, make sure the changes
 ####> are applicable to all of those.
 #### **--host**="::"
-IP address for llama.cpp to listen on. Defaults to "::" (dual-stack) on systems with IPv6 support, "0.0.0.0" on IPv4-only systems.
+IP address for service to listen on. Defaults to the value from
+`ramalama.conf` (typically "::" on dual-stack systems, "0.0.0.0" on IPv4-only
+systems).

--- a/docs/options/image.md
+++ b/docs/options/image.md
@@ -1,5 +1,5 @@
 ####> This option file is used in:
-####>   ramalama bench, ramalama perplexity, ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama sandbox pi, ramalama serve
+####>   ramalama bench, ramalama daemon start, ramalama perplexity, ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama sandbox pi, ramalama serve
 ####> If this file is edited, make sure the changes
 ####> are applicable to all of those.
 #### **--image**=IMAGE

--- a/docs/options/port.md
+++ b/docs/options/port.md
@@ -1,5 +1,5 @@
 ####> This option file is used in:
-####>   ramalama sandbox goose, ramalama sandbox opencode, ramalama sandbox pi, ramalama serve
+####>   ramalama daemon run, ramalama daemon start, ramalama sandbox goose, ramalama sandbox opencode, ramalama sandbox pi, ramalama serve
 ####> If this file is edited, make sure the changes
 ####> are applicable to all of those.
 #### **--port**, **-p**

--- a/docs/options/pull.md
+++ b/docs/options/pull.md
@@ -1,5 +1,5 @@
 ####> This option file is used in:
-####>   ramalama bench, ramalama perplexity, ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama sandbox pi, ramalama serve
+####>   ramalama bench, ramalama daemon start, ramalama perplexity, ramalama run, ramalama sandbox goose, ramalama sandbox opencode, ramalama sandbox pi, ramalama serve
 ####> If this file is edited, make sure the changes
 ####> are applicable to all of those.
 #### **--pull**=*policy*

--- a/docs/ramalama-daemon-run.1.md
+++ b/docs/ramalama-daemon-run.1.md
@@ -1,0 +1,64 @@
+% ramalama-daemon-run 1
+
+## NAME
+ramalama\-daemon\-run - run the RamaLama REST daemon process
+
+## SYNOPSIS
+**ramalama daemon run** [*options*]
+
+## DESCRIPTION
+Runs the RamaLama daemon process in the foreground on the host. This is the
+command used inside the container when **ramalama daemon start** runs with a
+container engine; it can also be invoked directly for host-only deployments.
+
+The daemon listens on the configured host and port and serves management APIs
+under **/api**. See **[ramalama-daemon(1)](ramalama-daemon.1.md)** for an
+overview of the daemon.
+
+## OPTIONS
+
+
+[//]: # (BEGIN included file options/help.md)
+#### **--help**, **-h**
+Show this help message and exit
+
+[//]: # (END   included file options/help.md)
+
+
+[//]: # (BEGIN included file options/host.md)
+#### **--host**="::"
+IP address for service to listen on. Defaults to the value from
+`ramalama.conf` (typically "::" on dual-stack systems, "0.0.0.0" on IPv4-only
+systems).
+
+[//]: # (END   included file options/host.md)
+
+
+[//]: # (BEGIN included file options/port.md)
+#### **--port**, **-p**
+port for AI Model server to listen on. It must be available. If not specified,
+a free port in the 8080-8180 range is selected, starting with 8080.
+
+The default can be overridden in the `ramalama.conf` file.
+
+[//]: # (END   included file options/port.md)
+
+## EXAMPLES
+
+Run the daemon process directly on the host:
+
+```shell
+ramalama daemon run --host :: --port 8080
+```
+
+Bind the daemon to localhost only:
+
+```shell
+ramalama daemon run --host 127.0.0.1 --port 8080
+```
+
+## SEE ALSO
+**[ramalama(1)](ramalama.1.md)**, **[ramalama-daemon(1)](ramalama-daemon.1.md)**, **[ramalama-daemon-start(1)](ramalama-daemon-start.1.md)**, **[ramalama-serve(1)](ramalama-serve.1.md)**
+
+## HISTORY
+Aug 2026, Split from ramalama-daemon(1)

--- a/docs/ramalama-daemon-run.1.md.in
+++ b/docs/ramalama-daemon-run.1.md.in
@@ -1,0 +1,44 @@
+% ramalama-daemon-run 1
+
+## NAME
+ramalama\-daemon\-run - run the RamaLama REST daemon process
+
+## SYNOPSIS
+**ramalama daemon run** [*options*]
+
+## DESCRIPTION
+Runs the RamaLama daemon process in the foreground on the host. This is the
+command used inside the container when **ramalama daemon start** runs with a
+container engine; it can also be invoked directly for host-only deployments.
+
+The daemon listens on the configured host and port and serves management APIs
+under **/api**. See **[ramalama-daemon(1)](ramalama-daemon.1.md)** for an
+overview of the daemon.
+
+## OPTIONS
+
+@@option help
+
+@@option host
+
+@@option port
+
+## EXAMPLES
+
+Run the daemon process directly on the host:
+
+```shell
+ramalama daemon run --host :: --port 8080
+```
+
+Bind the daemon to localhost only:
+
+```shell
+ramalama daemon run --host 127.0.0.1 --port 8080
+```
+
+## SEE ALSO
+**[ramalama(1)](ramalama.1.md)**, **[ramalama-daemon(1)](ramalama-daemon.1.md)**, **[ramalama-daemon-start(1)](ramalama-daemon-start.1.md)**, **[ramalama-serve(1)](ramalama-serve.1.md)**
+
+## HISTORY
+Aug 2026, Split from ramalama-daemon(1)

--- a/docs/ramalama-daemon-start.1.md
+++ b/docs/ramalama-daemon-start.1.md
@@ -1,0 +1,129 @@
+% ramalama-daemon-start 1
+
+## NAME
+ramalama\-daemon\-start - prepare and start a RamaLama REST daemon
+
+## SYNOPSIS
+**ramalama daemon start** [*options*]
+
+## DESCRIPTION
+Prepares and starts a new RamaLama daemon. When containers are enabled (the
+default), **start** launches the daemon inside a container with the model store
+mounted and publishes the host port. With **--nocontainer**, **start** runs the
+daemon directly on the host by invoking **ramalama daemon run**.
+
+## OPTIONS
+
+
+[//]: # (BEGIN included file options/help.md)
+#### **--help**, **-h**
+Show this help message and exit
+
+[//]: # (END   included file options/help.md)
+
+
+[//]: # (BEGIN included file options/host.md)
+#### **--host**="::"
+IP address for service to listen on. Defaults to the value from
+`ramalama.conf` (typically "::" on dual-stack systems, "0.0.0.0" on IPv4-only
+systems).
+
+[//]: # (END   included file options/host.md)
+
+When **daemon start** runs the daemon in a container, this value is used as the host
+IP for the published port mapping (`-p [host:]port:8080`). Wildcard addresses
+(`::`, `0.0.0.0`) publish on all host interfaces. The daemon process inside the
+container listens on all interfaces.
+
+With **--nocontainer**, this value is the address the daemon binds on the host.
+
+
+[//]: # (BEGIN included file options/image.md)
+#### **--image**=IMAGE
+OCI container image to run with specified AI model. RamaLama defaults to using
+images based on the accelerator it discovers and the selected `--backend`.
+For example: `quay.io/ramalama/ramalama`. See the table below for all default images.
+The default image tag is based on the minor version of the RamaLama package.
+Version 0.23.0 of RamaLama pulls an image with a `:0.23` tag from the quay.io/ramalama OCI repository. The --image option overrides this default.
+
+The default can be overridden in the `ramalama.conf` file or via the
+RAMALAMA_IMAGE environment variable. `export RAMALAMA_IMAGE=quay.io/ramalama/aiimage:1.2` tells
+RamaLama to use the `quay.io/ramalama/aiimage:1.2` image.
+
+**Note**: The `--backend` option provides a higher-level way to select the appropriate image
+based on GPU type. Use `--backend` to select vulkan, rocm, cuda, sycl, or openvino backends, which will
+automatically choose the correct image. Use `--image` only when you need to override the image
+selection entirely.
+
+Accelerated images:
+
+| Backend / Accelerator   | Image                      |
+| ------------------------| -------------------------- |
+|  CPU, Vulkan            | quay.io/ramalama/ramalama  |
+|  ROCm (AMD)             | quay.io/ramalama/rocm      |
+|  CUDA (NVIDIA)          | quay.io/ramalama/cuda      |
+|  Intel GPU (sycl)       | quay.io/ramalama/intel-gpu |
+|  Intel GPU (openvino)   | quay.io/ramalama/openvino  |
+|  Asahi (Apple Silicon)  | quay.io/ramalama/asahi     |
+|  CANN (Ascend)          | quay.io/ramalama/cann      |
+|  MUSA (Moore Threads)   | quay.io/ramalama/musa      |
+
+Upstream llama.cpp "full" images from `ghcr.io/ggml-org/llama.cpp` are also supported.
+RamaLama automatically detects the image type and adjusts the container CLI accordingly.
+
+```
+ramalama daemon start --image ghcr.io/ggml-org/llama.cpp:full-vulkan MODEL
+```
+
+[//]: # (END   included file options/image.md)
+
+
+[//]: # (BEGIN included file options/port.md)
+#### **--port**, **-p**
+port for AI Model server to listen on. It must be available. If not specified,
+a free port in the 8080-8180 range is selected, starting with 8080.
+
+The default can be overridden in the `ramalama.conf` file.
+
+[//]: # (END   included file options/port.md)
+
+When **daemon start** runs in a container, this is the published host port mapped
+to port 8080 in the container.
+
+
+[//]: # (BEGIN included file options/pull.md)
+#### **--pull**=*policy*
+Pull image policy. The default is **missing**.
+
+- **always**: Always pull the image and throw an error if the pull fails.
+- **missing**: Only pull the image when it does not exist in the local containers storage. Throw an error if no image is found and the pull fails.
+- **never**: Never pull the image but use the one from the local containers storage. Throw an error when no image is found.
+- **newer**: Pull if the image on the registry is newer than the one in the local containers storage. An image is considered to be newer when the digests are different. Comparing the time stamps is prone to errors. Pull errors are suppressed if a local image was found.
+
+[//]: # (END   included file options/pull.md)
+
+## EXAMPLES
+
+Start the daemon in a container (default), publishing port 8080:
+
+```shell
+ramalama daemon start --port 8080
+```
+
+Start the daemon on the host without a container:
+
+```shell
+ramalama --nocontainer daemon start --host 127.0.0.1 --port 8080
+```
+
+Publish only on localhost when running in a container:
+
+```shell
+ramalama daemon start --host 127.0.0.1 --port 8080
+```
+
+## SEE ALSO
+**[ramalama(1)](ramalama.1.md)**, **[ramalama-daemon(1)](ramalama-daemon.1.md)**, **[ramalama-daemon-run(1)](ramalama-daemon-run.1.md)**, **[ramalama-serve(1)](ramalama-serve.1.md)**
+
+## HISTORY
+Aug 2026, Split from ramalama-daemon(1)

--- a/docs/ramalama-daemon-start.1.md.in
+++ b/docs/ramalama-daemon-start.1.md.in
@@ -1,0 +1,61 @@
+% ramalama-daemon-start 1
+
+## NAME
+ramalama\-daemon\-start - prepare and start a RamaLama REST daemon
+
+## SYNOPSIS
+**ramalama daemon start** [*options*]
+
+## DESCRIPTION
+Prepares and starts a new RamaLama daemon. When containers are enabled (the
+default), **start** launches the daemon inside a container with the model store
+mounted and publishes the host port. With **--nocontainer**, **start** runs the
+daemon directly on the host by invoking **ramalama daemon run**.
+
+## OPTIONS
+
+@@option help
+
+@@option host
+
+When **daemon start** runs the daemon in a container, this value is used as the host
+IP for the published port mapping (`-p [host:]port:8080`). Wildcard addresses
+(`::`, `0.0.0.0`) publish on all host interfaces. The daemon process inside the
+container listens on all interfaces.
+
+With **--nocontainer**, this value is the address the daemon binds on the host.
+
+@@option image
+
+@@option port
+
+When **daemon start** runs in a container, this is the published host port mapped
+to port 8080 in the container.
+
+@@option pull
+
+## EXAMPLES
+
+Start the daemon in a container (default), publishing port 8080:
+
+```shell
+ramalama daemon start --port 8080
+```
+
+Start the daemon on the host without a container:
+
+```shell
+ramalama --nocontainer daemon start --host 127.0.0.1 --port 8080
+```
+
+Publish only on localhost when running in a container:
+
+```shell
+ramalama daemon start --host 127.0.0.1 --port 8080
+```
+
+## SEE ALSO
+**[ramalama(1)](ramalama.1.md)**, **[ramalama-daemon(1)](ramalama-daemon.1.md)**, **[ramalama-daemon-run(1)](ramalama-daemon-run.1.md)**, **[ramalama-serve(1)](ramalama-serve.1.md)**
+
+## HISTORY
+Aug 2026, Split from ramalama-daemon(1)

--- a/docs/ramalama-daemon.1.md
+++ b/docs/ramalama-daemon.1.md
@@ -1,14 +1,20 @@
 % ramalama-daemon 1
 
 ## NAME
-ramalama\-daemon - run a RamaLama REST server
+ramalama\-daemon - manage the RamaLama REST daemon
 
 ## SYNOPSIS
-**ramalama daemon** [*options*] [start|run]
+**ramalama daemon** *command* [*options*]
 
 ## DESCRIPTION
-Inspect the specified AI Model about additional information
-like the repository, its metadata and tensor information.
+Manage the RamaLama daemon, a REST server that can start and stop AI Models on
+demand and proxy inference requests to the models it manages.
+
+Unlike **ramalama serve**, which runs a single model (or router) in the
+foreground, the daemon stays up and exposes management APIs under **/api**
+(for example listing local models, serving a model, listing running models, and
+stopping a model). Inference traffic for served models is proxied under
+paths returned by the serve API.
 
 ## OPTIONS
 
@@ -17,62 +23,14 @@ Print usage message
 
 ## COMMANDS
 
-#### **start**
-pepares to run a new RamaLama REST server so it will be run either inside a RamaLama container or on the host
-
-#### **run**
-start a new RamaLama REST server
-
-## EXAMPLES
-
-Inspect the smollm:135m model for basic information
-```
-$ ramalama inspect smollm:135m
-smollm:135m
-   Path: /var/lib/ramalama/models/ollama/smollm:135m
-   Registry: ollama
-   Format: GGUF
-   Version: 3
-   Endianness: little
-   Metadata: 39 entries
-   Tensors: 272 entries
-```
-
-Inspect the smollm:135m model for all information in json format
-```
-$ ramalama inspect smollm:135m --all --json
-{
-    "Name": "smollm:135m",
-    "Path": "/home/mengel/.local/share/ramalama/models/ollama/smollm:135m",
-    "Registry": "ollama",
-    "Format": "GGUF",
-    "Version": 3,
-    "LittleEndian": true,
-    "Metadata": {
-        "general.architecture": "llama",
-        "general.base_model.0.name": "SmolLM 135M",
-        "general.base_model.0.organization": "HuggingFaceTB",
-        "general.base_model.0.repo_url": "https://huggingface.co/HuggingFaceTB/SmolLM-135M",
-        ...
-    },
-    "Tensors": [
-        {
-            "dimensions": [
-                576,
-                49152
-            ],
-            "n_dimensions": 2,
-            "name": "token_embd.weight",
-            "offset": 0,
-            "type": 8
-        },
-        ...
-    ]
-}
-```
+| Command | Man Page                                                         | Description                                      |
+| ------- | ---------------------------------------------------------------- | ------------------------------------------------ |
+| start   | [ramalama-daemon-start(1)](ramalama-daemon-start.1.md)           | prepare and start a RamaLama REST daemon         |
+| run     | [ramalama-daemon-run(1)](ramalama-daemon-run.1.md)               | run the RamaLama REST daemon process             |
 
 ## SEE ALSO
-**[ramalama(1)](ramalama.1.md)**
+**[ramalama(1)](ramalama.1.md)**, **[ramalama-daemon-start(1)](ramalama-daemon-start.1.md)**, **[ramalama-daemon-run(1)](ramalama-daemon-run.1.md)**, **[ramalama-serve(1)](ramalama-serve.1.md)**
 
 ## HISTORY
 Feb 2025, Originally compiled by Michael Engel <mengel@redhat.com>
+Aug 2026, Split daemon start/run into separate man pages

--- a/docs/ramalama-sandbox-goose.1.md
+++ b/docs/ramalama-sandbox-goose.1.md
@@ -165,7 +165,9 @@ Show this help message and exit
 
 [//]: # (BEGIN included file options/host.md)
 #### **--host**="::"
-IP address for llama.cpp to listen on. Defaults to "::" (dual-stack) on systems with IPv6 support, "0.0.0.0" on IPv4-only systems.
+IP address for service to listen on. Defaults to the value from
+`ramalama.conf` (typically "::" on dual-stack systems, "0.0.0.0" on IPv4-only
+systems).
 
 [//]: # (END   included file options/host.md)
 

--- a/docs/ramalama-sandbox-opencode.1.md
+++ b/docs/ramalama-sandbox-opencode.1.md
@@ -158,7 +158,9 @@ Show this help message and exit
 
 [//]: # (BEGIN included file options/host.md)
 #### **--host**="::"
-IP address for llama.cpp to listen on. Defaults to "::" (dual-stack) on systems with IPv6 support, "0.0.0.0" on IPv4-only systems.
+IP address for service to listen on. Defaults to the value from
+`ramalama.conf` (typically "::" on dual-stack systems, "0.0.0.0" on IPv4-only
+systems).
 
 [//]: # (END   included file options/host.md)
 

--- a/docs/ramalama-sandbox-pi.1.md
+++ b/docs/ramalama-sandbox-pi.1.md
@@ -162,7 +162,9 @@ Show this help message and exit
 
 [//]: # (BEGIN included file options/host.md)
 #### **--host**="::"
-IP address for llama.cpp to listen on. Defaults to "::" (dual-stack) on systems with IPv6 support, "0.0.0.0" on IPv4-only systems.
+IP address for service to listen on. Defaults to the value from
+`ramalama.conf` (typically "::" on dual-stack systems, "0.0.0.0" on IPv4-only
+systems).
 
 [//]: # (END   included file options/host.md)
 

--- a/docs/ramalama-serve.1.md
+++ b/docs/ramalama-serve.1.md
@@ -214,7 +214,9 @@ Show this help message and exit
 
 [//]: # (BEGIN included file options/host.md)
 #### **--host**="::"
-IP address for llama.cpp to listen on. Defaults to "::" (dual-stack) on systems with IPv6 support, "0.0.0.0" on IPv4-only systems.
+IP address for service to listen on. Defaults to the value from
+`ramalama.conf` (typically "::" on dual-stack systems, "0.0.0.0" on IPv4-only
+systems).
 
 [//]: # (END   included file options/host.md)
 

--- a/docs/ramalama.1.md
+++ b/docs/ramalama.1.md
@@ -145,7 +145,7 @@ Show the program version and exit.
 | [ramalama-chat(1)](ramalama-chat.1.md)            |OpenAI chat with the specified REST API URL|
 | [ramalama-containers(1)](ramalama-containers.1.md)|list all RamaLama containers|
 | [ramalama-convert(1)](ramalama-convert.1.md)      |convert AI Models from local storage to OCI Image|
-| [ramalama-daemon(1)](ramalama-daemon.1.md)        |run a RamaLama REST server|
+| [ramalama-daemon(1)](ramalama-daemon.1.md)        |manage the RamaLama REST daemon|
 | [ramalama-info(1)](ramalama-info.1.md)            |display RamaLama configuration information|
 | [ramalama-inspect(1)](ramalama-inspect.1.md)      |inspect the specified AI Model|
 | [ramalama-list(1)](ramalama-list.1.md)            |list all downloaded AI Models|

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -37,7 +37,7 @@ from ramalama.config import (
 )
 from ramalama.config_types import COLOR_OPTIONS
 from ramalama.endian import EndianMismatchError
-from ramalama.host_utils import format_bind_host_for_url
+from ramalama.host_utils import format_bind_host_for_url, format_bind_host_publish_prefix
 from ramalama.log_levels import LogLevel
 from ramalama.logger import configure_logger, logger
 from ramalama.model_inspect.error import ParseError
@@ -1209,6 +1209,9 @@ def daemon_start_cli(args):
     if is_daemon_in_container:
         # If run inside a container, map the model store to the container internal directory
         daemon_model_store_dir = "/ramalama/models"
+        # Honor --host for the published host binding; the inner daemon listens on all
+        # interfaces inside the container.
+        publish = f"{format_bind_host_publish_prefix(args.host)}{args.port}:8080"
 
         daemon_cmd += [
             args.engine,
@@ -1217,7 +1220,7 @@ def daemon_start_cli(args):
             args.pull,
             "-d",
             "-p",
-            f"{args.port}:8080",
+            publish,
             "-v",
             f"{args.store}:{daemon_model_store_dir}",
             args.image,

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -264,3 +264,35 @@ def test_post_parse_setup_model_input(
     assert input_args.UNRESOLVED_MODEL == expected_unresolved
     assert input_args.MODEL == expected_resolved
     assert input_args.model == input_args.MODEL
+
+
+@pytest.mark.parametrize(
+    "host, expected_publish",
+    [
+        ("127.0.0.1", "127.0.0.1:9090:8080"),
+        ("::1", "[::1]:9090:8080"),
+        ("::", "9090:8080"),
+        ("0.0.0.0", "0.0.0.0:9090:8080"),
+    ],
+)
+@mock.patch("ramalama.cli.exec_cmd")
+@mock.patch("ramalama.cli.ActiveConfig")
+def test_daemon_start_container_publishes_host(mock_config, mock_exec, host, expected_publish):
+    mock_config.return_value.host = "::"
+    args = Namespace(
+        container=True,
+        engine="podman",
+        store="/tmp/models",
+        pull="newer",
+        port="9090",
+        image="quay.io/ramalama/ramalama:latest",
+        host=host,
+    )
+
+    from ramalama.cli import daemon_start_cli
+
+    daemon_start_cli(args)
+
+    cmd = mock_exec.call_args.args[0]
+    assert cmd[cmd.index("-p") + 1] == expected_publish
+    assert cmd[cmd.index("--host") + 1] == "::"


### PR DESCRIPTION
Replace inspect-copied Description/Examples with daemon-specific text, document start/run options, and fix the "pepares" typo.

Fixes #2880