### PR TITLE
Fix RAG proxy streaming content-type

### DIFF
--- a/container-images/scripts/rag_framework
+++ b/container-images/scripts/rag_framework
@@ -338,7 +338,7 @@ class RagService:
 
         return StreamingResponse(
             generate(),
-            media_type="text/plain",
+            media_type="text/event-stream",
             headers={"Cache-Control": "no-cache", "Connection": "keep-alive"},
         )
 


### PR DESCRIPTION
Fixes #2837

The RAG proxy's streaming chat completion response was sent with `content-type: text/plain` instead of `text/event-stream`, breaking strict OpenAI clients like Open WebUI. The SSE framing itself was already correct — just the header was wrong. One-line fix in `container-images/scripts/rag_framework`.