### PR TITLE
serve: bind to loopback by default

### DIFF
--- a/docs/options/host.md
+++ b/docs/options/host.md
@@ -2,5 +2,8 @@
 ####>   ramalama sandbox goose, ramalama sandbox opencode, ramalama sandbox pi, ramalama serve
 ####> If this file is edited, make sure the changes
 ####> are applicable to all of those.
-#### **--host**="::"
-IP address for llama.cpp to listen on. Defaults to "::" (dual-stack) on systems with IPv6 support, "0.0.0.0" on IPv4-only systems.
+#### **--host**="127.0.0.1"
+IP address for the model server to listen on. Defaults to "127.0.0.1", so the
+served model is only reachable from the local machine. To expose it on the
+network, set this to a wildcard address such as "0.0.0.0" (IPv4) or "::"
+(dual-stack).

--- a/docs/options/url.md
+++ b/docs/options/url.md
@@ -3,4 +3,13 @@
 ####> If this file is edited, make sure the changes
 ####> are applicable to all of those.
 #### **--url**=URL
-The host to send requests to (default: http://localhost:8080)
+The host to send requests to (default: http://localhost:8080).
+
+When the URL points at localhost (the host's loopback, e.g. a `ramalama serve`
+container or any local OpenAI-compatible process), the agent container is wired to
+reach that loopback server without requiring it to be exposed on a
+container-reachable interface. On native Linux the agent shares the host network
+namespace and reaches the server directly as localhost. On VM-backed engines
+(podman machine / Docker Desktop on macOS and Windows) the localhost host is
+rewritten to `host.containers.internal` / `host.docker.internal`, which the VM's
+proxy forwards to the host's loopback.

--- a/docs/ramalama-sandbox-goose.1.md
+++ b/docs/ramalama-sandbox-goose.1.md
@@ -164,8 +164,11 @@ Show this help message and exit
 
 
 [//]: # (BEGIN included file options/host.md)
-#### **--host**="::"
-IP address for llama.cpp to listen on. Defaults to "::" (dual-stack) on systems with IPv6 support, "0.0.0.0" on IPv4-only systems.
+#### **--host**="127.0.0.1"
+IP address for the model server to listen on. Defaults to "127.0.0.1", so the
+served model is only reachable from the local machine. To expose it on the
+network, set this to a wildcard address such as "0.0.0.0" (IPv4) or "::"
+(dual-stack).
 
 [//]: # (END   included file options/host.md)
 
@@ -445,7 +448,16 @@ Require HTTPS and verify certificates when contacting OCI registries
 
 [//]: # (BEGIN included file options/url.md)
 #### **--url**=URL
-The host to send requests to (default: http://localhost:8080)
+The host to send requests to (default: http://localhost:8080).
+
+When the URL points at localhost (the host's loopback, e.g. a `ramalama serve`
+container or any local OpenAI-compatible process), the agent container is wired to
+reach that loopback server without requiring it to be exposed on a
+container-reachable interface. On native Linux the agent shares the host network
+namespace and reaches the server directly as localhost. On VM-backed engines
+(podman machine / Docker Desktop on macOS and Windows) the localhost host is
+rewritten to `host.containers.internal` / `host.docker.internal`, which the VM's
+proxy forwards to the host's loopback.
 
 [//]: # (END   included file options/url.md)
 

--- a/docs/ramalama-sandbox-opencode.1.md
+++ b/docs/ramalama-sandbox-opencode.1.md
@@ -157,8 +157,11 @@ Show this help message and exit
 
 
 [//]: # (BEGIN included file options/host.md)
-#### **--host**="::"
-IP address for llama.cpp to listen on. Defaults to "::" (dual-stack) on systems with IPv6 support, "0.0.0.0" on IPv4-only systems.
+#### **--host**="127.0.0.1"
+IP address for the model server to listen on. Defaults to "127.0.0.1", so the
+served model is only reachable from the local machine. To expose it on the
+network, set this to a wildcard address such as "0.0.0.0" (IPv4) or "::"
+(dual-stack).
 
 [//]: # (END   included file options/host.md)
 
@@ -445,7 +448,16 @@ Require HTTPS and verify certificates when contacting OCI registries
 
 [//]: # (BEGIN included file options/url.md)
 #### **--url**=URL
-The host to send requests to (default: http://localhost:8080)
+The host to send requests to (default: http://localhost:8080).
+
+When the URL points at localhost (the host's loopback, e.g. a `ramalama serve`
+container or any local OpenAI-compatible process), the agent container is wired to
+reach that loopback server without requiring it to be exposed on a
+container-reachable interface. On native Linux the agent shares the host network
+namespace and reaches the server directly as localhost. On VM-backed engines
+(podman machine / Docker Desktop on macOS and Windows) the localhost host is
+rewritten to `host.containers.internal` / `host.docker.internal`, which the VM's
+proxy forwards to the host's loopback.
 
 [//]: # (END   included file options/url.md)
 

--- a/docs/ramalama-sandbox-pi.1.md
+++ b/docs/ramalama-sandbox-pi.1.md
@@ -161,8 +161,11 @@ Show this help message and exit
 
 
 [//]: # (BEGIN included file options/host.md)
-#### **--host**="::"
-IP address for llama.cpp to listen on. Defaults to "::" (dual-stack) on systems with IPv6 support, "0.0.0.0" on IPv4-only systems.
+#### **--host**="127.0.0.1"
+IP address for the model server to listen on. Defaults to "127.0.0.1", so the
+served model is only reachable from the local machine. To expose it on the
+network, set this to a wildcard address such as "0.0.0.0" (IPv4) or "::"
+(dual-stack).
 
 [//]: # (END   included file options/host.md)
 
@@ -450,7 +453,16 @@ Require HTTPS and verify certificates when contacting OCI registries
 
 [//]: # (BEGIN included file options/url.md)
 #### **--url**=URL
-The host to send requests to (default: http://localhost:8080)
+The host to send requests to (default: http://localhost:8080).
+
+When the URL points at localhost (the host's loopback, e.g. a `ramalama serve`
+container or any local OpenAI-compatible process), the agent container is wired to
+reach that loopback server without requiring it to be exposed on a
+container-reachable interface. On native Linux the agent shares the host network
+namespace and reaches the server directly as localhost. On VM-backed engines
+(podman machine / Docker Desktop on macOS and Windows) the localhost host is
+rewritten to `host.containers.internal` / `host.docker.internal`, which the VM's
+proxy forwards to the host's loopback.
 
 [//]: # (END   included file options/url.md)
 

--- a/docs/ramalama-serve.1.md
+++ b/docs/ramalama-serve.1.md
@@ -213,8 +213,11 @@ Show this help message and exit
 
 
 [//]: # (BEGIN included file options/host.md)
-#### **--host**="::"
-IP address for llama.cpp to listen on. Defaults to "::" (dual-stack) on systems with IPv6 support, "0.0.0.0" on IPv4-only systems.
+#### **--host**="127.0.0.1"
+IP address for the model server to listen on. Defaults to "127.0.0.1", so the
+served model is only reachable from the local machine. To expose it on the
+network, set this to a wildcard address such as "0.0.0.0" (IPv4) or "::"
+(dual-stack).
 
 [//]: # (END   included file options/host.md)
 

--- a/docs/ramalama.conf
+++ b/docs/ramalama.conf
@@ -83,9 +83,11 @@
 #VLLM_INTEL_VISIBLE_DEVICES="docker.io/vllm/vllm-openai"
 #VLLM_MUSA_VISIBLE_DEVICES="docker.io/vllm/vllm-openai"
 
-# IP address for llama.cpp to listen on.
+# IP address for the model server to listen on. Defaults to the loopback
+# address so the model is only reachable locally; set to "0.0.0.0" or "::" to
+# expose it on the network.
 #
-#host = "::"
+#host = "127.0.0.1"
 
 # Pass `--group-add keep-groups` to podman, when using podman.
 # In some cases this is needed to access the gpu from a rootless container

--- a/docs/ramalama.conf.5.md
+++ b/docs/ramalama.conf.5.md
@@ -92,10 +92,12 @@ Override via `RAMALAMA_CONTAINER_ENGINE`.
 **env**=[]: Environment variables added to the container runtime environment.
 Example: "LLAMA_ARG_THREADS=10".
 
-**host**="::" | "0.0.0.0"
+**host**="127.0.0.1"
 
-IP address for llama.cpp to listen on.
-Defaults to "::" (dual-stack) on systems with IPv6 support, "0.0.0.0" (IPv4-only) otherwise.
+IP address for the model server to listen on.
+Defaults to "127.0.0.1", so the served model is only reachable from the local
+machine. Set to a wildcard address such as "0.0.0.0" (IPv4) or "::" (dual-stack)
+to expose it on the network.
 
 **image**="quay.io/ramalama/ramalama:latest"
 

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -33,11 +33,12 @@ from ramalama.config import (
     ActiveConfig,
     coerce_to_bool,
     ensure_tmpdir,
+    get_wildcard_host,
     load_file_config,
 )
 from ramalama.config_types import COLOR_OPTIONS
 from ramalama.endian import EndianMismatchError
-from ramalama.host_utils import format_bind_host_for_url
+from ramalama.host_utils import format_bind_host_for_url, format_vm_aware_publish_prefix
 from ramalama.log_levels import LogLevel
 from ramalama.logger import configure_logger, logger
 from ramalama.model_inspect.error import ParseError
@@ -1211,6 +1212,12 @@ def daemon_start_cli(args):
         # If run inside a container, map the model store to the container internal directory
         daemon_model_store_dir = "/ramalama/models"
 
+        # Honor the requested bind host (loopback by default) on the host-side
+        # port publish; the daemon inside the container binds the wildcard below
+        # so the published port can still reach it. On VM-backed engines a
+        # loopback publish is bound inside the VM and unreachable from the host,
+        # so format_vm_aware_publish_prefix drops the prefix there (matching serve).
+        publish_prefix = format_vm_aware_publish_prefix(args.host)
         daemon_cmd += [
             *engine_cmd(args.engine),
             "run",
@@ -1218,7 +1225,7 @@ def daemon_start_cli(args):
             args.pull,
             "-d",
             "-p",
-            f"{args.port}:8080",
+            f"{publish_prefix}{args.port}:8080",
             "-v",
             f"{args.store}:{daemon_model_store_dir}",
             args.image,
@@ -1232,8 +1239,12 @@ def daemon_start_cli(args):
         "run",
         "--port",
         "8080" if is_daemon_in_container else args.port,
+        # Inside the container the daemon must bind all interfaces so the
+        # published port can reach it; the container port publish above controls
+        # host-side exposure. Outside a container, honor the requested host
+        # (loopback by default).
         "--host",
-        ActiveConfig().host if is_daemon_in_container else args.host,
+        get_wildcard_host() if is_daemon_in_container else args.host,
     ]
     exec_cmd(daemon_cmd)
 

--- a/ramalama/compose.py
+++ b/ramalama/compose.py
@@ -7,6 +7,7 @@ from typing import Optional
 
 from ramalama.common import RAG_DIR, get_accel_env_vars, get_gpu_devices
 from ramalama.file import PlainFile
+from ramalama.host_utils import format_bind_host_publish_prefix
 from ramalama.version import version
 
 
@@ -107,14 +108,17 @@ class Compose:
 
     def _gen_ports(self) -> str:
         port_arg = getattr(self.args, "port", None)
+        # Prefix the published port with the bind host (loopback by default) so
+        # the service is only exposed locally unless --host is set to a wildcard.
+        host = format_bind_host_publish_prefix(getattr(self.args, "host", None))
         if not port_arg:
             # Default to 8080 if no port is specified
-            return '    ports:\n      - "8080:8080"'
+            return f'    ports:\n      - "{host}8080:8080"'
 
         p = port_arg.split(":", 2)
         host_port = p[1] if len(p) > 1 else p[0]
         container_port = p[0]
-        return f'    ports:\n      - "{host_port}:{container_port}"'
+        return f'    ports:\n      - "{host}{host_port}:{container_port}"'
 
     def _gen_environment(self) -> str:
         env_vars = get_accel_env_vars()

--- a/ramalama/config.py
+++ b/ramalama/config.py
@@ -58,7 +58,28 @@ DEFAULT_CONFIG_DIRS = _get_default_config_dirs()
 
 
 def get_default_host() -> str:
-    """Return :: on dual-stack/IPv6 systems, 0.0.0.0 on IPv4-only."""
+    """Return the default bind host.
+
+    Defaults to the IPv4 loopback address so a served model is only reachable
+    from the local machine. Binding to all interfaces (and thus exposing the
+    model to the network) is opt-in via ``--host 0.0.0.0`` / ``--host ::``.
+    """
+    return "127.0.0.1"
+
+
+def get_wildcard_host() -> str:
+    """Return a wildcard bind host reachable from other containers.
+
+    Internal helper servers (RAG embedding/docling/caption, sandbox model
+    server) are reached from a sibling container via ``host.containers.internal``
+    / ``host.docker.internal``, which a loopback-bound port cannot serve. They
+    bind the wildcard address so the sibling can connect. This is a stopgap
+    until those helpers move onto a private container network.
+
+    Probe for IPv6 support at runtime: return ``::`` on dual-stack/IPv6 systems
+    (binds both IPv4 and IPv6) and ``0.0.0.0`` on IPv4-only systems, since ``::``
+    cannot be bound when the kernel lacks IPv6.
+    """
     import socket
 
     try:

--- a/ramalama/engine.py
+++ b/ramalama/engine.py
@@ -18,7 +18,10 @@ from ramalama.arg_types import BaseEngineArgsType
 from ramalama.common import check_nvidia, engine_cmd, exec_cmd, get_accel_env_vars, host_path, perror, run_cmd
 from ramalama.compat import NamedTemporaryFile
 from ramalama.config import ActiveConfig
-from ramalama.host_utils import format_bind_host_for_connection, format_bind_host_publish_prefix
+from ramalama.host_utils import (
+    format_bind_host_for_connection,
+    format_vm_aware_publish_prefix,
+)
 from ramalama.logger import logger
 from ramalama.path_utils import normalize_host_path_for_container
 
@@ -216,11 +219,14 @@ class Engine(BaseEngine):
 
         # Convert port to string for processing
         port_str = str(port)
-        host = format_bind_host_publish_prefix(getattr(self.args, "host", "::"))
+        host = self._publish_host_prefix(getattr(self.args, "host", "::"))
         if ":" in port_str:
             self.add_args("-p", f"{host}{port_str}")
         else:
             self.add_args("-p", f"{host}{port_str}:{port_str}")
+
+    def _publish_host_prefix(self, host: Optional[str]) -> str:
+        return format_vm_aware_publish_prefix(host)
 
     def add_privileged_options(self) -> None:
         if getattr(self.args, "privileged", False):

--- a/ramalama/host_utils.py
+++ b/ramalama/host_utils.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import platform
 from typing import Optional
 
 WILDCARD_BIND_HOSTS = frozenset({"0.0.0.0", "::"})
+LOOPBACK_BIND_HOSTS = frozenset({"127.0.0.1", "::1", "localhost"})
 
 
 def normalize_bind_host(host: Optional[str]) -> str:
@@ -45,6 +47,13 @@ def format_bind_host_literal(host: Optional[str]) -> str:
     return f"[{normalized}]" if ":" in normalized else normalized
 
 
+def is_loopback_bind_host(host: Optional[str]) -> bool:
+    """Return True if host refers to the loopback interface (local-only)."""
+    if not host:
+        return False
+    return normalize_bind_host(host) in LOOPBACK_BIND_HOSTS
+
+
 def format_bind_host_publish_prefix(host: Optional[str]) -> str:
     """Return host prefix for container publish-port arguments, or empty for IPv6 wildcard."""
     if not host:
@@ -52,4 +61,24 @@ def format_bind_host_publish_prefix(host: Optional[str]) -> str:
     normalized = normalize_bind_host(host)
     if normalized == "::":
         return ""
+    # podman/docker -p requires an IP literal, not a hostname; map the loopback
+    # name to its IPv4 address.
+    if normalized == "localhost":
+        normalized = "127.0.0.1"
     return f"[{normalized}]:" if ":" in normalized else f"{normalized}:"
+
+
+def format_vm_aware_publish_prefix(host: Optional[str]) -> str:
+    """Return a publish-port host prefix, accounting for VM-backed engines.
+
+    On VM-backed engines (podman machine / Docker Desktop on macOS and Windows,
+    including WSL2), published ports are reached through a proxy (e.g. gvproxy)
+    that forwards the host's loopback into the VM. Binding the port to the VM's
+    loopback would make it unreachable from the host, so publish on all
+    interfaces inside the VM; the proxy still only exposes the port on the host's
+    loopback, so this does not widen access. On native engines this is identical
+    to format_bind_host_publish_prefix.
+    """
+    if is_loopback_bind_host(host) and platform.system() in ("Darwin", "Windows"):
+        return ""
+    return format_bind_host_publish_prefix(host)

--- a/ramalama/plugins/runtimes/inference/llama_cpp.py
+++ b/ramalama/plugins/runtimes/inference/llama_cpp.py
@@ -697,7 +697,7 @@ class LlamaCppPlugin(LlamaCppCommands, ContainerizedInferenceRuntimePlugin):
         embed_transport.ensure_model_exists(embed_serve_args)
 
         embed_cmd = assemble_command(embed_serve_args)
-        embed_proc = embed_transport.serve_nonblocking(embed_serve_args, embed_cmd)
+        embed_proc = embed_transport.serve_nonblocking(embed_serve_args, embed_cmd, expose_to_containers=True)
 
         if not args.dryrun:
             _wait_for_server(self, embed_serve_args, embed_transport.model_alias)

--- a/ramalama/plugins/runtimes/inference/rag/handler.py
+++ b/ramalama/plugins/runtimes/inference/rag/handler.py
@@ -92,14 +92,20 @@ def rag_handler(plugin: RuntimePlugin, args: argparse.Namespace) -> None:
     all_serve_args = [docling_serve_args, embed_serve_args]
     try:
         perror("Starting VLM server...")
-        docling_proc = docling_transport.serve_nonblocking(docling_serve_args, docling_cmd)  # type: ignore[union-attr]
+        docling_proc = docling_transport.serve_nonblocking(  # type: ignore[union-attr]
+            docling_serve_args, docling_cmd, expose_to_containers=True
+        )
         perror("Starting embedding server...")
-        embed_proc = embed_transport.serve_nonblocking(embed_serve_args, embed_cmd)  # type: ignore[union-attr]
+        embed_proc = embed_transport.serve_nonblocking(  # type: ignore[union-attr]
+            embed_serve_args, embed_cmd, expose_to_containers=True
+        )
 
         if caption_transport and caption_serve_args:
             caption_cmd = assemble_command(caption_serve_args)
             perror("Starting image captioning server...")
-            caption_proc = caption_transport.serve_nonblocking(caption_serve_args, caption_cmd)  # type: ignore[union-attr]
+            caption_proc = caption_transport.serve_nonblocking(  # type: ignore[union-attr]
+                caption_serve_args, caption_cmd, expose_to_containers=True
+            )
             all_serve_args.append(caption_serve_args)
 
         if not args.dryrun:

--- a/ramalama/quadlet.py
+++ b/ramalama/quadlet.py
@@ -6,7 +6,7 @@ from typing import Optional, Tuple
 
 from ramalama.common import MNT_DIR, RAG_DIR, ContainerEntryPoint, get_accel, get_accel_env_vars
 from ramalama.file import UnitFile
-from ramalama.host_utils import format_bind_host_literal
+from ramalama.host_utils import format_bind_host_publish_prefix, is_loopback_bind_host
 
 
 class Quadlet:
@@ -187,8 +187,22 @@ class Quadlet:
 
     def _gen_port(self, quadlet_file: UnitFile):
         if getattr(self.args, "port", "") != "":
-            host = format_bind_host_literal(getattr(self.args, "host", None) or "::")
-            quadlet_file.add("Container", "PublishPort", f"{host}:{self.args.port}:{self.args.port}")
+            host_arg = getattr(self.args, "host", None) or "::"
+            if is_loopback_bind_host(host_arg):
+                # On VM-backed engines a loopback publish is bound inside the VM
+                # and is not reachable from the host; flag it for the reader.
+                quadlet_file.add(
+                    "comment",
+                    "# NOTE: on VM-backed engines (podman machine / Docker Desktop on macOS\n"
+                    "# and Windows), the loopback PublishPort below is bound inside the VM and\n"
+                    "# is not reachable from the host. Set --host 0.0.0.0 (or edit PublishPort)\n"
+                    "# if you need to reach it there.",
+                )
+            # Use the publish-prefix form so `localhost` maps to 127.0.0.1 and the
+            # IPv6 wildcard drops the host, matching the compose generator; podman
+            # PublishPort requires an IP literal, not a hostname.
+            host = format_bind_host_publish_prefix(host_arg)
+            quadlet_file.add("Container", "PublishPort", f"{host}{self.args.port}:{self.args.port}")
 
     def _gen_rag_volume(self, quadlet_file: UnitFile):
         files: list[UnitFile] = []

--- a/ramalama/rag.py
+++ b/ramalama/rag.py
@@ -197,7 +197,7 @@ class RagTransport(OCI):
 
     def serve(self, args: RagArgsType, cmd: list[str]):
         args.model_args.name = self.imodel.get_container_name(args.model_args)
-        process = self.imodel.serve_nonblocking(args.model_args, self.model_cmd)
+        process = self.imodel.serve_nonblocking(args.model_args, self.model_cmd, expose_to_containers=True)
         if not args.dryrun:
             if process and process.wait() != 0:
                 raise subprocess.CalledProcessError(
@@ -213,7 +213,7 @@ class RagTransport(OCI):
 
     def run(self, args: RagArgsType, cmd: list[str]):
         args.model_args.name = self.imodel.get_container_name(args.model_args)
-        process = self.imodel.serve_nonblocking(args.model_args, self.model_cmd)
+        process = self.imodel.serve_nonblocking(args.model_args, self.model_cmd, expose_to_containers=True)
         rag_process = self.serve_nonblocking(args, cmd)
 
         if args.dryrun:

--- a/ramalama/sandbox.py
+++ b/ramalama/sandbox.py
@@ -9,15 +9,38 @@ from collections.abc import Callable
 from functools import partial
 from http.client import HTTPConnection
 from typing import Optional, cast
+from urllib.parse import urlparse
 
 from ramalama.arg_types import BaseEngineArgsType
 from ramalama.common import genname, perror, run_cmd
 from ramalama.config import ActiveConfig
 from ramalama.engine import Engine, is_healthy, stop_container, wait_for_healthy
+from ramalama.host_utils import is_loopback_bind_host
 from ramalama.model_server import ModelServerError, list_server_models
 from ramalama.plugins.loader import get_runtime
 from ramalama.transports.base import compute_serving_port
 from ramalama.transports.transport_factory import New
+
+
+def _wire_loopback_url(sb_args) -> None:
+    """Make a loopback --url reachable from the agent container.
+
+    On native Linux, share the host network namespace so the agent reaches the
+    server directly as localhost. On VM-backed engines (podman machine / Docker
+    Desktop on macOS and Windows) `--network host` shares the VM's namespace,
+    not the host's, so a host-side loopback server is unreachable that way;
+    instead rewrite the URL's loopback host to host.containers.internal (podman)
+    / host.docker.internal (docker), which the proxy (gvproxy) forwards to the
+    host's loopback. Neither exposes the server to the network.
+    """
+    if platform.system() not in ("Darwin", "Windows"):
+        sb_args.network = "host"
+        return
+
+    host = "host.containers.internal" if sb_args.engine == "podman" else "host.docker.internal"
+    parsed = urlparse(sb_args.url)
+    netloc = f"{host}:{parsed.port}" if parsed.port else host
+    sb_args.url = parsed._replace(netloc=netloc).geturl()
 
 
 def default_pi_image() -> str:
@@ -341,10 +364,12 @@ def run_sandbox(args: SandboxEngineArgsType, agent_cls: type[Agent]) -> None:
             raise ValueError(f"No model found at {url}")
 
     sb_args.start_model_server = sb_args.url is None
-    # ensure agent container can access model-server on localhost
-    if sb_args.url and (sb_args.url.startswith("http://localhost") or sb_args.url.startswith("https://localhost")):
-        middle = 'docker' if args.engine == 'docker' else 'containers'
-        sb_args.url = sb_args.url.replace("localhost", f"host.{middle}.internal")
+    # A loopback --url points at a server on the host's loopback (e.g. a
+    # `ramalama serve` container publishing to 127.0.0.1, or any local
+    # OpenAI-compatible process) that must be reached from the agent container.
+    # Remote URLs use the default network and are reached directly.
+    if sb_args.url and is_loopback_bind_host(urlparse(sb_args.url).hostname) and not getattr(sb_args, "network", None):
+        _wire_loopback_url(sb_args)
     models: list[str] = list(sb_args.MODEL)  # type: ignore[arg-type]
 
     if not sb_args.start_model_server:

--- a/ramalama/transports/base.py
+++ b/ramalama/transports/base.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 from ramalama import chat
 from ramalama.common import ContainerEntryPoint
 from ramalama.compose import Compose
-from ramalama.config import ActiveConfig
+from ramalama.config import ActiveConfig, get_wildcard_host
 from ramalama.engine import Engine, dry_run, is_healthy, wait_for_healthy
 from ramalama.kube import Kube
 from ramalama.model_inspect.base_info import ModelInfoBase
@@ -466,11 +466,17 @@ class Transport(TransportBase):
                     [f"--mount=type=bind,src={container_blob_path},destination={mount_path},ro{self.engine.relabel()}"]
                 )
 
-    def serve_nonblocking(self, args, cmd: list[str]) -> Optional[subprocess.Popen]:
+    def serve_nonblocking(self, args, cmd: list[str], expose_to_containers: bool = False) -> Optional[subprocess.Popen]:
         if args.container:
             args.name = self.get_container_name(args)
 
-        args.host = ActiveConfig().host
+        # Helper servers that a sibling container reaches via
+        # host.containers.internal must bind the wildcard; everything else
+        # honors the configured host (loopback by default).
+        if expose_to_containers:
+            args.host = get_wildcard_host()
+        else:
+            args.host = getattr(args, "host", None) or ActiveConfig().host
         args.detach = True
 
         set_accel_env_vars()

--- a/test/e2e/test_sandbox.py
+++ b/test/e2e/test_sandbox.py
@@ -1,4 +1,5 @@
 import logging
+import platform
 import random
 import re
 import string
@@ -102,6 +103,33 @@ def test_sandbox_dryrun_url(agent):
     """--url should overwrite the openai endpoint url."""
     result = check_output(_dryrun_cmd(agent) + ["--url", "http://model.server.local:8321/"])
     assert "http://model.server.local:8321" in result
+
+
+@pytest.mark.e2e
+@skip_if_no_container
+@pytest.mark.parametrize("agent", ["goose", "opencode", "pi"])
+def test_sandbox_dryrun_localhost_url_is_reachable(agent, container_engine):
+    """A localhost --url must be made reachable from the agent container.
+
+    On native Linux this shares the host network namespace and keeps the
+    localhost URL. On VM-backed engines (podman machine / Docker Desktop on
+    macOS and Windows) --network host would share the VM's namespace rather than
+    the host's, so the loopback host is rewritten to the engine's host-gateway
+    alias instead.
+    """
+    result = check_output(_dryrun_cmd(agent) + ["--url", "http://localhost:8321"])
+    if platform.system() in ("Darwin", "Windows"):
+        gateway = "host.containers.internal" if container_engine == "podman" else "host.docker.internal"
+        assert f"http://{gateway}:8321" in result
+        assert not re.search(r"--network host\b", result)
+        assert "http://localhost:8321" not in result
+    else:
+        # Share the host network namespace so the agent reaches a loopback-only server.
+        assert re.search(r"--network host\b", result)
+        # The URL is used as-is; no host.containers.internal / host.docker.internal rewrite.
+        assert "http://localhost:8321" in result
+        assert "host.containers.internal" not in result
+        assert "host.docker.internal" not in result
 
 
 @pytest.mark.e2e

--- a/test/e2e/test_serve.py
+++ b/test/e2e/test_serve.py
@@ -126,6 +126,15 @@ def test_basic_dry_run():
             id="check -p is modified when run within container", marks=skip_if_no_container
         ),
         pytest.param(
+            # VM-backed engines (podman machine / Docker Desktop on macOS and
+            # Windows) publish a loopback bind bare inside the VM; native Linux
+            # keeps the 127.0.0.1 prefix.
+            ["--port", "1234"],
+            r".*-p 1234:1234" if platform.system() in ("Darwin", "Windows") else r".*-p 127.0.0.1:1234:1234",
+            None, None, True,
+            id="check -p publishes on loopback by default in container", marks=skip_if_no_container
+        ),
+        pytest.param(
             [], r".*--temp 0.8", None, None, True,
             id="check --temp default value", marks=skip_if_no_container
         ),
@@ -178,7 +187,7 @@ def test_basic_dry_run():
             ["--selinux", "False"], r".*--security-opt=label=disable", None, None, True,
             id="check --selinux=False disables container separation", marks=skip_if_no_container),
         pytest.param(
-            [], r".*--host (::|0\.0\.0\.0)", None, None, True,
+            [], r".*--host 127.0.0.1", None, None, True,
             id="check default --host value", marks=skip_if_container
         ),
         pytest.param(
@@ -440,7 +449,7 @@ def test_quadlet_generation(shared_ctx, test_model):
     )
     with container_file.open("r") as f:
         content = f.read()
-        assert re.search(r".*PublishPort=(\[::\]|0\.0\.0\.0):1234:1234", content)
+        assert re.search(r".*PublishPort=127\.0\.0\.1:1234:1234", content)
         assert re.search(r".*llama-server --host (::|0\.0\.0\.0) --port 1234 --model .*", content)
         assert re.search(f".*Mount=type=bind,.*{test_model_full_name}", content)
         assert re.search(r".*Environment=HIP_VISIBLE_DEVICES=99", content)
@@ -538,7 +547,7 @@ def test_quadlet_and_kube_generation_with_container_registry(container_registry,
         quadlet_file = Path(ctx.workspace_dir) / "{}.container".format(container_name)
         with quadlet_file.open("r") as f:
             content = f.read()
-            assert re.search(f".*PublishPort=(\\[::\\]|0\\.0\\.0\\.0):{container_port}:{container_port}", content)
+            assert re.search(f".*PublishPort=127\\.0\\.0\\.1:{container_port}:{container_port}", content)
             assert re.search(f".*ContainerName={container_name}", content)
             host_re = r"(::|0\.0\.0\.0)"
             assert re.search(f".*Exec=.*llama-server --host {host_re} --port {container_port} --model .*", content)
@@ -689,7 +698,7 @@ def test_serve_generation(test_model, generate, env_vars):
                 elif "compose" in generate:
                     assert re.search(r".*command: .*serve.*", content)
                     assert re.search(r".*ports:", content)
-                    assert re.search(r".*- \"1234:1234\"", content)
+                    assert re.search(r".*- \"127\.0\.0\.1:1234:1234\"", content)
                 else:
                     raise Exception("Invalid generate option")
 

--- a/test/unit/data/test_quadlet/ipv6_host/tinyllama.container
+++ b/test/unit/data/test_quadlet/ipv6_host/tinyllama.container
@@ -1,3 +1,7 @@
+# NOTE: on VM-backed engines (podman machine / Docker Desktop on macOS
+# and Windows), the loopback PublishPort below is bound inside the VM and
+# is not reachable from the host. Set --host 0.0.0.0 (or edit PublishPort)
+# if you need to reach it there.
 [Unit]
 Description=RamaLama tinyllama AI Model Service
 After=local-fs.target

--- a/test/unit/data/test_quadlet/localhost/tinyllama.container
+++ b/test/unit/data/test_quadlet/localhost/tinyllama.container
@@ -1,3 +1,7 @@
+# NOTE: on VM-backed engines (podman machine / Docker Desktop on macOS
+# and Windows), the loopback PublishPort below is bound inside the VM and
+# is not reachable from the host. Set --host 0.0.0.0 (or edit PublishPort)
+# if you need to reach it there.
 [Unit]
 Description=RamaLama tinyllama AI Model Service
 After=local-fs.target

--- a/test/unit/data/test_quadlet/oci_port/oci-model-port.container
+++ b/test/unit/data/test_quadlet/oci_port/oci-model-port.container
@@ -14,7 +14,7 @@ Exec=
 SecurityLabelDisable=true
 DropCapability=all
 NoNewPrivileges=true
-PublishPort=[::]:8080:8080
+PublishPort=8080:8080
 Mount=type=image,source=registry.example.com/model:latest,destination=/mnt/models,subpath=/models,readwrite=false
 
 [Install]

--- a/test/unit/data/test_quadlet/portmapping/tinyllama.container
+++ b/test/unit/data/test_quadlet/portmapping/tinyllama.container
@@ -14,7 +14,7 @@ Exec=
 SecurityLabelDisable=true
 DropCapability=all
 NoNewPrivileges=true
-PublishPort=[::]:2020:2020
+PublishPort=2020:2020
 Mount=type=image,source=tinyllama,destination=/mnt/models,subpath=/models,readwrite=false
 
 [Install]

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -4,7 +4,13 @@ from unittest import mock
 
 import pytest
 
-from ramalama.cli import ParsedGenerateInput, _normalize_engine_args, parse_generate_option, post_parse_setup
+from ramalama.cli import (
+    ParsedGenerateInput,
+    _normalize_engine_args,
+    daemon_start_cli,
+    parse_generate_option,
+    post_parse_setup,
+)
 from ramalama.transports.base import NoGGUFModelFileFound, SafetensorModelNotSupported
 
 
@@ -264,3 +270,69 @@ def test_post_parse_setup_model_input(
     assert input_args.UNRESOLVED_MODEL == expected_unresolved
     assert input_args.MODEL == expected_resolved
     assert input_args.model == input_args.MODEL
+
+
+def _daemon_start_args(**overrides) -> Namespace:
+    args = Namespace(
+        container=True,
+        engine="podman",
+        store="/tmp/store",
+        port="1234",
+        host="127.0.0.1",
+        pull="missing",
+        image="testimage",
+    )
+    for key, value in overrides.items():
+        setattr(args, key, value)
+    return args
+
+
+def _capture_daemon_cmd(args) -> list:
+    with mock.patch("ramalama.cli.exec_cmd") as exec_cmd:
+        daemon_start_cli(args)
+    assert exec_cmd.call_count == 1
+    return exec_cmd.call_args.args[0]
+
+
+@pytest.mark.parametrize(
+    "host,expected_publish",
+    [
+        # loopback default must restrict the host-side publish to loopback
+        ("127.0.0.1", "127.0.0.1:1234:8080"),
+        # localhost normalizes to the IPv4 literal podman -p requires
+        ("localhost", "127.0.0.1:1234:8080"),
+        ("::1", "[::1]:1234:8080"),
+        # wildcard opt-in publishes on all interfaces (no host prefix)
+        ("::", "1234:8080"),
+        ("0.0.0.0", "0.0.0.0:1234:8080"),
+    ],
+)
+def test_daemon_start_container_publish_respects_host(monkeypatch, host, expected_publish):
+    # Pin a native engine so the host-side publish prefix is platform-independent;
+    # the VM-backed loopback-drop behavior is covered separately below.
+    monkeypatch.setattr("ramalama.host_utils.platform.system", lambda: "Linux")
+    cmd = _capture_daemon_cmd(_daemon_start_args(host=host))
+    # -p <publish> pair
+    assert "-p" in cmd
+    assert cmd[cmd.index("-p") + 1] == expected_publish
+    # The daemon inside the container still binds the wildcard so the published
+    # port can reach it, regardless of the host-side bind.
+    from ramalama.config import get_wildcard_host
+
+    assert cmd[cmd.index("--host") + 1] == get_wildcard_host()
+
+
+def test_daemon_start_nocontainer_honors_host():
+    cmd = _capture_daemon_cmd(_daemon_start_args(container=False, host="127.0.0.1"))
+    # No container run wrapper, no port publish; daemon binds the requested host.
+    assert "-p" not in cmd
+    assert cmd[cmd.index("--host") + 1] == "127.0.0.1"
+
+
+def test_daemon_start_container_publish_vm_backed_drops_loopback(monkeypatch):
+    # On VM-backed engines (macOS/Windows) a loopback publish is bound inside the
+    # VM and unreachable from the host, so the daemon path must drop the prefix
+    # just like serve does, publishing on all interfaces inside the VM.
+    monkeypatch.setattr("ramalama.host_utils.platform.system", lambda: "Darwin")
+    cmd = _capture_daemon_cmd(_daemon_start_args(host="127.0.0.1"))
+    assert cmd[cmd.index("-p") + 1] == "1234:8080"

--- a/test/unit/test_compose.py
+++ b/test/unit/test_compose.py
@@ -262,6 +262,28 @@ def test_compose_no_port_arg(monkeypatch):
     assert 'ports:\n      - "8080:8080"' in result
 
 
+@pytest.mark.parametrize(
+    "host, expected_ports",
+    [
+        ("127.0.0.1", 'ports:\n      - "127.0.0.1:9090:9090"'),
+        ("::", 'ports:\n      - "9090:9090"'),
+        ("::1", 'ports:\n      - "[::1]:9090:9090"'),
+    ],
+)
+def test_compose_ports_bind_host(monkeypatch, host, expected_ports):
+    """The published port is prefixed with the bind host (loopback by default)."""
+    monkeypatch.setattr("os.path.exists", lambda path: False)
+    monkeypatch.setattr("ramalama.compose.get_accel_env_vars", lambda: {})
+    monkeypatch.setattr("ramalama.compose.version", lambda: "test")
+
+    args = Args(port="9090")
+    args.host = host
+    compose = Compose("test", ("/a", "/b"), None, None, args, [], None)
+    result = compose.generate().content
+
+    assert expected_ports in result
+
+
 def test_compose_no_env_vars(monkeypatch):
     """Test Compose generation when no environment variables are set."""
     monkeypatch.setattr("os.path.exists", lambda path: False)

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -41,7 +41,7 @@ def test_correct_config_defaults(monkeypatch):
     assert cfg.ctx_size == 0
     assert cfg.engine in ["podman", "docker", None]
     assert cfg.env == []
-    assert cfg.host in ["::", "0.0.0.0"]
+    assert cfg.host == "127.0.0.1"
     assert cfg.image == cfg.default_image
     assert isinstance(cfg.images, dict)
     assert cfg.api == "none"

--- a/test/unit/test_engine.py
+++ b/test/unit/test_engine.py
@@ -175,7 +175,8 @@ class TestEngine(unittest.TestCase):
         "none-host",
     ],
 )
-def test_add_port_with_host(host, port, expected_port_arg):
+@patch("ramalama.engine.platform.system", return_value="Linux")
+def test_add_port_with_host(mock_system, host, port, expected_port_arg):
     base_args = Namespace(
         engine="podman",
         debug=False,
@@ -188,6 +189,39 @@ def test_add_port_with_host(host, port, expected_port_arg):
         port=port,
     )
     engine = ramalama.engine.Engine(base_args)
+    p_index = engine.exec_args.index("-p")
+    assert engine.exec_args[p_index + 1] == expected_port_arg
+
+
+@pytest.mark.parametrize("system", ["Darwin", "Windows"])
+@pytest.mark.parametrize(
+    "host, port, expected_port_arg",
+    [
+        # On VM-backed engines a loopback host must publish on all interfaces
+        # inside the VM so the host proxy (e.g. gvproxy) can reach it.
+        ("127.0.0.1", "8080", "8080:8080"),
+        ("::1", "8080", "8080:8080"),
+        ("localhost", "8080", "8080:8080"),
+        # Non-loopback hosts keep their explicit prefix.
+        ("::", "8080", "8080:8080"),
+        ("192.168.1.100", "8080", "192.168.1.100:8080:8080"),
+    ],
+    ids=["ipv4-loopback", "ipv6-loopback", "localhost", "ipv6-wildcard", "explicit-ip"],
+)
+def test_add_port_with_host_on_vm_engine(system, host, port, expected_port_arg):
+    base_args = Namespace(
+        engine="podman",
+        debug=False,
+        dryrun=False,
+        pull="never",
+        image="test-image:latest",
+        quiet=True,
+        selinux=False,
+        host=host,
+        port=port,
+    )
+    with patch("ramalama.engine.platform.system", return_value=system):
+        engine = ramalama.engine.Engine(base_args)
     p_index = engine.exec_args.index("-p")
     assert engine.exec_args[p_index + 1] == expected_port_arg
 

--- a/test/unit/test_host_utils.py
+++ b/test/unit/test_host_utils.py
@@ -5,6 +5,8 @@ from ramalama.host_utils import (
     format_bind_host_for_url,
     format_bind_host_literal,
     format_bind_host_publish_prefix,
+    format_vm_aware_publish_prefix,
+    is_loopback_bind_host,
     localhost_from_bind_host,
     normalize_bind_host,
 )
@@ -96,6 +98,7 @@ def test_format_bind_host_literal(host, expected):
     [
         ("::", ""),
         ("127.0.0.1", "127.0.0.1:"),
+        ("localhost", "127.0.0.1:"),
         ("::1", "[::1]:"),
         ("[::1]", "[::1]:"),
         ("fe80::1", "[fe80::1]:"),
@@ -105,3 +108,45 @@ def test_format_bind_host_literal(host, expected):
 )
 def test_format_bind_host_publish_prefix(host, expected):
     assert format_bind_host_publish_prefix(host) == expected
+
+
+@pytest.mark.parametrize(
+    "host, expected",
+    [
+        ("127.0.0.1", True),
+        ("::1", True),
+        ("[::1]", True),
+        ("localhost", True),
+        ("0.0.0.0", False),
+        ("::", False),
+        ("192.168.1.100", False),
+        ("127.1.2.3", False),
+        (None, False),
+        ("", False),
+    ],
+)
+def test_is_loopback_bind_host(host, expected):
+    assert is_loopback_bind_host(host) == expected
+
+
+@pytest.mark.parametrize(
+    "system, host, expected",
+    [
+        # Native engines: identical to format_bind_host_publish_prefix.
+        ("Linux", "127.0.0.1", "127.0.0.1:"),
+        ("Linux", "::1", "[::1]:"),
+        ("Linux", "0.0.0.0", "0.0.0.0:"),
+        ("Linux", "::", ""),
+        # VM-backed engines: a loopback bind is unreachable from the host, so the
+        # prefix is dropped (publish inside the VM on all interfaces).
+        ("Darwin", "127.0.0.1", ""),
+        ("Windows", "::1", ""),
+        ("Darwin", "localhost", ""),
+        # A wildcard bind is reachable, so it is left unchanged even on a VM.
+        ("Darwin", "0.0.0.0", "0.0.0.0:"),
+        ("Windows", "::", ""),
+    ],
+)
+def test_format_vm_aware_publish_prefix(monkeypatch, system, host, expected):
+    monkeypatch.setattr("ramalama.host_utils.platform.system", lambda: system)
+    assert format_vm_aware_publish_prefix(host) == expected

--- a/test/unit/test_quadlet.py
+++ b/test/unit/test_quadlet.py
@@ -137,6 +137,20 @@ DATA_PATH = Path(__file__).parent / "data" / "test_quadlet"
                 model_src_blob="sha256-2af3b81862c6be03c769683af18efdadb2c33f60ff32ab6f83e42c043d6c7816",
                 model_dest_name="tinyllama",
                 image="testimage",
+                # `localhost` must normalize to the 127.0.0.1 literal (podman
+                # PublishPort needs an IP, not a hostname), matching the compose
+                # generator; output is identical to the host="127.0.0.1" case.
+                args=Args(port="2020", host="localhost"),
+                accel_type="intel",
+            ),
+            DATA_PATH / "localhost",
+        ),
+        (
+            Input(
+                model_name="tinyllama",
+                model_src_blob="sha256-2af3b81862c6be03c769683af18efdadb2c33f60ff32ab6f83e42c043d6c7816",
+                model_dest_name="tinyllama",
+                image="testimage",
                 args=Args(port="2020", host="::1"),
                 accel_type="intel",
             ),

--- a/test/unit/test_sandbox_cmd.py
+++ b/test/unit/test_sandbox_cmd.py
@@ -6,7 +6,7 @@ import pytest
 
 from ramalama.cli import parse_args_from_cmd
 from ramalama.config import DEFAULT_PI_IMAGE
-from ramalama.sandbox import Agent, Goose, OpenCode, Pi, _pi_provider_id, _run_sandbox_router
+from ramalama.sandbox import Agent, Goose, OpenCode, Pi, _pi_provider_id, _run_sandbox_router, _wire_loopback_url
 
 TEST_MODEL = "qwen3:4b"
 
@@ -519,3 +519,28 @@ def test_sandbox_prompt_default_none():
     """Sandbox cli should default ARGS to None when --prompt is not specified"""
     _, args = parse_args_from_cmd(["sandbox", "pi", TEST_MODEL])
     assert args.ARGS is None
+
+
+def test_wire_loopback_url_linux_uses_host_network():
+    """On native Linux a loopback --url shares the host netns; URL is unchanged."""
+    args = SimpleNamespace(engine="podman", url="http://localhost:8321", network=None)
+    with patch("ramalama.sandbox.platform.system", return_value="Linux"):
+        _wire_loopback_url(args)
+    assert args.network == "host"
+    assert args.url == "http://localhost:8321"
+
+
+@pytest.mark.parametrize(
+    "system, engine, expected_host",
+    [
+        ("Darwin", "podman", "host.containers.internal"),
+        ("Windows", "docker", "host.docker.internal"),
+    ],
+)
+def test_wire_loopback_url_vm_engine_rewrites_host(system, engine, expected_host):
+    """On VM-backed engines the loopback host is rewritten; network stays default."""
+    args = SimpleNamespace(engine=engine, url="http://127.0.0.1:8321/v1", network=None)
+    with patch("ramalama.sandbox.platform.system", return_value=system):
+        _wire_loopback_url(args)
+    assert args.network is None
+    assert args.url == f"http://{expected_host}:8321/v1"


### PR DESCRIPTION
Served model ports were published on all host interfaces (0.0.0.0 / [::]) by default, exposing the model to the local network with no opt-in.
This changes the default bind host to the IPv4 loopback address (127.0.0.1), so a served model is only reachable from the local machine. Exposing it on the network is now opt-in via --host 0.0.0.0 / --host ::.