### PR TITLE
ci: work around hanging Azure apt mirror

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,9 @@ jobs:
       # is unreliable. The distro package is sufficient.
       - name: Install go-md2man
         run: |
+          # The Azure apt mirror on GitHub runners intermittently hangs; use
+          # the canonical Ubuntu archive instead.
+          sudo sed -i 's|azure.archive.ubuntu.com|archive.ubuntu.com|g' /etc/apt/apt-mirrors.txt
           sudo apt-get update
           sudo apt-get install -y go-md2man
 
@@ -144,6 +147,9 @@ jobs:
            sudo mkdir -m o=rwx -p /home/runner/.local
            sudo chown runner:runner /mnt/runner /home/runner/.local
            sudo mount --bind /mnt/runner /home/runner/.local
+           # The Azure apt mirror on GitHub runners intermittently hangs; use
+           # the canonical Ubuntu archive instead.
+           sudo sed -i 's|azure.archive.ubuntu.com|archive.ubuntu.com|g' /etc/apt/apt-mirrors.txt
            sudo apt-get update
            sudo apt-get install podman bash codespell
            uv tool install tox --with tox-uv
@@ -214,6 +220,9 @@ jobs:
         shell: bash
         run: |
           df -h
+          # The Azure apt mirror on GitHub runners intermittently hangs; use
+          # the canonical Ubuntu archive instead.
+          sudo sed -i 's|azure.archive.ubuntu.com|archive.ubuntu.com|g' /etc/apt/apt-mirrors.txt
           sudo apt-get update
           sudo apt-get install podman bash codespell git cmake libcurl4-openssl-dev
           sudo ./container-images/scripts/build_llama.sh
@@ -286,6 +295,9 @@ jobs:
       - name: install requirements
         shell: bash
         run: |
+           # The Azure apt mirror on GitHub runners intermittently hangs; use
+           # the canonical Ubuntu archive instead.
+           sudo sed -i 's|azure.archive.ubuntu.com|archive.ubuntu.com|g' /etc/apt/apt-mirrors.txt
            sudo apt-get update
            sudo apt-get install bash codespell
            uv tool install tox --with tox-uv

--- a/.github/workflows/install_ramalama.yml
+++ b/.github/workflows/install_ramalama.yml
@@ -30,6 +30,9 @@ jobs:
         timeout-minutes: 20
         if: matrix.os == 'ubuntu-latest'
         run: |
+          # The Azure apt mirror on GitHub runners intermittently hangs; use
+          # the canonical Ubuntu archive instead.
+          sudo sed -i 's|azure.archive.ubuntu.com|archive.ubuntu.com|g' /etc/apt/apt-mirrors.txt
           sudo apt-get install -y lshw curl
 
       - name: Set Up Dependencies (macOS)


### PR DESCRIPTION
GitHub-hosted Ubuntu runners default to azure.archive.ubuntu.com in /etc/apt/apt-mirrors.txt, which intermittently hangs. Replace it with the canonical archive.ubuntu.com before the first apt use in each Linux job so apt keeps a working mirror.

Assisted-by: Claude Opus 4.8 <noreply@anthropic.com>