### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1266,11 +1266,11 @@ This project wouldn't be possible without the help of other projects like:
 
 so if you like this tool, give some of these repos a :star:, and hey, give us a :star: too while you are at it.
 
-<a href="https://www.star-history.com/#containers/ramalama&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#containers/ramalama&type=date&legend=top-left">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=containers/ramalama&type=date&theme=dark&legend=top-left" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=containers/ramalama&type=date&legend=top-left" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=containers/ramalama&type=date&legend=top-left" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=containers/ramalama&type=date&theme=dark&legend=top-left" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=containers/ramalama&type=date&legend=top-left" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=containers/ramalama&type=date&legend=top-left" />
   </picture>
 </a>
 


### PR DESCRIPTION
The star history chart shown in the README is broken because of GitHub stargazer API restrictions. This PR updates the chart links to star-history.dera.page, which uses an alternative data source that requires no API token, so the chart renders correctly again.