### PR TITLE
openvino: bump OpenVINO to 2026.2.1 to match llama.cpp v0.1.2

### DIFF
--- a/.tekton/openvino/openvino-pull-request.yaml
+++ b/.tekton/openvino/openvino-pull-request.yaml
@@ -11,6 +11,8 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: >-
       event == "pull_request" && target_branch == "main" && body.action != "ready_for_review" &&
       (
+        "container-images/scripts/build_llama.sh".pathChanged() ||
+        "container-images/scripts/lib.sh".pathChanged() ||
         "container-images/openvino/*".pathChanged() ||
         ".tekton/pipelines/pull-request-pipeline.yaml".pathChanged() ||
         ".tekton/openvino/openvino-pull-request.yaml".pathChanged()

--- a/container-images/openvino/Containerfile
+++ b/container-images/openvino/Containerfile
@@ -12,8 +12,8 @@
 # The upstream llama.cpp OpenVINO Dockerfile installs OpenVINO the same way:
 # download tarball, extract to /opt/intel/openvino, source setupvars.sh.
 
-ARG OPENVINO_VERSION_MAJOR=2026.0
-ARG OPENVINO_VERSION_FULL=2026.0.0.20965.c6d6a13a886
+ARG OPENVINO_VERSION_MAJOR=2026.2.1
+ARG OPENVINO_VERSION_FULL=2026.2.1.21919.ede283a88e3
 
 FROM quay.io/fedora/fedora:44 AS builder
 


### PR DESCRIPTION
The llama.cpp OpenVINO backend at v0.1.2 uses the GatherMatmul and GatedDeltaNet internal ops, which are only available in OpenVINO 2026.2.1. Building against 2026.0.0 fails at link time with undefined references to these symbols. Bump to the same OpenVINO version pinned by the upstream llama.cpp.