### PR TITLE
Fix engine-args in router-mode

### DIFF
--- a/ramalama/plugins/runtimes/inference/llama_cpp.py
+++ b/ramalama/plugins/runtimes/inference/llama_cpp.py
@@ -580,7 +580,7 @@ class LlamaCppPlugin(LlamaCppCommands, ContainerizedInferenceRuntimePlugin):
             container_host_path = get_container_mount_path(host_path)
             engine.add([f"--mount=type=bind,src={container_host_path},destination={mount_path},ro{engine.relabel()}"])
 
-        engine.add([args.image] + cmd)
+        engine.add_container_image(args.image, cmd)
         return engine
 
     def _serve_router(self, args: argparse.Namespace) -> None:

--- a/test/unit/test_router_mode.py
+++ b/test/unit/test_router_mode.py
@@ -123,6 +123,25 @@ class TestServeRouter:
         with pytest.raises(SystemExit):
             self.plugin._serve_router(args)
 
+    @patch("ramalama.plugins.runtimes.inference.llama_cpp.enumerate_store_gguf_models", return_value=[("a", "model")])
+    @patch.object(LlamaCppPlugin, "_migrate_store_ref_files")
+    @patch("ramalama.plugins.runtimes.inference.llama_cpp_commands.should_colorize", return_value=False)
+    def test_engine_args_get_applied(self, mock_colorize, mock_migrate, mock_enum):
+        args = argparse.Namespace(
+            container=True,
+            store="/fake/store",
+            MODEL=[],
+            engine_args=["--volume", "./presets.ini:/config/presets.ini"],
+            dryrun=True,
+            engine='podman',
+            image="quay.io/ramalama/rocm",
+        )
+        engine = self.plugin._build_router_engine(args)
+
+        volume_index = engine.exec_args.index("--volume")
+        assert engine.exec_args[volume_index + 1] == "./presets.ini:/config/presets.ini"
+        assert volume_index < engine.exec_args.index(args.image)
+
 
 # ---------------------------------------------------------------------------
 # service_ready_check router mode


### PR DESCRIPTION
This PR allows to set engine-args when using router-mode, i.e. none or many models with serve and sandbox command.

Use case: setup a presets.ini and use it in router-mode, for this you need to mount a volume (engine-args) and add a runtime-args for the presets file