### PR TITLE
add ffmpeg as a runtime dependency for all container images

### DIFF
--- a/container-images/cann/Containerfile
+++ b/container-images/cann/Containerfile
@@ -10,6 +10,7 @@ WORKDIR /src/
 RUN ./build_llama.sh cann
 
 FROM quay.io/ascend/${ASCEND_VERSION}
+RUN dnf install -y --setopt=install_weak_deps=false ffmpeg && dnf -y clean all
 RUN --mount=type=bind,from=builder,source=/tmp/install,target=/tmp/install,relabel=private \
     cp -a /tmp/install/bin/ /usr/ && \
     cp -a /tmp/install/lib64/*.so* /usr/lib64/

--- a/container-images/musa/Containerfile
+++ b/container-images/musa/Containerfile
@@ -16,7 +16,7 @@ FROM docker.io/mthreads/musa:${VERSION}-runtime-ubuntu${UBUNTU_VERSION}-amd64
 COPY --from=builder /tmp/install /usr
 # pip install . --prefix=/tmp/install will install the wheel in /tmp/install/local/...
 
-RUN apt-get update && apt-get install -y python-is-python3 && apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends python-is-python3 ffmpeg && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 ENTRYPOINT []

--- a/container-images/scripts/build_llama.sh
+++ b/container-images/scripts/build_llama.sh
@@ -123,7 +123,19 @@ dnf_install() {
 }
 
 dnf_install_runtime_deps() {
-  local runtime_pkgs=()
+  # ffmpeg-free disables patent-encumbered decoders (h264, hevc) and loads
+  # Cisco's openh264 via dlopen; install_weak_deps=false skips it, so pull
+  # it in explicitly. openEuler ships full ffmpeg with decoders built in.
+  local runtime_pkgs=("ffmpeg-free" "openh264")
+  if [ "${ID}" = "openEuler" ]; then
+    runtime_pkgs=("ffmpeg")
+  fi
+  if is_rhel_based; then
+    dnf_install_epel
+    add_stream_repo "BaseOS"
+    add_stream_repo "AppStream"
+    add_stream_repo "CRB"
+  fi
   if [ "$containerfile" = "ramalama" ]; then
     # install python3 in the ramalama container to support a non-standard use-case
     runtime_pkgs+=(python3 python3-pip)
@@ -169,6 +181,7 @@ dnf_install_runtime_deps() {
   if [ ${#runtime_pkgs[@]} -gt 0 ]; then
     dnf install -y --setopt=install_weak_deps=false "${runtime_pkgs[@]}"
   fi
+  is_rhel_based && rm_non_ubi_repos
   dnf -y clean all
 }
 


### PR DESCRIPTION
ffmpeg is needed to decode user input video to raw rgb24 frames.
Installs ffmpeg-free on Fedora and UBI9 (via EPEL + CentOS Stream repos), and ffmpeg on openEuler (cann) and Ubuntu (musa).

Fixes: #2867