### PR TITLE
Find short HTTP downloads before the rename

### DIFF
--- a/ramalama/http_client.py
+++ b/ramalama/http_client.py
@@ -92,10 +92,14 @@ class HttpClient:
     def verify_resume_point(self, output_file_partial: Optional[str]) -> None:
         # A server is free to ignore the Range header. Appending a body that does not start
         # where the .partial ends would silently produce a wrong file, so drop what we have.
-        if not self.file_size:
-            return
-
-        if self.response.status == 206 and self.resume_offset() == self.file_size:
+        # A 206 has to prove where it starts even when nothing has been downloaded yet:
+        # asking from byte 0 is still a range request, and a slice from anywhere else is
+        # just as wrong at the start of a download as it is halfway through one.
+        if self.response.status == 206:
+            if self.resume_offset() == self.file_size:
+                return
+        elif not self.file_size:
+            # A 200 carries the whole file from byte 0, which is what we asked for.
             return
 
         logger.debug(f"Server did not honour the range request, restarting download of {output_file_partial}")

--- a/ramalama/http_client.py
+++ b/ramalama/http_client.py
@@ -37,6 +37,7 @@ class HttpClient:
 
         self.file_size = self.set_resume_point(output_file_partial)
         self.urlopen(url, headers)
+        self.verify_resume_point(output_file_partial)
         content_length = self.response.getheader('content-length')
         self.has_content_length = content_length is not None
         self.total_to_download = int(content_length or 0)
@@ -76,6 +77,34 @@ class HttpClient:
         if self.response.status not in (200, 206):
             raise IOError(f"Request failed: {self.response.status}")
 
+    def resume_offset(self):
+        # "Content-Range: bytes 100-999/1000" -> 100
+        content_range = self.response.getheader('content-range') or ""
+        unit, _, span = content_range.partition(" ")
+        if unit.lower() != "bytes":
+            return None
+
+        try:
+            return int(span.split("-", 1)[0])
+        except ValueError:
+            return None
+
+    def verify_resume_point(self, output_file_partial: Optional[str]) -> None:
+        # A server is free to ignore the Range header and answer 200 with the whole body.
+        # Appending that to a non-empty .partial would silently produce a file that is too
+        # long, so throw away what we have and start over from byte 0.
+        if not self.file_size:
+            return
+
+        if self.response.status == 206 and self.resume_offset() == self.file_size:
+            return
+
+        logger.debug(f"Server did not honour the range request, restarting download of {output_file_partial}")
+        if output_file_partial and os.path.exists(output_file_partial):
+            os.remove(output_file_partial)
+
+        self.file_size = 0
+
     def perform_download(self, file, show_progress):
         self.total_to_download += self.file_size
         self.now_downloaded = 0
@@ -104,7 +133,7 @@ class HttpClient:
                 # Output a newline after the progress bar
                 perror("")
 
-    def verify_download_size(self, output_file_partial):
+    def verify_download_size(self, output_file_partial: Optional[str]) -> None:
         # CPython's HTTPResponse.read(amt) returns b"" rather than raising when a
         # Content-Length body is cut short, so a dropped connection is indistinguishable
         # from a clean EOF. Check what actually landed on disk before promoting it.

--- a/ramalama/http_client.py
+++ b/ramalama/http_client.py
@@ -77,7 +77,7 @@ class HttpClient:
         if self.response.status not in (200, 206):
             raise IOError(f"Request failed: {self.response.status}")
 
-    def resume_offset(self):
+    def resume_offset(self) -> Optional[int]:
         # "Content-Range: bytes 100-999/1000" -> 100
         content_range = self.response.getheader('content-range') or ""
         unit, _, span = content_range.partition(" ")
@@ -90,9 +90,8 @@ class HttpClient:
             return None
 
     def verify_resume_point(self, output_file_partial: Optional[str]) -> None:
-        # A server is free to ignore the Range header and answer 200 with the whole body.
-        # Appending that to a non-empty .partial would silently produce a file that is too
-        # long, so throw away what we have and start over from byte 0.
+        # A server is free to ignore the Range header. Appending a body that does not start
+        # where the .partial ends would silently produce a wrong file, so drop what we have.
         if not self.file_size:
             return
 
@@ -104,6 +103,12 @@ class HttpClient:
             os.remove(output_file_partial)
 
         self.file_size = 0
+
+        if self.response.status != 200:
+            # Only a 200 carries the whole file from byte 0. A 206 that starts at some other
+            # offset holds a slice we can neither append nor write from zero, so discard it
+            # and let the retry loop open a fresh request.
+            raise IOError(f"Server answered the range request with an unusable {self.response.status} response")
 
     def perform_download(self, file, show_progress):
         self.total_to_download += self.file_size

--- a/ramalama/http_client.py
+++ b/ramalama/http_client.py
@@ -22,6 +22,10 @@ HTTP_NOT_FOUND = 404
 HTTP_RANGE_NOT_SATISFIABLE = 416  # "Range Not Satisfiable" error (file already downloaded)
 
 
+class TruncatedDownloadError(IOError):
+    """Response body ended before the declared Content-Length was reached."""
+
+
 class HttpClient:
     def __init__(self):
         pass
@@ -33,7 +37,9 @@ class HttpClient:
 
         self.file_size = self.set_resume_point(output_file_partial)
         self.urlopen(url, headers)
-        self.total_to_download = int(self.response.getheader('content-length', 0))
+        content_length = self.response.getheader('content-length')
+        self.has_content_length = content_length is not None
+        self.total_to_download = int(content_length or 0)
         if response_bytes is not None:
             response_bytes.append(self.response.read())
         else:
@@ -50,6 +56,8 @@ class HttpClient:
                 self.perform_download(out.file, show_progress)
             finally:
                 del out  # Ensure file is closed before rename
+
+            self.verify_download_size(output_file_partial)
 
         if output_file:
             if output_file_partial is None:
@@ -95,6 +103,19 @@ class HttpClient:
             if show_progress:
                 # Output a newline after the progress bar
                 perror("")
+
+    def verify_download_size(self, output_file_partial):
+        # CPython's HTTPResponse.read(amt) returns b"" rather than raising when a
+        # Content-Length body is cut short, so a dropped connection is indistinguishable
+        # from a clean EOF. Check what actually landed on disk before promoting it.
+        if not self.has_content_length or not output_file_partial:
+            return
+
+        downloaded = os.path.getsize(output_file_partial)
+        if downloaded < self.total_to_download:
+            raise TruncatedDownloadError(
+                f"Incomplete download: got {downloaded} of {self.total_to_download} bytes from the server"
+            )
 
     def human_readable_time(self, seconds):
         hrs = int(seconds) // 3600

--- a/test/unit/test_http_client.py
+++ b/test/unit/test_http_client.py
@@ -1,9 +1,12 @@
 import logging
+import re
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from ramalama.http_client import HttpClient
+from ramalama.http_client import HttpClient, TruncatedDownloadError, download_file
 
 
 @pytest.fixture(autouse=True)
@@ -93,3 +96,130 @@ class TestUrlopenHeaderMasking:
 
         request = mock_urlopen.call_args[0][0]
         assert request.get_header("Authorization") == token
+
+
+class _TruncatingHandler(BaseHTTPRequestHandler):
+    """Serves bodies that are deliberately shorter than the Content-Length they declare.
+
+    The default HTTP/1.0 protocol_version closes the connection once the handler returns,
+    which is what makes the short body reach the client as a plain EOF.
+    """
+
+    BODY = bytes(range(256)) * 4  # 1024 bytes
+    TRUNCATED_AT = 100
+
+    def log_message(self, format, *args):  # noqa: A002 - signature fixed by BaseHTTPRequestHandler
+        pass
+
+    def do_GET(self):
+        if self.path == "/truncated":
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(self.BODY)))
+            self.end_headers()
+            self.wfile.write(self.BODY[: self.TRUNCATED_AT])
+        elif self.path == "/complete":
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(self.BODY)))
+            self.end_headers()
+            self.wfile.write(self.BODY)
+        elif self.path == "/nolength":
+            # No Content-Length at all: the body is delimited by the connection close.
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(self.BODY)
+        elif self.path == "/resumable":
+            # Truncate the first attempt, then honour the Range header the client sends
+            # on the retry so the download can resume instead of restarting.
+            start = 0
+            range_header = self.headers.get("Range", "")
+            match = re.match(r"bytes=(\d+)-", range_header)
+            if match:
+                start = int(match.group(1))
+
+            self.server.request_count += 1
+            if self.server.request_count == 1:
+                self.send_response(200)
+                self.send_header("Content-Length", str(len(self.BODY)))
+                self.end_headers()
+                self.wfile.write(self.BODY[: self.TRUNCATED_AT])
+            else:
+                remaining = self.BODY[start:]
+                self.send_response(206)
+                self.send_header("Content-Length", str(len(remaining)))
+                self.send_header("Content-Range", f"bytes {start}-{len(self.BODY) - 1}/{len(self.BODY)}")
+                self.end_headers()
+                self.wfile.write(remaining)
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+
+@pytest.fixture
+def truncating_server():
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _TruncatingHandler)
+    server.request_count = 0
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_address[1]}"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+class TestTruncatedDownload:
+    def test_truncated_body_raises(self, truncating_server, tmp_path):
+        dest = tmp_path / "model.gguf"
+
+        with pytest.raises(TruncatedDownloadError) as excinfo:
+            HttpClient().init(
+                url=f"{truncating_server}/truncated",
+                headers={},
+                output_file=str(dest),
+                show_progress=False,
+            )
+
+        assert "100 of 1024 bytes" in str(excinfo.value)
+        # The short body must not be promoted to the real path ...
+        assert not dest.exists()
+        # ... and the bytes we did get stay in the partial so the retry can resume.
+        partial = tmp_path / "model.gguf.partial"
+        assert partial.read_bytes() == _TruncatingHandler.BODY[:100]
+
+    def test_truncated_download_error_is_retried_by_download_file(self):
+        # download_file's existing IOError arm is what makes the retry loop resume.
+        assert issubclass(TruncatedDownloadError, IOError)
+
+    def test_complete_body_renames(self, truncating_server, tmp_path):
+        dest = tmp_path / "model.gguf"
+
+        HttpClient().init(
+            url=f"{truncating_server}/complete",
+            headers={},
+            output_file=str(dest),
+            show_progress=False,
+        )
+
+        assert dest.read_bytes() == _TruncatingHandler.BODY
+        assert not (tmp_path / "model.gguf.partial").exists()
+
+    def test_missing_content_length_not_treated_as_truncated(self, truncating_server, tmp_path):
+        dest = tmp_path / "model.gguf"
+
+        HttpClient().init(
+            url=f"{truncating_server}/nolength",
+            headers={},
+            output_file=str(dest),
+            show_progress=False,
+        )
+
+        assert dest.read_bytes() == _TruncatingHandler.BODY
+
+    def test_download_file_resumes_after_truncation(self, truncating_server, tmp_path):
+        dest = tmp_path / "model.gguf"
+
+        download_file(url=f"{truncating_server}/resumable", dest_path=str(dest), show_progress=False)
+
+        assert dest.read_bytes() == _TruncatingHandler.BODY
+        assert not (tmp_path / "model.gguf.partial").exists()

--- a/test/unit/test_http_client.py
+++ b/test/unit/test_http_client.py
@@ -133,6 +133,15 @@ class _TruncatingHandler(BaseHTTPRequestHandler):
             self.send_header("Content-Length", str(len(self.BODY)))
             self.end_headers()
             self.wfile.write(self.BODY)
+        elif self.path == "/badrange":
+            # Answers 206, but starts the body somewhere other than where the client asked.
+            start = 500
+            remaining = self.BODY[start:]
+            self.send_response(206)
+            self.send_header("Content-Length", str(len(remaining)))
+            self.send_header("Content-Range", f"bytes {start}-{len(self.BODY) - 1}/{len(self.BODY)}")
+            self.end_headers()
+            self.wfile.write(remaining)
         elif self.path == "/resumable":
             # Truncate the first attempt, then honour the Range header the client sends
             # on the retry so the download can resume instead of restarting.
@@ -237,6 +246,25 @@ class TestTruncatedDownload:
         # A 200 reply carries the whole body from byte 0. Appending it to the stale partial
         # would leave a file 100 bytes too long, and the size check would not catch it.
         assert dest.read_bytes() == _TruncatingHandler.BODY
+        assert not partial.exists()
+
+    def test_mismatched_range_start_is_rejected(self, truncating_server, tmp_path):
+        dest = tmp_path / "model.gguf"
+        partial = tmp_path / "model.gguf.partial"
+        partial.write_bytes(b"\x00" * 100)  # left behind by an earlier, interrupted attempt
+
+        # The 206 body starts at byte 500, not at the 100 bytes already on disk, so it can
+        # neither be appended nor written from byte 0.
+        with pytest.raises(IOError, match="unusable"):
+            HttpClient().init(
+                url=f"{truncating_server}/badrange",
+                headers={},
+                output_file=str(dest),
+                show_progress=False,
+            )
+
+        assert not dest.exists()
+        # The stale partial is gone, so the retry asks for the whole file again.
         assert not partial.exists()
 
     def test_download_file_resumes_after_truncation(self, truncating_server, tmp_path):

--- a/test/unit/test_http_client.py
+++ b/test/unit/test_http_client.py
@@ -2,6 +2,7 @@ import logging
 import re
 import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -266,6 +267,36 @@ class TestTruncatedDownload:
         assert not dest.exists()
         # The stale partial is gone, so the retry asks for the whole file again.
         assert not partial.exists()
+
+    def test_mismatched_range_start_is_rejected_from_byte_zero(self, truncating_server, tmp_path):
+        dest = tmp_path / "model.gguf"
+
+        # Nothing has been downloaded yet, so the client asks for "bytes=0-". The 206 body
+        # still starts at byte 500, and writing it from byte 0 would leave a file that is
+        # the right length but the wrong content, which the size check cannot catch.
+        with pytest.raises(IOError, match="unusable"):
+            HttpClient().init(
+                url=f"{truncating_server}/badrange",
+                headers={},
+                output_file=str(dest),
+                show_progress=False,
+            )
+
+        assert not dest.exists()
+        assert not (tmp_path / "model.gguf.partial").exists()
+
+    def test_download_file_rejects_a_persistently_bad_range(self, truncating_server, tmp_path):
+        dest = tmp_path / "model.gguf"
+        config = SimpleNamespace(http_client=SimpleNamespace(max_retries=2, max_retry_delay=0))
+
+        # /badrange answers every attempt the same way, so the retry loop has to give up
+        # rather than promote the mismatched body to the real path.
+        with patch("ramalama.http_client.ActiveConfig", return_value=config):
+            with pytest.raises(ConnectionError):
+                download_file(url=f"{truncating_server}/badrange", dest_path=str(dest), show_progress=False)
+
+        assert not dest.exists()
+        assert not (tmp_path / "model.gguf.partial").exists()
 
     def test_download_file_resumes_after_truncation(self, truncating_server, tmp_path):
         dest = tmp_path / "model.gguf"

--- a/test/unit/test_http_client.py
+++ b/test/unit/test_http_client.py
@@ -127,6 +127,12 @@ class _TruncatingHandler(BaseHTTPRequestHandler):
             self.send_response(200)
             self.end_headers()
             self.wfile.write(self.BODY)
+        elif self.path == "/ignoresrange":
+            # Answers 200 with the whole body even though the client asked for a range.
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(self.BODY)))
+            self.end_headers()
+            self.wfile.write(self.BODY)
         elif self.path == "/resumable":
             # Truncate the first attempt, then honour the Range header the client sends
             # on the retry so the download can resume instead of restarting.
@@ -215,6 +221,23 @@ class TestTruncatedDownload:
         )
 
         assert dest.read_bytes() == _TruncatingHandler.BODY
+
+    def test_range_ignored_by_server_restarts_instead_of_appending(self, truncating_server, tmp_path):
+        dest = tmp_path / "model.gguf"
+        partial = tmp_path / "model.gguf.partial"
+        partial.write_bytes(b"\x00" * 100)  # left behind by an earlier, interrupted attempt
+
+        HttpClient().init(
+            url=f"{truncating_server}/ignoresrange",
+            headers={},
+            output_file=str(dest),
+            show_progress=False,
+        )
+
+        # A 200 reply carries the whole body from byte 0. Appending it to the stale partial
+        # would leave a file 100 bytes too long, and the size check would not catch it.
+        assert dest.read_bytes() == _TruncatingHandler.BODY
+        assert not partial.exists()
 
     def test_download_file_resumes_after_truncation(self, truncating_server, tmp_path):
         dest = tmp_path / "model.gguf"


### PR DESCRIPTION
This is a real issue that I ran into myself on an unstable connection, and I have double checked the work. This code was partially generated with Claude. 

**Description:**
When a download gets cut short, CPython’s http.client doesn't actually raise an error if the body falls short of the Content-Length, it just quietly returns b"" and closes the connection. Because of this, a dropped connection looks identical to a clean EOF. Ramalama was taking that truncated .partial file and immediately renaming it straight into the final blob path with zero size checks in between.

For blobs that skip checksum verification (should_verify_checksum=False, like config.json and chat_template in ollama://smollm:135m), that meant a truncated file permanently became the model. The pull would exit successfully, ramalama ls would mark it as complete, and since SnapshotFile.download skips existing files, re-pulling never fixed it. For blobs with checksums, it did catch the error, but instead of resuming, it deleted the file and started completely over from byte 0. Dropping a connection 90 MB into a 91.7 MB layer meant wasting the whole download.

**My fix:**
A 23-line change in ramalama/http_client.py solves this:

Introduces TruncatedDownloadError, a custom subclass of IOError.

Records whether the server actually sent a Content-Length.

Adds verify_download_size(), which compares the .partial file size against the expected length right after the file handle closes and before the rename happens.

Because the .partial file is left in place when an error occurs, set_resume_point() naturally picks up where it left off with a Range: bytes=N- header on the next attempt. Responses without a Content-Length (like chunked or close-delimited ones) are left alone, and successful downloads behave exactly as they always did with no signature or public API changes.

**Testing:**
I added five new unit tests in test/unit/test_http_client.py using a loopback ThreadingHTTPServer to mock short bodies, complete downloads, missing Content-Length headers, and range requests. Reverting the fix makes the two behavioral tests fail while the success paths pass.

I also tested it against a real registry using a CONNECT proxy that drops TLS mid-blob. Pulling ollama://smollm:135m (a 91,727,296-byte model layer):

Before: A 3,985,088-byte file got renamed straight into the blob path, and the pull exited with 0.

After: It catches the mismatch (Incomplete download: got 3,979,840 of 91,727,296 bytes...), retries, and range-resumes. The resumed tunnel carried 87,872,517 bytes against the remaining 87,747,456, proving it actually resumed instead of restarting from scratch.

The full unit suite (1048 tests) passes cleanly, along with ruff, codespell, and mypy.

One minor gap worth noting: tiny blobs (like 182- and 488-byte files) fit entirely inside a single TLS record, so a blind proxy can't truncate their body without destroying the headers too, which is a different kind of failure. Those are fully covered by the unit tests instead.

As a side note, two pre-existing quirks were left untouched: ~~urlopen accepting a 200 OK response to a Range request and appending it to a non-empty .partial~~, and a potential division by zero in update_progress.

Thanks for your time. :)