### PR TITLE
e2e: tolerate read timeouts while waiting for ollama server

### DIFF
--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -133,12 +133,12 @@ class OllamaServer:
             try:
                 requests.get(self.url, timeout=0.5)
                 break
-            except requests.exceptions.ConnectionError:
+            except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
                 time.sleep(0.5)
         else:
             pytest.fail("Ollama server did not start in time")
 
-        assert requests.get(self.url).text == "Ollama is running"
+        assert requests.get(self.url, timeout=self.timeout).text == "Ollama is running"
 
     def _stop_process(self):
         if self.proc:


### PR DESCRIPTION
The ollama_server fixture polls GET / until the server responds, but only caught requests.exceptions.ConnectionError. ReadTimeout derives from Timeout, not ConnectionError, so once ollama binds the port and is slow to answer (e.g. while it runs GPU discovery at startup) the 0.5s read timeout escaped the retry loop and aborted fixture setup with an error instead of retrying.

Catch Timeout as well, matching the container_registry fixture, and give the final readiness assertion a timeout so it cannot hang indefinitely.