### PR TITLE
gguf_inspect: support NVFP4 format

### DIFF
--- a/ramalama/model_inspect/gguf_parser.py
+++ b/ramalama/model_inspect/gguf_parser.py
@@ -54,6 +54,9 @@ class GGML_TYPE(IntEnum):
     # GGML_TYPE_IQ4_NL_4_8 = 37,
     # GGML_TYPE_IQ4_NL_8_8 = 38,
     GGML_TYPE_MXFP4 = (39,)  # MXFP4 (1 block)
+    GGML_TYPE_NVFP4 = (40,)
+    GGML_TYPE_Q1_0 = (41,)
+    GGML_TYPE_Q2_0 = (42,)
 
 
 # Based on gguf_metadata_value_type in


### PR DESCRIPTION
When pulling a model in the NVFP4 format, it fails with: "Error:
Failed to pull model: 40 is not a valid GGML_TYPE".

It is registered in gguf-py as:
https://github.com/ggml-org/llama.cpp/blob/7077abbe14c510cb829c93a1328c2815b5805ebd/gguf-py/gguf/constants.py#L5293